### PR TITLE
feat(character): find player equipments api

### DIFF
--- a/src/main/java/online/lifeasgame/character/application/PlayerEquipmentFacade.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerEquipmentFacade.java
@@ -1,5 +1,6 @@
 package online.lifeasgame.character.application;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.character.application.command.PlayerEquipmentCommand;
 import online.lifeasgame.character.application.result.PlayerEquipmentResult;
@@ -21,5 +22,10 @@ public class PlayerEquipmentFacade {
     public void unEquip(Long slotId) {
         Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
         playerEquipmentService.unEquip(playerId, slotId);
+    }
+
+    public List<PlayerEquipmentResult.PlayerEquipmentInfo> getPlayerEquipmentInfos() {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        return playerEquipmentService.getPlayerEquipmentInfos(playerId);
     }
 }

--- a/src/main/java/online/lifeasgame/character/application/PlayerEquipmentReader.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerEquipmentReader.java
@@ -1,6 +1,8 @@
 package online.lifeasgame.character.application;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.domain.PlayerEquipment;
 import online.lifeasgame.character.domain.repository.PlayerEquipmentRepository;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -15,5 +17,9 @@ public class PlayerEquipmentReader {
 
     public boolean existsItemInstance(Long itemInstanceId) {
         return playerEquipmentRepository.existsByItemInstanceId(itemInstanceId);
+    }
+
+    public List<PlayerEquipment> getPlayerEquipmentInfos(Long playerId) {
+        return playerEquipmentRepository.findByPlayerId(playerId);
     }
 }

--- a/src/main/java/online/lifeasgame/character/application/PlayerEquipmentService.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerEquipmentService.java
@@ -1,8 +1,10 @@
 package online.lifeasgame.character.application;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.character.application.command.PlayerEquipmentCommand.EquipEquipment;
 import online.lifeasgame.character.application.result.PlayerEquipmentResult;
+import online.lifeasgame.character.domain.PlayerEquipment;
 import online.lifeasgame.character.domain.error.PlayerEquipmentError;
 import online.lifeasgame.core.error.DomainException;
 import org.springframework.stereotype.Service;
@@ -31,5 +33,12 @@ public class PlayerEquipmentService {
     @Transactional
     public void unEquip(Long playerId, Long slotId) {
         playerEquipmentWriter.unEquip(playerId, slotId);
+    }
+
+    public List<PlayerEquipmentResult.PlayerEquipmentInfo> getPlayerEquipmentInfos(Long playerId) {
+        List<PlayerEquipment> playerEquipmentInfos = playerEquipmentReader.getPlayerEquipmentInfos(playerId);
+        return playerEquipmentInfos.stream()
+                .map(PlayerEquipmentResult.PlayerEquipmentInfo::from)
+                .toList();
     }
 }

--- a/src/main/java/online/lifeasgame/character/application/result/PlayerEquipmentResult.java
+++ b/src/main/java/online/lifeasgame/character/application/result/PlayerEquipmentResult.java
@@ -15,4 +15,16 @@ public class PlayerEquipmentResult {
             );
         }
     }
+
+    public record PlayerEquipmentInfo(
+            Long slotId,
+            Long itemInstanceId
+    ) {
+        public static PlayerEquipmentResult.PlayerEquipmentInfo from(PlayerEquipment playerEquipment) {
+            return new PlayerEquipmentResult.PlayerEquipmentInfo(
+                    playerEquipment.getSlotId(),
+                    playerEquipment.getItemInstanceId()
+            );
+        }
+    }
 }

--- a/src/main/java/online/lifeasgame/character/domain/repository/PlayerEquipmentRepository.java
+++ b/src/main/java/online/lifeasgame/character/domain/repository/PlayerEquipmentRepository.java
@@ -1,5 +1,6 @@
 package online.lifeasgame.character.domain.repository;
 
+import java.util.List;
 import java.util.Optional;
 import online.lifeasgame.character.domain.PlayerEquipment;
 
@@ -9,4 +10,6 @@ public interface PlayerEquipmentRepository {
     Optional<PlayerEquipment> findByPlayerIdAndSlotIdForUpdate(Long playerId, Long slotId);    // write
 
     boolean existsByItemInstanceId(Long itemInstanceId);
+
+    List<PlayerEquipment> findByPlayerId(Long playerId);
 }

--- a/src/main/java/online/lifeasgame/character/infra/JpaPlayerEquipmentRepository.java
+++ b/src/main/java/online/lifeasgame/character/infra/JpaPlayerEquipmentRepository.java
@@ -2,6 +2,7 @@ package online.lifeasgame.character.infra;
 
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.QueryHint;
+import java.util.List;
 import java.util.Optional;
 import online.lifeasgame.character.domain.PlayerEquipment;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -20,4 +21,6 @@ public interface JpaPlayerEquipmentRepository extends JpaRepository<PlayerEquipm
     Optional<PlayerEquipment> findByPlayerIdAndSlotIdForUpdate(Long playerId, Long slotId);
 
     boolean existsByItemInstanceId(Long itemInstanceId);
+
+    List<PlayerEquipment> findByPlayerId(Long playerId);
 }

--- a/src/main/java/online/lifeasgame/character/infra/PlayerEquipmentRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/character/infra/PlayerEquipmentRepositoryAdapter.java
@@ -1,5 +1,6 @@
 package online.lifeasgame.character.infra;
 
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.character.domain.PlayerEquipment;
@@ -25,5 +26,10 @@ public class PlayerEquipmentRepositoryAdapter implements PlayerEquipmentReposito
     @Override
     public boolean existsByItemInstanceId(Long itemInstanceId) {
         return jpaRepository.existsByItemInstanceId(itemInstanceId);
+    }
+
+    @Override
+    public List<PlayerEquipment> findByPlayerId(Long playerId) {
+        return jpaRepository.findByPlayerId(playerId);
     }
 }

--- a/src/main/java/online/lifeasgame/character/presentation/PlayerEquipmentController.java
+++ b/src/main/java/online/lifeasgame/character/presentation/PlayerEquipmentController.java
@@ -1,8 +1,10 @@
 package online.lifeasgame.character.presentation;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.character.application.PlayerEquipmentFacade;
 import online.lifeasgame.character.application.result.PlayerEquipmentResult;
+import online.lifeasgame.character.application.result.PlayerEquipmentResult.PlayerEquipmentInfo;
 import online.lifeasgame.character.presentation.mapper.PlayerEquipmentWebMapper;
 import online.lifeasgame.character.presentation.request.PlayerEquipmentRequest;
 import online.lifeasgame.character.presentation.response.PlayerEquipmentResponse;
@@ -11,6 +13,7 @@ import online.lifeasgame.core.response.ApiResponse;
 import online.lifeasgame.platform.web.response.ApiResponses;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -36,6 +39,15 @@ public class PlayerEquipmentController implements PlayerEquipmentApiSpecV1 {
 
         return ApiResponses.ok(
                 PlayerEquipmentWebMapper.toEquippedEquipment(equippedEquipment)
+        );
+    }
+
+    @Override
+    @GetMapping("/equipment")
+    public ResponseEntity<ApiResponse<PlayerEquipmentResponse.PlayerEquipmentInfos>> playerEquipmentInfos() {
+        List<PlayerEquipmentInfo> playerEquipmentInfos = playerEquipmentFacade.getPlayerEquipmentInfos();
+        return ApiResponses.ok(
+                PlayerEquipmentWebMapper.toPlayerEquipmentInfos(playerEquipmentInfos)
         );
     }
 

--- a/src/main/java/online/lifeasgame/character/presentation/mapper/PlayerEquipmentWebMapper.java
+++ b/src/main/java/online/lifeasgame/character/presentation/mapper/PlayerEquipmentWebMapper.java
@@ -1,5 +1,6 @@
 package online.lifeasgame.character.presentation.mapper;
 
+import java.util.List;
 import online.lifeasgame.character.application.command.PlayerEquipmentCommand;
 import online.lifeasgame.character.application.result.PlayerEquipmentResult;
 import online.lifeasgame.character.presentation.request.PlayerEquipmentRequest;
@@ -20,5 +21,19 @@ public class PlayerEquipmentWebMapper {
             PlayerEquipmentResult.EquippedEquipment equippedEquipment
     ) {
         return PlayerEquipmentResponse.EquippedEquipment.of(equippedEquipment);
+    }
+
+    public static PlayerEquipmentResponse.PlayerEquipmentInfos toPlayerEquipmentInfos(List<PlayerEquipmentResult.PlayerEquipmentInfo> playerEquipmentInfos) {
+        return PlayerEquipmentResponse.PlayerEquipmentInfos.of(
+                playerEquipmentInfos.stream()
+                        .map(
+                                playerEquipmentInfo ->
+                                        PlayerEquipmentResponse.PlayerEquipmentInfo.of(
+                                                playerEquipmentInfo.slotId(),
+                                                playerEquipmentInfo.itemInstanceId()
+                                        )
+                        )
+                        .toList()
+        );
     }
 }

--- a/src/main/java/online/lifeasgame/character/presentation/response/PlayerEquipmentResponse.java
+++ b/src/main/java/online/lifeasgame/character/presentation/response/PlayerEquipmentResponse.java
@@ -1,5 +1,6 @@
 package online.lifeasgame.character.presentation.response;
 
+import java.util.List;
 import online.lifeasgame.character.application.result.PlayerEquipmentResult;
 
 public class PlayerEquipmentResponse {
@@ -13,6 +14,24 @@ public class PlayerEquipmentResponse {
                     equippedEquipment.slotId(),
                     equippedEquipment.itemInstanceId()
             );
+        }
+    }
+
+    public record PlayerEquipmentInfos(List<PlayerEquipmentResponse.PlayerEquipmentInfo> playerEquipmentInfos) {
+        public static PlayerEquipmentResponse.PlayerEquipmentInfos of(List<PlayerEquipmentResponse.PlayerEquipmentInfo> playerEquipmentInfos) {
+            return new PlayerEquipmentResponse.PlayerEquipmentInfos(playerEquipmentInfos);
+        }
+    }
+
+    public record PlayerEquipmentInfo(
+            Long slotId,
+            Long itemInstanceId
+    ) {
+        public static PlayerEquipmentResponse.PlayerEquipmentInfo of(
+                Long slotId,
+                Long itemInstanceId
+        ) {
+            return new PlayerEquipmentResponse.PlayerEquipmentInfo(slotId, itemInstanceId);
         }
     }
 }

--- a/src/main/java/online/lifeasgame/character/presentation/spec/PlayerEquipmentApiSpecV1.java
+++ b/src/main/java/online/lifeasgame/character/presentation/spec/PlayerEquipmentApiSpecV1.java
@@ -16,6 +16,9 @@ public interface PlayerEquipmentApiSpecV1 {
             @RequestBody PlayerEquipmentRequest.EquipEquipment request
     );
 
+    @Operation(summary = "Player 장비 현황 조회", description = "파츠별 장비를 조회합니다")
+    ResponseEntity<ApiResponse<PlayerEquipmentResponse.PlayerEquipmentInfos>> playerEquipmentInfos();
+
     @Operation(summary = "Player 장비 해제", description = "장비를 해제합니다")
     ResponseEntity<ApiResponse<Long>> unEquip(
             @PathVariable Long slotId


### PR DESCRIPTION
## 📝 Summary
<!-- PR의 목적과 변경 내용 간략 요약 -->

## 📌 Related Issue
- Close #57 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a GET endpoint to retrieve the current player’s equipment overview.
  - Returns a list of equipped items by slot, including slot and item instance identifiers.
  - Introduced response models to deliver multiple equipment entries in a consistent format.
  - Mapped service outputs to user-facing responses for easier integration.
  - Non-breaking change; existing equip/unequip actions remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->