### PR TITLE
feat(character): grant achievement admin api

### DIFF
--- a/src/main/java/online/lifeasgame/character/application/AchievementReader.java
+++ b/src/main/java/online/lifeasgame/character/application/AchievementReader.java
@@ -4,11 +4,16 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.character.domain.Achievement;
 import online.lifeasgame.character.domain.AchievementCategory;
+import online.lifeasgame.character.domain.error.AchievementError;
 import online.lifeasgame.character.domain.repository.AchievementRepository;
+import online.lifeasgame.core.error.DomainException;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
 public class AchievementReader {
 
     private final AchievementRepository repository;
@@ -18,5 +23,10 @@ public class AchievementReader {
             return repository.findAll();
         }
         return repository.findByCategoryIn(categories);
+    }
+
+    public Achievement getAchievement(Long achievementId) {
+        return repository.findById(achievementId)
+                .orElseThrow(() -> new DomainException(AchievementError.ACHIEVEMENT_NOT_FOUND));
     }
 }

--- a/src/main/java/online/lifeasgame/character/application/AdminPlayerAchievementService.java
+++ b/src/main/java/online/lifeasgame/character/application/AdminPlayerAchievementService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import online.lifeasgame.character.application.result.AdminPlayerAchievementResult;
 import online.lifeasgame.character.domain.Achievement;
 import online.lifeasgame.character.domain.PlayerAchievement;
+import online.lifeasgame.character.domain.error.PlayerError;
+import online.lifeasgame.core.error.DomainException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,9 +17,14 @@ public class AdminPlayerAchievementService {
 
     private final AchievementReader achievementReader;
     private final PlayerAchievementWriter playerAchievementWriter;
+    private final PlayerReader playerReader;
 
     @Transactional
     public AdminPlayerAchievementResult.GrantedAchievement grantAchievement(Long playerId, Long achievementId) {
+        if (!playerReader.exists(playerId)) {
+            throw new DomainException(PlayerError.PLAYER_NOT_FOUND);
+        }
+
         Achievement achievement = achievementReader.getAchievement(achievementId);
 
         PlayerAchievement saved = playerAchievementWriter.grantAchievement(

--- a/src/main/java/online/lifeasgame/character/application/AdminPlayerAchievementService.java
+++ b/src/main/java/online/lifeasgame/character/application/AdminPlayerAchievementService.java
@@ -1,0 +1,39 @@
+package online.lifeasgame.character.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.application.result.AdminPlayerAchievementResult;
+import online.lifeasgame.character.domain.Achievement;
+import online.lifeasgame.character.domain.PlayerAchievement;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+public class AdminPlayerAchievementService {
+
+    private final AchievementReader achievementReader;
+    private final PlayerAchievementWriter playerAchievementWriter;
+
+    @Transactional
+    public AdminPlayerAchievementResult.GrantedAchievement grantAchievement(Long playerId, Long achievementId) {
+        Achievement achievement = achievementReader.getAchievement(achievementId);
+
+        PlayerAchievement saved = playerAchievementWriter.grantAchievement(
+                PlayerAchievement.create(
+                        playerId,
+                        achievementId
+                )
+        );
+
+        return AdminPlayerAchievementResult.GrantedAchievement.of(
+                saved.getPlayerId(),
+                saved.getAchievementId(),
+                achievement.getCode(),
+                achievement.getName(),
+                achievement.getCategory().name(),
+                saved.getAcquiredAt()
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/PlayerAchievementWriter.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerAchievementWriter.java
@@ -1,0 +1,20 @@
+package online.lifeasgame.character.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.domain.PlayerAchievement;
+import online.lifeasgame.character.domain.repository.PlayerAchievementRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.MANDATORY)
+public class PlayerAchievementWriter {
+
+    private final PlayerAchievementRepository repository;
+
+    public PlayerAchievement grantAchievement(PlayerAchievement playerAchievement) {
+        return repository.save(playerAchievement);
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/PlayerReader.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerReader.java
@@ -21,4 +21,8 @@ public class PlayerReader {
                 () -> new DomainException(PlayerError.PLAYER_NOT_FOUND)
         );
     }
+
+    public boolean exists(Long playerId) {
+        return playerRepository.existsById(playerId);
+    }
 }

--- a/src/main/java/online/lifeasgame/character/application/PlayerTitleWriter.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerTitleWriter.java
@@ -12,9 +12,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(propagation = Propagation.MANDATORY)
 public class PlayerTitleWriter {
 
-    private final PlayerTitleRepository playerTitleRepository;
+    private final PlayerTitleRepository repository;
 
     public PlayerTitle grantTitle(PlayerTitle playerTitle) {
-        return playerTitleRepository.save(playerTitle);
+        return repository.save(playerTitle);
     }
 }

--- a/src/main/java/online/lifeasgame/character/application/result/AdminPlayerAchievementResult.java
+++ b/src/main/java/online/lifeasgame/character/application/result/AdminPlayerAchievementResult.java
@@ -1,0 +1,36 @@
+package online.lifeasgame.character.application.result;
+
+import java.time.Instant;
+
+public class AdminPlayerAchievementResult {
+
+    private AdminPlayerAchievementResult() {
+    }
+
+    public record GrantedAchievement(
+            Long playerId,
+            Long achievementId,
+            String code,
+            String name,
+            String category,
+            Instant acquiredAt
+    ) {
+        public static AdminPlayerAchievementResult.GrantedAchievement of(
+                Long playerId,
+                Long achievementId,
+                String code,
+                String name,
+                String category,
+                Instant acquiredAt
+        ) {
+            return new AdminPlayerAchievementResult.GrantedAchievement(
+                    playerId,
+                    achievementId,
+                    code,
+                    name,
+                    category,
+                    acquiredAt
+            );
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/character/domain/PlayerAchievement.java
+++ b/src/main/java/online/lifeasgame/character/domain/PlayerAchievement.java
@@ -2,20 +2,22 @@ package online.lifeasgame.character.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import online.lifeasgame.core.annotation.AggregateRoot;
 import online.lifeasgame.platform.persistence.jpa.AbstractTime;
 
+@Getter
 @Entity
 @AggregateRoot
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(
         name = "player_achievements",
         uniqueConstraints = @UniqueConstraint(name = "uq_player_achv", columnNames = {"player_id", "achievement_id"})
@@ -26,13 +28,22 @@ public class PlayerAchievement extends AbstractTime {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "player_id", nullable = false)
-    private Player player;
+    @Column(name = "player_id", nullable = false)
+    private Long playerId;
 
     @Column(name = "achievement_id", nullable = false)
     private Long achievementId;
 
     @Column(name = "acquired_at", nullable = false)
-    private Instant acquiredAt = Instant.now();
+    private Instant acquiredAt;
+
+    public PlayerAchievement(Long playerId, Long achievementId) {
+        this.playerId = playerId;
+        this.achievementId = achievementId;
+        this.acquiredAt = Instant.now();
+    }
+
+    public static PlayerAchievement create(Long playerId, Long achievementId) {
+        return new PlayerAchievement(playerId, achievementId);
+    }
 }

--- a/src/main/java/online/lifeasgame/character/domain/repository/AchievementRepository.java
+++ b/src/main/java/online/lifeasgame/character/domain/repository/AchievementRepository.java
@@ -1,6 +1,7 @@
 package online.lifeasgame.character.domain.repository;
 
 import java.util.List;
+import java.util.Optional;
 import online.lifeasgame.character.domain.Achievement;
 import online.lifeasgame.character.domain.AchievementCategory;
 
@@ -10,4 +11,6 @@ public interface AchievementRepository {
     List<Achievement> findAll();
 
     List<Achievement> findByCategoryIn(List<AchievementCategory> categories);
+
+    Optional<Achievement> findById(Long id);
 }

--- a/src/main/java/online/lifeasgame/character/domain/repository/PlayerAchievementRepository.java
+++ b/src/main/java/online/lifeasgame/character/domain/repository/PlayerAchievementRepository.java
@@ -1,0 +1,7 @@
+package online.lifeasgame.character.domain.repository;
+
+import online.lifeasgame.character.domain.PlayerAchievement;
+
+public interface PlayerAchievementRepository {
+    PlayerAchievement save(PlayerAchievement playerAchievement);
+}

--- a/src/main/java/online/lifeasgame/character/domain/repository/PlayerRepository.java
+++ b/src/main/java/online/lifeasgame/character/domain/repository/PlayerRepository.java
@@ -9,4 +9,6 @@ public interface PlayerRepository {
     boolean existsByUserId(Long userId);
 
     Optional<Player> findById(Long playerId);
+
+    boolean existsById(Long playerId);
 }

--- a/src/main/java/online/lifeasgame/character/infra/AchievementRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/character/infra/AchievementRepositoryAdapter.java
@@ -2,6 +2,7 @@ package online.lifeasgame.character.infra;
 
 
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.character.domain.Achievement;
 import online.lifeasgame.character.domain.AchievementCategory;
@@ -27,5 +28,10 @@ public class AchievementRepositoryAdapter implements AchievementRepository {
     @Override
     public List<Achievement> findByCategoryIn(List<AchievementCategory> achievementCategories) {
         return jpaRepository.findByCategoryIn(achievementCategories);
+    }
+
+    @Override
+    public Optional<Achievement> findById(Long id) {
+        return jpaRepository.findById(id);
     }
 }

--- a/src/main/java/online/lifeasgame/character/infra/JpaPlayerAchievementRepository.java
+++ b/src/main/java/online/lifeasgame/character/infra/JpaPlayerAchievementRepository.java
@@ -1,0 +1,7 @@
+package online.lifeasgame.character.infra;
+
+import online.lifeasgame.character.domain.PlayerAchievement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaPlayerAchievementRepository extends JpaRepository<PlayerAchievement, Long> {
+}

--- a/src/main/java/online/lifeasgame/character/infra/PlayerAchievementAdapter.java
+++ b/src/main/java/online/lifeasgame/character/infra/PlayerAchievementAdapter.java
@@ -1,0 +1,18 @@
+package online.lifeasgame.character.infra;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.domain.PlayerAchievement;
+import online.lifeasgame.character.domain.repository.PlayerAchievementRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PlayerAchievementAdapter implements PlayerAchievementRepository {
+
+    private final JpaPlayerAchievementRepository jpaRepository;
+
+    @Override
+    public PlayerAchievement save(PlayerAchievement playerAchievement) {
+        return jpaRepository.save(playerAchievement);
+    }
+}

--- a/src/main/java/online/lifeasgame/character/infra/PlayerRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/character/infra/PlayerRepositoryAdapter.java
@@ -26,4 +26,9 @@ public class PlayerRepositoryAdapter implements PlayerRepository {
     public Optional<Player> findById(Long playerId) {
         return jpaRepository.findById(playerId);
     }
+
+    @Override
+    public boolean existsById(Long playerId) {
+        return jpaRepository.existsById(playerId);
+    }
 }

--- a/src/main/java/online/lifeasgame/character/presentation/AdminPlayerAchievementController.java
+++ b/src/main/java/online/lifeasgame/character/presentation/AdminPlayerAchievementController.java
@@ -1,0 +1,36 @@
+package online.lifeasgame.character.presentation;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.application.AdminPlayerAchievementService;
+import online.lifeasgame.character.application.result.AdminPlayerAchievementResult;
+import online.lifeasgame.character.presentation.mapper.AdminPlayerAchievementWebMapper;
+import online.lifeasgame.character.presentation.response.AdminPlayerAchievementResponse;
+import online.lifeasgame.character.presentation.spec.AdminPlayerAchievementApiSpecV1;
+import online.lifeasgame.core.response.ApiResponse;
+import online.lifeasgame.platform.web.response.ApiResponses;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/v1/players")
+public class AdminPlayerAchievementController implements AdminPlayerAchievementApiSpecV1 {
+
+    private final AdminPlayerAchievementService adminPlayerAchievementService;
+
+    @Override
+    @PostMapping("/{playerId}/achievements/{achievementId}")
+    public ResponseEntity<ApiResponse<AdminPlayerAchievementResponse.GrantedAchievement>> grantAchievement(
+            @PathVariable Long playerId,
+            @PathVariable Long achievementId
+    ) {
+        AdminPlayerAchievementResult.GrantedAchievement grantedAchievement = adminPlayerAchievementService.grantAchievement(playerId, achievementId);
+
+        return ApiResponses.ok(
+                AdminPlayerAchievementWebMapper.toGrantedAchievement(grantedAchievement)
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/character/presentation/mapper/AdminPlayerAchievementWebMapper.java
+++ b/src/main/java/online/lifeasgame/character/presentation/mapper/AdminPlayerAchievementWebMapper.java
@@ -1,0 +1,22 @@
+package online.lifeasgame.character.presentation.mapper;
+
+import online.lifeasgame.character.application.result.AdminPlayerAchievementResult;
+import online.lifeasgame.character.presentation.response.AdminPlayerAchievementResponse;
+
+public class AdminPlayerAchievementWebMapper {
+
+    private AdminPlayerAchievementWebMapper() {}
+
+    public static AdminPlayerAchievementResponse.GrantedAchievement toGrantedAchievement(
+            AdminPlayerAchievementResult.GrantedAchievement result
+    ) {
+        return AdminPlayerAchievementResponse.GrantedAchievement.of(
+                result.playerId(),
+                result.achievementId(),
+                result.code(),
+                result.name(),
+                result.category(),
+                result.acquiredAt()
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/character/presentation/response/AdminPlayerAchievementResponse.java
+++ b/src/main/java/online/lifeasgame/character/presentation/response/AdminPlayerAchievementResponse.java
@@ -1,0 +1,36 @@
+package online.lifeasgame.character.presentation.response;
+
+import java.time.Instant;
+
+public class AdminPlayerAchievementResponse {
+
+    private AdminPlayerAchievementResponse() {
+    }
+
+    public record GrantedAchievement(
+            Long playerId,
+            Long achievementId,
+            String code,
+            String name,
+            String category,
+            Instant acquiredAt
+    ) {
+        public static AdminPlayerAchievementResponse.GrantedAchievement of(
+                Long playerId,
+                Long achievementId,
+                String code,
+                String name,
+                String category,
+                Instant acquiredAt
+        ) {
+            return new AdminPlayerAchievementResponse.GrantedAchievement(
+                    playerId,
+                    achievementId,
+                    code,
+                    name,
+                    category,
+                    acquiredAt
+            );
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/character/presentation/spec/AdminPlayerAchievementApiSpecV1.java
+++ b/src/main/java/online/lifeasgame/character/presentation/spec/AdminPlayerAchievementApiSpecV1.java
@@ -1,0 +1,16 @@
+package online.lifeasgame.character.presentation.spec;
+
+import io.swagger.v3.oas.annotations.Operation;
+import online.lifeasgame.character.presentation.response.AdminPlayerAchievementResponse.GrantedAchievement;
+import online.lifeasgame.core.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+public interface AdminPlayerAchievementApiSpecV1 {
+
+    @Operation(summary = "Player Achievement 지급", description = "Player에게 Achievement를 지급합니다")
+    ResponseEntity<ApiResponse<GrantedAchievement>> grantAchievement(
+            @PathVariable Long playerId,
+            @PathVariable Long achievementId
+    );
+}


### PR DESCRIPTION
## 📝 Summary
<!-- PR의 목적과 변경 내용 간략 요약 -->

## 📌 Related Issue
- Close #55 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can grant achievements via POST /admin/v1/players/{playerId}/achievements/{achievementId}.
  * Successful responses return playerId, achievementId, code, name, category, and acquiredAt.
  * Requests now validate player existence and return a clear error if the player is missing.

* **Bug Fixes**
  * Achievement lookup by ID now returns a clear not-found error when the achievement does not exist.

* **Refactor**
  * Internal player-achievement data handling streamlined for reliability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->