### PR TITLE
feat(character): find player title infos api

### DIFF
--- a/src/main/java/online/lifeasgame/character/application/PlayerTitleFacade.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerTitleFacade.java
@@ -1,0 +1,20 @@
+package online.lifeasgame.character.application;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.application.result.PlayerTitleResult;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PlayerTitleFacade {
+
+    private final CurrentPlayerAccessor currentPlayerAccessor;
+    private final PlayerTitleService playerTitleService;
+
+
+    public List<PlayerTitleResult.PlayerTitleInfo> getPlayerTitleInfos() {
+        return playerTitleService.getPlayerTitleInfos(currentPlayerAccessor.currentPlayerIdOrThrow());
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/PlayerTitleReader.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerTitleReader.java
@@ -1,0 +1,21 @@
+package online.lifeasgame.character.application;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.application.query.PlayerTitleQuery;
+import online.lifeasgame.character.application.view.PlayerTitleView;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+public class PlayerTitleReader {
+
+    private final PlayerTitleQuery playerTitleQuery;
+
+    public List<PlayerTitleView> getPlayerTitleInfos(Long playerId) {
+        return playerTitleQuery.findPlayerTitleInfos(playerId);
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/PlayerTitleService.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerTitleService.java
@@ -1,0 +1,25 @@
+package online.lifeasgame.character.application;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import online.lifeasgame.character.application.result.PlayerTitleResult;
+import online.lifeasgame.character.application.view.PlayerTitleView;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PlayerTitleService {
+
+    private final PlayerTitleReader playerTitleReader;
+
+    public List<PlayerTitleResult.PlayerTitleInfo> getPlayerTitleInfos(Long playerId) {
+        List<PlayerTitleView> playerTitleViews = playerTitleReader.getPlayerTitleInfos(playerId);
+        return playerTitleViews.stream()
+                .map(PlayerTitleResult.PlayerTitleInfo::from)
+                .toList();
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/TitleReader.java
+++ b/src/main/java/online/lifeasgame/character/application/TitleReader.java
@@ -18,7 +18,7 @@ public class TitleReader {
 
     private final TitleRepository repository;
 
-    public List<Title> getTitleList(List<TitleCategory> categories) {
+    public List<Title> getTitles(List<TitleCategory> categories) {
         if (categories == null || categories.isEmpty()) {
             return repository.findAll();
         }

--- a/src/main/java/online/lifeasgame/character/application/TitleService.java
+++ b/src/main/java/online/lifeasgame/character/application/TitleService.java
@@ -15,8 +15,8 @@ public class TitleService {
 
     private final TitleReader titleReader;
 
-    public List<TitleResult.TitleInfo> getTitleList(List<String> categories) {
-        List<Title> titles = titleReader.getTitleList(TitleCategory.parse(categories));
+    public List<TitleResult.TitleInfo> getTitles(List<String> categories) {
+        List<Title> titles = titleReader.getTitles(TitleCategory.parse(categories));
         return TitleResult.TitleInfo.fromList(titles);
     }
 }

--- a/src/main/java/online/lifeasgame/character/application/query/PlayerTitleQuery.java
+++ b/src/main/java/online/lifeasgame/character/application/query/PlayerTitleQuery.java
@@ -1,0 +1,8 @@
+package online.lifeasgame.character.application.query;
+
+import java.util.List;
+import online.lifeasgame.character.application.view.PlayerTitleView;
+
+public interface PlayerTitleQuery {
+    List<PlayerTitleView> findPlayerTitleInfos(Long playerId);
+}

--- a/src/main/java/online/lifeasgame/character/application/result/PlayerTitleResult.java
+++ b/src/main/java/online/lifeasgame/character/application/result/PlayerTitleResult.java
@@ -1,0 +1,30 @@
+package online.lifeasgame.character.application.result;
+
+import java.time.Instant;
+import online.lifeasgame.character.application.view.PlayerTitleView;
+
+public class PlayerTitleResult {
+
+    private PlayerTitleResult() {
+    }
+
+    public record PlayerTitleInfo(
+            Long titleId,
+            String code,
+            String name,
+            String category,
+            String descMd,
+            Instant acquiredAt
+    ) {
+        public static PlayerTitleInfo from(PlayerTitleView v) {
+            return new PlayerTitleInfo(
+                    v.getTitleId(),
+                    v.getCode(),
+                    v.getName(),
+                    v.getCategory() != null ? v.getCategory().name() : null,
+                    v.getDescMd(),
+                    v.getAcquiredAt()
+            );
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/view/PlayerTitleView.java
+++ b/src/main/java/online/lifeasgame/character/application/view/PlayerTitleView.java
@@ -1,0 +1,13 @@
+package online.lifeasgame.character.application.view;
+
+import java.time.Instant;
+import online.lifeasgame.character.domain.TitleCategory;
+
+public interface PlayerTitleView {
+    Long getTitleId();
+    String getCode();
+    String getName();
+    TitleCategory getCategory();
+    String getDescMd();
+    Instant getAcquiredAt();
+}

--- a/src/main/java/online/lifeasgame/character/domain/repository/PlayerTitleRepository.java
+++ b/src/main/java/online/lifeasgame/character/domain/repository/PlayerTitleRepository.java
@@ -4,6 +4,4 @@ import online.lifeasgame.character.domain.PlayerTitle;
 
 public interface PlayerTitleRepository {
     PlayerTitle save(PlayerTitle playerTitle);
-
-    boolean existsByPlayerIdAndTitleId(Long playerId, Long titleId);
 }

--- a/src/main/java/online/lifeasgame/character/infra/JpaPlayerTitleRepository.java
+++ b/src/main/java/online/lifeasgame/character/infra/JpaPlayerTitleRepository.java
@@ -1,9 +1,25 @@
 package online.lifeasgame.character.infra;
 
+import java.util.List;
+import online.lifeasgame.character.application.view.PlayerTitleView;
 import online.lifeasgame.character.domain.PlayerTitle;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface JpaPlayerTitleRepository extends JpaRepository<PlayerTitle, Long> {
 
-    boolean existsByPlayerIdAndTitleId(Long playerId, Long titleId);
+    @Query(
+        """
+            SELECT t.id AS titleId,
+                   t.code AS code,
+                   t.name AS name,
+                   t.category  AS category,
+                   t.descMd          AS descMd,
+                   pt.acquiredAt     AS acquiredAt
+            FROM PlayerTitle pt
+            JOIN Title t ON t.id = pt.titleId
+            WHERE pt.playerId = :playerId
+            ORDER BY pt.acquiredAt DESC
+    """)
+    List<PlayerTitleView> findPlayerTitleViews(Long playerId);
 }

--- a/src/main/java/online/lifeasgame/character/infra/JpaPlayerTitleRepository.java
+++ b/src/main/java/online/lifeasgame/character/infra/JpaPlayerTitleRepository.java
@@ -5,6 +5,7 @@ import online.lifeasgame.character.application.view.PlayerTitleView;
 import online.lifeasgame.character.domain.PlayerTitle;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface JpaPlayerTitleRepository extends JpaRepository<PlayerTitle, Long> {
 
@@ -21,5 +22,5 @@ public interface JpaPlayerTitleRepository extends JpaRepository<PlayerTitle, Lon
             WHERE pt.playerId = :playerId
             ORDER BY pt.acquiredAt DESC
     """)
-    List<PlayerTitleView> findPlayerTitleViews(Long playerId);
+    List<PlayerTitleView> findPlayerTitleViews(@Param("playerId") Long playerId);
 }

--- a/src/main/java/online/lifeasgame/character/infra/PlayerTitleRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/character/infra/PlayerTitleRepositoryAdapter.java
@@ -1,13 +1,16 @@
 package online.lifeasgame.character.infra;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.application.query.PlayerTitleQuery;
+import online.lifeasgame.character.application.view.PlayerTitleView;
 import online.lifeasgame.character.domain.PlayerTitle;
 import online.lifeasgame.character.domain.repository.PlayerTitleRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class PlayerTitleRepositoryAdapter implements PlayerTitleRepository {
+public class PlayerTitleRepositoryAdapter implements PlayerTitleRepository, PlayerTitleQuery {
 
     private final JpaPlayerTitleRepository jpaRepository;
 
@@ -16,7 +19,7 @@ public class PlayerTitleRepositoryAdapter implements PlayerTitleRepository {
     }
 
     @Override
-    public boolean existsByPlayerIdAndTitleId(Long playerId, Long titleId) {
-        return jpaRepository.existsByPlayerIdAndTitleId(playerId, titleId);
+    public List<PlayerTitleView> findPlayerTitleInfos(Long playerId) {
+        return jpaRepository.findPlayerTitleViews(playerId);
     }
 }

--- a/src/main/java/online/lifeasgame/character/presentation/PlayerTitleController.java
+++ b/src/main/java/online/lifeasgame/character/presentation/PlayerTitleController.java
@@ -1,0 +1,33 @@
+package online.lifeasgame.character.presentation;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.application.PlayerTitleFacade;
+import online.lifeasgame.character.application.result.PlayerTitleResult;
+import online.lifeasgame.character.presentation.mapper.PlayerTitleWebMapper;
+import online.lifeasgame.character.presentation.response.PlayerTitleResponse;
+import online.lifeasgame.character.presentation.spec.PlayerTitleApiSpecV1;
+import online.lifeasgame.core.response.ApiResponse;
+import online.lifeasgame.platform.web.response.ApiResponses;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/players")
+public class PlayerTitleController implements PlayerTitleApiSpecV1 {
+
+    private final PlayerTitleFacade playerTitleFacade;
+
+    @Override
+    @GetMapping("/titles")
+    public ResponseEntity<ApiResponse<PlayerTitleResponse.PlayerTitleInfos>> playerTitleInfos() {
+        List<PlayerTitleResult.PlayerTitleInfo> playerTitleInfos = playerTitleFacade.getPlayerTitleInfos();
+
+        return ApiResponses.ok(
+                PlayerTitleWebMapper.toPlayerTitleInfos(playerTitleInfos)
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/character/presentation/TitleController.java
+++ b/src/main/java/online/lifeasgame/character/presentation/TitleController.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import online.lifeasgame.character.application.TitleService;
 import online.lifeasgame.character.application.result.TitleResult;
 import online.lifeasgame.character.presentation.mapper.TitleWebMapper;
-import online.lifeasgame.character.presentation.response.TitleResponse.TitleInfos;
+import online.lifeasgame.character.presentation.response.TitleResponse;
 import online.lifeasgame.character.presentation.spec.TitleApiSpecV1;
 import online.lifeasgame.core.response.ApiResponse;
 import online.lifeasgame.platform.web.response.ApiResponses;
@@ -24,10 +24,10 @@ public class TitleController implements TitleApiSpecV1 {
 
     @Override
     @GetMapping
-    public ResponseEntity<ApiResponse<TitleInfos>> titleInfos(
+    public ResponseEntity<ApiResponse<TitleResponse.TitleInfos>> titleInfos(
             @RequestParam(name = "category", required = false) List<String> categories
     ) {
-        List<TitleResult.TitleInfo> titleList = titleService.getTitleList(categories);
+        List<TitleResult.TitleInfo> titleList = titleService.getTitles(categories);
         return ApiResponses.ok(
                 TitleWebMapper.toTitleList(titleList)
         );

--- a/src/main/java/online/lifeasgame/character/presentation/mapper/PlayerTitleWebMapper.java
+++ b/src/main/java/online/lifeasgame/character/presentation/mapper/PlayerTitleWebMapper.java
@@ -1,0 +1,29 @@
+package online.lifeasgame.character.presentation.mapper;
+
+import java.util.List;
+import online.lifeasgame.character.application.result.PlayerTitleResult;
+import online.lifeasgame.character.presentation.response.PlayerTitleResponse;
+
+public class PlayerTitleWebMapper {
+
+    private PlayerTitleWebMapper() {}
+
+    public static PlayerTitleResponse.PlayerTitleInfos toPlayerTitleInfos(List<PlayerTitleResult.PlayerTitleInfo> playerTitleInfos) {
+        return PlayerTitleResponse.PlayerTitleInfos.of(
+                playerTitleInfos.stream()
+                        .map(
+                                playerTitleInfo ->
+                                        PlayerTitleResponse.PlayerTitleInfo.of(
+                                                playerTitleInfo.titleId(),
+                                                playerTitleInfo.code(),
+                                                playerTitleInfo.name(),
+                                                playerTitleInfo.category(),
+                                                playerTitleInfo.descMd(),
+                                                playerTitleInfo.acquiredAt()
+                                        )
+                        )
+                        .toList()
+        );
+    }
+}
+

--- a/src/main/java/online/lifeasgame/character/presentation/mapper/TitleWebMapper.java
+++ b/src/main/java/online/lifeasgame/character/presentation/mapper/TitleWebMapper.java
@@ -3,14 +3,13 @@ package online.lifeasgame.character.presentation.mapper;
 import java.util.List;
 import online.lifeasgame.character.application.result.TitleResult;
 import online.lifeasgame.character.presentation.response.TitleResponse;
-import online.lifeasgame.character.presentation.response.TitleResponse.TitleInfos;
 
 public class TitleWebMapper {
 
     private TitleWebMapper() {}
 
     public static TitleResponse.TitleInfos toTitleList(List<TitleResult.TitleInfo> titleInfos) {
-        return TitleInfos.of(
+        return TitleResponse.TitleInfos.of(
                 titleInfos.stream()
                         .map(
                                 titleInfo ->

--- a/src/main/java/online/lifeasgame/character/presentation/response/PlayerTitleResponse.java
+++ b/src/main/java/online/lifeasgame/character/presentation/response/PlayerTitleResponse.java
@@ -1,0 +1,36 @@
+package online.lifeasgame.character.presentation.response;
+
+import java.time.Instant;
+import java.util.List;
+
+public class PlayerTitleResponse {
+
+    private PlayerTitleResponse() {
+    }
+
+    public record PlayerTitleInfos(List<PlayerTitleInfo> playerTitleInfos) {
+        public static PlayerTitleInfos of(List<PlayerTitleInfo> playerTitleInfos) {
+            return new PlayerTitleInfos(playerTitleInfos);
+        }
+    }
+
+    public record PlayerTitleInfo(
+            Long titleId,
+            String code,
+            String name,
+            String category,
+            String descMd,
+            Instant acquiredAt
+    ) {
+        public static PlayerTitleInfo of(
+                Long titleId,
+                String code,
+                String name,
+                String category,
+                String descMd,
+                Instant acquiredAt
+        ) {
+            return new PlayerTitleInfo(titleId, code, name, category, descMd, acquiredAt);
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/character/presentation/spec/PlayerTitleApiSpecV1.java
+++ b/src/main/java/online/lifeasgame/character/presentation/spec/PlayerTitleApiSpecV1.java
@@ -1,0 +1,12 @@
+package online.lifeasgame.character.presentation.spec;
+
+import io.swagger.v3.oas.annotations.Operation;
+import online.lifeasgame.character.presentation.response.PlayerTitleResponse;
+import online.lifeasgame.core.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+
+public interface PlayerTitleApiSpecV1 {
+
+    @Operation(summary = "Player 보유 칭호 목록 출력", description = "사용자가 보유한 칭호 목록을 출력합니다")
+    ResponseEntity<ApiResponse<PlayerTitleResponse.PlayerTitleInfos>> playerTitleInfos();
+}


### PR DESCRIPTION
## 📝 Summary
<!-- PR의 목적과 변경 내용 간략 요약 -->

## 📌 Related Issue
- Close #50 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added endpoint to view your owned character titles: GET /api/v1/players/titles.
  - Returns each title’s ID, code, name, category, description (Markdown), and acquisition time, sorted by most recently acquired.
  - Uses your current login to fetch data; no extra parameters required.
- API
  - Existing title listing APIs remain unchanged; no breaking changes to request/response formats outside the new endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->