### PR TITLE
Feature/#52 set player main title

### DIFF
--- a/src/main/java/online/lifeasgame/character/application/AdminPlayerService.java
+++ b/src/main/java/online/lifeasgame/character/application/AdminPlayerService.java
@@ -8,6 +8,8 @@ import online.lifeasgame.character.domain.Player;
 import online.lifeasgame.character.domain.Player.GainResult;
 import online.lifeasgame.character.domain.StatusEffectCode;
 import online.lifeasgame.character.domain.StatusEffects;
+import online.lifeasgame.character.domain.error.PlayerError;
+import online.lifeasgame.core.error.DomainException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminPlayerService {
 
     private final PlayerWriter playerWriter;
+    private final PlayerTitleReader playerTitleReader;
 
     @Transactional
     public AdminPlayerResult.ExpGranted grantExp(Long playerId, long exp) {
@@ -93,6 +96,10 @@ public class AdminPlayerService {
 
     @Transactional
     public AdminPlayerResult.UpdatedTitle changeRepresentativeTitle(Long playerId, Long titleId) {
+        if (!playerTitleReader.hasTitle(playerId, titleId)) {
+            throw new DomainException(PlayerError.INVALID_TITLE);
+        }
+
         return AdminPlayerResult.UpdatedTitle.of(
                 playerWriter.changeRepresentativeTitle(playerId, titleId)
         );

--- a/src/main/java/online/lifeasgame/character/application/AdminPlayerService.java
+++ b/src/main/java/online/lifeasgame/character/application/AdminPlayerService.java
@@ -90,4 +90,11 @@ public class AdminPlayerService {
                 player.getStatusEffects()
         );
     }
+
+    @Transactional
+    public AdminPlayerResult.UpdatedTitle changeRepresentativeTitle(Long playerId, Long titleId) {
+        return AdminPlayerResult.UpdatedTitle.of(
+                playerWriter.changeRepresentativeTitle(playerId, titleId)
+        );
+    }
 }

--- a/src/main/java/online/lifeasgame/character/application/AdminPlayerService.java
+++ b/src/main/java/online/lifeasgame/character/application/AdminPlayerService.java
@@ -9,11 +9,12 @@ import online.lifeasgame.character.domain.Player.GainResult;
 import online.lifeasgame.character.domain.StatusEffectCode;
 import online.lifeasgame.character.domain.StatusEffects;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
 public class AdminPlayerService {
 
     private final PlayerWriter playerWriter;

--- a/src/main/java/online/lifeasgame/character/application/AdminPlayerTitleService.java
+++ b/src/main/java/online/lifeasgame/character/application/AdminPlayerTitleService.java
@@ -5,11 +5,12 @@ import online.lifeasgame.character.application.result.AdminPlayerTitleResult;
 import online.lifeasgame.character.domain.PlayerTitle;
 import online.lifeasgame.character.domain.Title;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
 public class AdminPlayerTitleService {
 
     private final PlayerTitleWriter playerTitleWriter;

--- a/src/main/java/online/lifeasgame/character/application/AdminTitleService.java
+++ b/src/main/java/online/lifeasgame/character/application/AdminTitleService.java
@@ -6,11 +6,12 @@ import online.lifeasgame.character.application.result.AdminTitleResult;
 import online.lifeasgame.character.domain.Title;
 import online.lifeasgame.character.domain.TitleCategory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
 public class AdminTitleService {
 
     private final TitleWriter titleWriter;

--- a/src/main/java/online/lifeasgame/character/application/PlayerFacade.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerFacade.java
@@ -24,4 +24,9 @@ public class PlayerFacade {
         Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
         return playerService.getPlayerInfo(playerId);
     }
+
+    public PlayerResult.UpdatedTitle changeRepresentativeTitle(Long titleId) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        return playerService.changeRepresentativeTitle(playerId, titleId);
+    }
 }

--- a/src/main/java/online/lifeasgame/character/application/PlayerService.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerService.java
@@ -6,6 +6,8 @@ import online.lifeasgame.character.application.result.PlayerResult;
 import online.lifeasgame.character.domain.GenderType;
 import online.lifeasgame.character.domain.Name;
 import online.lifeasgame.character.domain.Player;
+import online.lifeasgame.character.domain.error.PlayerError;
+import online.lifeasgame.core.error.DomainException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +19,7 @@ public class PlayerService {
 
     private final PlayerWriter playerWriter;
     private final PlayerReader playerReader;
+    private final PlayerTitleReader playerTitleReader;
 
     @Transactional
     public PlayerResult.Created linkStart(Long userId, PlayerCommand.Register register) {
@@ -34,6 +37,18 @@ public class PlayerService {
     public PlayerResult.PlayerInfo getPlayerInfo(Long playerId) {
         return PlayerResult.PlayerInfo.from(
                 playerReader.getPlayer(playerId)
+        );
+    }
+
+    @Transactional
+    public PlayerResult.UpdatedTitle changeRepresentativeTitle(Long playerId, Long titleId) {
+        boolean owned = playerTitleReader.hasTitle(playerId, titleId);
+        if (!owned) {
+            throw new DomainException(PlayerError.INVALID_TITLE);
+        }
+
+        return PlayerResult.UpdatedTitle.of(
+                playerWriter.changeRepresentativeTitle(playerId, titleId)
         );
     }
 }

--- a/src/main/java/online/lifeasgame/character/application/PlayerService.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerService.java
@@ -7,11 +7,12 @@ import online.lifeasgame.character.domain.GenderType;
 import online.lifeasgame.character.domain.Name;
 import online.lifeasgame.character.domain.Player;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
 public class PlayerService {
 
     private final PlayerWriter playerWriter;

--- a/src/main/java/online/lifeasgame/character/application/PlayerTitleReader.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerTitleReader.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.character.application.query.PlayerTitleQuery;
 import online.lifeasgame.character.application.view.PlayerTitleView;
+import online.lifeasgame.character.domain.repository.PlayerTitleRepository;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,8 +15,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class PlayerTitleReader {
 
     private final PlayerTitleQuery playerTitleQuery;
+    private final PlayerTitleRepository playerTitleRepository;
 
     public List<PlayerTitleView> getPlayerTitleInfos(Long playerId) {
         return playerTitleQuery.findPlayerTitleInfos(playerId);
+    }
+
+    public boolean hasTitle(Long playerId, Long titleId) {
+        return playerTitleRepository.existsByPlayerIdAndTitleId(playerId, titleId);
     }
 }

--- a/src/main/java/online/lifeasgame/character/application/PlayerTitleService.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerTitleService.java
@@ -6,12 +6,13 @@ import lombok.extern.slf4j.Slf4j;
 import online.lifeasgame.character.application.result.PlayerTitleResult;
 import online.lifeasgame.character.application.view.PlayerTitleView;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
 public class PlayerTitleService {
 
     private final PlayerTitleReader playerTitleReader;

--- a/src/main/java/online/lifeasgame/character/application/PlayerWriter.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerWriter.java
@@ -123,4 +123,10 @@ public class PlayerWriter {
         return playerRepository.findById(playerId)
                 .orElseThrow(() -> new DomainException(PlayerError.PLAYER_NOT_FOUND));
     }
+
+    public Long changeRepresentativeTitle(Long playerId, Long titleId) {
+        Player player = getPlayer(playerId);
+        player.changeRepresentativeTitle(titleId);
+        return player.getTitleId();
+    }
 }

--- a/src/main/java/online/lifeasgame/character/application/TitleService.java
+++ b/src/main/java/online/lifeasgame/character/application/TitleService.java
@@ -6,11 +6,12 @@ import online.lifeasgame.character.application.result.TitleResult;
 import online.lifeasgame.character.domain.Title;
 import online.lifeasgame.character.domain.TitleCategory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
 public class TitleService {
 
     private final TitleReader titleReader;

--- a/src/main/java/online/lifeasgame/character/application/result/AdminPlayerResult.java
+++ b/src/main/java/online/lifeasgame/character/application/result/AdminPlayerResult.java
@@ -111,4 +111,10 @@ public class AdminPlayerResult {
         public record Item(String code, String category) {
         }
     }
+
+    public record UpdatedTitle(Long titleId) {
+        public static UpdatedTitle of(Long titleId) {
+            return new UpdatedTitle(titleId);
+        }
+    }
 }

--- a/src/main/java/online/lifeasgame/character/application/result/PlayerResult.java
+++ b/src/main/java/online/lifeasgame/character/application/result/PlayerResult.java
@@ -53,9 +53,9 @@ public class PlayerResult {
         }
     }
 
-    public record UpdatedTitle(Long title) {
-        public static UpdatedTitle of(Long title) {
-            return new UpdatedTitle(title);
+    public record UpdatedTitle(Long titleId) {
+        public static UpdatedTitle of(Long titleId) {
+            return new UpdatedTitle(titleId);
         }
     }
 }

--- a/src/main/java/online/lifeasgame/character/application/result/PlayerResult.java
+++ b/src/main/java/online/lifeasgame/character/application/result/PlayerResult.java
@@ -52,4 +52,10 @@ public class PlayerResult {
             );
         }
     }
+
+    public record UpdatedTitle(Long title) {
+        public static UpdatedTitle of(Long title) {
+            return new UpdatedTitle(title);
+        }
+    }
 }

--- a/src/main/java/online/lifeasgame/character/domain/Player.java
+++ b/src/main/java/online/lifeasgame/character/domain/Player.java
@@ -169,6 +169,10 @@ public class Player extends AbstractTime {
         this.statusEffects = this.statusEffects.merged(statusEffects);
     }
 
+    public void changeRepresentativeTitle(Long titleId) {
+        this.titleId = titleId;
+    }
+
     public record GainResult(
             long requestedExp,
             long appliedExp,

--- a/src/main/java/online/lifeasgame/character/domain/error/PlayerError.java
+++ b/src/main/java/online/lifeasgame/character/domain/error/PlayerError.java
@@ -10,7 +10,7 @@ public enum PlayerError implements ErrorCode {
     INVALID_HP("PLR-400-INVALID-HP", "Invalid hpDelta", 400),
     INVALID_MP_CAPACITY("PLR-400-INVALID-MP-CAP", "Invalid mpDelta capacity", 400),
     INVALID_MP("PLR-400-INVALID-MP", "Invalid mpDelta", 400),
-    ;
+    INVALID_TITLE("PLR-400-INVALID-TITLE", "Invalid title", 400),;
 
     private final String code;
     private final String message;

--- a/src/main/java/online/lifeasgame/character/domain/repository/PlayerTitleRepository.java
+++ b/src/main/java/online/lifeasgame/character/domain/repository/PlayerTitleRepository.java
@@ -4,4 +4,6 @@ import online.lifeasgame.character.domain.PlayerTitle;
 
 public interface PlayerTitleRepository {
     PlayerTitle save(PlayerTitle playerTitle);
+
+    boolean existsByPlayerIdAndTitleId(Long playerId, Long titleId);
 }

--- a/src/main/java/online/lifeasgame/character/infra/JpaPlayerTitleRepository.java
+++ b/src/main/java/online/lifeasgame/character/infra/JpaPlayerTitleRepository.java
@@ -23,4 +23,6 @@ public interface JpaPlayerTitleRepository extends JpaRepository<PlayerTitle, Lon
             ORDER BY pt.acquiredAt DESC
     """)
     List<PlayerTitleView> findPlayerTitleViews(@Param("playerId") Long playerId);
+
+    boolean existsByPlayerIdAndTitleId(Long playerId, Long titleId);
 }

--- a/src/main/java/online/lifeasgame/character/infra/PlayerTitleRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/character/infra/PlayerTitleRepositoryAdapter.java
@@ -19,6 +19,11 @@ public class PlayerTitleRepositoryAdapter implements PlayerTitleRepository, Play
     }
 
     @Override
+    public boolean existsByPlayerIdAndTitleId(Long playerId, Long titleId) {
+        return jpaRepository.existsByPlayerIdAndTitleId(playerId, titleId);
+    }
+
+    @Override
     public List<PlayerTitleView> findPlayerTitleInfos(Long playerId) {
         return jpaRepository.findPlayerTitleViews(playerId);
     }

--- a/src/main/java/online/lifeasgame/character/presentation/AdminPlayerController.java
+++ b/src/main/java/online/lifeasgame/character/presentation/AdminPlayerController.java
@@ -109,4 +109,17 @@ public class AdminPlayerController implements AdminPlayerApiSpecV1 {
                 AdminPlayerWebMapper.toStatusEffectsGranted(statusEffectsGranted)
         );
     }
+
+    @Override
+    @PatchMapping("/{playerId}/titles/{titleId}")
+    public ResponseEntity<ApiResponse<AdminPlayerResponse.UpdatedTitle>> updateTitle(
+            @PathVariable Long playerId,
+            @PathVariable Long titleId
+    ) {
+        AdminPlayerResult.UpdatedTitle updatedTitle = adminPlayerService.changeRepresentativeTitle(playerId, titleId);
+
+        return ApiResponses.ok(
+                AdminPlayerWebMapper.toUpdatedTitle(updatedTitle)
+        );
+    }
 }

--- a/src/main/java/online/lifeasgame/character/presentation/PlayerController.java
+++ b/src/main/java/online/lifeasgame/character/presentation/PlayerController.java
@@ -13,6 +13,8 @@ import online.lifeasgame.core.response.ApiResponse;
 import online.lifeasgame.platform.web.response.ApiResponses;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -43,6 +45,18 @@ public class PlayerController implements PlayerApiSpecV1 {
         PlayerResult.PlayerInfo playerInfo = playerFacade.getPlayerInfo();
         return ApiResponses.ok(
                 PlayerWebMapper.toPlayerInfo(playerInfo)
+        );
+    }
+
+    @Override
+    @PatchMapping("/titles/{titleId}")
+    public ResponseEntity<ApiResponse<PlayerResponse.UpdatedTitle>> updateTitle(
+            @PathVariable Long titleId
+    ) {
+        PlayerResult.UpdatedTitle updatedTitle = playerFacade.changeRepresentativeTitle(titleId);
+
+        return ApiResponses.ok(
+                PlayerWebMapper.toUpdatedTitle(updatedTitle)
         );
     }
 }

--- a/src/main/java/online/lifeasgame/character/presentation/mapper/AdminPlayerWebMapper.java
+++ b/src/main/java/online/lifeasgame/character/presentation/mapper/AdminPlayerWebMapper.java
@@ -107,4 +107,10 @@ public class AdminPlayerWebMapper {
                         .toList()
         );
     }
+
+    public static AdminPlayerResponse.UpdatedTitle toUpdatedTitle(AdminPlayerResult.UpdatedTitle updatedTitle) {
+        return AdminPlayerResponse.UpdatedTitle.of(
+                updatedTitle.titleId()
+        );
+    }
 }

--- a/src/main/java/online/lifeasgame/character/presentation/mapper/PlayerWebMapper.java
+++ b/src/main/java/online/lifeasgame/character/presentation/mapper/PlayerWebMapper.java
@@ -44,7 +44,7 @@ public class PlayerWebMapper {
 
     public static PlayerResponse.UpdatedTitle toUpdatedTitle(PlayerResult.UpdatedTitle updatedTitle) {
         return PlayerResponse.UpdatedTitle.of(
-                updatedTitle.title()
+                updatedTitle.titleId()
         );
     }
 }

--- a/src/main/java/online/lifeasgame/character/presentation/mapper/PlayerWebMapper.java
+++ b/src/main/java/online/lifeasgame/character/presentation/mapper/PlayerWebMapper.java
@@ -41,4 +41,10 @@ public class PlayerWebMapper {
                         .toList()
         );
     }
+
+    public static PlayerResponse.UpdatedTitle toUpdatedTitle(PlayerResult.UpdatedTitle updatedTitle) {
+        return PlayerResponse.UpdatedTitle.of(
+                updatedTitle.title()
+        );
+    }
 }

--- a/src/main/java/online/lifeasgame/character/presentation/response/AdminPlayerResponse.java
+++ b/src/main/java/online/lifeasgame/character/presentation/response/AdminPlayerResponse.java
@@ -97,4 +97,10 @@ public class AdminPlayerResponse {
         public record Item(String code, String category) {
         }
     }
+
+    public record UpdatedTitle(Long titleId) {
+        public static UpdatedTitle of(Long titleId) {
+            return new UpdatedTitle(titleId);
+        }
+    }
 }

--- a/src/main/java/online/lifeasgame/character/presentation/response/PlayerResponse.java
+++ b/src/main/java/online/lifeasgame/character/presentation/response/PlayerResponse.java
@@ -64,4 +64,10 @@ public class PlayerResponse {
             }
         }
     }
+
+    public record UpdatedTitle(Long titleId) {
+        public static UpdatedTitle of(Long titleId) {
+            return new UpdatedTitle(titleId);
+        }
+    }
 }

--- a/src/main/java/online/lifeasgame/character/presentation/spec/AdminPlayerApiSpecV1.java
+++ b/src/main/java/online/lifeasgame/character/presentation/spec/AdminPlayerApiSpecV1.java
@@ -54,4 +54,10 @@ public interface AdminPlayerApiSpecV1 {
             @PathVariable Long playerId,
             @Valid @RequestBody AdminPlayerRequest.GrantStatusEffects request
     );
+
+    @Operation(summary = "Player 대표 Title 변경", description = "Player 대표 Title을 변경합니다")
+    ResponseEntity<ApiResponse<AdminPlayerResponse.UpdatedTitle>> updateTitle(
+            @PathVariable Long playerId,
+            @PathVariable Long titleId
+    );
 }

--- a/src/main/java/online/lifeasgame/character/presentation/spec/PlayerApiSpecV1.java
+++ b/src/main/java/online/lifeasgame/character/presentation/spec/PlayerApiSpecV1.java
@@ -7,6 +7,7 @@ import online.lifeasgame.character.presentation.request.PlayerRequest;
 import online.lifeasgame.character.presentation.response.PlayerResponse;
 import online.lifeasgame.core.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Player API V1")
@@ -17,4 +18,9 @@ public interface PlayerApiSpecV1 {
 
     @Operation(summary = "Player 정보 조회", description = "Player 정보를 조회합니다.")
     ResponseEntity<ApiResponse<PlayerResponse.PlayerInfo>> playerInfo();
+
+    @Operation(summary = "Player 대표 Title 변경", description = "Player 대표 Title을 변경합니다")
+    ResponseEntity<ApiResponse<PlayerResponse.UpdatedTitle>> updateTitle(
+            @PathVariable Long titleId
+    );
 }

--- a/src/main/java/online/lifeasgame/lifelog/domain/MediaEntry.java
+++ b/src/main/java/online/lifeasgame/lifelog/domain/MediaEntry.java
@@ -87,7 +87,7 @@ public class MediaEntry extends AbstractTime {
     private MediaEntry(Long playerId, MediaKind kind, String title) {
         this.playerId = Guard.notNull(playerId, "playerId");
         this.kind = Guard.notNull(kind, "kind");
-        this.title = Guard.notBlank(title, "titleId");
+        this.title = Guard.notBlank(title, "title");
     }
 
     public static MediaEntry plan(Long playerId, MediaKind kind, String title) {

--- a/src/main/java/online/lifeasgame/lifelog/domain/MediaEntry.java
+++ b/src/main/java/online/lifeasgame/lifelog/domain/MediaEntry.java
@@ -87,7 +87,7 @@ public class MediaEntry extends AbstractTime {
     private MediaEntry(Long playerId, MediaKind kind, String title) {
         this.playerId = Guard.notNull(playerId, "playerId");
         this.kind = Guard.notNull(kind, "kind");
-        this.title = Guard.notBlank(title, "title");
+        this.title = Guard.notBlank(title, "titleId");
     }
 
     public static MediaEntry plan(Long playerId, MediaKind kind, String title) {

--- a/src/main/java/online/lifeasgame/platform/web/error/GlobalExceptionHandler.java
+++ b/src/main/java/online/lifeasgame/platform/web/error/GlobalExceptionHandler.java
@@ -160,6 +160,34 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(status).body(pd);
     }
 
+    @ExceptionHandler(org.springframework.web.HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ProblemDetail> handleMethodNotAllowed(
+            org.springframework.web.HttpRequestMethodNotSupportedException ex,
+            WebRequest req
+    ) {
+        var status = HttpStatus.METHOD_NOT_ALLOWED;
+
+        String detail = props.includeDetailInResponse() ? "지원하지 않는 HTTP 메서드입니다." : null;
+        var pd = pdf.base(
+                status,
+                "Method Not Allowed",
+                detail,
+                "METHOD_NOT_ALLOWED",
+                req
+        );
+
+        var headers = new org.springframework.http.HttpHeaders();
+        var supported = ex.getSupportedHttpMethods();
+        if (supported != null && !supported.isEmpty()) {
+            headers.setAllow(supported);
+        }
+
+        var path = pd.getProperties().get(online.lifeasgame.core.error.ErrorKeys.PATH);
+        log.info("405 method-not-allowed method={} path={}", ex.getMethod(), path);
+
+        return new ResponseEntity<>(pd, headers, status);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ProblemDetail> handleEtc(Exception ex, WebRequest req) {
         var err = CommonError.GEN_000;

--- a/src/main/java/online/lifeasgame/quest/domain/QuestTitle.java
+++ b/src/main/java/online/lifeasgame/quest/domain/QuestTitle.java
@@ -10,12 +10,12 @@ import online.lifeasgame.core.guard.Guard;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class QuestTitle {
 
-    @Column(name = "title", length = 120, nullable = false)
+    @Column(name = "titleId", length = 120, nullable = false)
     private String value;
 
     private QuestTitle(String raw) {
-        String v = Guard.notBlank(raw, "title").trim();
-        Guard.inRange(v.length(), 2, 120, "title");
+        String v = Guard.notBlank(raw, "titleId").trim();
+        Guard.inRange(v.length(), 2, 120, "titleId");
         this.value = v;
     }
 

--- a/src/main/java/online/lifeasgame/quest/domain/QuestTitle.java
+++ b/src/main/java/online/lifeasgame/quest/domain/QuestTitle.java
@@ -14,8 +14,8 @@ public class QuestTitle {
     private String value;
 
     private QuestTitle(String raw) {
-        String v = Guard.notBlank(raw, "titleId").trim();
-        Guard.inRange(v.length(), 2, 120, "titleId");
+        String v = Guard.notBlank(raw, "title").trim();
+        Guard.inRange(v.length(), 2, 120, "title");
         this.value = v;
     }
 


### PR DESCRIPTION
## 📝 Summary
<!-- PR의 목적과 변경 내용 간략 요약 -->

## 📌 Related Issue
- Close #52 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Players can now change their representative title via PATCH /api/v1/players/titles/{titleId}; response returns the updated titleId.
  - Admins can update any player’s representative title via PATCH /admin/v1/players/{playerId}/titles/{titleId}.
  - Title ownership is validated; invalid titles are rejected with a clear error.

- Bug Fixes
  - Improved error handling: 405 Method Not Allowed now returns a structured response with supported methods.

- Documentation
  - Public API specifications updated with new title update endpoints and response schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->