### PR TITLE
feat(character): equip & unEquip api

### DIFF
--- a/src/main/java/online/lifeasgame/character/application/PlayerEquipmentFacade.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerEquipmentFacade.java
@@ -1,0 +1,25 @@
+package online.lifeasgame.character.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.application.command.PlayerEquipmentCommand;
+import online.lifeasgame.character.application.result.PlayerEquipmentResult;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PlayerEquipmentFacade {
+
+    public final CurrentPlayerAccessor currentPlayerAccessor;
+    private final PlayerEquipmentService playerEquipmentService;
+
+    public PlayerEquipmentResult.EquippedEquipment equip(PlayerEquipmentCommand.EquipEquipment command) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        return playerEquipmentService.equip(playerId, command);
+    }
+
+    public void unEquip(Long slotId) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        playerEquipmentService.unEquip(playerId, slotId);
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/PlayerEquipmentReader.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerEquipmentReader.java
@@ -1,0 +1,19 @@
+package online.lifeasgame.character.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.domain.repository.PlayerEquipmentRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+public class PlayerEquipmentReader {
+
+    private final PlayerEquipmentRepository playerEquipmentRepository;
+
+    public boolean existsItemInstance(Long itemInstanceId) {
+        return playerEquipmentRepository.existsByItemInstanceId(itemInstanceId);
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/PlayerEquipmentService.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerEquipmentService.java
@@ -1,0 +1,35 @@
+package online.lifeasgame.character.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.application.command.PlayerEquipmentCommand.EquipEquipment;
+import online.lifeasgame.character.application.result.PlayerEquipmentResult;
+import online.lifeasgame.character.domain.error.PlayerEquipmentError;
+import online.lifeasgame.core.error.DomainException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+public class PlayerEquipmentService {
+
+    private final PlayerEquipmentWriter playerEquipmentWriter;
+    private final PlayerEquipmentReader playerEquipmentReader;
+
+    @Transactional
+    public PlayerEquipmentResult.EquippedEquipment equip(Long playerId, EquipEquipment command) {
+        if (playerEquipmentReader.existsItemInstance(command.itemInstanceId())) {
+            throw new DomainException(PlayerEquipmentError.ALREADY_EQUIPPED_ITEM);
+        }
+
+        return PlayerEquipmentResult.EquippedEquipment.of(
+                playerEquipmentWriter.equip(playerId, command.slotId(), command.itemInstanceId())
+        );
+    }
+
+    @Transactional
+    public void unEquip(Long playerId, Long slotId) {
+        playerEquipmentWriter.unEquip(playerId, slotId);
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/PlayerEquipmentWriter.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerEquipmentWriter.java
@@ -1,0 +1,39 @@
+package online.lifeasgame.character.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.domain.PlayerEquipment;
+import online.lifeasgame.character.domain.error.PlayerEquipmentError;
+import online.lifeasgame.character.domain.repository.PlayerEquipmentRepository;
+import online.lifeasgame.core.error.DomainException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.MANDATORY)
+public class PlayerEquipmentWriter {
+
+    private final PlayerEquipmentRepository playerEquipmentRepository;
+
+    public PlayerEquipment equip(Long playerId, Long slotId, Long itemInstanceId) {
+        if (itemInstanceId == null) {
+            throw new DomainException(PlayerEquipmentError.INVALID_ITEM_INSTANCE_ID);
+        }
+
+        PlayerEquipment playerEquipment = getPlayerEquipment(playerId, slotId);
+        playerEquipment.equip(itemInstanceId);
+        return playerEquipment;
+    }
+
+    public PlayerEquipment unEquip(Long playerId, Long slotId) {
+        PlayerEquipment playerEquipment = getPlayerEquipment(playerId, slotId);
+        playerEquipment.unEquip();
+        return playerEquipment;
+    }
+
+    private PlayerEquipment getPlayerEquipment(Long playerId, Long slotId) {
+        return playerEquipmentRepository.findByPlayerIdAndSlotId(playerId, slotId)
+                .orElseThrow(() -> new DomainException(PlayerEquipmentError.PLAYER_EQUIPMENT_NOT_FOUND));
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/PlayerEquipmentWriter.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerEquipmentWriter.java
@@ -21,19 +21,24 @@ public class PlayerEquipmentWriter {
             throw new DomainException(PlayerEquipmentError.INVALID_ITEM_INSTANCE_ID);
         }
 
-        PlayerEquipment playerEquipment = getPlayerEquipment(playerId, slotId);
+        PlayerEquipment playerEquipment = getPlayerEquipmentForUpdate(playerId, slotId);
         playerEquipment.equip(itemInstanceId);
         return playerEquipment;
     }
 
     public PlayerEquipment unEquip(Long playerId, Long slotId) {
-        PlayerEquipment playerEquipment = getPlayerEquipment(playerId, slotId);
+        PlayerEquipment playerEquipment = getPlayerEquipmentForUpdate(playerId, slotId);
         playerEquipment.unEquip();
         return playerEquipment;
     }
 
     private PlayerEquipment getPlayerEquipment(Long playerId, Long slotId) {
         return playerEquipmentRepository.findByPlayerIdAndSlotId(playerId, slotId)
+                .orElseThrow(() -> new DomainException(PlayerEquipmentError.PLAYER_EQUIPMENT_NOT_FOUND));
+    }
+
+    private PlayerEquipment getPlayerEquipmentForUpdate(Long playerId, Long slotId) {
+        return playerEquipmentRepository.findByPlayerIdAndSlotIdForUpdate(playerId, slotId)
                 .orElseThrow(() -> new DomainException(PlayerEquipmentError.PLAYER_EQUIPMENT_NOT_FOUND));
     }
 }

--- a/src/main/java/online/lifeasgame/character/application/command/PlayerEquipmentCommand.java
+++ b/src/main/java/online/lifeasgame/character/application/command/PlayerEquipmentCommand.java
@@ -1,0 +1,13 @@
+package online.lifeasgame.character.application.command;
+
+public class PlayerEquipmentCommand {
+
+    private PlayerEquipmentCommand() {
+    }
+
+    public record EquipEquipment(Long slotId, Long itemInstanceId) {
+        public static EquipEquipment of(Long slotId, Long itemInstanceId) {
+            return new EquipEquipment(slotId, itemInstanceId);
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/result/PlayerEquipmentResult.java
+++ b/src/main/java/online/lifeasgame/character/application/result/PlayerEquipmentResult.java
@@ -1,0 +1,18 @@
+package online.lifeasgame.character.application.result;
+
+import online.lifeasgame.character.domain.PlayerEquipment;
+
+public class PlayerEquipmentResult {
+
+    private PlayerEquipmentResult() {
+    }
+
+    public record EquippedEquipment(Long slotId, Long itemInstanceId) {
+        public static EquippedEquipment of(PlayerEquipment playerEquipment) {
+            return new EquippedEquipment(
+                    playerEquipment.getSlotId(),
+                    playerEquipment.getItemInstanceId()
+            );
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/character/domain/PlayerEquipment.java
+++ b/src/main/java/online/lifeasgame/character/domain/PlayerEquipment.java
@@ -9,11 +9,13 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.Instant;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import online.lifeasgame.core.annotation.AggregateRoot;
 import online.lifeasgame.core.guard.Guard;
 import online.lifeasgame.platform.persistence.jpa.AbstractTime;
 
+@Getter
 @Entity
 @AggregateRoot
 @Table(
@@ -33,10 +35,10 @@ public class PlayerEquipment extends AbstractTime {
     @Column(name = "slot_id", nullable = false)
     private Long slotId;
 
-    @Column(name = "item_inst_id", nullable = false)
+    @Column(name = "item_inst_id")
     private Long itemInstanceId;
 
-    @Column(name = "equipped_at", nullable = false)
+    @Column(name = "equipped_at")
     private Instant equippedAt;
 
     private PlayerEquipment(Long playerId, Long slotId, Long itemInstanceId) {
@@ -46,7 +48,17 @@ public class PlayerEquipment extends AbstractTime {
         this.equippedAt = Instant.now();
     }
 
-    public static PlayerEquipment equip(Long playerId, Long slotId, Long itemInstanceId) {
+    public static PlayerEquipment create(Long playerId, Long slotId, Long itemInstanceId) {
         return new PlayerEquipment(playerId, slotId, itemInstanceId);
+    }
+
+    public void equip(Long itemInstanceId) {
+        this.itemInstanceId = itemInstanceId;
+        this.equippedAt = Instant.now();
+    }
+
+    public void unEquip() {
+        this.itemInstanceId = null;
+        this.equippedAt = null;
     }
 }

--- a/src/main/java/online/lifeasgame/character/domain/error/PlayerEquipmentError.java
+++ b/src/main/java/online/lifeasgame/character/domain/error/PlayerEquipmentError.java
@@ -1,0 +1,37 @@
+package online.lifeasgame.character.domain.error;
+
+import online.lifeasgame.core.error.ErrorCode;
+
+public enum PlayerEquipmentError implements ErrorCode {
+    PLAYER_EQUIPMENT_NOT_FOUND("PEQ-404-NOT-FOUND", "Player equipment not found", 404),
+    ALREADY_EQUIPPED_ITEM("PEQ-409-ALREADY-EQUIPPED", "Item is already equipped", 409),
+    INVALID_ITEM_INSTANCE_ID("PEQ-400-INVALID-ITEM-INSTANCE", "Item instance id is required", 400),
+    ITEM_NOT_OWNED_BY_PLAYER("PEQ-403-NOT-OWNER", "Item is not owned by the player", 403),
+    ITEM_NOT_COMPATIBLE_WITH_SLOT("PEQ-422-NOT-COMPATIBLE", "Item is not compatible with the slot", 422)
+    ;
+
+    private final String code;
+    private final String message;
+    private final int status;
+
+    PlayerEquipmentError(String code, String message, int status) {
+        this.code = code;
+        this.message = message;
+        this.status = status;
+    }
+
+    @Override
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public int status() {
+        return status;
+    }
+}

--- a/src/main/java/online/lifeasgame/character/domain/error/TitleError.java
+++ b/src/main/java/online/lifeasgame/character/domain/error/TitleError.java
@@ -4,7 +4,7 @@ import online.lifeasgame.core.error.ErrorCode;
 
 public enum TitleError implements ErrorCode {
     INVALID_TITLE_CATEGORY("TIT-400-INVALID-TITLE-CATEGORY", "Invalid title category", 400),
-    TITLE_NOT_FOUND("TIT-404-NOT_FOUND", "Title not found", 404)
+    TITLE_NOT_FOUND("TIT-404-NOT-FOUND", "Title not found", 404)
     ;
 
     private final String code;

--- a/src/main/java/online/lifeasgame/character/domain/repository/PlayerEquipmentRepository.java
+++ b/src/main/java/online/lifeasgame/character/domain/repository/PlayerEquipmentRepository.java
@@ -6,5 +6,7 @@ import online.lifeasgame.character.domain.PlayerEquipment;
 public interface PlayerEquipmentRepository {
     Optional<PlayerEquipment> findByPlayerIdAndSlotId(Long playerId, Long slotId);
 
+    Optional<PlayerEquipment> findByPlayerIdAndSlotIdForUpdate(Long playerId, Long slotId);    // write
+
     boolean existsByItemInstanceId(Long itemInstanceId);
 }

--- a/src/main/java/online/lifeasgame/character/domain/repository/PlayerEquipmentRepository.java
+++ b/src/main/java/online/lifeasgame/character/domain/repository/PlayerEquipmentRepository.java
@@ -1,0 +1,10 @@
+package online.lifeasgame.character.domain.repository;
+
+import java.util.Optional;
+import online.lifeasgame.character.domain.PlayerEquipment;
+
+public interface PlayerEquipmentRepository {
+    Optional<PlayerEquipment> findByPlayerIdAndSlotId(Long playerId, Long slotId);
+
+    boolean existsByItemInstanceId(Long itemInstanceId);
+}

--- a/src/main/java/online/lifeasgame/character/infra/JpaPlayerEquipmentRepository.java
+++ b/src/main/java/online/lifeasgame/character/infra/JpaPlayerEquipmentRepository.java
@@ -1,0 +1,11 @@
+package online.lifeasgame.character.infra;
+
+import java.util.Optional;
+import online.lifeasgame.character.domain.PlayerEquipment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaPlayerEquipmentRepository extends JpaRepository<PlayerEquipment, Long> {
+    Optional<PlayerEquipment> findByPlayerIdAndSlotId(Long playerId, Long slotId);
+
+    boolean existsByItemInstanceId(Long itemInstanceId);
+}

--- a/src/main/java/online/lifeasgame/character/infra/JpaPlayerEquipmentRepository.java
+++ b/src/main/java/online/lifeasgame/character/infra/JpaPlayerEquipmentRepository.java
@@ -1,11 +1,23 @@
 package online.lifeasgame.character.infra;
 
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import java.util.Optional;
 import online.lifeasgame.character.domain.PlayerEquipment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 
 public interface JpaPlayerEquipmentRepository extends JpaRepository<PlayerEquipment, Long> {
     Optional<PlayerEquipment> findByPlayerIdAndSlotId(Long playerId, Long slotId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({
+            @QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000")
+    })
+    @Query("SELECT pe FROM PlayerEquipment pe WHERE pe.playerId = :playerId AND pe.slotId = :slotId")
+    Optional<PlayerEquipment> findByPlayerIdAndSlotIdForUpdate(Long playerId, Long slotId);
 
     boolean existsByItemInstanceId(Long itemInstanceId);
 }

--- a/src/main/java/online/lifeasgame/character/infra/PlayerEquipmentRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/character/infra/PlayerEquipmentRepositoryAdapter.java
@@ -1,0 +1,24 @@
+package online.lifeasgame.character.infra;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.domain.PlayerEquipment;
+import online.lifeasgame.character.domain.repository.PlayerEquipmentRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PlayerEquipmentRepositoryAdapter implements PlayerEquipmentRepository {
+
+    private final JpaPlayerEquipmentRepository jpaRepository;
+
+    @Override
+    public Optional<PlayerEquipment> findByPlayerIdAndSlotId(Long playerId, Long slotId) {
+        return jpaRepository.findByPlayerIdAndSlotId(playerId, slotId);
+    }
+
+    @Override
+    public boolean existsByItemInstanceId(Long itemInstanceId) {
+        return jpaRepository.existsByItemInstanceId(itemInstanceId);
+    }
+}

--- a/src/main/java/online/lifeasgame/character/infra/PlayerEquipmentRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/character/infra/PlayerEquipmentRepositoryAdapter.java
@@ -18,6 +18,11 @@ public class PlayerEquipmentRepositoryAdapter implements PlayerEquipmentReposito
     }
 
     @Override
+    public Optional<PlayerEquipment> findByPlayerIdAndSlotIdForUpdate(Long playerId, Long slotId) {
+        return jpaRepository.findByPlayerIdAndSlotIdForUpdate(playerId, slotId);
+    }
+
+    @Override
     public boolean existsByItemInstanceId(Long itemInstanceId) {
         return jpaRepository.existsByItemInstanceId(itemInstanceId);
     }

--- a/src/main/java/online/lifeasgame/character/presentation/PlayerEquipmentController.java
+++ b/src/main/java/online/lifeasgame/character/presentation/PlayerEquipmentController.java
@@ -1,0 +1,50 @@
+package online.lifeasgame.character.presentation;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.application.PlayerEquipmentFacade;
+import online.lifeasgame.character.application.result.PlayerEquipmentResult;
+import online.lifeasgame.character.presentation.mapper.PlayerEquipmentWebMapper;
+import online.lifeasgame.character.presentation.request.PlayerEquipmentRequest;
+import online.lifeasgame.character.presentation.response.PlayerEquipmentResponse;
+import online.lifeasgame.character.presentation.spec.PlayerEquipmentApiSpecV1;
+import online.lifeasgame.core.response.ApiResponse;
+import online.lifeasgame.platform.web.response.ApiResponses;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/players")
+public class PlayerEquipmentController implements PlayerEquipmentApiSpecV1 {
+
+    private final PlayerEquipmentFacade playerEquipmentFacade;
+
+    @Override
+    @PutMapping("/equipment/{slotId}")
+    public ResponseEntity<ApiResponse<PlayerEquipmentResponse.EquippedEquipment>> equip(
+            @PathVariable Long slotId,
+            @RequestBody PlayerEquipmentRequest.EquipEquipment request
+    ) {
+        PlayerEquipmentResult.EquippedEquipment equippedEquipment = playerEquipmentFacade.equip(
+                PlayerEquipmentWebMapper.toCommand(slotId, request)
+        );
+
+        return ApiResponses.ok(
+                PlayerEquipmentWebMapper.toEquippedEquipment(equippedEquipment)
+        );
+    }
+
+    @Override
+    @DeleteMapping("/equipment/{slotId}")
+    public ResponseEntity<ApiResponse<Long>> unEquip(
+            @PathVariable Long slotId
+    ) {
+        playerEquipmentFacade.unEquip(slotId);
+        return ApiResponses.deleted(slotId);
+    }
+}

--- a/src/main/java/online/lifeasgame/character/presentation/mapper/PlayerEquipmentWebMapper.java
+++ b/src/main/java/online/lifeasgame/character/presentation/mapper/PlayerEquipmentWebMapper.java
@@ -1,0 +1,24 @@
+package online.lifeasgame.character.presentation.mapper;
+
+import online.lifeasgame.character.application.command.PlayerEquipmentCommand;
+import online.lifeasgame.character.application.result.PlayerEquipmentResult;
+import online.lifeasgame.character.presentation.request.PlayerEquipmentRequest;
+import online.lifeasgame.character.presentation.response.PlayerEquipmentResponse;
+
+public class PlayerEquipmentWebMapper {
+
+    private PlayerEquipmentWebMapper() {}
+
+    public static PlayerEquipmentCommand.EquipEquipment toCommand(Long slotId, PlayerEquipmentRequest.EquipEquipment request) {
+        return PlayerEquipmentCommand.EquipEquipment.of(
+                slotId,
+                request.itemInstanceId()
+        );
+    }
+
+    public static PlayerEquipmentResponse.EquippedEquipment toEquippedEquipment(
+            PlayerEquipmentResult.EquippedEquipment equippedEquipment
+    ) {
+        return PlayerEquipmentResponse.EquippedEquipment.of(equippedEquipment);
+    }
+}

--- a/src/main/java/online/lifeasgame/character/presentation/request/PlayerEquipmentRequest.java
+++ b/src/main/java/online/lifeasgame/character/presentation/request/PlayerEquipmentRequest.java
@@ -1,0 +1,15 @@
+package online.lifeasgame.character.presentation.request;
+
+public class PlayerEquipmentRequest {
+
+    private PlayerEquipmentRequest() {
+    }
+
+    public record EquipEquipment(
+            Long itemInstanceId
+    ) {
+        public static EquipEquipment of(Long itemInstanceId) {
+            return new EquipEquipment(itemInstanceId);
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/character/presentation/response/PlayerEquipmentResponse.java
+++ b/src/main/java/online/lifeasgame/character/presentation/response/PlayerEquipmentResponse.java
@@ -1,0 +1,18 @@
+package online.lifeasgame.character.presentation.response;
+
+import online.lifeasgame.character.application.result.PlayerEquipmentResult;
+
+public class PlayerEquipmentResponse {
+
+    private PlayerEquipmentResponse() {
+    }
+
+    public record EquippedEquipment(Long slotId, Long itemInstanceId) {
+        public static EquippedEquipment of(PlayerEquipmentResult.EquippedEquipment equippedEquipment) {
+            return new EquippedEquipment(
+                    equippedEquipment.slotId(),
+                    equippedEquipment.itemInstanceId()
+            );
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/character/presentation/spec/PlayerEquipmentApiSpecV1.java
+++ b/src/main/java/online/lifeasgame/character/presentation/spec/PlayerEquipmentApiSpecV1.java
@@ -1,0 +1,23 @@
+package online.lifeasgame.character.presentation.spec;
+
+import io.swagger.v3.oas.annotations.Operation;
+import online.lifeasgame.character.presentation.request.PlayerEquipmentRequest;
+import online.lifeasgame.character.presentation.response.PlayerEquipmentResponse;
+import online.lifeasgame.core.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+public interface PlayerEquipmentApiSpecV1 {
+
+    @Operation(summary = "Player 장비 장착", description = "장비를 장착합니다.")
+    ResponseEntity<ApiResponse<PlayerEquipmentResponse.EquippedEquipment>> equip(
+            @PathVariable Long slotId,
+            @RequestBody PlayerEquipmentRequest.EquipEquipment request
+    );
+
+    @Operation(summary = "Player 장비 해제", description = "장비를 해제합니다")
+    ResponseEntity<ApiResponse<Long>> unEquip(
+            @PathVariable Long slotId
+    );
+}


### PR DESCRIPTION
## 📝 Summary
<!-- PR의 목적과 변경 내용 간략 요약 -->

## 📌 Related Issue
- Close #58


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Player equipment management API: PUT /api/v1/players/equipment/{slotId} to equip an item (returns slotId & itemInstanceId) and DELETE /api/v1/players/equipment/{slotId} to unequip.
  - Prevents duplicate equips and enforces equipment/ownership/validity checks with clear error responses.

- **Bug Fixes**
  - Standardized Title not-found error code for consistent API error codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->