### PR TITLE
Feature/#47 corestats grant

### DIFF
--- a/src/main/java/online/lifeasgame/character/application/AdminPlayerService.java
+++ b/src/main/java/online/lifeasgame/character/application/AdminPlayerService.java
@@ -1,33 +1,46 @@
 package online.lifeasgame.character.application;
 
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.application.command.AdminPlayerCommand;
 import online.lifeasgame.character.application.result.AdminPlayerResult;
-import online.lifeasgame.character.domain.service.LevelingPolicy;
-import online.lifeasgame.character.domain.repository.LevelCurveParametersLoader;
+import online.lifeasgame.character.domain.CoreStatDelta;
 import online.lifeasgame.character.domain.Player;
 import online.lifeasgame.character.domain.Player.GainResult;
-import online.lifeasgame.character.domain.service.PrecomputedLevelingPolicy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class AdminPlayerService {
 
-    private final PlayerReader playerReader;
-    private final LevelingPolicy levelingPolicy;
-
-    public AdminPlayerService(PlayerReader playerReader, LevelCurveParametersLoader loader) {
-        this.playerReader = playerReader;
-        this.levelingPolicy = new PrecomputedLevelingPolicy(loader.load());
-    }
+    private final PlayerWriter playerWriter;
 
     @Transactional
     public AdminPlayerResult.ExpGranted grantExp(Long playerId, long exp) {
-        Player player = playerReader.getPlayer(playerId);
-        GainResult gainResult = player.gainExp(exp, levelingPolicy);
+        GainResult gainResult = playerWriter.grantExp(playerId, exp);
         return AdminPlayerResult.ExpGranted.of(
-                player.getId(),
+                playerId,
                 gainResult
+        );
+    }
+
+    @Transactional
+    public AdminPlayerResult.CoreStatsGranted grantCoreStats(AdminPlayerCommand.GrantCoreStats command) {
+        Player player = playerWriter.grantCoreStats(
+                command.playerId(),
+                CoreStatDelta.of(
+                        command.str(),
+                        command.agi(),
+                        command.dex(),
+                        command.intel(),
+                        command.vit(),
+                        command.luc()
+                )
+        );
+        return AdminPlayerResult.CoreStatsGranted.of(
+                player.getId(),
+                player.getStats()
         );
     }
 }

--- a/src/main/java/online/lifeasgame/character/application/PlayerWriter.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerWriter.java
@@ -1,10 +1,13 @@
 package online.lifeasgame.character.application;
 
 import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.domain.CoreStatDelta;
 import online.lifeasgame.character.domain.Player;
+import online.lifeasgame.character.domain.Player.GainResult;
 import online.lifeasgame.character.domain.event.PlayerRegistered;
 import online.lifeasgame.character.domain.error.PlayerError;
 import online.lifeasgame.character.domain.repository.PlayerRepository;
+import online.lifeasgame.character.domain.service.LevelingPolicy;
 import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.core.event.DomainEventPublisher;
 import org.springframework.stereotype.Component;
@@ -17,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PlayerWriter {
 
     private final PlayerRepository playerRepository;
+    private final LevelingPolicy levelingPolicy;
     private final DomainEventPublisher domainEventPublisher;
 
     public Long register(Player player) {
@@ -114,6 +118,20 @@ public class PlayerWriter {
             }
         }
 
+        return player;
+    }
+
+    public GainResult grantExp(Long playerId, long exp) {
+        Player player = playerRepository.findById(playerId)
+                .orElseThrow(() -> new DomainException(PlayerError.PLAYER_NOT_FOUND));
+        return player.gainExp(exp, levelingPolicy);
+    }
+
+    public Player grantCoreStats(Long playerId, CoreStatDelta coreStatDelta) {
+        Player player = playerRepository.findById(playerId)
+                .orElseThrow(() -> new DomainException(PlayerError.PLAYER_NOT_FOUND));
+
+        player.gainCoreStats(coreStatDelta);
         return player;
     }
 }

--- a/src/main/java/online/lifeasgame/character/application/command/AdminPlayerCommand.java
+++ b/src/main/java/online/lifeasgame/character/application/command/AdminPlayerCommand.java
@@ -1,0 +1,19 @@
+package online.lifeasgame.character.application.command;
+
+public class AdminPlayerCommand {
+
+    private AdminPlayerCommand() {
+    }
+
+
+    public record GrantCoreStats(
+            Long playerId,
+            int str,
+            int agi,
+            int dex,
+            int intel,
+            int vit,
+            int luc
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/config/CharacterConfig.java
+++ b/src/main/java/online/lifeasgame/character/application/config/CharacterConfig.java
@@ -1,0 +1,16 @@
+package online.lifeasgame.character.application.config;
+
+import online.lifeasgame.character.domain.repository.LevelCurveParametersLoader;
+import online.lifeasgame.character.domain.service.LevelingPolicy;
+import online.lifeasgame.character.domain.service.PrecomputedLevelingPolicy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CharacterConfig {
+
+    @Bean
+    LevelingPolicy levelingPolicy(LevelCurveParametersLoader loader) {
+        return new PrecomputedLevelingPolicy(loader.load());
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/result/AdminPlayerResult.java
+++ b/src/main/java/online/lifeasgame/character/application/result/AdminPlayerResult.java
@@ -1,5 +1,6 @@
 package online.lifeasgame.character.application.result;
 
+import online.lifeasgame.character.domain.CoreStats;
 import online.lifeasgame.character.domain.Player.GainResult;
 
 public class AdminPlayerResult {
@@ -32,6 +33,28 @@ public class AdminPlayerResult {
                     gainResult.expToNext(),
                     gainResult.capForLevel(),
                     gainResult.progressRatio()
+            );
+        }
+    }
+
+    public record CoreStatsGranted(
+            Long playerId,
+            int str,
+            int agi,
+            int dex,
+            int intel,
+            int vit,
+            int luc
+    ) {
+        public static CoreStatsGranted of(Long playerId, CoreStats coreStats) {
+            return new CoreStatsGranted(
+                    playerId,
+                    coreStats.str(),
+                    coreStats.agi(),
+                    coreStats.dex(),
+                    coreStats.intel(),
+                    coreStats.vit(),
+                    coreStats.luc()
             );
         }
     }

--- a/src/main/java/online/lifeasgame/character/domain/CoreStatDelta.java
+++ b/src/main/java/online/lifeasgame/character/domain/CoreStatDelta.java
@@ -1,0 +1,12 @@
+package online.lifeasgame.character.domain;
+
+public record CoreStatDelta(int str, int agi, int dex, int intel, int vit, int luc) {
+
+    public boolean isZero() {
+        return str == 0 && agi == 0 && dex == 0 && intel == 0 && vit == 0 && luc == 0;
+    }
+
+    public static CoreStatDelta of(int str, int agi, int dex, int intel, int vit, int luc) {
+        return new CoreStatDelta(str, agi, dex, intel, vit, luc);
+    }
+}

--- a/src/main/java/online/lifeasgame/character/domain/CoreStats.java
+++ b/src/main/java/online/lifeasgame/character/domain/CoreStats.java
@@ -12,23 +12,26 @@ import online.lifeasgame.core.guard.Guard;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CoreStats {
 
+    public static final int MIN = 1;
+    public static final int MAX = 9999;
+
     @Column(name = "str_stat", nullable = false)
-    private int str = 1;
+    private int str;
 
     @Column(name = "agi_stat", nullable = false)
-    private int agi = 1;
+    private int agi;
 
     @Column(name = "dex_stat", nullable = false)
-    private int dex = 1;
+    private int dex;
 
     @Column(name = "int_stat", nullable = false)
-    private int intel = 1;
+    private int intel;
 
     @Column(name = "vit_stat", nullable = false)
-    private int vit = 1;
+    private int vit;
 
     @Column(name = "luc_stat", nullable = false)
-    private int luc = 1;
+    private int luc;
 
     private CoreStats(int str, int agi, int dex, int intel, int vit, int luc) {
         Guard.minValue(str, 1, "str");
@@ -64,4 +67,29 @@ public class CoreStats {
     public int vit(){ return vit; }
 
     public int luc(){ return luc; }
+
+    public CoreStats grant(CoreStatDelta d) {
+        if (d == null || d.isZero()) {
+            return this;
+        }
+
+        return new CoreStats(
+                addClamp(this.str, d.str()),
+                addClamp(this.agi, d.agi()),
+                addClamp(this.dex, d.dex()),
+                addClamp(this.intel, d.intel()),
+                addClamp(this.vit, d.vit()),
+                addClamp(this.luc, d.luc())
+        );
+    }
+
+    private static int addClamp(int base, int delta) {
+        long sum = (long) base + (long) delta;
+        if (sum >= MAX) {
+            return MAX;
+        } else if (sum <= MIN) {
+            return MIN;
+        }
+        return (int) sum;
+    }
 }

--- a/src/main/java/online/lifeasgame/character/domain/Player.java
+++ b/src/main/java/online/lifeasgame/character/domain/Player.java
@@ -162,6 +162,10 @@ public class Player extends AbstractTime {
         this.mana = this.mana.decreaseCap(mpCapacity);
     }
 
+    public void gainCoreStats(CoreStatDelta coreStatDelta) {
+        this.stats = this.stats.grant(coreStatDelta);
+    }
+
     public record GainResult(
             long requestedExp,
             long appliedExp,

--- a/src/main/java/online/lifeasgame/character/domain/error/PlayerError.java
+++ b/src/main/java/online/lifeasgame/character/domain/error/PlayerError.java
@@ -5,11 +5,12 @@ import online.lifeasgame.core.error.ErrorCode;
 public enum PlayerError implements ErrorCode {
     INVALID_GENDER("PLR-400-INVALID-GENDER", "Invalid gender", 400),
     PLAYER_ALREADY_EXISTS("PLR-409-ALREADY_EXISTS", "Player already exists", 409),
-    PLAYER_NOT_FOUND("PLR-404-NOT_FOUND", "Player not found" , 404 ),
-    INVALID_HP_CAPACITY("PLR-400-INVALID-HP-CAP", "Invalid hp capacity" , 400 ),
+    PLAYER_NOT_FOUND("PLR-404-NOT_FOUND", "Player not found", 404),
+    INVALID_HP_CAPACITY("PLR-400-INVALID-HP-CAP", "Invalid hp capacity", 400),
     INVALID_HP("PLR-400-INVALID-HP", "Invalid hp", 400),
-    INVALID_MP_CAPACITY("PLR-400-INVALID-MP-CAP", "Invalid mp capacity" , 400 ),
-    INVALID_MP("PLR-400-INVALID-MP", "Invalid mp", 400);
+    INVALID_MP_CAPACITY("PLR-400-INVALID-MP-CAP", "Invalid mp capacity", 400),
+    INVALID_MP("PLR-400-INVALID-MP", "Invalid mp", 400),
+    ;
 
     private final String code;
     private final String message;

--- a/src/main/java/online/lifeasgame/character/presentation/AdminPlayerController.java
+++ b/src/main/java/online/lifeasgame/character/presentation/AdminPlayerController.java
@@ -3,6 +3,7 @@ package online.lifeasgame.character.presentation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.character.application.AdminPlayerService;
+import online.lifeasgame.character.application.result.AdminPlayerResult;
 import online.lifeasgame.character.application.result.AdminPlayerResult.ExpGranted;
 import online.lifeasgame.character.presentation.mapper.AdminPlayerWebMapper;
 import online.lifeasgame.character.presentation.request.AdminPlayerRequest;
@@ -11,6 +12,7 @@ import online.lifeasgame.character.presentation.spec.AdminPlayerApiSpecV1;
 import online.lifeasgame.core.response.ApiResponse;
 import online.lifeasgame.platform.web.response.ApiResponses;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,13 +26,27 @@ public class AdminPlayerController implements AdminPlayerApiSpecV1 {
     private final AdminPlayerService adminPlayerService;
 
     @Override
-    @PostMapping("/exp/grant")
+    @PostMapping("/{playerId}/exp/grant")
     public ResponseEntity<ApiResponse<AdminPlayerResponse.ExpGranted>> grantExp(
+            @PathVariable Long playerId,
             @Valid @RequestBody AdminPlayerRequest.GrantExp request
     ) {
-        ExpGranted expGranted = adminPlayerService.grantExp(request.playerId(), request.exp());
+        ExpGranted expGranted = adminPlayerService.grantExp(playerId, request.exp());
         return ApiResponses.ok(
                 AdminPlayerWebMapper.toExpGranted(expGranted)
+        );
+    }
+
+    @Override
+    @PostMapping("/{playerId}/core-stats/grant")
+    public ResponseEntity<ApiResponse<AdminPlayerResponse.CoreStatsGranted>> grantCoreStats(
+            @PathVariable Long playerId,
+            @Valid @RequestBody AdminPlayerRequest.GrantCoreStats request
+    ) {
+        AdminPlayerResult.CoreStatsGranted coreStatsGranted =
+                adminPlayerService.grantCoreStats(AdminPlayerWebMapper.toCommand(playerId, request));
+        return ApiResponses.ok(
+                AdminPlayerWebMapper.toCoreStatsGranted(coreStatsGranted)
         );
     }
 }

--- a/src/main/java/online/lifeasgame/character/presentation/mapper/AdminPlayerWebMapper.java
+++ b/src/main/java/online/lifeasgame/character/presentation/mapper/AdminPlayerWebMapper.java
@@ -1,6 +1,8 @@
 package online.lifeasgame.character.presentation.mapper;
 
+import online.lifeasgame.character.application.command.AdminPlayerCommand;
 import online.lifeasgame.character.application.result.AdminPlayerResult;
+import online.lifeasgame.character.presentation.request.AdminPlayerRequest;
 import online.lifeasgame.character.presentation.response.AdminPlayerResponse;
 
 public class AdminPlayerWebMapper {
@@ -20,6 +22,30 @@ public class AdminPlayerWebMapper {
                 expGranted.expToNext(),
                 expGranted.capForLevel(),
                 expGranted.progressRatio()
+        );
+    }
+
+    public static AdminPlayerCommand.GrantCoreStats toCommand(Long playerId, AdminPlayerRequest.GrantCoreStats request) {
+        return new AdminPlayerCommand.GrantCoreStats(
+                playerId,
+                request.nStr(),
+                request.nAgi(),
+                request.nDex(),
+                request.nInt(),
+                request.nVit(),
+                request.nLuc()
+        );
+    }
+
+    public static AdminPlayerResponse.CoreStatsGranted toCoreStatsGranted(AdminPlayerResult.CoreStatsGranted coreStatsGranted) {
+        return AdminPlayerResponse.CoreStatsGranted.of(
+                coreStatsGranted.playerId(),
+                coreStatsGranted.str(),
+                coreStatsGranted.agi(),
+                coreStatsGranted.dex(),
+                coreStatsGranted.intel(),
+                coreStatsGranted.vit(),
+                coreStatsGranted.luc()
         );
     }
 }

--- a/src/main/java/online/lifeasgame/character/presentation/request/AdminPlayerRequest.java
+++ b/src/main/java/online/lifeasgame/character/presentation/request/AdminPlayerRequest.java
@@ -1,5 +1,6 @@
 package online.lifeasgame.character.presentation.request;
 
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
@@ -9,8 +10,33 @@ public class AdminPlayerRequest {
     }
 
     public record GrantExp(
-            @NotNull @Positive Long playerId,
             @NotNull @Positive Long exp
     ) {
+    }
+
+    public record GrantCoreStats(
+            Integer str,
+            Integer agi,
+            Integer dex,
+            Integer intel,
+            Integer vit,
+            Integer luc
+    ) {
+        @AssertTrue(message = "at least one positive delta required")
+        public boolean isAnyPositive() {
+            return (str != null && str > 0)
+                    || (agi != null && agi > 0)
+                    || (dex != null && dex > 0)
+                    || (intel != null && intel > 0)
+                    || (vit != null && vit > 0)
+                    || (luc != null && luc > 0);
+        }
+
+        public int nStr() { return str == null ? 0 : str; }
+        public int nAgi() { return agi == null ? 0 : agi; }
+        public int nDex() { return dex == null ? 0 : dex; }
+        public int nInt() { return intel == null ? 0 : intel; }
+        public int nVit() { return vit == null ? 0 : vit; }
+        public int nLuc() { return luc == null ? 0 : luc; }
     }
 }

--- a/src/main/java/online/lifeasgame/character/presentation/response/AdminPlayerResponse.java
+++ b/src/main/java/online/lifeasgame/character/presentation/response/AdminPlayerResponse.java
@@ -43,4 +43,12 @@ public class AdminPlayerResponse {
             );
         }
     }
+
+    public record CoreStatsGranted(
+            Long playerId, int str, int agi, int dex, int intel, int vit, int luc
+    ) {
+        public static CoreStatsGranted of(Long playerId, int str, int agi, int dex, int intel, int vit, int luc) {
+            return new CoreStatsGranted(playerId, str, agi, dex, intel, vit, luc);
+        }
+    }
 }

--- a/src/main/java/online/lifeasgame/character/presentation/spec/AdminPlayerApiSpecV1.java
+++ b/src/main/java/online/lifeasgame/character/presentation/spec/AdminPlayerApiSpecV1.java
@@ -7,11 +7,21 @@ import online.lifeasgame.character.presentation.request.AdminPlayerRequest;
 import online.lifeasgame.character.presentation.response.AdminPlayerResponse;
 import online.lifeasgame.core.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Admin API V1")
 public interface AdminPlayerApiSpecV1 {
 
     @Operation(summary = "Player Exp 지급", description = "사용자에게 exp를 지급합니다.")
-    ResponseEntity<ApiResponse<AdminPlayerResponse.ExpGranted>> grantExp(@Valid @RequestBody AdminPlayerRequest.GrantExp grantExp);
+    ResponseEntity<ApiResponse<AdminPlayerResponse.ExpGranted>> grantExp(
+            @PathVariable Long playerId,
+            @Valid @RequestBody AdminPlayerRequest.GrantExp grantExp
+    );
+
+    @Operation(summary = "Player core-stats 지급", description = "사용자에게 core-stats를 지급합니다")
+    ResponseEntity<ApiResponse<AdminPlayerResponse.CoreStatsGranted>> grantCoreStats(
+            @PathVariable Long playerId,
+            @Valid @RequestBody AdminPlayerRequest.GrantCoreStats request
+    );
 }


### PR DESCRIPTION
## 📝 Summary
<!-- PR의 목적과 변경 내용 간략 요약 -->

## 📌 Related Issue
- Close #47


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Admin endpoint to grant core stats to a player, with response returning updated stats.
- API Changes
  - grantExp moved to POST /{playerId}/exp/grant; playerId removed from request body.
  - New endpoint: POST /{playerId}/core-stats/grant.
- Validation
  - Core stat grants require at least one positive delta; null values default to zero.
- Behavioral Changes
  - Core stats are clamped between 1 and 9999 when applying grants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->