### PR TITLE
feat(social): party api

### DIFF
--- a/src/main/java/online/lifeasgame/social/api/admin/AdminGuildController.java
+++ b/src/main/java/online/lifeasgame/social/api/admin/AdminGuildController.java
@@ -24,12 +24,12 @@ public class AdminGuildController implements AdminGuildApiSpecV1 {
 
     @Override
     @GetMapping("/players/{playerId}/guilds/{guildId}")
-    public ResponseEntity<ApiResponse<AdminGuildResponse.Summary>> getGuildInfo(
+    public ResponseEntity<ApiResponse<AdminGuildResponse.Info>> getGuildInfo(
             @PathVariable Long playerId,
             @PathVariable Long guildId
     ) {
         var info = guildService.getGuild(playerId, guildId);
-        return ApiResponses.ok(AdminGuildWebMapper.toSummary(info));
+        return ApiResponses.ok(AdminGuildWebMapper.toInfo(info));
     }
 
     // ===== 일반 조회 =====

--- a/src/main/java/online/lifeasgame/social/api/admin/AdminPartyController.java
+++ b/src/main/java/online/lifeasgame/social/api/admin/AdminPartyController.java
@@ -24,12 +24,12 @@ public class AdminPartyController implements AdminPartyApiSpecV1 {
 
     @Override
     @GetMapping("/players/{playerId}/parties/{partyId}")
-    public ResponseEntity<ApiResponse<AdminPartyResponse.Summary>> getPartyInfo(
+    public ResponseEntity<ApiResponse<AdminPartyResponse.Info>> getPartyInfo(
             @PathVariable Long playerId,
             @PathVariable Long partyId
     ) {
         var info = partyService.getParty(playerId, partyId);
-        return ApiResponses.ok(AdminPartyWebMapper.toSummary(info));
+        return ApiResponses.ok(AdminPartyWebMapper.toInfo(info));
     }
 
     // ===== 일반 조회 =====
@@ -113,7 +113,7 @@ public class AdminPartyController implements AdminPartyApiSpecV1 {
             @PathVariable Long partyId,
             @Valid @RequestBody AdminPartyRequest.ChangeEmblem body
     ) {
-        var info = partyService.changeEmblem(playerId, partyId, AdminPartyWebMapper.toCommand(body));
+        var info = partyService.changeBanner(playerId, partyId, AdminPartyWebMapper.toCommand(body));
         return ApiResponses.ok(AdminPartyWebMapper.toDetail(info));
     }
 

--- a/src/main/java/online/lifeasgame/social/api/admin/AdminPartyController.java
+++ b/src/main/java/online/lifeasgame/social/api/admin/AdminPartyController.java
@@ -1,0 +1,269 @@
+package online.lifeasgame.social.api.admin;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.response.ApiResponse;
+import online.lifeasgame.platform.web.response.ApiResponses;
+import online.lifeasgame.social.api.admin.mapper.AdminPartyWebMapper;
+import online.lifeasgame.social.api.admin.request.AdminPartyRequest;
+import online.lifeasgame.social.api.admin.response.AdminPartyResponse;
+import online.lifeasgame.social.api.admin.spec.AdminPartyApiSpecV1;
+import online.lifeasgame.social.application.PartyService;
+import online.lifeasgame.social.application.result.PartyResult;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/v1")
+public class AdminPartyController implements AdminPartyApiSpecV1 {
+
+    private final PartyService partyService;
+
+    @Override
+    @GetMapping("/players/{playerId}/parties/{partyId}")
+    public ResponseEntity<ApiResponse<AdminPartyResponse.Summary>> getPartyInfo(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId
+    ) {
+        var info = partyService.getParty(playerId, partyId);
+        return ApiResponses.ok(AdminPartyWebMapper.toSummary(info));
+    }
+
+    // ===== 일반 조회 =====
+    @Override
+    @GetMapping("/parties/search")
+    public ResponseEntity<ApiResponse<AdminPartyResponse.Page<AdminPartyResponse.Summary>>> search(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String visibility,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        PartyResult.Page<PartyResult.Summary> pages = partyService.search(
+                keyword,
+                visibility,
+                Math.max(page, 0),
+                Math.min(Math.max(size, 1), 100)
+        );
+        return ApiResponses.ok(AdminPartyWebMapper.toSummaryPage(pages));
+    }
+
+    @Override
+    @GetMapping("/parties/recent")
+    public ResponseEntity<ApiResponse<List<AdminPartyResponse.Summary>>> recent(
+            @RequestParam(defaultValue="10") Integer limit
+    ) {
+        var infos = partyService.recent(Math.min(Math.max(limit, 1), 100));
+        return ApiResponses.ok(AdminPartyWebMapper.toSummaries(infos));
+    }
+
+    // ===== 플레이어 스코프(acting as playerId) =====
+
+    // 생성
+    @Override
+    @PostMapping("/players/{playerId}/parties")
+    public ResponseEntity<ApiResponse<AdminPartyResponse.Detail>> create(
+            @PathVariable Long playerId,
+            @Valid @RequestBody AdminPartyRequest.Create body
+    ) {
+        var info = partyService.create(playerId, AdminPartyWebMapper.toCommand(body));
+        return ApiResponses.ok(AdminPartyWebMapper.toDetail(info));
+    }
+
+    // 기본 변경
+    @Override
+    @PostMapping("/players/{playerId}/parties/{partyId}/rename")
+    public ResponseEntity<ApiResponse<AdminPartyResponse.Detail>> rename(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.Rename body
+    ) {
+        var info = partyService.rename(playerId, partyId, AdminPartyWebMapper.toCommand(body));
+        return ApiResponses.ok(AdminPartyWebMapper.toDetail(info));
+    }
+
+    @Override
+    @PostMapping("/players/{playerId}/parties/{partyId}/policy")
+    public ResponseEntity<ApiResponse<AdminPartyResponse.Detail>> changePolicy(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.ChangePolicy body
+    ) {
+        var info = partyService.changePolicy(playerId, partyId, AdminPartyWebMapper.toCommand(body));
+        return ApiResponses.ok(AdminPartyWebMapper.toDetail(info));
+    }
+
+    @Override
+    @PostMapping("/players/{playerId}/parties/{partyId}/description")
+    public ResponseEntity<ApiResponse<AdminPartyResponse.Detail>> changeDescription(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.ChangeDescription body
+    ) {
+        var info = partyService.changeDescription(playerId, partyId, AdminPartyWebMapper.toCommand(body));
+        return ApiResponses.ok(AdminPartyWebMapper.toDetail(info));
+    }
+
+    @Override
+    @PostMapping("/players/{playerId}/parties/{partyId}/emblem")
+    public ResponseEntity<ApiResponse<AdminPartyResponse.Detail>> changeEmblem(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.ChangeEmblem body
+    ) {
+        var info = partyService.changeEmblem(playerId, partyId, AdminPartyWebMapper.toCommand(body));
+        return ApiResponses.ok(AdminPartyWebMapper.toDetail(info));
+    }
+
+    @Override
+    @PostMapping("/players/{playerId}/parties/{partyId}/tags/add")
+    public ResponseEntity<ApiResponse<AdminPartyResponse.Detail>> addTag(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.TagOp body
+    ) {
+        var info = partyService.addTag(playerId, partyId, AdminPartyWebMapper.toCommand(body));
+        return ApiResponses.ok(AdminPartyWebMapper.toDetail(info));
+    }
+
+    @Override
+    @PostMapping("/players/{playerId}/parties/{partyId}/tags/remove")
+    public ResponseEntity<ApiResponse<AdminPartyResponse.Detail>> removeTag(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.TagOp body
+    ) {
+        var info = partyService.removeTag(playerId, partyId, AdminPartyWebMapper.toCommand(body));
+        return ApiResponses.ok(AdminPartyWebMapper.toDetail(info));
+    }
+
+    // 가입/권한
+    @Override
+    @PostMapping("/players/{playerId}/parties/{partyId}/request-join")
+    public ResponseEntity<ApiResponse<Void>> requestJoin(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.RequestJoin body
+    ) {
+        partyService.requestJoin(playerId, partyId, AdminPartyWebMapper.toCommand(body));
+        return ApiResponses.ok(null);
+    }
+
+    @Override
+    @PostMapping("/players/{playerId}/parties/{partyId}/approve")
+    public ResponseEntity<ApiResponse<Void>> approve(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.Approve body
+    ) {
+        partyService.approveJoin(playerId, partyId, AdminPartyWebMapper.toCommand(body));
+        return ApiResponses.ok(null);
+    }
+
+    @Override
+    @PostMapping("/players/{playerId}/parties/{partyId}/reject")
+    public ResponseEntity<ApiResponse<Void>> reject(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.Reject body
+    ) {
+        partyService.rejectJoin(playerId, partyId, AdminPartyWebMapper.toCommand(body));
+        return ApiResponses.ok(null);
+    }
+
+    @Override
+    @PostMapping("/players/{playerId}/parties/{partyId}/cancel-join")
+    public ResponseEntity<ApiResponse<Void>> cancelJoin(@PathVariable Long playerId, @PathVariable Long partyId) {
+        partyService.cancelJoin(playerId, partyId);
+        return ApiResponses.ok(null);
+    }
+
+    @Override
+    @PostMapping("/players/{playerId}/parties/{partyId}/transfer-leader")
+    public ResponseEntity<ApiResponse<Void>> transferLeader(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.TransferLeader body
+    ) {
+        partyService.transferLeader(playerId, partyId, AdminPartyWebMapper.toCommand(body));
+        return ApiResponses.ok(null);
+    }
+
+    @Override
+    @PostMapping("/players/{playerId}/parties/{partyId}/kick")
+    public ResponseEntity<ApiResponse<Void>> kick(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.Kick body
+    ) {
+        partyService.kick(playerId, partyId, AdminPartyWebMapper.toCommand(body));
+        return ApiResponses.ok(null);
+    }
+
+    @Override
+    @PostMapping("/players/{playerId}/parties/{partyId}/promote")
+    public ResponseEntity<ApiResponse<Void>> promote(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.MemberOp body
+    ) {
+        partyService.promote(playerId, partyId, AdminPartyWebMapper.toCommandPromote(body));
+        return ApiResponses.ok(null);
+    }
+
+    @Override
+    @PostMapping("/players/{playerId}/parties/{partyId}/demote")
+    public ResponseEntity<ApiResponse<Void>> demote(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.MemberOp body
+    ) {
+        partyService.demote(playerId, partyId, AdminPartyWebMapper.toCommandDemote(body));
+        return ApiResponses.ok(null);
+    }
+
+    @Override
+    @PostMapping("/players/{playerId}/parties/{partyId}/leave")
+    public ResponseEntity<ApiResponse<Void>> leave(@PathVariable Long playerId, @PathVariable Long partyId) {
+        partyService.leave(playerId, partyId);
+        return ApiResponses.ok(null);
+    }
+
+    @Override
+    @PostMapping("/players/{playerId}/parties/{partyId}/disband")
+    public ResponseEntity<ApiResponse<Void>> disband(@PathVariable Long playerId, @PathVariable Long partyId) {
+        partyService.disbandByLeader(playerId, partyId);
+        return ApiResponses.ok(null);
+    }
+
+    // 초대
+    @Override
+    @PostMapping("/players/{playerId}/parties/{partyId}/invite")
+    public ResponseEntity<ApiResponse<Void>> invite(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.Invite body
+    ) {
+        partyService.invite(playerId, partyId, AdminPartyWebMapper.toCommand(body));
+        return ApiResponses.ok(null);
+    }
+
+    @Override
+    @PostMapping("/players/{playerId}/parties/{partyId}/accept-invitation")
+    public ResponseEntity<ApiResponse<Void>> acceptInvitation(@PathVariable Long playerId, @PathVariable Long partyId) {
+        partyService.acceptInvitation(playerId, partyId);
+        return ApiResponses.ok(null);
+    }
+
+    @Override
+    @PostMapping("/players/{playerId}/parties/{partyId}/decline-invitation")
+    public ResponseEntity<ApiResponse<Void>> declineInvitation(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId
+    ) {
+        partyService.declineInvitation(playerId, partyId);
+        return ApiResponses.ok(null);
+    }
+}

--- a/src/main/java/online/lifeasgame/social/api/admin/mapper/AdminGuildWebMapper.java
+++ b/src/main/java/online/lifeasgame/social/api/admin/mapper/AdminGuildWebMapper.java
@@ -2,6 +2,7 @@ package online.lifeasgame.social.api.admin.mapper;
 
 import online.lifeasgame.social.api.admin.request.AdminGuildRequest;
 import online.lifeasgame.social.api.admin.response.AdminGuildResponse;
+import online.lifeasgame.social.api.player.response.PlayerGuildResponse;
 import online.lifeasgame.social.application.command.GuildCommand;
 import online.lifeasgame.social.application.result.GuildResult;
 
@@ -119,6 +120,26 @@ public final class AdminGuildWebMapper {
                 p.size(),
                 p.totalElements(),
                 p.totalPages()
+        );
+    }
+
+    public static AdminGuildResponse.Info toInfo(GuildResult.Info r) {
+        return AdminGuildResponse.Info.of(
+                r.id(),
+                r.playerId(),
+                r.name(),
+                r.code(),
+                r.visibility(),
+                r.joinPolicy(),
+                r.status(),
+                r.maxMembers(),
+                r.tags(),
+                r.descriptionMd(),
+                r.emblemImageUrl(),
+                r.emblemBgColor(),
+                r.leaderPlayerId(),
+                r.createdAt(),
+                r.updatedAt()
         );
     }
 }

--- a/src/main/java/online/lifeasgame/social/api/admin/mapper/AdminPartyWebMapper.java
+++ b/src/main/java/online/lifeasgame/social/api/admin/mapper/AdminPartyWebMapper.java
@@ -2,6 +2,7 @@ package online.lifeasgame.social.api.admin.mapper;
 
 import online.lifeasgame.social.api.admin.request.AdminPartyRequest;
 import online.lifeasgame.social.api.admin.response.AdminPartyResponse;
+import online.lifeasgame.social.api.player.response.PlayerPartyResponse;
 import online.lifeasgame.social.application.command.PartyCommand;
 import online.lifeasgame.social.application.result.PartyResult;
 
@@ -113,6 +114,27 @@ public final class AdminPartyWebMapper {
     public static java.util.List<AdminPartyResponse.Summary> toSummaries(List<PartyResult.Summary> rs) {
         return rs.stream().map(AdminPartyWebMapper::toSummary).toList();
     }
+
+    public static AdminPartyResponse.Info toInfo(PartyResult.Info r) {
+        return AdminPartyResponse.Info.of(
+                r.id(),
+                r.playerId(),
+                r.name(),
+                r.code(),
+                r.visibility(),
+                r.joinPolicy(),
+                r.status(),
+                r.maxMembers(),
+                r.tags(),
+                r.descriptionMd(),
+                r.bannerImageUrl(),
+                r.bannerBgColor(),
+                r.leaderPlayerId(),
+                r.createdAt(),
+                r.updatedAt()
+        );
+    }
+
 
     public static AdminPartyResponse.Page<AdminPartyResponse.Summary> toSummaryPage(PartyResult.Page<PartyResult.Summary> p) {
         return AdminPartyResponse.Page.of(

--- a/src/main/java/online/lifeasgame/social/api/admin/mapper/AdminPartyWebMapper.java
+++ b/src/main/java/online/lifeasgame/social/api/admin/mapper/AdminPartyWebMapper.java
@@ -1,0 +1,126 @@
+package online.lifeasgame.social.api.admin.mapper;
+
+import online.lifeasgame.social.api.admin.request.AdminPartyRequest;
+import online.lifeasgame.social.api.admin.response.AdminPartyResponse;
+import online.lifeasgame.social.application.command.PartyCommand;
+import online.lifeasgame.social.application.result.PartyResult;
+
+import java.util.List;
+
+public final class AdminPartyWebMapper {
+    private AdminPartyWebMapper() {
+    }
+
+    // Request → Command
+    public static PartyCommand.Create toCommand(AdminPartyRequest.Create r) {
+        return PartyCommand.Create.of(
+                r.name(),
+                r.code(),
+                r.descriptionMd(),
+                r.bannerImageUrl(),
+                r.bannerBgColor(),
+                r.visibility(),
+                r.joinPolicy(),
+                r.maxMembers()
+        );
+    }
+
+    public static PartyCommand.Rename toCommand(AdminPartyRequest.Rename r) {
+        return PartyCommand.Rename.of(r.name());
+    }
+
+    public static PartyCommand.ChangePolicy toCommand(AdminPartyRequest.ChangePolicy r) {
+        return PartyCommand.ChangePolicy.of(r.visibility(), r.joinPolicy(), r.maxMembers());
+    }
+
+    public static PartyCommand.ChangeDescription toCommand(AdminPartyRequest.ChangeDescription r) {
+        return PartyCommand.ChangeDescription.of(r.descriptionMd());
+    }
+
+    public static PartyCommand.ChangeEmblem toCommand(AdminPartyRequest.ChangeEmblem r) {
+        return PartyCommand.ChangeEmblem.of(r.emblemImageUrl(), r.emblemBgColor());
+    }
+
+    public static PartyCommand.TagOp toCommand(AdminPartyRequest.TagOp r) {
+        return PartyCommand.TagOp.of(r.tag());
+    }
+
+    public static PartyCommand.Approve toCommand(AdminPartyRequest.Approve r) {
+        return PartyCommand.Approve.of(r.applicantPlayerId());
+    }
+
+    public static PartyCommand.Reject toCommand(AdminPartyRequest.Reject r) {
+        return PartyCommand.Reject.of(r.applicantPlayerId());
+    }
+
+    public static PartyCommand.Kick toCommand(AdminPartyRequest.Kick r) {
+        return PartyCommand.Kick.of(r.targetPlayerId());
+    }
+
+    public static PartyCommand.TransferLeader toCommand(AdminPartyRequest.TransferLeader r) {
+        return PartyCommand.TransferLeader.of(r.fromLeaderPlayerId(), r.toPlayerId());
+    }
+
+    public static PartyCommand.Invite toCommand(AdminPartyRequest.Invite r) {
+        return PartyCommand.Invite.of(r.inviteePlayerId(), r.message(), r.expiresAt());
+    }
+
+    public static PartyCommand.Promote toCommandPromote(AdminPartyRequest.MemberOp r) {
+        return PartyCommand.Promote.of(r.targetPlayerId());
+    }
+
+    public static PartyCommand.Demote toCommandDemote(AdminPartyRequest.MemberOp r) {
+        return PartyCommand.Demote.of(r.targetPlayerId());
+    }
+
+    public static PartyCommand.RequestJoin toCommand(AdminPartyRequest.RequestJoin r) {
+        return PartyCommand.RequestJoin.of(r.message());
+    }
+
+    // Result → Response
+    public static AdminPartyResponse.Summary toSummary(PartyResult.Summary r) {
+        return AdminPartyResponse.Summary.of(
+                r.id(),
+                r.name(),
+                r.code(),
+                r.visibility(),
+                r.joinPolicy(),
+                r.status(),
+                r.maxMembers()
+        );
+    }
+
+    public static AdminPartyResponse.Detail toDetail(PartyResult.Info r) {
+        return AdminPartyResponse.Detail.of(
+                r.id(),
+                r.playerId(),
+                r.name(),
+                r.code(),
+                r.visibility(),
+                r.joinPolicy(),
+                r.status(),
+                r.maxMembers(),
+                r.tags(),
+                r.descriptionMd(),
+                r.bannerImageUrl(),
+                r.bannerBgColor(),
+                r.leaderPlayerId(),
+                r.createdAt(),
+                r.updatedAt()
+        );
+    }
+
+    public static java.util.List<AdminPartyResponse.Summary> toSummaries(List<PartyResult.Summary> rs) {
+        return rs.stream().map(AdminPartyWebMapper::toSummary).toList();
+    }
+
+    public static AdminPartyResponse.Page<AdminPartyResponse.Summary> toSummaryPage(PartyResult.Page<PartyResult.Summary> p) {
+        return AdminPartyResponse.Page.of(
+                toSummaries(p.contents()),
+                p.page(),
+                p.size(),
+                p.totalElements(),
+                p.totalPages()
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/social/api/admin/request/AdminPartyRequest.java
+++ b/src/main/java/online/lifeasgame/social/api/admin/request/AdminPartyRequest.java
@@ -1,0 +1,97 @@
+package online.lifeasgame.social.api.admin.request;
+
+import jakarta.validation.constraints.*;
+
+
+public final class AdminPartyRequest {
+    public record Create(
+            @NotBlank String name,
+            @NotBlank String code,
+            String descriptionMd,
+            String bannerImageUrl,
+            String bannerBgColor,
+            @Pattern(regexp = "PUBLIC|PRIVATE") String visibility,
+            @Pattern(regexp = "OPEN|APPROVAL|INVITE_ONLY") String joinPolicy,
+            @Min(1) @Max(500) int maxMembers
+    ) {
+        public static Create of(String n, String c, String d, String u, String bg, String v, String j, int m) {
+            return new Create(n, c, d, u, bg, v, j, m);
+        }
+    }
+
+    public record Rename(@NotBlank String name) {
+        public static Rename of(String n) {
+            return new Rename(n);
+        }
+    }
+
+    public record ChangePolicy(
+            @Pattern(regexp = "PUBLIC|PRIVATE") String visibility,
+            @Pattern(regexp = "OPEN|APPROVAL|INVITE_ONLY") String joinPolicy,
+            @Min(1) @Max(500) int maxMembers
+    ) {
+        public static ChangePolicy of(String v, String j, int m) {
+            return new ChangePolicy(v, j, m);
+        }
+    }
+
+    public record ChangeDescription(String descriptionMd) {
+        public static ChangeDescription of(String d) {
+            return new ChangeDescription(d);
+        }
+    }
+
+    public record ChangeEmblem(String emblemImageUrl, String emblemBgColor) {
+        public static ChangeEmblem of(String u, String bg) {
+            return new ChangeEmblem(u, bg);
+        }
+    }
+
+    public record TagOp(@NotBlank String tag) {
+        public static TagOp of(String t) {
+            return new TagOp(t);
+        }
+    }
+
+    public record Approve(@NotNull Long applicantPlayerId) {
+        public static Approve of(Long id) {
+            return new Approve(id);
+        }
+    }
+
+    public record Reject(@NotNull Long applicantPlayerId) {
+        public static Reject of(Long id) {
+            return new Reject(id);
+        }
+    }
+
+    public record Kick(@NotNull Long targetPlayerId) {
+        public static Kick of(Long id) {
+            return new Kick(id);
+        }
+    }
+
+    public record TransferLeader(@NotNull Long fromLeaderPlayerId, @NotNull Long toPlayerId) {
+        public static TransferLeader of(Long f, Long t) {
+            return new TransferLeader(f, t);
+        }
+    }
+
+    public record Invite(@NotNull Long inviteePlayerId, String message, String expiresAt) {
+        public static Invite of(Long id, String m, String at) {
+            return new Invite(id, m, at);
+        }
+    }
+
+    public record MemberOp(@NotNull Long targetPlayerId) {
+        public static MemberOp of(Long id) {
+            return new MemberOp(id);
+        }
+    }
+
+    public record RequestJoin(String message) {
+        public static RequestJoin of(String m) {
+            return new RequestJoin(m);
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/social/api/admin/request/AdminPartyRequest.java
+++ b/src/main/java/online/lifeasgame/social/api/admin/request/AdminPartyRequest.java
@@ -47,7 +47,7 @@ public final class AdminPartyRequest {
         }
     }
 
-    public record TagOp(@NotBlank String tag) {
+    public record TagOp(@NotBlank @Size(max = 64) String tag) {
         public static TagOp of(String t) {
             return new TagOp(t);
         }
@@ -77,7 +77,7 @@ public final class AdminPartyRequest {
         }
     }
 
-    public record Invite(@NotNull Long inviteePlayerId, String message, String expiresAt) {
+    public record Invite(@NotNull Long inviteePlayerId, @Size(max = 1000) String message, String expiresAt) {
         public static Invite of(Long id, String m, String at) {
             return new Invite(id, m, at);
         }
@@ -89,7 +89,7 @@ public final class AdminPartyRequest {
         }
     }
 
-    public record RequestJoin(String message) {
+    public record RequestJoin(@Size(max = 1000) String message) {
         public static RequestJoin of(String m) {
             return new RequestJoin(m);
         }

--- a/src/main/java/online/lifeasgame/social/api/admin/response/AdminGuildResponse.java
+++ b/src/main/java/online/lifeasgame/social/api/admin/response/AdminGuildResponse.java
@@ -74,6 +74,60 @@ public final class AdminGuildResponse {
         }
     }
 
+    public record Info(
+            Long id,
+            Long playerId,
+            String name,
+            String code,
+            String visibility,
+            String joinPolicy,
+            String status,
+            int maxMembers,
+            List<String> tags,
+            String descriptionMd,
+            String emblemImageUrl,
+            String emblemBgColor,
+            Long leaderPlayerId,
+            Instant createdAt,
+            Instant updatedAt
+    ) {
+        public static AdminGuildResponse.Info of(
+                Long id,
+                Long playerId,
+                String name,
+                String code,
+                String visibility,
+                String joinPolicy,
+                String status,
+                int maxMembers,
+                List<String> tags,
+                String descriptionMd,
+                String emblemImageUrl,
+                String emblemBgColor,
+                Long leaderPlayerId,
+                Instant createdAt,
+                Instant updatedAt
+        ) {
+            return new AdminGuildResponse.Info(
+                    id,
+                    playerId,
+                    name,
+                    code,
+                    visibility,
+                    joinPolicy,
+                    status,
+                    maxMembers,
+                    tags,
+                    descriptionMd,
+                    emblemImageUrl,
+                    emblemBgColor,
+                    leaderPlayerId,
+                    createdAt,
+                    updatedAt
+            );
+        }
+    }
+
     public record Page<T>(List<T> contents, int page, int size, long totalElements, int totalPages) {
         public static <T> Page<T> of(List<T> contents, int page, int size, long totalElements, int totalPages) {
             return new Page<>(contents, page, size, totalElements, totalPages);

--- a/src/main/java/online/lifeasgame/social/api/admin/response/AdminPartyResponse.java
+++ b/src/main/java/online/lifeasgame/social/api/admin/response/AdminPartyResponse.java
@@ -74,6 +74,61 @@ public final class AdminPartyResponse {
         }
     }
 
+    public record Info(
+            Long id,
+            Long playerId,
+            String name,
+            String code,
+            String visibility,
+            String joinPolicy,
+            String status,
+            int maxMembers,
+            List<String> tags,
+            String descriptionMd,
+            String emblemImageUrl,
+            String emblemBgColor,
+            Long leaderPlayerId,
+            Instant createdAt,
+            Instant updatedAt
+    ) {
+        public static AdminPartyResponse.Info of(
+                Long id,
+                Long playerId,
+                String name,
+                String code,
+                String visibility,
+                String joinPolicy,
+                String status,
+                int maxMembers,
+                List<String> tags,
+                String descriptionMd,
+                String emblemImageUrl,
+                String emblemBgColor,
+                Long leaderPlayerId,
+                Instant createdAt,
+                Instant updatedAt
+        ) {
+            return new AdminPartyResponse.Info(
+                    id,
+                    playerId,
+                    name,
+                    code,
+                    visibility,
+                    joinPolicy,
+                    status,
+                    maxMembers,
+                    tags,
+                    descriptionMd,
+                    emblemImageUrl,
+                    emblemBgColor,
+                    leaderPlayerId,
+                    createdAt,
+                    updatedAt
+            );
+        }
+    }
+
+
     public record Page<T>(List<T> contents, int page, int size, long totalElements, int totalPages) {
         public static <T> Page<T> of(List<T> contents, int page, int size, long totalElements, int totalPages) {
             return new Page<>(contents, page, size, totalElements, totalPages);

--- a/src/main/java/online/lifeasgame/social/api/admin/response/AdminPartyResponse.java
+++ b/src/main/java/online/lifeasgame/social/api/admin/response/AdminPartyResponse.java
@@ -1,0 +1,82 @@
+package online.lifeasgame.social.api.admin.response;
+
+import java.time.Instant;
+import java.util.List;
+
+public final class AdminPartyResponse {
+    public record Summary(
+            Long id, String name, String code, String visibility, String joinPolicy, String status, int maxMembers
+    ) {
+        public static Summary of(
+                Long id,
+                String name,
+                String code,
+                String visibility,
+                String joinPolicy,
+                String status,
+                int maxMembers
+        ) {
+            return new Summary(id, name, code, visibility, joinPolicy, status, maxMembers);
+        }
+    }
+
+    public record Detail(
+            Long id,
+            Long playerId,
+            String name,
+            String code,
+            String visibility,
+            String joinPolicy,
+            String status,
+            int maxMembers,
+            List<String> tags,
+            String descriptionMd,
+            String bannerImageUrl,
+            String bannerBgColor,
+            Long leaderPlayerId,
+            Instant createdAt,
+            Instant updatedAt
+    ) {
+        public static Detail of(
+                Long id,
+                Long playerId,
+                String name,
+                String code,
+                String visibility,
+                String joinPolicy,
+                String status,
+                int maxMembers,
+                List<String> tags,
+                String descriptionMd,
+                String bannerImageUrl,
+                String bannerBgColor,
+                Long leaderPlayerId,
+                Instant createdAt,
+                Instant updatedAt
+        ) {
+            return new Detail(
+                    id,
+                    playerId,
+                    name,
+                    code,
+                    visibility,
+                    joinPolicy,
+                    status,
+                    maxMembers,
+                    tags,
+                    descriptionMd,
+                    bannerImageUrl,
+                    bannerBgColor,
+                    leaderPlayerId,
+                    createdAt,
+                    updatedAt
+            );
+        }
+    }
+
+    public record Page<T>(List<T> contents, int page, int size, long totalElements, int totalPages) {
+        public static <T> Page<T> of(List<T> contents, int page, int size, long totalElements, int totalPages) {
+            return new Page<>(contents, page, size, totalElements, totalPages);
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/social/api/admin/spec/AdminGuildApiSpecV1.java
+++ b/src/main/java/online/lifeasgame/social/api/admin/spec/AdminGuildApiSpecV1.java
@@ -19,7 +19,7 @@ import java.util.List;
 public interface AdminGuildApiSpecV1 {
 
     @Operation(summary = "길드 단건 조회 (Admin)")
-    ResponseEntity<ApiResponse<AdminGuildResponse.Summary>> getGuildInfo(
+    ResponseEntity<ApiResponse<AdminGuildResponse.Info>> getGuildInfo(
             @PathVariable Long playerId,
             @PathVariable Long guildId
     );

--- a/src/main/java/online/lifeasgame/social/api/admin/spec/AdminPartyApiSpecV1.java
+++ b/src/main/java/online/lifeasgame/social/api/admin/spec/AdminPartyApiSpecV1.java
@@ -19,7 +19,7 @@ import java.util.List;
 public interface AdminPartyApiSpecV1 {
 
     @Operation(summary = "길드 단건 조회 (Admin)")
-    ResponseEntity<ApiResponse<AdminPartyResponse.Summary>> getPartyInfo(
+    ResponseEntity<ApiResponse<AdminPartyResponse.Info>> getPartyInfo(
             @PathVariable Long playerId,
             @PathVariable Long partyId
     );

--- a/src/main/java/online/lifeasgame/social/api/admin/spec/AdminPartyApiSpecV1.java
+++ b/src/main/java/online/lifeasgame/social/api/admin/spec/AdminPartyApiSpecV1.java
@@ -1,0 +1,165 @@
+package online.lifeasgame.social.api.admin.spec;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import online.lifeasgame.core.response.ApiResponse;
+import online.lifeasgame.social.api.admin.request.AdminPartyRequest;
+import online.lifeasgame.social.api.admin.response.AdminPartyResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Tag(name = "Social Party API V1 (Admin)")
+public interface AdminPartyApiSpecV1 {
+
+    @Operation(summary = "길드 단건 조회 (Admin)")
+    ResponseEntity<ApiResponse<AdminPartyResponse.Summary>> getPartyInfo(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId
+    );
+
+    // 조회
+    @Operation(summary = "길드 검색 (Admin)")
+    ResponseEntity<ApiResponse<AdminPartyResponse.Page<AdminPartyResponse.Summary>>> search(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String visibility,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    );
+
+    @Operation(summary = "최근 길드 조회 (Admin)")
+    ResponseEntity<ApiResponse<List<AdminPartyResponse.Summary>>> recent(
+            @RequestParam(defaultValue = "10") @Min(1) @Max(100) Integer limit
+    );
+
+    // 플레이어 스코프(acting as player)
+    @Operation(summary = "플레이어로 길드 생성")
+    ResponseEntity<ApiResponse<AdminPartyResponse.Detail>> create(
+            @PathVariable Long playerId,
+            @Valid @RequestBody AdminPartyRequest.Create request
+    );
+
+    @Operation(summary = "플레이어로 길드 이름 변경")
+    ResponseEntity<ApiResponse<AdminPartyResponse.Detail>> rename(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.Rename request
+    );
+
+    @Operation(summary = "플레이어로 길드 정책 변경")
+    ResponseEntity<ApiResponse<AdminPartyResponse.Detail>> changePolicy(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody
+            AdminPartyRequest.ChangePolicy request
+    );
+
+    @Operation(summary = "플레이어로 길드 설명 변경")
+    ResponseEntity<ApiResponse<AdminPartyResponse.Detail>> changeDescription(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody
+            AdminPartyRequest.ChangeDescription request
+    );
+
+    @Operation(summary = "플레이어로 길드 엠블럼 변경")
+    ResponseEntity<ApiResponse<AdminPartyResponse.Detail>> changeEmblem(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody
+            AdminPartyRequest.ChangeEmblem request
+    );
+
+    @Operation(summary = "플레이어로 태그 추가")
+    ResponseEntity<ApiResponse<AdminPartyResponse.Detail>> addTag(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.TagOp request
+    );
+
+    @Operation(summary = "플레이어로 태그 제거")
+    ResponseEntity<ApiResponse<AdminPartyResponse.Detail>> removeTag(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.TagOp request
+    );
+
+    // 가입/권한
+    @Operation(summary = "플레이어로 가입 요청")
+    ResponseEntity<ApiResponse<Void>> requestJoin(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.RequestJoin request
+    );
+
+    @Operation(summary = "플레이어로 가입 승인")
+    ResponseEntity<ApiResponse<Void>> approve(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.Approve request
+    );
+
+    @Operation(summary = "플레이어로 가입 거절")
+    ResponseEntity<ApiResponse<Void>> reject(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.Reject request
+    );
+
+    @Operation(summary = "플레이어로 가입 요청 취소")
+    ResponseEntity<ApiResponse<Void>> cancelJoin(@PathVariable Long playerId, @PathVariable Long partyId);
+
+    @Operation(summary = "플레이어로 리더 위임")
+    ResponseEntity<ApiResponse<Void>> transferLeader(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.TransferLeader request
+    );
+
+    @Operation(summary = "플레이어로 멤버 강퇴")
+    ResponseEntity<ApiResponse<Void>> kick(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.Kick request
+    );
+
+    @Operation(summary = "플레이어로 승격")
+    ResponseEntity<ApiResponse<Void>> promote(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.MemberOp request
+    );
+
+    @Operation(summary = "플레이어로 강등")
+    ResponseEntity<ApiResponse<Void>> demote(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.MemberOp request
+    );
+
+    @Operation(summary = "플레이어로 길드 탈퇴")
+    ResponseEntity<ApiResponse<Void>> leave(@PathVariable Long playerId, @PathVariable Long partyId);
+
+    @Operation(summary = "플레이어로 길드 해산")
+    ResponseEntity<ApiResponse<Void>> disband(@PathVariable Long playerId, @PathVariable Long partyId);
+
+    // 초대
+    @Operation(summary = "플레이어로 초대")
+    ResponseEntity<ApiResponse<Void>> invite(
+            @PathVariable Long playerId,
+            @PathVariable Long partyId,
+            @Valid @RequestBody AdminPartyRequest.Invite request
+    );
+
+    @Operation(summary = "플레이어로 초대 수락")
+    ResponseEntity<ApiResponse<Void>> acceptInvitation(@PathVariable Long playerId, @PathVariable Long partyId);
+
+    @Operation(summary = "플레이어로 초대 거절")
+    ResponseEntity<ApiResponse<Void>> declineInvitation(@PathVariable Long playerId, @PathVariable Long partyId);
+}

--- a/src/main/java/online/lifeasgame/social/api/player/PlayerGuildController.java
+++ b/src/main/java/online/lifeasgame/social/api/player/PlayerGuildController.java
@@ -223,11 +223,11 @@ public class PlayerGuildController implements PlayerGuildApiSpecV1 {
 
     @Override
     @GetMapping("/{guildId}")
-    public ResponseEntity<ApiResponse<PlayerGuildResponse.Summary>> getGuildInfo(
+    public ResponseEntity<ApiResponse<PlayerGuildResponse.Info>> getGuildInfo(
             @PathVariable Long guildId
     ) {
         var info = guildFacade.getGuild(guildId);
-        return ApiResponses.ok(PlayerGuildWebMapper.toSummary(info));
+        return ApiResponses.ok(PlayerGuildWebMapper.toInfo(info));
     }
 
     @Override

--- a/src/main/java/online/lifeasgame/social/api/player/PlayerPartyController.java
+++ b/src/main/java/online/lifeasgame/social/api/player/PlayerPartyController.java
@@ -230,11 +230,11 @@ public class PlayerPartyController implements PlayerPartyApiSpecV1 {
 
     @Override
     @GetMapping("/{partyId}")
-    public ResponseEntity<ApiResponse<PlayerPartyResponse.Summary>> getPartyInfo(
+    public ResponseEntity<ApiResponse<PlayerPartyResponse.Info>> getPartyInfo(
             @PathVariable Long partyId
     ) {
         var info = partyFacade.getParty(partyId);
-        return ApiResponses.ok(PlayerPartyWebMapper.toSummary(info));
+        return ApiResponses.ok(PlayerPartyWebMapper.toInfo(info));
     }
 
     @Override

--- a/src/main/java/online/lifeasgame/social/api/player/PlayerPartyController.java
+++ b/src/main/java/online/lifeasgame/social/api/player/PlayerPartyController.java
@@ -1,0 +1,251 @@
+package online.lifeasgame.social.api.player;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.response.ApiResponse;
+import online.lifeasgame.platform.web.response.ApiResponses;
+import online.lifeasgame.social.api.player.mapper.PlayerPartyWebMapper;
+import online.lifeasgame.social.api.player.request.PlayerPartyRequest;
+import online.lifeasgame.social.api.player.response.PlayerPartyResponse;
+import online.lifeasgame.social.api.player.spec.PlayerPartyApiSpecV1;
+import online.lifeasgame.social.application.PartyFacade;
+import online.lifeasgame.social.application.result.PartyResult;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/parties")
+public class PlayerPartyController implements PlayerPartyApiSpecV1 {
+
+    private final PartyFacade partyFacade;
+
+    @Override
+    @PostMapping
+    public ResponseEntity<ApiResponse<PlayerPartyResponse.Info>> create(
+            @Valid @RequestBody PlayerPartyRequest.Create request
+    ) {
+        PartyResult.Info result = partyFacade.create(PlayerPartyWebMapper.toCommand(request));
+        return ApiResponses.ok(PlayerPartyWebMapper.toInfo(result));
+    }
+
+    @Override
+    @PostMapping("/{partyId}/rename")
+    public ResponseEntity<ApiResponse<PlayerPartyResponse.Info>> rename(
+            @PathVariable Long partyId,
+            @Valid @RequestBody
+            PlayerPartyRequest.Rename request
+    ) {
+        PartyResult.Info result = partyFacade.rename(partyId, PlayerPartyWebMapper.toCommand(request));
+        return ApiResponses.ok(PlayerPartyWebMapper.toInfo(result));
+    }
+
+    @Override
+    @PostMapping("/{partyId}/policy")
+    public ResponseEntity<ApiResponse<PlayerPartyResponse.Info>> changePolicy(
+            @PathVariable Long partyId,
+            @Valid @RequestBody
+            PlayerPartyRequest.ChangePolicy request
+    ) {
+        PartyResult.Info result = partyFacade.changePolicy(partyId, PlayerPartyWebMapper.toCommand(request));
+        return ApiResponses.ok(PlayerPartyWebMapper.toInfo(result));
+    }
+
+    @Override
+    @PostMapping("/{partyId}/description")
+    public ResponseEntity<ApiResponse<PlayerPartyResponse.Info>> changeDescription(
+            @PathVariable Long partyId,
+            @Valid @RequestBody
+            PlayerPartyRequest.ChangeDescription request
+    ) {
+        PartyResult.Info result = partyFacade.changeDescription(partyId, PlayerPartyWebMapper.toCommand(request));
+        return ApiResponses.ok(PlayerPartyWebMapper.toInfo(result));
+    }
+
+    @Override
+    @PostMapping("/{partyId}/banner")
+    public ResponseEntity<ApiResponse<PlayerPartyResponse.Info>> changeBanner(
+            @PathVariable Long partyId,
+            @Valid @RequestBody
+            PlayerPartyRequest.ChangeBanner request
+    ) {
+        PartyResult.Info result = partyFacade.changeBanner(partyId, PlayerPartyWebMapper.toCommand(request));
+        return ApiResponses.ok(PlayerPartyWebMapper.toInfo(result));
+    }
+
+    @Override
+    @PostMapping("/{partyId}/tags/add")
+    public ResponseEntity<ApiResponse<PlayerPartyResponse.Info>> addTag(
+            @PathVariable Long partyId,
+            @Valid @RequestBody
+            PlayerPartyRequest.TagOp request
+    ) {
+        PartyResult.Info result = partyFacade.addTag(partyId, PlayerPartyWebMapper.toCommand(request));
+        return ApiResponses.ok(PlayerPartyWebMapper.toInfo(result));
+    }
+
+    @Override
+    @PostMapping("/{partyId}/tags/remove")
+    public ResponseEntity<ApiResponse<PlayerPartyResponse.Info>> removeTag(
+            @PathVariable Long partyId,
+            @Valid @RequestBody
+            PlayerPartyRequest.TagOp request
+    ) {
+        PartyResult.Info result = partyFacade.removeTag(partyId, PlayerPartyWebMapper.toCommand(request));
+        return ApiResponses.ok(PlayerPartyWebMapper.toInfo(result));
+    }
+
+    // 가입/권한
+    @Override
+    @PostMapping("/{partyId}/request-join")
+    public ResponseEntity<ApiResponse<Void>> requestJoin(
+            @PathVariable Long partyId,
+            @Valid @RequestBody PlayerPartyRequest.RequestJoin request
+    ) {
+        partyFacade.requestJoin(partyId, PlayerPartyWebMapper.toCommand(request));
+        return ApiResponses.ok(null);
+    }
+
+    @Override
+    @PostMapping("/{partyId}/approve")
+    public ResponseEntity<ApiResponse<Void>> approveJoin(
+            @PathVariable Long partyId,
+            @Valid @RequestBody PlayerPartyRequest.Approve request
+    ) {
+        partyFacade.approveJoin(partyId, PlayerPartyWebMapper.toCommand(request));
+        return ApiResponses.ok(null);
+    }
+
+    @Override
+    @PostMapping("/{partyId}/reject")
+    public ResponseEntity<ApiResponse<Void>> rejectJoin(
+            @PathVariable Long partyId,
+            @Valid @RequestBody PlayerPartyRequest.Reject request
+    ) {
+        partyFacade.rejectJoin(partyId, PlayerPartyWebMapper.toCommand(request));
+        return ApiResponses.ok(null);
+    }
+
+    @Override
+    @PostMapping("/{partyId}/cancel-join")
+    public ResponseEntity<ApiResponse<Void>> cancelJoin(@PathVariable Long partyId) {
+        partyFacade.cancelJoin(partyId);
+        return ApiResponses.ok(null);
+    }
+
+    @Override
+    @PostMapping("/{partyId}/transfer-leader")
+    public ResponseEntity<ApiResponse<Void>> transferLeader(
+            @PathVariable Long partyId,
+            @Valid @RequestBody
+            PlayerPartyRequest.TransferLeader request
+    ) {
+        partyFacade.transferLeader(partyId, PlayerPartyWebMapper.toCommand(request));
+        return ApiResponses.ok(null);
+    }
+
+    @Override
+    @PostMapping("/{partyId}/kick")
+    public ResponseEntity<ApiResponse<Void>> kick(
+            @PathVariable Long partyId,
+            @Valid @RequestBody PlayerPartyRequest.Kick request
+    ) {
+        partyFacade.kick(partyId, PlayerPartyWebMapper.toCommand(request));
+        return ApiResponses.ok(null);
+    }
+
+    @Override
+    @PostMapping("/{partyId}/promote")
+    public ResponseEntity<ApiResponse<Void>> promote(
+            @PathVariable Long partyId,
+            @Valid @RequestBody PlayerPartyRequest.MemberOp request
+    ) {
+        partyFacade.promote(partyId, PlayerPartyWebMapper.toCommandPromote(request));
+        return ApiResponses.ok(null);
+    }
+
+    @Override
+    @PostMapping("/{partyId}/demote")
+    public ResponseEntity<ApiResponse<Void>> demote(
+            @PathVariable Long partyId,
+            @Valid @RequestBody PlayerPartyRequest.MemberOp request
+    ) {
+        partyFacade.demote(partyId, PlayerPartyWebMapper.toCommandDemote(request));
+        return ApiResponses.ok(null);
+    }
+
+    @Override
+    @PostMapping("/{partyId}/leave")
+    public ResponseEntity<ApiResponse<Void>> leave(@PathVariable Long partyId) {
+        partyFacade.leave(partyId);
+        return ApiResponses.ok(null);
+    }
+
+    @Override
+    @PostMapping("/{partyId}/disband")
+    public ResponseEntity<ApiResponse<Void>> disband(@PathVariable Long partyId) {
+        partyFacade.disband(partyId);
+        return ApiResponses.ok(null);
+    }
+
+    // 초대
+    @Override
+    @PostMapping("/{partyId}/invite")
+    public ResponseEntity<ApiResponse<Void>> invite(
+            @PathVariable Long partyId,
+            @Valid @RequestBody PlayerPartyRequest.Invite request
+    ) {
+        partyFacade.invite(partyId, PlayerPartyWebMapper.toCommand(request));
+        return ApiResponses.ok(null);
+    }
+
+    @Override
+    @PostMapping("/{partyId}/accept-invitation")
+    public ResponseEntity<ApiResponse<Void>> acceptInvitation(@PathVariable Long partyId) {
+        partyFacade.acceptInvitation(partyId);
+        return ApiResponses.ok(null);
+    }
+
+    @Override
+    @PostMapping("/{partyId}/decline-invitation")
+    public ResponseEntity<ApiResponse<Void>> declineInvitation(@PathVariable Long partyId) {
+        partyFacade.declineInvitation(partyId);
+        return ApiResponses.ok(null);
+    }
+
+    // 조회
+    @Override
+    @GetMapping("/recent")
+    public ResponseEntity<ApiResponse<List<PlayerPartyResponse.Summary>>> recent(
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) Integer limit
+    ) {
+        var infos = partyFacade.recent(limit);
+        return ApiResponses.ok(PlayerPartyWebMapper.toSummaryList(infos));
+    }
+
+    @Override
+    @GetMapping("/{partyId}")
+    public ResponseEntity<ApiResponse<PlayerPartyResponse.Summary>> getPartyInfo(
+            @PathVariable Long partyId
+    ) {
+        var info = partyFacade.getParty(partyId);
+        return ApiResponses.ok(PlayerPartyWebMapper.toSummary(info));
+    }
+
+    @Override
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<PlayerPartyResponse.Page<PlayerPartyResponse.Summary>>> search(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String visibility,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size
+    ) {
+        PartyResult.Page<PartyResult.Summary> pages = partyFacade.search(keyword, visibility, page, size);
+        return ApiResponses.ok(PlayerPartyWebMapper.toSummaryPage(pages));
+    }
+}

--- a/src/main/java/online/lifeasgame/social/api/player/mapper/PlayerPartyWebMapper.java
+++ b/src/main/java/online/lifeasgame/social/api/player/mapper/PlayerPartyWebMapper.java
@@ -1,0 +1,126 @@
+package online.lifeasgame.social.api.player.mapper;
+
+import online.lifeasgame.social.api.player.request.PlayerPartyRequest;
+import online.lifeasgame.social.api.player.response.PlayerPartyResponse;
+import online.lifeasgame.social.application.command.PartyCommand;
+import online.lifeasgame.social.application.result.PartyResult;
+
+import java.util.List;
+
+public final class PlayerPartyWebMapper {
+    private PlayerPartyWebMapper() {
+    }
+
+    // Request → Command
+    public static PartyCommand.Create toCommand(PlayerPartyRequest.Create r) {
+        return PartyCommand.Create.of(
+                r.name(),
+                r.code(),
+                r.descriptionMd(),
+                r.bannerImageUrl(),
+                r.bannerBgColor(),
+                r.visibility(),
+                r.joinPolicy(),
+                r.maxMembers()
+        );
+    }
+
+    public static PartyCommand.Rename toCommand(PlayerPartyRequest.Rename r) {
+        return PartyCommand.Rename.of(r.name());
+    }
+
+    public static PartyCommand.ChangePolicy toCommand(PlayerPartyRequest.ChangePolicy r) {
+        return PartyCommand.ChangePolicy.of(r.visibility(), r.joinPolicy(), r.maxMembers());
+    }
+
+    public static PartyCommand.ChangeDescription toCommand(PlayerPartyRequest.ChangeDescription r) {
+        return PartyCommand.ChangeDescription.of(r.descriptionMd());
+    }
+
+    public static PartyCommand.ChangeEmblem toCommand(PlayerPartyRequest.ChangeBanner r) {
+        return PartyCommand.ChangeEmblem.of(r.bannerImageUrl(), r.bannerBgColor());
+    }
+
+    public static PartyCommand.TagOp toCommand(PlayerPartyRequest.TagOp r) {
+        return PartyCommand.TagOp.of(r.tag());
+    }
+
+    public static PartyCommand.RequestJoin toCommand(PlayerPartyRequest.RequestJoin r) {
+        return PartyCommand.RequestJoin.of(r.message());
+    }
+
+    public static PartyCommand.Approve toCommand(PlayerPartyRequest.Approve r) {
+        return PartyCommand.Approve.of(r.applicantPlayerId());
+    }
+
+    public static PartyCommand.Reject toCommand(PlayerPartyRequest.Reject r) {
+        return PartyCommand.Reject.of(r.applicantPlayerId());
+    }
+
+    public static PartyCommand.TransferLeader toCommand(PlayerPartyRequest.TransferLeader r) {
+        return PartyCommand.TransferLeader.of(r.fromLeaderPlayerId(), r.toPlayerId());
+    }
+
+    public static PartyCommand.Kick toCommand(PlayerPartyRequest.Kick r) {
+        return PartyCommand.Kick.of(r.targetPlayerId());
+    }
+
+    public static PartyCommand.Promote toCommandPromote(PlayerPartyRequest.MemberOp r) {
+        return PartyCommand.Promote.of(r.targetPlayerId());
+    }
+
+    public static PartyCommand.Demote toCommandDemote(PlayerPartyRequest.MemberOp r) {
+        return PartyCommand.Demote.of(r.targetPlayerId());
+    }
+
+    public static PartyCommand.Invite toCommand(PlayerPartyRequest.Invite r) {
+        return PartyCommand.Invite.of(r.inviteePlayerId(), r.message(), r.expiresAt());
+    }
+
+    // Result → Response
+    public static PlayerPartyResponse.Summary toSummary(PartyResult.Summary r) {
+        return PlayerPartyResponse.Summary.of(
+                r.id(),
+                r.name(),
+                r.code(),
+                r.visibility(),
+                r.joinPolicy(),
+                r.status(),
+                r.maxMembers()
+        );
+    }
+
+    public static PlayerPartyResponse.Info toInfo(PartyResult.Info r) {
+        return PlayerPartyResponse.Info.of(
+                r.id(),
+                r.playerId(),
+                r.name(),
+                r.code(),
+                r.visibility(),
+                r.joinPolicy(),
+                r.status(),
+                r.maxMembers(),
+                r.tags(),
+                r.descriptionMd(),
+                r.bannerImageUrl(),
+                r.bannerBgColor(),
+                r.leaderPlayerId(),
+                r.createdAt(),
+                r.updatedAt()
+        );
+    }
+
+    public static List<PlayerPartyResponse.Summary> toSummaryList(List<PartyResult.Summary> rs) {
+        return rs.stream().map(PlayerPartyWebMapper::toSummary).toList();
+    }
+
+    public static PlayerPartyResponse.Page<PlayerPartyResponse.Summary> toSummaryPage(PartyResult.Page<PartyResult.Summary> p) {
+        return PlayerPartyResponse.Page.of(
+                toSummaryList(p.contents()),
+                p.page(),
+                p.size(),
+                p.totalElements(),
+                p.totalPages()
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/social/api/player/request/PlayerPartyRequest.java
+++ b/src/main/java/online/lifeasgame/social/api/player/request/PlayerPartyRequest.java
@@ -1,0 +1,96 @@
+package online.lifeasgame.social.api.player.request;
+
+import jakarta.validation.constraints.*;
+
+public final class PlayerPartyRequest {
+    public record Create(
+            @NotBlank String name,
+            @NotBlank String code,
+            String descriptionMd,
+            String bannerImageUrl,
+            String bannerBgColor,
+            @Pattern(regexp = "PUBLIC|PRIVATE") String visibility,
+            @Pattern(regexp = "OPEN|APPROVAL|INVITE_ONLY") String joinPolicy,
+            @Min(1) @Max(500) int maxMembers
+    ) {
+        public static Create of(String n, String c, String d, String u, String bg, String v, String j, int m) {
+            return new Create(n, c, d, u, bg, v, j, m);
+        }
+    }
+
+    public record Rename(@NotBlank String name) {
+        public static Rename of(String n) {
+            return new Rename(n);
+        }
+    }
+
+    public record ChangePolicy(
+            @Pattern(regexp = "PUBLIC|PRIVATE") String visibility,
+            @Pattern(regexp = "OPEN|APPROVAL|INVITE_ONLY") String joinPolicy,
+            @Min(1) @Max(500) int maxMembers
+    ) {
+        public static ChangePolicy of(String v, String j, int m) {
+            return new ChangePolicy(v, j, m);
+        }
+    }
+
+    public record ChangeDescription(String descriptionMd) {
+        public static ChangeDescription of(String d) {
+            return new ChangeDescription(d);
+        }
+    }
+
+    public record ChangeBanner(String bannerImageUrl, String bannerBgColor) {
+        public static ChangeBanner of(String u, String bg) {
+            return new ChangeBanner(u, bg);
+        }
+    }
+
+    public record TagOp(@NotBlank String tag) {
+        public static TagOp of(String t) {
+            return new TagOp(t);
+        }
+    }
+
+    public record RequestJoin(String message) {
+        public static RequestJoin of(String m) {
+            return new RequestJoin(m);
+        }
+    }
+
+    public record Approve(@NotNull Long applicantPlayerId) {
+        public static Approve of(Long id) {
+            return new Approve(id);
+        }
+    }
+
+    public record Reject(@NotNull Long applicantPlayerId) {
+        public static Reject of(Long id) {
+            return new Reject(id);
+        }
+    }
+
+    public record TransferLeader(@NotNull Long fromLeaderPlayerId, @NotNull Long toPlayerId) {
+        public static TransferLeader of(Long f, Long t) {
+            return new TransferLeader(f, t);
+        }
+    }
+
+    public record Kick(@NotNull Long targetPlayerId) {
+        public static Kick of(Long id) {
+            return new Kick(id);
+        }
+    }
+
+    public record MemberOp(@NotNull Long targetPlayerId) {
+        public static MemberOp of(Long id) {
+            return new MemberOp(id);
+        }
+    }
+
+    public record Invite(@NotNull Long inviteePlayerId, String message, String expiresAt) {
+        public static Invite of(Long id, String m, String at) {
+            return new Invite(id, m, at);
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/social/api/player/request/PlayerPartyRequest.java
+++ b/src/main/java/online/lifeasgame/social/api/player/request/PlayerPartyRequest.java
@@ -46,13 +46,13 @@ public final class PlayerPartyRequest {
         }
     }
 
-    public record TagOp(@NotBlank String tag) {
+    public record TagOp(@NotBlank @Size(max = 64) String tag) {
         public static TagOp of(String t) {
             return new TagOp(t);
         }
     }
 
-    public record RequestJoin(String message) {
+    public record RequestJoin(@Size(max = 1000) String message) {
         public static RequestJoin of(String m) {
             return new RequestJoin(m);
         }
@@ -88,7 +88,7 @@ public final class PlayerPartyRequest {
         }
     }
 
-    public record Invite(@NotNull Long inviteePlayerId, String message, String expiresAt) {
+    public record Invite(@NotNull Long inviteePlayerId, @Size(max = 1000) String message, String expiresAt) {
         public static Invite of(Long id, String m, String at) {
             return new Invite(id, m, at);
         }

--- a/src/main/java/online/lifeasgame/social/api/player/response/PlayerPartyResponse.java
+++ b/src/main/java/online/lifeasgame/social/api/player/response/PlayerPartyResponse.java
@@ -1,0 +1,82 @@
+package online.lifeasgame.social.api.player.response;
+
+import java.time.Instant;
+import java.util.List;
+
+public final class PlayerPartyResponse {
+    public record Summary(
+            Long id, String name, String code, String visibility, String joinPolicy, String status, int maxMembers
+    ) {
+        public static Summary of(
+                Long id,
+                String name,
+                String code,
+                String visibility,
+                String joinPolicy,
+                String status,
+                int maxMembers
+        ) {
+            return new Summary(id, name, code, visibility, joinPolicy, status, maxMembers);
+        }
+    }
+
+    public record Info(
+            Long id,
+            Long playerId,
+            String name,
+            String code,
+            String visibility,
+            String joinPolicy,
+            String status,
+            int maxMembers,
+            List<String> tags,
+            String descriptionMd,
+            String emblemImageUrl,
+            String emblemBgColor,
+            Long leaderPlayerId,
+            Instant createdAt,
+            Instant updatedAt
+    ) {
+        public static Info of(
+                Long id,
+                Long playerId,
+                String name,
+                String code,
+                String visibility,
+                String joinPolicy,
+                String status,
+                int maxMembers,
+                List<String> tags,
+                String descriptionMd,
+                String emblemImageUrl,
+                String emblemBgColor,
+                Long leaderPlayerId,
+                Instant createdAt,
+                Instant updatedAt
+        ) {
+            return new Info(
+                    id,
+                    playerId,
+                    name,
+                    code,
+                    visibility,
+                    joinPolicy,
+                    status,
+                    maxMembers,
+                    tags,
+                    descriptionMd,
+                    emblemImageUrl,
+                    emblemBgColor,
+                    leaderPlayerId,
+                    createdAt,
+                    updatedAt
+            );
+        }
+    }
+
+    public record Page<T>(List<T> contents, int page, int size, long totalElements, int totalPages) {
+        public static <T> Page<T> of(List<T> contents, int page, int size, long totalElements, int totalPages) {
+            return new Page<>(contents, page, size, totalElements, totalPages);
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/social/api/player/response/PlayerPartyResponse.java
+++ b/src/main/java/online/lifeasgame/social/api/player/response/PlayerPartyResponse.java
@@ -48,8 +48,8 @@ public final class PlayerPartyResponse {
                 int maxMembers,
                 List<String> tags,
                 String descriptionMd,
-                String emblemImageUrl,
-                String emblemBgColor,
+                String bannerImageUrl,
+                String bannerBgColor,
                 Long leaderPlayerId,
                 Instant createdAt,
                 Instant updatedAt
@@ -65,8 +65,8 @@ public final class PlayerPartyResponse {
                     maxMembers,
                     tags,
                     descriptionMd,
-                    emblemImageUrl,
-                    emblemBgColor,
+                    bannerImageUrl,
+                    bannerBgColor,
                     leaderPlayerId,
                     createdAt,
                     updatedAt

--- a/src/main/java/online/lifeasgame/social/api/player/spec/PlayerGuildApiSpecV1.java
+++ b/src/main/java/online/lifeasgame/social/api/player/spec/PlayerGuildApiSpecV1.java
@@ -134,7 +134,7 @@ public interface PlayerGuildApiSpecV1 {
     );
 
     @Operation(summary = "길드 상세 조회")
-    ResponseEntity<ApiResponse<PlayerGuildResponse.Summary>> getGuildInfo(
+    ResponseEntity<ApiResponse<PlayerGuildResponse.Info>> getGuildInfo(
             @PathVariable Long guildId
     );
 

--- a/src/main/java/online/lifeasgame/social/api/player/spec/PlayerPartyApiSpecV1.java
+++ b/src/main/java/online/lifeasgame/social/api/player/spec/PlayerPartyApiSpecV1.java
@@ -142,7 +142,7 @@ public interface PlayerPartyApiSpecV1 {
 
 
     @Operation(summary = "파티 상세 조회")
-    ResponseEntity<ApiResponse<PlayerPartyResponse.Summary>> getPartyInfo(
+    ResponseEntity<ApiResponse<PlayerPartyResponse.Info>> getPartyInfo(
             @PathVariable Long partyId
     );
 }

--- a/src/main/java/online/lifeasgame/social/api/player/spec/PlayerPartyApiSpecV1.java
+++ b/src/main/java/online/lifeasgame/social/api/player/spec/PlayerPartyApiSpecV1.java
@@ -1,0 +1,148 @@
+package online.lifeasgame.social.api.player.spec;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import online.lifeasgame.core.response.ApiResponse;
+import online.lifeasgame.social.api.player.request.PlayerPartyRequest;
+import online.lifeasgame.social.api.player.response.PlayerPartyResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+
+@Tag(name = "Social Party API V1 (Player)")
+public interface PlayerPartyApiSpecV1 {
+
+    @Operation(summary = "파티 생성")
+    ResponseEntity<ApiResponse<PlayerPartyResponse.Info>> create(@Valid @RequestBody PlayerPartyRequest.Create request);
+
+    @Operation(summary = "파티 이름 변경")
+    ResponseEntity<ApiResponse<PlayerPartyResponse.Info>> rename(
+            @PathVariable Long partyId,
+            @Valid @RequestBody PlayerPartyRequest.Rename request
+    );
+
+    @Operation(summary = "파티 정책 변경")
+    ResponseEntity<ApiResponse<PlayerPartyResponse.Info>> changePolicy(
+            @PathVariable Long partyId,
+            @Valid @RequestBody
+            PlayerPartyRequest.ChangePolicy request
+    );
+
+    @Operation(summary = "파티 설명 변경")
+    ResponseEntity<ApiResponse<PlayerPartyResponse.Info>> changeDescription(
+            @PathVariable Long partyId,
+            @Valid @RequestBody
+            PlayerPartyRequest.ChangeDescription request
+    );
+
+    @Operation(summary = "파티 배너 변경")
+    ResponseEntity<ApiResponse<PlayerPartyResponse.Info>> changeBanner(
+            @PathVariable Long partyId,
+            @Valid @RequestBody
+            PlayerPartyRequest.ChangeBanner request
+    );
+
+    @Operation(summary = "태그 추가")
+    ResponseEntity<ApiResponse<PlayerPartyResponse.Info>> addTag(
+            @PathVariable Long partyId,
+            @Valid @RequestBody PlayerPartyRequest.TagOp request
+    );
+
+    @Operation(summary = "태그 제거")
+    ResponseEntity<ApiResponse<PlayerPartyResponse.Info>> removeTag(
+            @PathVariable Long partyId,
+            @Valid @RequestBody PlayerPartyRequest.TagOp request
+    );
+
+    // 가입/권한
+    @Operation(summary = "가입 요청")
+    ResponseEntity<ApiResponse<Void>> requestJoin(
+            @PathVariable Long partyId,
+            @Valid @RequestBody PlayerPartyRequest.RequestJoin request
+    );
+
+    @Operation(summary = "가입 승인(리더)")
+    ResponseEntity<ApiResponse<Void>> approveJoin(
+            @PathVariable Long partyId,
+            @Valid @RequestBody PlayerPartyRequest.Approve request
+    );
+
+    @Operation(summary = "가입 거절(리더)")
+    ResponseEntity<ApiResponse<Void>> rejectJoin(
+            @PathVariable Long partyId,
+            @Valid @RequestBody PlayerPartyRequest.Reject request
+    );
+
+    @Operation(summary = "가입 요청 취소(본인)")
+    ResponseEntity<ApiResponse<Void>> cancelJoin(@PathVariable Long partyId);
+
+    @Operation(summary = "리더 위임")
+    ResponseEntity<ApiResponse<Void>> transferLeader(
+            @PathVariable Long partyId,
+            @Valid @RequestBody PlayerPartyRequest.TransferLeader request
+    );
+
+    @Operation(summary = "멤버 강퇴(오피서/리더)")
+    ResponseEntity<ApiResponse<Void>> kick(
+            @PathVariable Long partyId,
+            @Valid @RequestBody PlayerPartyRequest.Kick request
+    );
+
+    @Operation(summary = "오피서 승격(리더)")
+    ResponseEntity<ApiResponse<Void>> promote(
+            @PathVariable Long partyId,
+            @Valid @RequestBody PlayerPartyRequest.MemberOp request
+    );
+
+    @Operation(summary = "멤버 강등(리더)")
+    ResponseEntity<ApiResponse<Void>> demote(
+            @PathVariable Long partyId,
+            @Valid @RequestBody PlayerPartyRequest.MemberOp request
+    );
+
+    @Operation(summary = "파티 탈퇴(본인)")
+    ResponseEntity<ApiResponse<Void>> leave(@PathVariable Long partyId);
+
+    @Operation(summary = "파티 해산(리더)")
+    ResponseEntity<ApiResponse<Void>> disband(@PathVariable Long partyId);
+
+    // 초대
+    @Operation(summary = "파티 초대(오피서/리더)")
+    ResponseEntity<ApiResponse<Void>> invite(
+            @PathVariable Long partyId,
+            @Valid @RequestBody PlayerPartyRequest.Invite request
+    );
+
+    @Operation(summary = "초대 수락")
+    ResponseEntity<ApiResponse<Void>> acceptInvitation(@PathVariable Long partyId);
+
+    @Operation(summary = "초대 거절")
+    ResponseEntity<ApiResponse<Void>> declineInvitation(@PathVariable Long partyId);
+
+    // 조회
+    @Operation(summary = "최근 파티 조회")
+    ResponseEntity<ApiResponse<List<PlayerPartyResponse.Summary>>> recent(
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) Integer limit
+    );
+
+    @Operation(summary = "파티 검색")
+    ResponseEntity<ApiResponse<PlayerPartyResponse.Page<PlayerPartyResponse.Summary>>> search(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String visibility,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size
+    );
+
+
+    @Operation(summary = "파티 상세 조회")
+    ResponseEntity<ApiResponse<PlayerPartyResponse.Summary>> getPartyInfo(
+            @PathVariable Long partyId
+    );
+}

--- a/src/main/java/online/lifeasgame/social/application/GuildFacade.java
+++ b/src/main/java/online/lifeasgame/social/application/GuildFacade.java
@@ -104,7 +104,7 @@ public class GuildFacade {
         return guildService.search(keyword, visibility, page, size);
     }
 
-    public GuildResult.Summary getGuild(Long guildId) {
+    public GuildResult.Info getGuild(Long guildId) {
         return guildService.getGuild(player(), guildId);
     }
 

--- a/src/main/java/online/lifeasgame/social/application/GuildReader.java
+++ b/src/main/java/online/lifeasgame/social/application/GuildReader.java
@@ -22,13 +22,14 @@ public class GuildReader {
     private final GuildQueryRepository guildQueryRepository;
 
     public Guild get(Long guildId) {
-        return guildRepository.findById(guildId)
-                .orElseThrow(() -> new DomainException(SocialError.GUILD_NOT_FOUND));
+        return guildRepository.findById(guildId).orElseThrow(() -> new DomainException(SocialError.GUILD_NOT_FOUND));
     }
 
     public Guild getOwned(Long playerId, Long id) {
-        return guildRepository.findByIdAndPlayerId(id, playerId)
-                .orElseThrow(() -> new DomainException(SocialError.GUILD_NOT_FOUND));
+        return guildRepository.findByIdAndPlayerId(
+                id,
+                playerId
+        ).orElseThrow(() -> new DomainException(SocialError.GUILD_NOT_FOUND));
     }
 
     public List<Guild> search(String keyword, String visibility, int page, int size) {
@@ -49,8 +50,10 @@ public class GuildReader {
         return guildQueryRepository.recent(limit);
     }
 
-    public Guild getGuild(Long playerId, Long guildId) {
-        return guildRepository.findByIdAndPlayerId(playerId, guildId)
-                .orElseThrow(() -> new DomainException(SocialError.GUILD_NOT_FOUND));
+    public Guild getGuild(Long playerId, Long id) {
+        return guildRepository.findByIdAndPlayerId(
+                id,
+                playerId
+        ).orElseThrow(() -> new DomainException(SocialError.GUILD_NOT_FOUND));
     }
 }

--- a/src/main/java/online/lifeasgame/social/application/GuildService.java
+++ b/src/main/java/online/lifeasgame/social/application/GuildService.java
@@ -163,9 +163,9 @@ public class GuildService {
         return guildReader.recent(limit).stream().map(GuildResult.Summary::from).toList();
     }
 
-    public GuildResult.Summary getGuild(Long playerId, Long id) {
+    public GuildResult.Info getGuild(Long playerId, Long id) {
         Guild guild = guildReader.getGuild(playerId, id);
-        return GuildResult.Summary.from(guild);
+        return GuildResult.Info.from(guild);
     }
 
     private static void ensureLeader(Guild g, Long actorId) {

--- a/src/main/java/online/lifeasgame/social/application/PartyFacade.java
+++ b/src/main/java/online/lifeasgame/social/application/PartyFacade.java
@@ -37,7 +37,7 @@ public class PartyFacade {
     }
 
     public PartyResult.Info changeBanner(Long partyId, PartyCommand.ChangeEmblem c) {
-        return partyService.changeEmblem(player(), partyId, c);
+        return partyService.changeBanner(player(), partyId, c);
     }
 
     public PartyResult.Info addTag(Long partyId, PartyCommand.TagOp c) {
@@ -104,7 +104,7 @@ public class PartyFacade {
         return partyService.search(keyword, visibility, page, size);
     }
 
-    public PartyResult.Summary getParty(Long partyId) {
+    public PartyResult.Info getParty(Long partyId) {
         return partyService.getParty(player(), partyId);
     }
 

--- a/src/main/java/online/lifeasgame/social/application/PartyFacade.java
+++ b/src/main/java/online/lifeasgame/social/application/PartyFacade.java
@@ -1,0 +1,114 @@
+package online.lifeasgame.social.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.social.application.command.PartyCommand;
+import online.lifeasgame.social.application.result.PartyResult;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+
+@Component
+@RequiredArgsConstructor
+public class PartyFacade {
+
+    private final PartyService partyService;
+    private final CurrentPlayerAccessor currentPlayerAccessor;
+
+    private Long player() {
+        return currentPlayerAccessor.currentPlayerIdOrThrow();
+    }
+
+    public PartyResult.Info create(PartyCommand.Create c) {
+        return partyService.create(player(), c);
+    }
+
+    public PartyResult.Info rename(Long partyId, PartyCommand.Rename c) {
+        return partyService.rename(player(), partyId, c);
+    }
+
+    public PartyResult.Info changePolicy(Long partyId, PartyCommand.ChangePolicy c) {
+        return partyService.changePolicy(player(), partyId, c);
+    }
+
+    public PartyResult.Info changeDescription(Long partyId, PartyCommand.ChangeDescription c) {
+        return partyService.changeDescription(player(), partyId, c);
+    }
+
+    public PartyResult.Info changeBanner(Long partyId, PartyCommand.ChangeEmblem c) {
+        return partyService.changeEmblem(player(), partyId, c);
+    }
+
+    public PartyResult.Info addTag(Long partyId, PartyCommand.TagOp c) {
+        return partyService.addTag(player(), partyId, c);
+    }
+
+    public PartyResult.Info removeTag(Long partyId, PartyCommand.TagOp c) {
+        return partyService.removeTag(player(), partyId, c);
+    }
+
+    public void requestJoin(Long partyId, PartyCommand.RequestJoin c) {
+        partyService.requestJoin(player(), partyId, c);
+    }
+
+    public void approveJoin(Long partyId, PartyCommand.Approve c) {
+        partyService.approveJoin(player(), partyId, c);
+    }
+
+    public void rejectJoin(Long partyId, PartyCommand.Reject c) {
+        partyService.rejectJoin(player(), partyId, c);
+    }
+
+    public void cancelJoin(Long partyId) {
+        partyService.cancelJoin(player(), partyId);
+    }
+
+    public void transferLeader(Long partyId, PartyCommand.TransferLeader c) {
+        partyService.transferLeader(player(), partyId, c);
+    }
+
+    public void kick(Long partyId, PartyCommand.Kick c) {
+        partyService.kick(player(), partyId, c);
+    }
+
+    public void promote(Long partyId, PartyCommand.Promote c) {
+        partyService.promote(player(), partyId, c);
+    }
+
+    public void demote(Long partyId, PartyCommand.Demote c) {
+        partyService.demote(player(), partyId, c);
+    }
+
+    public void leave(Long partyId) {
+        partyService.leave(player(), partyId);
+    }
+
+    public void disband(Long partyId) {
+        partyService.disbandByLeader(player(), partyId);
+    }
+
+    public void invite(Long partyId, PartyCommand.Invite c) {
+        partyService.invite(player(), partyId, c);
+    }
+
+    public void acceptInvitation(Long partyId) {
+        partyService.acceptInvitation(player(), partyId);
+    }
+
+    public void declineInvitation(Long partyId) {
+        partyService.declineInvitation(player(), partyId);
+    }
+
+    public PartyResult.Page<PartyResult.Summary> search(String keyword, String visibility, int page, int size) {
+        return partyService.search(keyword, visibility, page, size);
+    }
+
+    public PartyResult.Summary getParty(Long partyId) {
+        return partyService.getParty(player(), partyId);
+    }
+
+    public List<PartyResult.Summary> recent(int limit) {
+        return partyService.recent(limit);
+    }
+}

--- a/src/main/java/online/lifeasgame/social/application/PartyReader.java
+++ b/src/main/java/online/lifeasgame/social/application/PartyReader.java
@@ -25,7 +25,7 @@ public class PartyReader {
         return partyRepository.findById(id).orElseThrow(() -> new DomainException(SocialError.PARTY_NOT_FOUND));
     }
 
-    public Party getOwned(Long playerId, Long id) {
+    public Party getParty(Long playerId, Long id) {
         return partyRepository.findByIdAndPlayerId(
                 id,
                 playerId
@@ -48,12 +48,5 @@ public class PartyReader {
 
     public List<Party> recent(int limit) {
         return partyQueryRepository.recent(limit);
-    }
-
-    public Party getParty(Long playerId, Long id) {
-        return partyRepository.findByIdAndPlayerId(
-                id,
-                playerId
-        ).orElseThrow(() -> new DomainException(SocialError.PARTY_NOT_FOUND));
     }
 }

--- a/src/main/java/online/lifeasgame/social/application/PartyReader.java
+++ b/src/main/java/online/lifeasgame/social/application/PartyReader.java
@@ -1,0 +1,59 @@
+package online.lifeasgame.social.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.social.application.query.PartyQueryRepository;
+import online.lifeasgame.social.domain.Party;
+import online.lifeasgame.social.domain.PartyVisibility;
+import online.lifeasgame.social.domain.error.SocialError;
+import online.lifeasgame.social.domain.repository.PartyRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+public class PartyReader {
+
+    private final PartyRepository partyRepository;
+    private final PartyQueryRepository partyQueryRepository;
+
+    public Party get(Long id) {
+        return partyRepository.findById(id).orElseThrow(() -> new DomainException(SocialError.PARTY_NOT_FOUND));
+    }
+
+    public Party getOwned(Long playerId, Long id) {
+        return partyRepository.findByIdAndPlayerId(
+                id,
+                playerId
+        ).orElseThrow(() -> new DomainException(SocialError.PARTY_NOT_FOUND));
+    }
+
+    public List<Party> search(String keyword, String visibility, int page, int size) {
+        PartyVisibility vis = parseVisibility(visibility);
+        return partyQueryRepository.search(keyword, vis, page, size);
+    }
+
+    public long countSearch(String keyword, String visibility) {
+        PartyVisibility vis = parseVisibility(visibility);
+        return partyQueryRepository.countSearch(keyword, vis);
+    }
+
+    private PartyVisibility parseVisibility(String visibility) {
+        return (visibility == null || visibility.isBlank()) ? null : PartyVisibility.valueOf(visibility);
+    }
+
+    public List<Party> recent(int limit) {
+        return partyQueryRepository.recent(limit);
+    }
+
+    public Party getParty(Long playerId, Long id) {
+        return partyRepository.findByIdAndPlayerId(
+                id,
+                playerId
+        ).orElseThrow(() -> new DomainException(SocialError.PARTY_NOT_FOUND));
+    }
+}

--- a/src/main/java/online/lifeasgame/social/application/PartyService.java
+++ b/src/main/java/online/lifeasgame/social/application/PartyService.java
@@ -30,37 +30,37 @@ public class PartyService {
 
     @Transactional
     public PartyResult.Info rename(Long playerId, Long id, PartyCommand.Rename c) {
-        Party party = partyReader.getOwned(playerId, id);
+        Party party = partyReader.getParty(playerId, id);
         return PartyResult.Info.from(partyWriter.rename(party, c));
     }
 
     @Transactional
     public PartyResult.Info changePolicy(Long playerId, Long id, PartyCommand.ChangePolicy c) {
-        Party party = partyReader.getOwned(playerId, id);
+        Party party = partyReader.getParty(playerId, id);
         return PartyResult.Info.from(partyWriter.changePolicy(party, c));
     }
 
     @Transactional
     public PartyResult.Info changeDescription(Long playerId, Long id, PartyCommand.ChangeDescription c) {
-        Party party = partyReader.getOwned(playerId, id);
+        Party party = partyReader.getParty(playerId, id);
         return PartyResult.Info.from(partyWriter.changeDescription(party, c));
     }
 
     @Transactional
-    public PartyResult.Info changeEmblem(Long playerId, Long id, PartyCommand.ChangeEmblem c) {
-        Party party = partyReader.getOwned(playerId, id);
+    public PartyResult.Info changeBanner(Long playerId, Long id, PartyCommand.ChangeEmblem c) {
+        Party party = partyReader.getParty(playerId, id);
         return PartyResult.Info.from(partyWriter.changeBanner(party, c));
     }
 
     @Transactional
     public PartyResult.Info addTag(Long playerId, Long id, PartyCommand.TagOp c) {
-        Party party = partyReader.getOwned(playerId, id);
+        Party party = partyReader.getParty(playerId, id);
         return PartyResult.Info.from(partyWriter.addTag(party, c));
     }
 
     @Transactional
     public PartyResult.Info removeTag(Long playerId, Long id, PartyCommand.TagOp c) {
-        Party party = partyReader.getOwned(playerId, id);
+        Party party = partyReader.getParty(playerId, id);
         return PartyResult.Info.from(partyWriter.removeTag(party, c));
     }
 
@@ -163,9 +163,9 @@ public class PartyService {
         return partyReader.recent(limit).stream().map(PartyResult.Summary::from).toList();
     }
 
-    public PartyResult.Summary getParty(Long playerId, Long id) {
+    public PartyResult.Info getParty(Long playerId, Long id) {
         Party party = partyReader.getParty(playerId, id);
-        return PartyResult.Summary.from(party);
+        return PartyResult.Info.from(party);
     }
 
     private static void ensureLeader(Party party, Long actorId) {

--- a/src/main/java/online/lifeasgame/social/application/PartyService.java
+++ b/src/main/java/online/lifeasgame/social/application/PartyService.java
@@ -1,0 +1,184 @@
+package online.lifeasgame.social.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.social.application.command.PartyCommand;
+import online.lifeasgame.social.application.model.PartySpec;
+import online.lifeasgame.social.application.result.PartyResult;
+import online.lifeasgame.social.domain.Party;
+import online.lifeasgame.social.domain.PartyMemberRole;
+import online.lifeasgame.social.domain.error.SocialError;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+public class PartyService {
+
+    private final PartyReader partyReader;
+    private final PartyWriter partyWriter;
+
+    @Transactional
+    public PartyResult.Info create(Long playerId, PartyCommand.Create c) {
+        Party saved = partyWriter.create(PartySpec.Create.from(playerId, c));
+        return PartyResult.Info.from(saved);
+    }
+
+    @Transactional
+    public PartyResult.Info rename(Long playerId, Long id, PartyCommand.Rename c) {
+        Party party = partyReader.getOwned(playerId, id);
+        return PartyResult.Info.from(partyWriter.rename(party, c));
+    }
+
+    @Transactional
+    public PartyResult.Info changePolicy(Long playerId, Long id, PartyCommand.ChangePolicy c) {
+        Party party = partyReader.getOwned(playerId, id);
+        return PartyResult.Info.from(partyWriter.changePolicy(party, c));
+    }
+
+    @Transactional
+    public PartyResult.Info changeDescription(Long playerId, Long id, PartyCommand.ChangeDescription c) {
+        Party party = partyReader.getOwned(playerId, id);
+        return PartyResult.Info.from(partyWriter.changeDescription(party, c));
+    }
+
+    @Transactional
+    public PartyResult.Info changeEmblem(Long playerId, Long id, PartyCommand.ChangeEmblem c) {
+        Party party = partyReader.getOwned(playerId, id);
+        return PartyResult.Info.from(partyWriter.changeBanner(party, c));
+    }
+
+    @Transactional
+    public PartyResult.Info addTag(Long playerId, Long id, PartyCommand.TagOp c) {
+        Party party = partyReader.getOwned(playerId, id);
+        return PartyResult.Info.from(partyWriter.addTag(party, c));
+    }
+
+    @Transactional
+    public PartyResult.Info removeTag(Long playerId, Long id, PartyCommand.TagOp c) {
+        Party party = partyReader.getOwned(playerId, id);
+        return PartyResult.Info.from(partyWriter.removeTag(party, c));
+    }
+
+    // 가입/권한
+    @Transactional
+    public void requestJoin(Long playerId, Long id, PartyCommand.RequestJoin c) {
+        Party party = partyReader.get(id);
+        partyWriter.requestJoin(party, playerId, c);
+    }
+
+    @Transactional
+    public void approveJoin(Long playerId, Long id, PartyCommand.Approve c) {
+        Party party = partyReader.get(id);
+        ensureLeader(party, playerId);
+        partyWriter.approveJoin(party, c);
+    }
+
+    @Transactional
+    public void rejectJoin(Long playerId, Long id, PartyCommand.Reject c) {
+        Party party = partyReader.get(id);
+        ensureLeader(party, playerId);
+        partyWriter.rejectJoin(party, c);
+    }
+
+    @Transactional
+    public void cancelJoin(Long playerId, Long id) {
+        Party party = partyReader.get(id);
+        partyWriter.cancelJoin(party, playerId);
+    }
+
+    @Transactional
+    public void transferLeader(Long playerId, Long id, PartyCommand.TransferLeader c) {
+        Party party = partyReader.get(id);
+        ensureLeader(party, playerId);
+        partyWriter.transferLeader(party, c);
+    }
+
+    @Transactional
+    public void kick(Long playerId, Long id, PartyCommand.Kick c) {
+        Party party = partyReader.get(id);
+        ensureLeaderOrOfficer(party, playerId);
+        partyWriter.kick(party, c);
+    }
+
+    @Transactional
+    public void promote(Long playerId, Long id, PartyCommand.Promote c) {
+        Party party = partyReader.get(id);
+        ensureLeader(party, playerId);
+        partyWriter.promote(party, c);
+    }
+
+    @Transactional
+    public void demote(Long playerId, Long id, PartyCommand.Demote c) {
+        Party party = partyReader.get(id);
+        ensureLeader(party, playerId);
+        partyWriter.demote(party, c);
+    }
+
+    @Transactional
+    public void leave(Long playerId, Long id) {
+        Party party = partyReader.get(id);
+        partyWriter.leave(party, playerId);
+    }
+
+    @Transactional
+    public void disbandByLeader(Long playerId, Long id) {
+        Party party = partyReader.get(id);
+        ensureLeader(party, playerId);
+        partyWriter.disbandByLeader(party, playerId);
+    }
+
+    // 초대
+    @Transactional
+    public void invite(Long playerId, Long id, PartyCommand.Invite c) {
+        Party party = partyReader.get(id);
+        ensureLeaderOrOfficer(party, playerId);
+        partyWriter.invite(party, playerId, c);
+    }
+
+    @Transactional
+    public void acceptInvitation(Long playerId, Long id) {
+        Party party = partyReader.get(id);
+        partyWriter.acceptInvitation(party, playerId);
+    }
+
+    @Transactional
+    public void declineInvitation(Long playerId, Long id) {
+        Party party = partyReader.get(id);
+        partyWriter.declineInvitation(party, playerId);
+    }
+
+    public PartyResult.Page<PartyResult.Summary> search(String keyword, String visibility, int page, int size) {
+        List<Party> domains = partyReader.search(keyword, visibility, page, size);
+        long total = partyReader.countSearch(keyword, visibility);
+        List<PartyResult.Summary> contents = domains.stream().map(PartyResult.Summary::from).toList();
+        return PartyResult.Page.of(contents, page, size, total);
+    }
+
+    public List<PartyResult.Summary> recent(int limit) {
+        return partyReader.recent(limit).stream().map(PartyResult.Summary::from).toList();
+    }
+
+    public PartyResult.Summary getParty(Long playerId, Long id) {
+        Party party = partyReader.getParty(playerId, id);
+        return PartyResult.Summary.from(party);
+    }
+
+    private static void ensureLeader(Party party, Long actorId) {
+        var me = party.findMember(actorId).orElseThrow(() -> new DomainException(SocialError.NOT_MEMBER));
+        if (me.getRole() != PartyMemberRole.LEADER) {
+            throw new DomainException(SocialError.LEADER_ONLY);
+        }
+    }
+
+    private static void ensureLeaderOrOfficer(Party party, Long actorId) {
+        var me = party.findMember(actorId).orElseThrow(() -> new DomainException(SocialError.NOT_MEMBER));
+        if (me.getRole() == PartyMemberRole.MEMBER) {
+            throw new DomainException(SocialError.OFFICER_OR_LEADER_ONLY);
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/social/application/PartyWriter.java
+++ b/src/main/java/online/lifeasgame/social/application/PartyWriter.java
@@ -29,8 +29,8 @@ public class PartyWriter {
                 spec.name(),
                 spec.code(),
                 spec.descriptionMd(),
-                spec.emblemImageUrl(),
-                spec.emblemBgColor(),
+                spec.bannerImageUrl(),
+                spec.bannerBgColor(),
                 spec.visibility(),
                 spec.joinPolicy(),
                 spec.maxMembers()

--- a/src/main/java/online/lifeasgame/social/application/PartyWriter.java
+++ b/src/main/java/online/lifeasgame/social/application/PartyWriter.java
@@ -1,0 +1,143 @@
+package online.lifeasgame.social.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.social.application.command.PartyCommand;
+import online.lifeasgame.social.application.model.PartySpec;
+import online.lifeasgame.social.domain.Party;
+import online.lifeasgame.social.domain.PartyJoinPolicy;
+import online.lifeasgame.social.domain.PartyVisibility;
+import online.lifeasgame.social.domain.error.SocialError;
+import online.lifeasgame.social.domain.repository.PartyRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.MANDATORY)
+public class PartyWriter {
+
+    private final PartyRepository partyRepository;
+
+    public Party create(PartySpec.Create spec) {
+        return partyRepository.save(Party.create(
+                spec.playerId(),
+                spec.name(),
+                spec.code(),
+                spec.descriptionMd(),
+                spec.emblemImageUrl(),
+                spec.emblemBgColor(),
+                spec.visibility(),
+                spec.joinPolicy(),
+                spec.maxMembers()
+        ));
+    }
+
+    public Party rename(Party party, PartyCommand.Rename c) {
+        party.rename(c.name());
+        return party;
+    }
+
+    public Party changePolicy(Party party, PartyCommand.ChangePolicy c) {
+        if (c.visibility() != null) {
+            party.changeVisibility(PartyVisibility.valueOf(c.visibility()));
+        }
+        if (c.joinPolicy() != null) {
+            party.changeJoinPolicy(PartyJoinPolicy.valueOf(c.joinPolicy()));
+        }
+        if (c.maxMembers() > 0) {
+            party.changeMaxMembers(c.maxMembers());
+        }
+        return party;
+    }
+
+    public Party changeDescription(Party party, PartyCommand.ChangeDescription c) {
+        party.updateDescription(c.descriptionMd());
+        return party;
+    }
+
+    public Party changeBanner(Party party, PartyCommand.ChangeEmblem c) {
+        party.updateBanner(c.emblemImageUrl(), c.emblemBgColor());
+        return party;
+    }
+
+    public Party addTag(Party party, PartyCommand.TagOp c) {
+        party.addTag(c.tag());
+        return party;
+    }
+
+    public Party removeTag(Party party, PartyCommand.TagOp c) {
+        party.removeTag(c.tag());
+        return party;
+    }
+
+    // 가입/권한
+    public void requestJoin(Party party, Long applicantId, PartyCommand.RequestJoin c) {
+        party.requestJoin(applicantId, c.message());
+    }
+
+    public void approveJoin(Party party, PartyCommand.Approve c) {
+        party.approveJoin(c.applicantPlayerId());
+    }
+
+    public void rejectJoin(Party party, PartyCommand.Reject c) {
+        party.rejectJoin(c.applicantPlayerId());
+    }
+
+    public void cancelJoin(Party party, Long playerId) {
+        party.cancelJoinRequest(playerId);
+    }
+
+    public void transferLeader(Party party, PartyCommand.TransferLeader c) {
+        party.transferLeadership(c.fromLeaderPlayerId(), c.toPlayerId());
+    }
+
+    public void kick(Party party, PartyCommand.Kick c) {
+        party.kickMember(c.targetPlayerId());
+    }
+
+    public void promote(Party party, PartyCommand.Promote c) {
+        party.promoteOfficer(party.getLeaderPlayerId(), c.targetPlayerId());
+    }
+
+    public void demote(Party party, PartyCommand.Demote c) {
+        party.demoteToMember(party.getLeaderPlayerId(), c.targetPlayerId());
+    }
+
+    public void leave(Party party, Long playerId) {
+        party.leave(playerId);
+    }
+
+    public void disbandByLeader(Party party, Long leaderId) {
+        party.disbandByLeader(leaderId);
+    }
+
+    // 초대
+    public void invite(Party Party, Long inviterId, PartyCommand.Invite c) {
+        Party.invite(inviterId, c.inviteePlayerId(), c.message(), parseDateTime(c.expiresAtIso()));
+    }
+
+    public void acceptInvitation(Party Party, Long playerId) {
+        Party.acceptInvitation(playerId);
+    }
+
+    public void declineInvitation(Party Party, Long playerId) {
+        Party.declineInvitation(playerId);
+    }
+
+    private static LocalDateTime parseDateTime(String iso) {
+        if (iso == null || iso.isBlank()) {
+            return null;
+        }
+
+        try {
+            return LocalDateTime.parse(iso);
+        } catch (DateTimeParseException e) {
+            throw new DomainException(SocialError.INVALID_STATE, "INVALID_EXPIRES_AT");
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/social/application/command/PartyCommand.java
+++ b/src/main/java/online/lifeasgame/social/application/command/PartyCommand.java
@@ -1,0 +1,115 @@
+package online.lifeasgame.social.application.command;
+
+
+public final class PartyCommand {
+    public record Create(
+            String name,
+            String code,
+            String descriptionMd,
+            String bannerImageUrl,
+            String bannerBgColor,
+            String visibility,
+            String joinPolicy,
+            int maxMembers
+    ) {
+        public static Create of(
+                String name,
+                String code,
+                String descriptionMd,
+                String bannerImageUrl,
+                String bannerBgColor,
+                String visibility,
+                String joinPolicy,
+                int maxMembers
+        ) {
+            return new Create(
+                    name,
+                    code,
+                    descriptionMd,
+                    bannerImageUrl,
+                    bannerBgColor,
+                    visibility,
+                    joinPolicy,
+                    maxMembers
+            );
+        }
+    }
+
+    public record Rename(String name) {
+        public static Rename of(String name) {
+            return new Rename(name);
+        }
+    }
+
+    public record ChangePolicy(String visibility, String joinPolicy, int maxMembers) {
+        public static ChangePolicy of(String v, String j, int m) {
+            return new ChangePolicy(v, j, m);
+        }
+    }
+
+    public record ChangeDescription(String descriptionMd) {
+        public static ChangeDescription of(String d) {
+            return new ChangeDescription(d);
+        }
+    }
+
+    public record ChangeEmblem(String emblemImageUrl, String emblemBgColor) {
+        public static ChangeEmblem of(String u, String bg) {
+            return new ChangeEmblem(u, bg);
+        }
+    }
+
+    public record TagOp(String tag) {
+        public static TagOp of(String t) {
+            return new TagOp(t);
+        }
+    }
+
+    public record RequestJoin(String message) {
+        public static RequestJoin of(String m) {
+            return new RequestJoin(m);
+        }
+    }
+
+    public record Approve(Long applicantPlayerId) {
+        public static Approve of(Long id) {
+            return new Approve(id);
+        }
+    }
+
+    public record Reject(Long applicantPlayerId) {
+        public static Reject of(Long id) {
+            return new Reject(id);
+        }
+    }
+
+    public record TransferLeader(Long fromLeaderPlayerId, Long toPlayerId) {
+        public static TransferLeader of(Long f, Long t) {
+            return new TransferLeader(f, t);
+        }
+    }
+
+    public record Kick(Long targetPlayerId) {
+        public static Kick of(Long id) {
+            return new Kick(id);
+        }
+    }
+
+    public record Promote(Long targetPlayerId) {
+        public static Promote of(Long id) {
+            return new Promote(id);
+        }
+    }
+
+    public record Demote(Long targetPlayerId) {
+        public static Demote of(Long id) {
+            return new Demote(id);
+        }
+    }
+
+    public record Invite(Long inviteePlayerId, String message, String expiresAtIso) {
+        public static Invite of(Long id, String m, String at) {
+            return new Invite(id, m, at);
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/social/application/model/PartySpec.java
+++ b/src/main/java/online/lifeasgame/social/application/model/PartySpec.java
@@ -1,0 +1,34 @@
+package online.lifeasgame.social.application.model;
+
+
+import online.lifeasgame.social.application.command.PartyCommand;
+import online.lifeasgame.social.domain.PartyJoinPolicy;
+import online.lifeasgame.social.domain.PartyVisibility;
+
+public final class PartySpec {
+    public record Create(
+            Long playerId,
+            String name,
+            String code,
+            String descriptionMd,
+            String emblemImageUrl,
+            String emblemBgColor,
+            PartyVisibility visibility,
+            PartyJoinPolicy joinPolicy,
+            int maxMembers
+    ) {
+        public static Create from(Long playerId, PartyCommand.Create c) {
+            return new Create(
+                    playerId,
+                    c.name(),
+                    c.code(),
+                    c.descriptionMd(),
+                    c.bannerImageUrl(),
+                    c.bannerBgColor(),
+                    c.visibility() == null ? null : PartyVisibility.valueOf(c.visibility()),
+                    c.joinPolicy() == null ? null : PartyJoinPolicy.valueOf(c.joinPolicy()),
+                    c.maxMembers()
+            );
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/social/application/model/PartySpec.java
+++ b/src/main/java/online/lifeasgame/social/application/model/PartySpec.java
@@ -11,8 +11,8 @@ public final class PartySpec {
             String name,
             String code,
             String descriptionMd,
-            String emblemImageUrl,
-            String emblemBgColor,
+            String bannerImageUrl,
+            String bannerBgColor,
             PartyVisibility visibility,
             PartyJoinPolicy joinPolicy,
             int maxMembers

--- a/src/main/java/online/lifeasgame/social/application/query/PartyQueryRepository.java
+++ b/src/main/java/online/lifeasgame/social/application/query/PartyQueryRepository.java
@@ -1,0 +1,14 @@
+package online.lifeasgame.social.application.query;
+
+import online.lifeasgame.social.domain.Party;
+import online.lifeasgame.social.domain.PartyVisibility;
+
+import java.util.List;
+
+public interface PartyQueryRepository {
+    List<Party> search(String keyword, PartyVisibility visibility, int page, int size);
+
+    long countSearch(String keyword, PartyVisibility visibility);
+
+    List<Party> recent(int limit);
+}

--- a/src/main/java/online/lifeasgame/social/application/result/PartyResult.java
+++ b/src/main/java/online/lifeasgame/social/application/result/PartyResult.java
@@ -1,0 +1,76 @@
+package online.lifeasgame.social.application.result;
+
+import online.lifeasgame.social.domain.Party;
+
+import java.time.Instant;
+import java.util.List;
+
+public final class PartyResult {
+
+    public record Summary(
+            Long id,
+            String name,
+            String code,
+            String visibility,
+            String joinPolicy,
+            String status,
+            int maxMembers
+    ) {
+        public static Summary from(Party g) {
+            return new Summary(
+                    g.getId(),
+                    g.getName().getOriginal(),
+                    g.getCode().getValue(),
+                    g.getVisibility().name(),
+                    g.getJoinPolicy().name(),
+                    g.getStatus().name(),
+                    g.getMaxMembers()
+            );
+        }
+    }
+
+    public record Info(
+            Long id,
+            Long playerId,
+            String name,
+            String code,
+            String visibility,
+            String joinPolicy,
+            String status,
+            int maxMembers,
+            List<String> tags,
+            String descriptionMd,
+            String bannerImageUrl,
+            String bannerBgColor,
+            Long leaderPlayerId,
+            Instant createdAt,
+            Instant updatedAt
+    ) {
+        public static Info from(Party g) {
+            return new Info(
+                    g.getId(),
+                    g.getPlayerId(),
+                    g.getName().getOriginal(),
+                    g.getCode().getValue(),
+                    g.getVisibility().name(),
+                    g.getJoinPolicy().name(),
+                    g.getStatus().name(),
+                    g.getMaxMembers(),
+                    g.getTags().stream().toList(),
+                    g.getDescription() == null ? null : g.getDescription().getMd(),
+                    g.getBanner() == null ? null : g.getBanner().getImageUrl(),
+                    g.getBanner() == null ? null : g.getBanner().getBgColor(),
+                    g.getLeaderPlayerId(),
+                    g.getCreatedAt(),
+                    g.getUpdatedAt()
+            );
+        }
+    }
+    
+    public record Page<T>(List<T> contents, int page, int size, long totalElements, int totalPages) {
+        public static <T> Page<T> of(List<T> contents, int page, int size, long totalElements) {
+            int totalPages = (int) Math.ceil(totalElements / (double) Math.max(size, 1));
+            return new Page<>(contents, page, size, totalElements, totalPages);
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/social/domain/Party.java
+++ b/src/main/java/online/lifeasgame/social/domain/Party.java
@@ -1,74 +1,288 @@
 package online.lifeasgame.social.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import jakarta.persistence.Version;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import online.lifeasgame.core.annotation.AggregateRoot;
-import online.lifeasgame.platform.persistence.jpa.AbstractTime;
+import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.core.guard.Guard;
+import online.lifeasgame.platform.persistence.jpa.AbstractTime;
+import online.lifeasgame.social.domain.error.SocialError;
+import org.hibernate.annotations.BatchSize;
 
-@Entity
-@AggregateRoot
-@Table(name = "parties")
+import java.time.LocalDateTime;
+import java.util.*;
+
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AggregateRoot
+@Entity(name = "Party")
+@Table(name = "parties")
 public class Party extends AbstractTime {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "party_id")
     private Long id;
 
-    @Column(length = 60, nullable = false)
-    private String name;
+    // 소유자(간접참조): 파티 리더 == 생성자
+    @Column(name = "player_id", nullable = false)
+    private Long playerId;
 
-    @Column(name = "leader_id", nullable = false)
-    private Long leaderId;
+    @Column(name = "leader_player_id", nullable = false)
+    private Long leaderPlayerId;
 
-    @Column(name = "capacity", nullable = false)
-    private int capacity = 4;
+    @Embedded
+    private PartyName name;
+
+    @Embedded
+    private PartyCode code;
+
+    @Embedded
+    private PartyDescription description;
+
+    @Embedded
+    private PartyBanner banner;
 
     @Enumerated(EnumType.STRING)
-    @Column(length = 20, nullable = false)
-    private PartyState state = PartyState.OPEN;
+    @Column(name = "visibility", nullable = false, length = 32)
+    private PartyVisibility visibility;
 
-    @Version
-    private Long version;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "join_policy", nullable = false, length = 32)
+    private PartyJoinPolicy joinPolicy;
 
-    private Party(String name, Long leaderId, int capacity) {
-        rename(name);
-        this.leaderId = leaderId;
-        changeCapacity(capacity);
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private PartyStatus status;
+
+    @Column(name = "max_members", nullable = false)
+    private int maxMembers;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "party_tags", joinColumns = @JoinColumn(name = "party_id"))
+    @Column(name = "tag_value", nullable = false, length = 64)
+    @BatchSize(size = 100)
+    private Set<String> tags = new HashSet<>();
+
+    @OneToMany(mappedBy = "party", cascade = CascadeType.ALL, orphanRemoval = true)
+    @BatchSize(size = 100)
+    private List<PartyMember> members = new ArrayList<>();
+
+    @OneToMany(mappedBy = "party", cascade = CascadeType.ALL, orphanRemoval = true)
+    @BatchSize(size = 100)
+    private List<PartyWaitMember> waitMembers = new ArrayList<>();
+
+    // 생성 팩토리
+    public static Party create(
+            Long playerId,
+            String name,
+            String code,
+            String descriptionMd,
+            String bannerImageUrl,
+            String bannerBgColor,
+            PartyVisibility visibility,
+            PartyJoinPolicy joinPolicy,
+            int maxMembers
+    ) {
+        Guard.notNull(playerId, "playerId");
+        Guard.notBlank(name, "name");
+        Guard.notBlank(code, "code");
+        Guard.minValue(maxMembers, 1, "maxMembers");
+        Guard.notNull(visibility, "visibility");
+        Guard.notNull(joinPolicy, "joinPolicy");
+
+        Party p = new Party();
+        p.playerId = playerId;
+        p.name = PartyName.of(name);
+        p.code = PartyCode.of(code);
+        p.description = PartyDescription.of(descriptionMd);
+        p.banner = PartyBanner.of(bannerImageUrl, bannerBgColor);
+        p.visibility = visibility;
+        p.joinPolicy = joinPolicy;
+        p.status = PartyStatus.ACTIVE;
+        p.maxMembers = maxMembers;
+
+        PartyMember leader = PartyMember.createLeader(p, playerId);
+        p.members.add(leader);
+        p.leaderPlayerId = playerId;
+        return p;
     }
 
-    public static Party create(String name, Long leaderId, int capacity) {
-        Guard.notNull(leaderId, "leaderId");
-        return new Party(name, leaderId, capacity);
+    // ===== 조회 유틸 =====
+    public Optional<PartyMember> findMember(Long playerId) {
+        return members.stream().filter(m -> m.getPlayerId().equals(playerId)).findFirst();
     }
 
+    public Optional<PartyWaitMember> findPendingJoin(Long playerId) {
+        return waitMembers.stream().filter(w -> w.getPlayerId().equals(playerId) &&
+                w.getType() == PartyWaitType.JOIN_REQUEST &&
+                w.getStatus() == PartyWaitStatus.PENDING).findFirst();
+    }
+
+    public Optional<PartyWaitMember> findPendingInvite(Long playerId) {
+        return waitMembers.stream().filter(w -> w.getPlayerId().equals(playerId) &&
+                w.getType() == PartyWaitType.INVITATION &&
+                w.getStatus() == PartyWaitStatus.PENDING).findFirst();
+    }
+
+    public int memberCount() {
+        return (int) members.stream().count();
+    }
+
+    // ===== 기본 변경 =====
     public void rename(String newName) {
-        Guard.notBlank(newName, "new party name");
-        String newPartyName = Guard.maxLength(newName.strip(), 60, "new party name");
-        this.name = newPartyName;
+        Guard.notBlank(newName, "newName");
+        this.name = PartyName.of(newName);
     }
 
-    public void changeLeader(Long newLeader) {
-        Guard.notNull(newLeader, "newLeader");
-        this.leaderId = newLeader;
+    public void changeVisibility(PartyVisibility v) {
+        Guard.notNull(v, "visibility");
+        this.visibility = v;
     }
 
-    public void changeCapacity(int cap){
-        Guard.inRange(cap, 2, 20, "capacity");
-        this.capacity = cap;
+    public void changeJoinPolicy(PartyJoinPolicy p) {
+        Guard.notNull(p, "joinPolicy");
+        this.joinPolicy = p;
     }
 
-    public void disband() {
-        this.state = PartyState.DISBANDED;
+    public void changeMaxMembers(int max) {
+        Guard.minValue(max, 1, "maxMembers");
+        Guard.check(memberCount() <= max, "maxMembers must be >= current members");
+        this.maxMembers = max;
+    }
+
+    public void updateDescription(String md) {
+        this.description = PartyDescription.of(md);
+    }
+
+    public void updateBanner(String imageUrl, String bgColor) {
+        this.banner = PartyBanner.of(imageUrl, bgColor);
+    }
+
+    public void addTag(String tag) {
+        Guard.notBlank(tag, "tag");
+        tags.add(tag.trim());
+    }
+
+    public void removeTag(String tag) {
+        Guard.notBlank(tag, "tag");
+        tags.remove(tag.trim());
+    }
+
+    // ===== 가입/초대 =====
+    public void requestJoin(Long applicantPlayerId, String message) {
+        Guard.notNull(applicantPlayerId, "applicantPlayerId");
+        Guard.checkState(status == PartyStatus.ACTIVE, "party not active");
+        Guard.checkState(joinPolicy != PartyJoinPolicy.INVITE_ONLY, "invite only");
+        Guard.check(findMember(applicantPlayerId).isEmpty(), "already member");
+        Guard.check(findPendingJoin(applicantPlayerId).isEmpty(), "already requested");
+
+        PartyWaitMember wait = PartyWaitMember.joinRequest(this, applicantPlayerId, message);
+        waitMembers.add(wait);
+        if (joinPolicy == PartyJoinPolicy.OPEN) approveJoin(applicantPlayerId);
+    }
+
+    public void cancelJoinRequest(Long playerId) {
+        PartyWaitMember wait = findPendingJoin(playerId).orElseThrow(() -> new IllegalStateException(
+                "join request not found"));
+        wait.cancel();
+    }
+
+    public void approveJoin(Long applicantPlayerId) {
+        Guard.check(memberCount() < maxMembers, "capacity exceeded");
+        PartyWaitMember wait = findPendingJoin(applicantPlayerId).orElseThrow(() -> new IllegalStateException(
+                "join request not found"));
+        wait.approve();
+        Guard.check(findMember(applicantPlayerId).isEmpty(), "already member");
+        members.add(PartyMember.createMember(this, applicantPlayerId));
+    }
+
+    public void rejectJoin(Long applicantPlayerId) {
+        PartyWaitMember wait = findPendingJoin(applicantPlayerId).orElseThrow(() -> new IllegalStateException(
+                "join request not found"));
+        wait.reject();
+    }
+
+    public void invite(Long inviterPlayerId, Long inviteePlayerId, String message, LocalDateTime expiresAt) {
+        Guard.notNull(inviterPlayerId, "inviterPlayerId");
+        Guard.notNull(inviteePlayerId, "inviteePlayerId");
+        Guard.checkState(status == PartyStatus.ACTIVE, "party not active");
+        Guard.check(findMember(inviterPlayerId).isPresent(), "inviter must be member");
+        Guard.check(findMember(inviteePlayerId).isEmpty(), "invitee already member");
+        Guard.check(findPendingInvite(inviteePlayerId).isEmpty(), "already invited");
+
+        waitMembers.add(PartyWaitMember.invitation(this, inviteePlayerId, message, expiresAt));
+    }
+
+    public void acceptInvitation(Long playerId) {
+        Guard.check(memberCount() < maxMembers, "capacity exceeded");
+        PartyWaitMember inv = findPendingInvite(playerId).orElseThrow(() -> new IllegalStateException(
+                "invitation not found"));
+        inv.approve();
+        Guard.check(findMember(playerId).isEmpty(), "already member");
+        members.add(PartyMember.createMember(this, playerId));
+    }
+
+    public void declineInvitation(Long playerId) {
+        PartyWaitMember inv = findPendingInvite(playerId).orElseThrow(() -> new IllegalStateException(
+                "invitation not found"));
+        inv.reject();
+    }
+
+    // ===== 멤버/권한 =====
+    public void transferLeadership(Long fromLeaderPlayerId, Long toPlayerId) {
+        Guard.notNull(fromLeaderPlayerId, "fromLeader");
+        Guard.notNull(toPlayerId, "toPlayerId");
+        Guard.check(fromLeaderPlayerId.equals(leaderPlayerId), "only current leader can transfer");
+
+        PartyMember from = findMember(fromLeaderPlayerId).orElseThrow();
+        PartyMember to = findMember(toPlayerId).orElseThrow(() -> new IllegalStateException("target not member"));
+
+        from.changeRole(PartyMemberRole.MEMBER);
+        to.changeRole(PartyMemberRole.LEADER);
+        this.leaderPlayerId = toPlayerId;
+        this.playerId = toPlayerId;
+    }
+
+    public void promoteOfficer(Long actorId, Long targetPlayerId) {
+        ensureLeaderOrOfficer(actorId);
+        PartyMember target = findMember(targetPlayerId).orElseThrow();
+        target.changeRole(PartyMemberRole.OFFICER);
+    }
+
+    public void demoteToMember(Long actorId, Long targetPlayerId) {
+        ensureLeaderOrOfficer(actorId);
+        PartyMember target = findMember(targetPlayerId).orElseThrow();
+        Guard.checkState(!target.getRole().equals(PartyMemberRole.LEADER), "leader cannot be demoted");
+        target.changeRole(PartyMemberRole.MEMBER);
+    }
+
+    public void kickMember(Long targetPlayerId) {
+        PartyMember target = findMember(targetPlayerId).orElseThrow();
+        Guard.checkState(!target.getRole().equals(PartyMemberRole.LEADER), "cannot kick leader");
+        members.remove(target);
+    }
+
+    public void leave(Long playerId) {
+        PartyMember me = findMember(playerId).orElseThrow(() -> new DomainException(SocialError.NOT_MEMBER));
+        Guard.checkState(!me.getRole().equals(PartyMemberRole.LEADER), "leader cannot leave");
+        members.remove(me);
+    }
+
+    public void disbandByLeader(Long leaderId) {
+        Guard.check(leaderId.equals(leaderPlayerId), "only leader");
+        this.status = PartyStatus.DISBANDED;
+        members.clear();
+        waitMembers.clear();
+    }
+
+    private void ensureLeaderOrOfficer(Long actorId) {
+        PartyMember me = findMember(actorId).orElseThrow(() -> new IllegalStateException("not member"));
+        Guard.checkState(
+                me.getRole() == PartyMemberRole.LEADER || me.getRole() == PartyMemberRole.OFFICER,
+                "officer or leader only"
+        );
     }
 }

--- a/src/main/java/online/lifeasgame/social/domain/Party.java
+++ b/src/main/java/online/lifeasgame/social/domain/Party.java
@@ -220,6 +220,9 @@ public class Party extends AbstractTime {
         Guard.check(memberCount() < maxMembers, "capacity exceeded");
         PartyWaitMember inv = findPendingInvite(playerId).orElseThrow(() -> new IllegalStateException(
                 "invitation not found"));
+        if (inv.getExpiresAt() != null) {
+            Guard.checkState(!inv.isExpired(), "invitation expired");
+        }
         inv.approve();
         Guard.check(findMember(playerId).isEmpty(), "already member");
         members.add(PartyMember.createMember(this, playerId));

--- a/src/main/java/online/lifeasgame/social/domain/PartyBanner.java
+++ b/src/main/java/online/lifeasgame/social/domain/PartyBanner.java
@@ -1,0 +1,26 @@
+package online.lifeasgame.social.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class PartyBanner {
+    @Column(name = "banner_image_url", length = 512)
+    private String imageUrl;
+    @Column(name = "banner_bg_color", length = 16)
+    private String bgColor;
+
+    public static PartyBanner of(String imageUrl, String bgColor) {
+        return new PartyBanner(imageUrl, bgColor);
+    }
+
+    private PartyBanner(String imageUrl, String bgColor) {
+        this.imageUrl = imageUrl;
+        this.bgColor = bgColor;
+    }
+}

--- a/src/main/java/online/lifeasgame/social/domain/PartyCode.java
+++ b/src/main/java/online/lifeasgame/social/domain/PartyCode.java
@@ -1,0 +1,25 @@
+package online.lifeasgame.social.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import online.lifeasgame.core.guard.Guard;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class PartyCode {
+    @Column(name = "code_value", nullable = false, length = 32, unique = true)
+    private String value;
+
+    public static PartyCode of(String code) {
+        Guard.notBlank(code, "code");
+        return new PartyCode(code.trim().toUpperCase());
+    }
+
+    private PartyCode(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/online/lifeasgame/social/domain/PartyDescription.java
+++ b/src/main/java/online/lifeasgame/social/domain/PartyDescription.java
@@ -1,0 +1,23 @@
+package online.lifeasgame.social.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class PartyDescription {
+    @Column(name = "description_md", columnDefinition = "text")
+    private String md;
+
+    public static PartyDescription of(String md) {
+        return new PartyDescription(md == null ? "" : md);
+    }
+
+    private PartyDescription(String md) {
+        this.md = md;
+    }
+}

--- a/src/main/java/online/lifeasgame/social/domain/PartyJoinPolicy.java
+++ b/src/main/java/online/lifeasgame/social/domain/PartyJoinPolicy.java
@@ -1,0 +1,3 @@
+package online.lifeasgame.social.domain;
+
+public enum PartyJoinPolicy {OPEN, APPROVAL, INVITE_ONLY}

--- a/src/main/java/online/lifeasgame/social/domain/PartyMember.java
+++ b/src/main/java/online/lifeasgame/social/domain/PartyMember.java
@@ -1,37 +1,27 @@
 package online.lifeasgame.social.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
-import jakarta.persistence.Version;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import online.lifeasgame.platform.persistence.jpa.AbstractTime;
-import online.lifeasgame.core.guard.Guard;
+
+import java.time.LocalDateTime;
 
 @Getter
-@Entity
-@Table(
-        name = "party_members",
-        uniqueConstraints = @UniqueConstraint(name = "uq_party_member", columnNames = {"party_id", "player_id"}),
-        indexes = @Index(name = "idx_party_member_player", columnList = "player_id")
-)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "PartyMember")
+@Table(
+        name = "party_members", indexes = {
+        @Index(name = "idx_party_member_party", columnList = "party_id"),
+        @Index(name = "idx_party_member_player", columnList = "player_id")
+}
+)
 public class PartyMember extends AbstractTime {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "party_member_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -42,18 +32,31 @@ public class PartyMember extends AbstractTime {
     private Long playerId;
 
     @Enumerated(EnumType.STRING)
-    @Column(length = 20, nullable = false)
-    private PartyRole role = PartyRole.MEMBER;
+    @Column(name = "role", nullable = false, length = 32)
+    private PartyMemberRole role;
 
-    @Version
-    private Long version;
+    @Column(name = "joined_at", nullable = false)
+    private LocalDateTime joinedAt;
 
-    private PartyMember(Party party, Long playerId, PartyRole role) {
-        Guard.notNull(party, "party");
-        Guard.notNull(playerId, "playerId");
-        Guard.minValue(playerId, 1, "playerId");
-        this.party = party;
-        this.playerId = playerId;
-        this.role = role == null ? PartyRole.MEMBER : role;
+    public static PartyMember createLeader(Party party, Long playerId) {
+        PartyMember m = new PartyMember();
+        m.party = party;
+        m.playerId = playerId;
+        m.role = PartyMemberRole.LEADER;
+        m.joinedAt = LocalDateTime.now();
+        return m;
+    }
+
+    public static PartyMember createMember(Party party, Long playerId) {
+        PartyMember m = new PartyMember();
+        m.party = party;
+        m.playerId = playerId;
+        m.role = PartyMemberRole.MEMBER;
+        m.joinedAt = LocalDateTime.now();
+        return m;
+    }
+
+    public void changeRole(PartyMemberRole role) {
+        this.role = role;
     }
 }

--- a/src/main/java/online/lifeasgame/social/domain/PartyMemberRole.java
+++ b/src/main/java/online/lifeasgame/social/domain/PartyMemberRole.java
@@ -1,0 +1,5 @@
+package online.lifeasgame.social.domain;
+
+public enum PartyMemberRole {
+    LEADER, OFFICER, MEMBER
+}

--- a/src/main/java/online/lifeasgame/social/domain/PartyName.java
+++ b/src/main/java/online/lifeasgame/social/domain/PartyName.java
@@ -21,6 +21,7 @@ public class PartyName {
 
     public static PartyName of(String original) {
         Guard.notBlank(original, "name");
+        Guard.maxLength(original, 128, "name");
         String norm = original.trim();
         return new PartyName(norm.toLowerCase(), norm);
     }

--- a/src/main/java/online/lifeasgame/social/domain/PartyName.java
+++ b/src/main/java/online/lifeasgame/social/domain/PartyName.java
@@ -1,0 +1,32 @@
+package online.lifeasgame.social.domain;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import online.lifeasgame.core.guard.Guard;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class PartyName {
+
+    @Column(name = "name_value", nullable = false, length = 128)
+    private String value;
+
+    @Column(name = "name_original", nullable = false, length = 128)
+    private String original;
+
+    public static PartyName of(String original) {
+        Guard.notBlank(original, "name");
+        String norm = original.trim();
+        return new PartyName(norm.toLowerCase(), norm);
+    }
+
+    private PartyName(String value, String original) {
+        this.value = value;
+        this.original = original;
+    }
+}

--- a/src/main/java/online/lifeasgame/social/domain/PartyRole.java
+++ b/src/main/java/online/lifeasgame/social/domain/PartyRole.java
@@ -1,5 +1,0 @@
-package online.lifeasgame.social.domain;
-
-public enum PartyRole {
-    LEADER, SUBLEADER, MEMBER
-}

--- a/src/main/java/online/lifeasgame/social/domain/PartyState.java
+++ b/src/main/java/online/lifeasgame/social/domain/PartyState.java
@@ -1,5 +1,0 @@
-package online.lifeasgame.social.domain;
-
-public enum PartyState {
-    OPEN, FULL, DISBANDED
-}

--- a/src/main/java/online/lifeasgame/social/domain/PartyStatus.java
+++ b/src/main/java/online/lifeasgame/social/domain/PartyStatus.java
@@ -1,0 +1,3 @@
+package online.lifeasgame.social.domain;
+
+public enum PartyStatus {ACTIVE, INACTIVE, DISBANDED}

--- a/src/main/java/online/lifeasgame/social/domain/PartyVisibility.java
+++ b/src/main/java/online/lifeasgame/social/domain/PartyVisibility.java
@@ -1,0 +1,3 @@
+package online.lifeasgame.social.domain;
+
+public enum PartyVisibility {PUBLIC, PRIVATE}

--- a/src/main/java/online/lifeasgame/social/domain/PartyWaitMember.java
+++ b/src/main/java/online/lifeasgame/social/domain/PartyWaitMember.java
@@ -82,4 +82,8 @@ public class PartyWaitMember extends AbstractTime {
     public void cancel() {
         this.status = PartyWaitStatus.CANCELLED;
     }
+
+    public boolean isExpired() {
+        return expiresAt != null && expiresAt.isBefore(LocalDateTime.now());
+    }
 }

--- a/src/main/java/online/lifeasgame/social/domain/PartyWaitMember.java
+++ b/src/main/java/online/lifeasgame/social/domain/PartyWaitMember.java
@@ -1,0 +1,85 @@
+package online.lifeasgame.social.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import online.lifeasgame.platform.persistence.jpa.AbstractTime;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "PartyWaitMember")
+@Table(
+        name = "party_wait_members", indexes = {
+        @Index(name = "idx_wait_party", columnList = "party_id"),
+        @Index(name = "idx_wait_player", columnList = "player_id")
+}
+)
+public class PartyWaitMember extends AbstractTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "party_wait_member_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "party_id", nullable = false)
+    private Party party;
+
+    @Column(name = "player_id", nullable = false)
+    private Long playerId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 32)
+    private PartyWaitType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private PartyWaitStatus status;
+
+    @Column(name = "message", length = 1000)
+    private String message;
+
+    @Column(name = "requested_at", nullable = false)
+    private LocalDateTime requestedAt;
+
+    @Column(name = "expires_at")
+    private LocalDateTime expiresAt;
+
+    public static PartyWaitMember joinRequest(Party party, Long playerId, String message) {
+        PartyWaitMember w = new PartyWaitMember();
+        w.party = party;
+        w.playerId = playerId;
+        w.type = PartyWaitType.JOIN_REQUEST;
+        w.status = PartyWaitStatus.PENDING;
+        w.message = message;
+        w.requestedAt = LocalDateTime.now();
+        return w;
+    }
+
+    public static PartyWaitMember invitation(Party party, Long invitee, String message, LocalDateTime expiresAt) {
+        PartyWaitMember w = new PartyWaitMember();
+        w.party = party;
+        w.playerId = invitee;
+        w.type = PartyWaitType.INVITATION;
+        w.status = PartyWaitStatus.PENDING;
+        w.message = message;
+        w.requestedAt = LocalDateTime.now();
+        w.expiresAt = expiresAt;
+        return w;
+    }
+
+    public void approve() {
+        this.status = PartyWaitStatus.APPROVED;
+    }
+
+    public void reject() {
+        this.status = PartyWaitStatus.REJECTED;
+    }
+
+    public void cancel() {
+        this.status = PartyWaitStatus.CANCELLED;
+    }
+}

--- a/src/main/java/online/lifeasgame/social/domain/PartyWaitStatus.java
+++ b/src/main/java/online/lifeasgame/social/domain/PartyWaitStatus.java
@@ -1,0 +1,3 @@
+package online.lifeasgame.social.domain;
+
+public enum PartyWaitStatus { PENDING, APPROVED, REJECTED, CANCELLED }

--- a/src/main/java/online/lifeasgame/social/domain/PartyWaitType.java
+++ b/src/main/java/online/lifeasgame/social/domain/PartyWaitType.java
@@ -1,0 +1,3 @@
+package online.lifeasgame.social.domain;
+
+public enum PartyWaitType { JOIN_REQUEST, INVITATION }

--- a/src/main/java/online/lifeasgame/social/domain/error/SocialError.java
+++ b/src/main/java/online/lifeasgame/social/domain/error/SocialError.java
@@ -8,7 +8,9 @@ public enum SocialError implements ErrorCode {
     NOT_MEMBER("SOC-403-NOT-MEMBER","Not a member",403),
     LEADER_ONLY("SOC-403-LEADER-ONLY","Leader Only",403),
     OFFICER_OR_LEADER_ONLY("SOC-403-OFF-OR-LEADER","Officer or Leader Only",403),
-    INVALID_STATE("SOC-400-INVALID-STATE","Invalid State",400);
+    INVALID_STATE("SOC-400-INVALID-STATE","Invalid State",400),
+
+    PARTY_NOT_FOUND("SOC-404-PARTY-NOT-FOUND","Party Not Found",404);
 
     private final String code;
     private final String message;

--- a/src/main/java/online/lifeasgame/social/domain/repository/PartyRepository.java
+++ b/src/main/java/online/lifeasgame/social/domain/repository/PartyRepository.java
@@ -1,0 +1,13 @@
+package online.lifeasgame.social.domain.repository;
+
+import online.lifeasgame.social.domain.Party;
+
+import java.util.Optional;
+
+public interface PartyRepository {
+    Party save(Party party);
+
+    Optional<Party> findById(Long id);
+
+    Optional<Party> findByIdAndPlayerId(Long id, Long playerId);
+}

--- a/src/main/java/online/lifeasgame/social/infra/GuildJpaRepository.java
+++ b/src/main/java/online/lifeasgame/social/infra/GuildJpaRepository.java
@@ -2,7 +2,6 @@ package online.lifeasgame.social.infra;
 
 import online.lifeasgame.social.domain.Guild;
 import online.lifeasgame.social.domain.GuildVisibility;
-import org.springframework.data.domain.Limit;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -53,8 +52,6 @@ public interface GuildJpaRepository extends JpaRepository<Guild, Long> {
                     """
     )
     List<Guild> findRecentWithTags(List<Long> ids);
-
-    List<Guild> findById(Long id, Limit limit);
 
     @Query(
             value = """

--- a/src/main/java/online/lifeasgame/social/infra/PartyJpaRepository.java
+++ b/src/main/java/online/lifeasgame/social/infra/PartyJpaRepository.java
@@ -2,7 +2,6 @@ package online.lifeasgame.social.infra;
 
 import online.lifeasgame.social.domain.Party;
 import online.lifeasgame.social.domain.PartyVisibility;
-import org.springframework.data.domain.Limit;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -52,12 +51,10 @@ public interface PartyJpaRepository extends JpaRepository<Party, Long> {
                         where p.id in :ids
                     """
     )
-    List<Party> findRecentWithTags(List<Long> ids);
-
-    List<Party> findById(Long id, Limit limit);
+    List<Party> findRecentWithTags(@Param("ids") List<Long> ids);
 
     @Query(
-            value = """
+            """
                 SELECT p.id
                 FROM Party p
                 ORDER BY p.createdAt

--- a/src/main/java/online/lifeasgame/social/infra/PartyJpaRepository.java
+++ b/src/main/java/online/lifeasgame/social/infra/PartyJpaRepository.java
@@ -1,0 +1,67 @@
+package online.lifeasgame.social.infra;
+
+import online.lifeasgame.social.domain.Party;
+import online.lifeasgame.social.domain.PartyVisibility;
+import org.springframework.data.domain.Limit;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface PartyJpaRepository extends JpaRepository<Party, Long> {
+
+    Optional<Party> findByIdAndPlayerId(Long id, Long playerId);
+
+    @Query(
+            """
+                        select p.id
+                        from Party p
+                        where (:keyword is null or :keyword='' or lower(p.name.value) like lower(concat('%',:keyword,'%'))
+                               or lower(p.code.value) like lower(concat('%',:keyword,'%')))
+                          and (:visibility is null or p.visibility = :visibility)
+                        order by p.id desc
+                    """
+    )
+    Page<Long> searchIds(
+            @Param("keyword") String keyword,
+            @Param("visibility") PartyVisibility visibility,
+            Pageable pageable
+    );
+
+    @Query(
+            """
+                        select distinct p
+                        from Party p
+                        left join fetch p.tags t
+                        where p.id in :ids
+                    """
+    )
+    List<Party> fetchWithTagsByIds(@Param("ids") List<Long> ids);
+
+    @Query(
+            """
+                        select distinct p
+                        from Party p
+                        left join fetch p.tags t
+                        where p.id in :ids
+                    """
+    )
+    List<Party> findRecentWithTags(List<Long> ids);
+
+    List<Party> findById(Long id, Limit limit);
+
+    @Query(
+            value = """
+                SELECT p.id
+                FROM Party p
+                ORDER BY p.createdAt
+                LIMIT :limits
+            """)
+    List<Long> findRecent(@Param("limits") Integer limits);
+}

--- a/src/main/java/online/lifeasgame/social/infra/PartyRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/social/infra/PartyRepositoryAdapter.java
@@ -1,0 +1,64 @@
+package online.lifeasgame.social.infra;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.social.application.query.PartyQueryRepository;
+import online.lifeasgame.social.domain.Party;
+import online.lifeasgame.social.domain.PartyVisibility;
+import online.lifeasgame.social.domain.repository.PartyRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+
+@Repository
+@RequiredArgsConstructor
+public class PartyRepositoryAdapter implements PartyRepository, PartyQueryRepository {
+
+    private final PartyJpaRepository partyJpaRepository;
+
+    @Override
+    public Party save(Party party) {
+        return partyJpaRepository.save(party);
+    }
+
+    @Override
+    public Optional<Party> findById(Long id) {
+        return partyJpaRepository.findById(id);
+    }
+
+    @Override
+    public Optional<Party> findByIdAndPlayerId(Long id, Long playerId) {
+        return partyJpaRepository.findByIdAndPlayerId(id, playerId);
+    }
+
+    @Override
+    public List<Party> search(String keyword, PartyVisibility visibility, int page, int size) {
+        Page<Long> idPage = partyJpaRepository.searchIds(
+                keyword,
+                visibility,
+                PageRequest.of(Math.max(page, 0), Math.min(Math.max(size, 1), 100))
+        );
+        if (idPage.isEmpty()) return List.of();
+        List<Long> ids = idPage.getContent();
+        List<Party> list = partyJpaRepository.fetchWithTagsByIds(ids);
+
+        Map<Long, Integer> order = new HashMap<>();
+        for (int i = 0; i < ids.size(); i++) {
+            order.put(ids.get(i), i);
+        }
+        list.sort(Comparator.comparingInt(party -> order.getOrDefault(party.getId(), Integer.MAX_VALUE)));
+        return list;
+    }
+
+    @Override
+    public long countSearch(String keyword, PartyVisibility visibility) {
+        return partyJpaRepository.searchIds(keyword, visibility, PageRequest.of(0, 1)).getTotalElements();
+    }
+
+    @Override
+    public List<Party> recent(int limit) {
+        List<Long> ids = partyJpaRepository.findRecent(limit);
+        return partyJpaRepository.findRecentWithTags(ids);
+    }
+}


### PR DESCRIPTION
## 📝 Summary
<!-- PR의 목적과 변경 내용 간략 요약 -->

## 📌 Related Issue
- Close #118 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comprehensive party management for players and admins: create, rename, change policy/description/emblem, tags, search, recent listing.
  * Full membership workflow: join requests, approvals/rejections, cancel, transfers, kick, promote/demote, leave, disband.
  * Invitation system with optional message and expiration.
  * Admin-specific endpoints for managing parties on behalf of players.
  * Guild info endpoint now returns expanded detail payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->