### PR TITLE
[Reward] Add reward definition foundation

### DIFF
--- a/src/main/java/online/lifeasgame/reward/application/RewardDefinitionReader.java
+++ b/src/main/java/online/lifeasgame/reward/application/RewardDefinitionReader.java
@@ -1,0 +1,23 @@
+package online.lifeasgame.reward.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.reward.domain.RewardDefinition;
+import online.lifeasgame.reward.domain.error.RewardError;
+import online.lifeasgame.reward.domain.repository.RewardDefinitionRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+public class RewardDefinitionReader {
+
+    private final RewardDefinitionRepository repository;
+
+    public RewardDefinition getByCodeOrThrow(String code) {
+        return repository.findByCode(code)
+                .orElseThrow(() -> new DomainException(RewardError.REWARD_DEFINITION_NOT_FOUND));
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/application/RewardProfileQueryService.java
+++ b/src/main/java/online/lifeasgame/reward/application/RewardProfileQueryService.java
@@ -1,0 +1,28 @@
+package online.lifeasgame.reward.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.reward.application.query.RewardProfileQueryRepository;
+import online.lifeasgame.reward.application.result.RewardProfileResult;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RewardProfileQueryService {
+
+    private final RewardProfileReader rewardProfileReader;
+    private final RewardProfileQueryRepository queryRepository;
+
+    public RewardProfileResult.Detail getProfileView(String code) {
+        return RewardProfileResult.Detail.from(rewardProfileReader.getByCodeOrThrow(code));
+    }
+
+    public List<RewardProfileResult.Summary> listActiveProfiles() {
+        return queryRepository.findActiveSummaries().stream()
+                .map(RewardProfileResult.Summary::from)
+                .toList();
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/application/RewardProfileReader.java
+++ b/src/main/java/online/lifeasgame/reward/application/RewardProfileReader.java
@@ -1,0 +1,29 @@
+package online.lifeasgame.reward.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.reward.domain.RewardProfile;
+import online.lifeasgame.reward.domain.error.RewardError;
+import online.lifeasgame.reward.domain.repository.RewardProfileRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+public class RewardProfileReader {
+
+    private final RewardProfileRepository repository;
+
+    public RewardProfile getActiveByCodeOrThrow(String code) {
+        RewardProfile profile = getByCodeOrThrow(code);
+        profile.assertActive();
+        return profile;
+    }
+
+    public RewardProfile getByCodeOrThrow(String code) {
+        return repository.findByCode(code)
+                .orElseThrow(() -> new DomainException(RewardError.REWARD_PROFILE_NOT_FOUND));
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/application/query/RewardProfileQueryRepository.java
+++ b/src/main/java/online/lifeasgame/reward/application/query/RewardProfileQueryRepository.java
@@ -1,0 +1,8 @@
+package online.lifeasgame.reward.application.query;
+
+import java.util.List;
+
+public interface RewardProfileQueryRepository {
+
+    List<RewardProfileSummaryView> findActiveSummaries();
+}

--- a/src/main/java/online/lifeasgame/reward/application/query/RewardProfileSummaryView.java
+++ b/src/main/java/online/lifeasgame/reward/application/query/RewardProfileSummaryView.java
@@ -1,0 +1,11 @@
+package online.lifeasgame.reward.application.query;
+
+import online.lifeasgame.reward.domain.RewardProfileStatus;
+
+public record RewardProfileSummaryView(
+        Long id,
+        String code,
+        String name,
+        RewardProfileStatus status
+) {
+}

--- a/src/main/java/online/lifeasgame/reward/application/result/RewardDefinitionResult.java
+++ b/src/main/java/online/lifeasgame/reward/application/result/RewardDefinitionResult.java
@@ -1,0 +1,31 @@
+package online.lifeasgame.reward.application.result;
+
+import online.lifeasgame.reward.domain.RewardDefinition;
+
+public final class RewardDefinitionResult {
+
+    private RewardDefinitionResult() {
+    }
+
+    public record Detail(
+            Long id,
+            String code,
+            String name,
+            String rewardType,
+            Long amount,
+            Long itemId,
+            boolean active
+    ) {
+        public static Detail from(RewardDefinition definition) {
+            return new Detail(
+                    definition.getId(),
+                    definition.getCode(),
+                    definition.getName(),
+                    definition.getRewardType().name(),
+                    definition.getAmount(),
+                    definition.getItemId(),
+                    definition.isActive()
+            );
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/application/result/RewardProfileResult.java
+++ b/src/main/java/online/lifeasgame/reward/application/result/RewardProfileResult.java
@@ -1,0 +1,60 @@
+package online.lifeasgame.reward.application.result;
+
+import online.lifeasgame.reward.domain.RewardProfile;
+import online.lifeasgame.reward.domain.RewardProfileLine;
+import online.lifeasgame.reward.application.query.RewardProfileSummaryView;
+
+import java.util.List;
+
+public final class RewardProfileResult {
+
+    private RewardProfileResult() {
+    }
+
+    public record Detail(
+            Long id,
+            String code,
+            String name,
+            String status,
+            List<Line> lines
+    ) {
+        public static Detail from(RewardProfile profile) {
+            return new Detail(
+                    profile.getId(),
+                    profile.getCode(),
+                    profile.getName(),
+                    profile.getStatus().name(),
+                    profile.getLines().stream().map(Line::from).toList()
+            );
+        }
+    }
+
+    public record Summary(Long id, String code, String name, String status) {
+        public static Summary from(RewardProfileSummaryView profile) {
+            return new Summary(
+                    profile.id(),
+                    profile.code(),
+                    profile.name(),
+                    profile.status().name()
+            );
+        }
+    }
+
+    public record Line(
+            Long id,
+            int sortOrder,
+            Long amountOverride,
+            long effectiveAmount,
+            RewardDefinitionResult.Detail rewardDefinition
+    ) {
+        private static Line from(RewardProfileLine line) {
+            return new Line(
+                    line.getId(),
+                    line.getSortOrder(),
+                    line.getAmountOverride(),
+                    line.effectiveAmount(),
+                    RewardDefinitionResult.Detail.from(line.getRewardDefinition())
+            );
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/domain/RewardDefinition.java
+++ b/src/main/java/online/lifeasgame/reward/domain/RewardDefinition.java
@@ -1,0 +1,134 @@
+package online.lifeasgame.reward.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import online.lifeasgame.core.annotation.AggregateRoot;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.platform.persistence.jpa.AbstractTime;
+import online.lifeasgame.reward.domain.error.RewardError;
+
+@Getter
+@Entity
+@AggregateRoot
+@Table(name = "reward_definitions")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RewardDefinition extends AbstractTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 80, nullable = false, unique = true)
+    private String code;
+
+    @Column(length = 120, nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reward_type", length = 20, nullable = false)
+    private RewardType rewardType;
+
+    @Column
+    private Long amount;
+
+    @Column(name = "item_id")
+    private Long itemId;
+
+    @Column(nullable = false)
+    private boolean active;
+
+    private RewardDefinition(
+            String code,
+            String name,
+            RewardType rewardType,
+            Long amount,
+            Long itemId,
+            boolean active
+    ) {
+        this.code = normalizeRequired(
+                code,
+                80,
+                RewardError.REWARD_DEFINITION_CODE_REQUIRED,
+                RewardError.REWARD_DEFINITION_CODE_TOO_LONG
+        );
+        this.name = normalizeRequired(
+                name,
+                120,
+                RewardError.REWARD_DEFINITION_NAME_REQUIRED,
+                RewardError.REWARD_DEFINITION_NAME_TOO_LONG
+        );
+        if (rewardType == null) {
+            throw new DomainException(RewardError.REWARD_LINE_TYPE_REQUIRED);
+        }
+        this.rewardType = rewardType;
+        validatePayload(rewardType, amount, itemId);
+        this.amount = amount;
+        this.itemId = itemId;
+        this.active = active;
+    }
+
+    public static RewardDefinition create(
+            String code,
+            String name,
+            RewardType rewardType,
+            Long amount,
+            Long itemId,
+            boolean active
+    ) {
+        return new RewardDefinition(code, name, rewardType, amount, itemId, active);
+    }
+
+    public void activate() {
+        this.active = true;
+    }
+
+    public void deactivate() {
+        this.active = false;
+    }
+
+    private static String normalizeRequired(
+            String value,
+            int maxLength,
+            RewardError requiredError,
+            RewardError tooLongError
+    ) {
+        if (value == null || value.isBlank()) {
+            throw new DomainException(requiredError);
+        }
+        String normalized = value.trim();
+        if (normalized.length() > maxLength) {
+            throw new DomainException(tooLongError);
+        }
+        return normalized;
+    }
+
+    private static void validatePayload(RewardType rewardType, Long amount, Long itemId) {
+        if (rewardType == RewardType.EXP) {
+            if (amount == null || amount <= 0) {
+                throw new DomainException(RewardError.REWARD_AMOUNT_MUST_BE_POSITIVE);
+            }
+            if (itemId != null) {
+                throw new DomainException(RewardError.REWARD_EXP_ITEM_ID_NOT_ALLOWED);
+            }
+            return;
+        }
+        if (amount == null || amount <= 0) {
+            throw new DomainException(RewardError.REWARD_ITEM_QUANTITY_MUST_BE_POSITIVE);
+        }
+        if (itemId == null) {
+            throw new DomainException(RewardError.REWARD_ITEM_ID_REQUIRED);
+        }
+        if (itemId <= 0) {
+            throw new DomainException(RewardError.REWARD_ITEM_ID_MUST_BE_POSITIVE);
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/domain/RewardProfile.java
+++ b/src/main/java/online/lifeasgame/reward/domain/RewardProfile.java
@@ -1,0 +1,122 @@
+package online.lifeasgame.reward.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import online.lifeasgame.core.annotation.AggregateRoot;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.platform.persistence.jpa.AbstractTime;
+import online.lifeasgame.reward.domain.error.RewardError;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+@Getter
+@Entity
+@AggregateRoot
+@Table(name = "reward_profiles")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RewardProfile extends AbstractTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 80, nullable = false, unique = true)
+    private String code;
+
+    @Column(length = 120, nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    private RewardProfileStatus status;
+
+    @OneToMany(mappedBy = "profile", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("sortOrder ASC")
+    private List<RewardProfileLine> lines = new ArrayList<>();
+
+    private RewardProfile(String code, String name, RewardProfileStatus status) {
+        this.code = normalizeRequired(
+                code,
+                80,
+                RewardError.REWARD_PROFILE_CODE_REQUIRED,
+                RewardError.REWARD_PROFILE_CODE_TOO_LONG
+        );
+        this.name = normalizeRequired(
+                name,
+                120,
+                RewardError.REWARD_PROFILE_NAME_REQUIRED,
+                RewardError.REWARD_PROFILE_NAME_TOO_LONG
+        );
+        this.status = status == null ? RewardProfileStatus.INACTIVE : status;
+    }
+
+    public static RewardProfile create(String code, String name, RewardProfileStatus status) {
+        return new RewardProfile(code, name, status);
+    }
+
+    public RewardProfileLine addLine(
+            RewardDefinition rewardDefinition,
+            int sortOrder,
+        Long amountOverride
+    ) {
+        if (lines.stream().anyMatch(line -> line.getSortOrder() == sortOrder)) {
+            throw new DomainException(RewardError.REWARD_LINE_SORT_ORDER_DUPLICATED);
+        }
+        RewardProfileLine line = RewardProfileLine.create(this, rewardDefinition, sortOrder, amountOverride);
+        lines.add(line);
+        lines.sort(Comparator.comparingInt(RewardProfileLine::getSortOrder));
+        return line;
+    }
+
+    public List<RewardProfileLine> getLines() {
+        return List.copyOf(lines);
+    }
+
+    public boolean isActive() {
+        return status == RewardProfileStatus.ACTIVE;
+    }
+
+    public void assertActive() {
+        if (!isActive()) {
+            throw new DomainException(RewardError.REWARD_PROFILE_INACTIVE);
+        }
+    }
+
+    public void activate() {
+        this.status = RewardProfileStatus.ACTIVE;
+    }
+
+    public void deactivate() {
+        this.status = RewardProfileStatus.INACTIVE;
+    }
+
+    private static String normalizeRequired(
+            String value,
+            int maxLength,
+            RewardError requiredError,
+            RewardError tooLongError
+    ) {
+        if (value == null || value.isBlank()) {
+            throw new DomainException(requiredError);
+        }
+        String normalized = value.trim();
+        if (normalized.length() > maxLength) {
+            throw new DomainException(tooLongError);
+        }
+        return normalized;
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/domain/RewardProfile.java
+++ b/src/main/java/online/lifeasgame/reward/domain/RewardProfile.java
@@ -71,7 +71,7 @@ public class RewardProfile extends AbstractTime {
     public RewardProfileLine addLine(
             RewardDefinition rewardDefinition,
             int sortOrder,
-        Long amountOverride
+            Long amountOverride
     ) {
         if (lines.stream().anyMatch(line -> line.getSortOrder() == sortOrder)) {
             throw new DomainException(RewardError.REWARD_LINE_SORT_ORDER_DUPLICATED);

--- a/src/main/java/online/lifeasgame/reward/domain/RewardProfileLine.java
+++ b/src/main/java/online/lifeasgame/reward/domain/RewardProfileLine.java
@@ -1,0 +1,86 @@
+package online.lifeasgame.reward.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.platform.persistence.jpa.AbstractTime;
+import online.lifeasgame.reward.domain.error.RewardError;
+
+@Getter
+@Entity
+@Table(
+        name = "reward_profile_lines",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_reward_profile_line_sort_order",
+                columnNames = {"reward_profile_id", "sort_order"}
+        )
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RewardProfileLine extends AbstractTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reward_profile_id", nullable = false)
+    private RewardProfile profile;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reward_definition_id", nullable = false)
+    private RewardDefinition rewardDefinition;
+
+    @Column(name = "sort_order", nullable = false)
+    private int sortOrder;
+
+    @Column(name = "amount_override")
+    private Long amountOverride;
+
+    private RewardProfileLine(
+            RewardProfile profile,
+            RewardDefinition rewardDefinition,
+            int sortOrder,
+            Long amountOverride
+    ) {
+        if (profile == null) {
+            throw new DomainException(RewardError.REWARD_PROFILE_LINE_REQUIRED);
+        }
+        if (rewardDefinition == null) {
+            throw new DomainException(RewardError.REWARD_LINE_TARGET_REQUIRED);
+        }
+        if (sortOrder < 0) {
+            throw new DomainException(RewardError.REWARD_LINE_SORT_ORDER_MUST_BE_NON_NEGATIVE);
+        }
+        if (amountOverride != null && amountOverride <= 0) {
+            throw new DomainException(RewardError.REWARD_AMOUNT_OVERRIDE_MUST_BE_POSITIVE);
+        }
+        this.profile = profile;
+        this.rewardDefinition = rewardDefinition;
+        this.sortOrder = sortOrder;
+        this.amountOverride = amountOverride;
+    }
+
+    static RewardProfileLine create(
+            RewardProfile profile,
+            RewardDefinition rewardDefinition,
+            int sortOrder,
+            Long amountOverride
+    ) {
+        return new RewardProfileLine(profile, rewardDefinition, sortOrder, amountOverride);
+    }
+
+    public long effectiveAmount() {
+        return amountOverride == null ? rewardDefinition.getAmount() : amountOverride;
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/domain/RewardProfileStatus.java
+++ b/src/main/java/online/lifeasgame/reward/domain/RewardProfileStatus.java
@@ -1,0 +1,6 @@
+package online.lifeasgame.reward.domain;
+
+public enum RewardProfileStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/src/main/java/online/lifeasgame/reward/domain/RewardType.java
+++ b/src/main/java/online/lifeasgame/reward/domain/RewardType.java
@@ -1,0 +1,6 @@
+package online.lifeasgame.reward.domain;
+
+public enum RewardType {
+    EXP,
+    ITEM
+}

--- a/src/main/java/online/lifeasgame/reward/domain/error/RewardError.java
+++ b/src/main/java/online/lifeasgame/reward/domain/error/RewardError.java
@@ -1,0 +1,98 @@
+package online.lifeasgame.reward.domain.error;
+
+import online.lifeasgame.core.error.ErrorCode;
+
+public enum RewardError implements ErrorCode {
+
+    REWARD_DEFINITION_NOT_FOUND(
+            "RWD-404-DEFINITION-NOT-FOUND", "Reward definition not found", 404
+    ),
+    REWARD_DEFINITION_CODE_REQUIRED(
+            "RWD-400-DEFINITION-CODE-REQUIRED", "Reward definition code is required", 400
+    ),
+    REWARD_DEFINITION_CODE_TOO_LONG(
+            "RWD-400-DEFINITION-CODE-TOO-LONG", "Reward definition code is too long", 400
+    ),
+    REWARD_DEFINITION_NAME_REQUIRED(
+            "RWD-400-DEFINITION-NAME-REQUIRED", "Reward definition name is required", 400
+    ),
+    REWARD_DEFINITION_NAME_TOO_LONG(
+            "RWD-400-DEFINITION-NAME-TOO-LONG", "Reward definition name is too long", 400
+    ),
+    REWARD_PROFILE_NOT_FOUND(
+            "RWD-404-PROFILE-NOT-FOUND", "Reward profile not found", 404
+    ),
+    REWARD_PROFILE_CODE_REQUIRED(
+            "RWD-400-PROFILE-CODE-REQUIRED", "Reward profile code is required", 400
+    ),
+    REWARD_PROFILE_CODE_TOO_LONG(
+            "RWD-400-PROFILE-CODE-TOO-LONG", "Reward profile code is too long", 400
+    ),
+    REWARD_PROFILE_NAME_REQUIRED(
+            "RWD-400-PROFILE-NAME-REQUIRED", "Reward profile name is required", 400
+    ),
+    REWARD_PROFILE_NAME_TOO_LONG(
+            "RWD-400-PROFILE-NAME-TOO-LONG", "Reward profile name is too long", 400
+    ),
+    REWARD_PROFILE_INACTIVE(
+            "RWD-409-PROFILE-INACTIVE", "Reward profile is inactive", 409
+    ),
+    REWARD_LINE_TYPE_REQUIRED(
+            "RWD-400-LINE-TYPE-REQUIRED", "Reward type is required", 400
+    ),
+    REWARD_AMOUNT_MUST_BE_POSITIVE(
+            "RWD-400-AMOUNT-NOT-POSITIVE", "Reward amount must be positive", 400
+    ),
+    REWARD_EXP_ITEM_ID_NOT_ALLOWED(
+            "RWD-400-EXP-ITEM-ID-NOT-ALLOWED", "EXP reward must not have an item id", 400
+    ),
+    REWARD_ITEM_ID_REQUIRED(
+            "RWD-400-ITEM-ID-REQUIRED", "Item reward requires an item id", 400
+    ),
+    REWARD_ITEM_ID_MUST_BE_POSITIVE(
+            "RWD-400-ITEM-ID-NOT-POSITIVE", "Reward item id must be positive", 400
+    ),
+    REWARD_ITEM_QUANTITY_MUST_BE_POSITIVE(
+            "RWD-400-ITEM-QUANTITY-NOT-POSITIVE", "Item reward quantity must be positive", 400
+    ),
+    REWARD_PROFILE_LINE_REQUIRED(
+            "RWD-400-PROFILE-LINE-REQUIRED", "Reward profile line requires a profile", 400
+    ),
+    REWARD_LINE_TARGET_REQUIRED(
+            "RWD-400-LINE-TARGET-REQUIRED", "Reward profile line requires a definition", 400
+    ),
+    REWARD_LINE_SORT_ORDER_MUST_BE_NON_NEGATIVE(
+            "RWD-400-LINE-SORT-ORDER-NEGATIVE", "Reward line sort order must be non-negative", 400
+    ),
+    REWARD_LINE_SORT_ORDER_DUPLICATED(
+            "RWD-409-LINE-SORT-ORDER-DUPLICATED", "Reward line sort order must be unique", 409
+    ),
+    REWARD_AMOUNT_OVERRIDE_MUST_BE_POSITIVE(
+            "RWD-400-AMOUNT-OVERRIDE-NOT-POSITIVE", "Reward amount override must be positive", 400
+    );
+
+    private final String code;
+    private final String message;
+    private final int status;
+
+    RewardError(String code, String message, int status) {
+        this.code = code;
+        this.message = message;
+        this.status = status;
+    }
+
+    @Override
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public int status() {
+        return status;
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/domain/repository/RewardDefinitionRepository.java
+++ b/src/main/java/online/lifeasgame/reward/domain/repository/RewardDefinitionRepository.java
@@ -1,0 +1,12 @@
+package online.lifeasgame.reward.domain.repository;
+
+import online.lifeasgame.reward.domain.RewardDefinition;
+
+import java.util.Optional;
+
+public interface RewardDefinitionRepository {
+
+    RewardDefinition save(RewardDefinition rewardDefinition);
+
+    Optional<RewardDefinition> findByCode(String code);
+}

--- a/src/main/java/online/lifeasgame/reward/domain/repository/RewardProfileRepository.java
+++ b/src/main/java/online/lifeasgame/reward/domain/repository/RewardProfileRepository.java
@@ -1,0 +1,12 @@
+package online.lifeasgame.reward.domain.repository;
+
+import online.lifeasgame.reward.domain.RewardProfile;
+
+import java.util.Optional;
+
+public interface RewardProfileRepository {
+
+    RewardProfile save(RewardProfile rewardProfile);
+
+    Optional<RewardProfile> findByCode(String code);
+}

--- a/src/main/java/online/lifeasgame/reward/infra/JpaRewardDefinitionRepository.java
+++ b/src/main/java/online/lifeasgame/reward/infra/JpaRewardDefinitionRepository.java
@@ -1,0 +1,11 @@
+package online.lifeasgame.reward.infra;
+
+import online.lifeasgame.reward.domain.RewardDefinition;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface JpaRewardDefinitionRepository extends JpaRepository<RewardDefinition, Long> {
+
+    Optional<RewardDefinition> findByCode(String code);
+}

--- a/src/main/java/online/lifeasgame/reward/infra/JpaRewardProfileQueryRepository.java
+++ b/src/main/java/online/lifeasgame/reward/infra/JpaRewardProfileQueryRepository.java
@@ -1,0 +1,26 @@
+package online.lifeasgame.reward.infra;
+
+import online.lifeasgame.reward.application.query.RewardProfileSummaryView;
+import online.lifeasgame.reward.domain.RewardProfile;
+import online.lifeasgame.reward.domain.RewardProfileStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface JpaRewardProfileQueryRepository extends JpaRepository<RewardProfile, Long> {
+
+    @Query("""
+            SELECT new online.lifeasgame.reward.application.query.RewardProfileSummaryView(
+                profile.id,
+                profile.code,
+                profile.name,
+                profile.status
+            )
+            FROM RewardProfile profile
+            WHERE profile.status = :status
+            ORDER BY profile.code
+            """)
+    List<RewardProfileSummaryView> findSummariesByStatus(@Param("status") RewardProfileStatus status);
+}

--- a/src/main/java/online/lifeasgame/reward/infra/JpaRewardProfileRepository.java
+++ b/src/main/java/online/lifeasgame/reward/infra/JpaRewardProfileRepository.java
@@ -1,0 +1,13 @@
+package online.lifeasgame.reward.infra;
+
+import online.lifeasgame.reward.domain.RewardProfile;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface JpaRewardProfileRepository extends JpaRepository<RewardProfile, Long> {
+
+    @EntityGraph(attributePaths = {"lines", "lines.rewardDefinition"})
+    Optional<RewardProfile> findByCode(String code);
+}

--- a/src/main/java/online/lifeasgame/reward/infra/RewardDefinitionRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/reward/infra/RewardDefinitionRepositoryAdapter.java
@@ -1,0 +1,25 @@
+package online.lifeasgame.reward.infra;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.reward.domain.RewardDefinition;
+import online.lifeasgame.reward.domain.repository.RewardDefinitionRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class RewardDefinitionRepositoryAdapter implements RewardDefinitionRepository {
+
+    private final JpaRewardDefinitionRepository jpaRepository;
+
+    @Override
+    public RewardDefinition save(RewardDefinition rewardDefinition) {
+        return jpaRepository.save(rewardDefinition);
+    }
+
+    @Override
+    public Optional<RewardDefinition> findByCode(String code) {
+        return jpaRepository.findByCode(code);
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/infra/RewardProfileQueryRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/reward/infra/RewardProfileQueryRepositoryAdapter.java
@@ -1,0 +1,21 @@
+package online.lifeasgame.reward.infra;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.reward.application.query.RewardProfileQueryRepository;
+import online.lifeasgame.reward.application.query.RewardProfileSummaryView;
+import online.lifeasgame.reward.domain.RewardProfileStatus;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class RewardProfileQueryRepositoryAdapter implements RewardProfileQueryRepository {
+
+    private final JpaRewardProfileQueryRepository jpaRepository;
+
+    @Override
+    public List<RewardProfileSummaryView> findActiveSummaries() {
+        return jpaRepository.findSummariesByStatus(RewardProfileStatus.ACTIVE);
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/infra/RewardProfileRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/reward/infra/RewardProfileRepositoryAdapter.java
@@ -1,0 +1,25 @@
+package online.lifeasgame.reward.infra;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.reward.domain.RewardProfile;
+import online.lifeasgame.reward.domain.repository.RewardProfileRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class RewardProfileRepositoryAdapter implements RewardProfileRepository {
+
+    private final JpaRewardProfileRepository jpaRepository;
+
+    @Override
+    public RewardProfile save(RewardProfile rewardProfile) {
+        return jpaRepository.save(rewardProfile);
+    }
+
+    @Override
+    public Optional<RewardProfile> findByCode(String code) {
+        return jpaRepository.findByCode(code);
+    }
+}

--- a/src/main/resources/db/migration/V2__reward_definition_foundation.sql
+++ b/src/main/resources/db/migration/V2__reward_definition_foundation.sql
@@ -1,0 +1,105 @@
+-- Reward definition foundation only.
+-- Settlement, mailbox delivery, inventory mutation, and economy behavior are out of scope.
+
+CREATE TABLE reward_definitions (
+    active BIT NOT NULL,
+    amount BIGINT,
+    created_at DATETIME(6) NOT NULL,
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    item_id BIGINT,
+    updated_at DATETIME(6) NOT NULL,
+    code VARCHAR(80) NOT NULL,
+    name VARCHAR(120) NOT NULL,
+    reward_type ENUM ('EXP','ITEM') NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_reward_definition_code UNIQUE (code),
+    CONSTRAINT ck_reward_definition_payload CHECK (
+        (reward_type = 'EXP' AND amount IS NOT NULL AND amount > 0 AND item_id IS NULL)
+        OR (
+            reward_type = 'ITEM'
+            AND amount IS NOT NULL
+            AND amount > 0
+            AND item_id IS NOT NULL
+            AND item_id > 0
+        )
+    )
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE reward_profiles (
+    created_at DATETIME(6) NOT NULL,
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    updated_at DATETIME(6) NOT NULL,
+    code VARCHAR(80) NOT NULL,
+    name VARCHAR(120) NOT NULL,
+    status ENUM ('ACTIVE','INACTIVE') NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_reward_profile_code UNIQUE (code)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE reward_profile_lines (
+    sort_order INTEGER NOT NULL,
+    amount_override BIGINT,
+    created_at DATETIME(6) NOT NULL,
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    reward_definition_id BIGINT NOT NULL,
+    reward_profile_id BIGINT NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_reward_profile_line_sort_order UNIQUE (reward_profile_id, sort_order),
+    CONSTRAINT ck_reward_profile_line_sort_order CHECK (sort_order >= 0),
+    CONSTRAINT ck_reward_profile_line_amount_override CHECK (
+        amount_override IS NULL OR amount_override > 0
+    )
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE INDEX idx_reward_profile_line_definition
+    ON reward_profile_lines (reward_definition_id);
+
+ALTER TABLE reward_profile_lines
+    ADD CONSTRAINT fk_reward_profile_line_profile
+    FOREIGN KEY (reward_profile_id)
+    REFERENCES reward_profiles (id);
+
+ALTER TABLE reward_profile_lines
+    ADD CONSTRAINT fk_reward_profile_line_definition
+    FOREIGN KEY (reward_definition_id)
+    REFERENCES reward_definitions (id);
+
+-- ITEM seed is intentionally omitted because no stable catalog item id is guaranteed here.
+INSERT INTO reward_definitions (
+    code, name, reward_type, amount, item_id, active, created_at, updated_at
+) VALUES
+    ('RD_EXP_10', 'EXP 10', 'EXP', 10, NULL, TRUE, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)),
+    ('RD_EXP_30', 'EXP 30', 'EXP', 30, NULL, TRUE, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6));
+
+INSERT INTO reward_profiles (
+    code, name, status, created_at, updated_at
+) VALUES
+    ('RP_EXP_10', 'EXP 10 Profile', 'ACTIVE', CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)),
+    ('RP_EXP_30', 'EXP 30 Profile', 'ACTIVE', CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6));
+
+INSERT INTO reward_profile_lines (
+    reward_profile_id,
+    reward_definition_id,
+    sort_order,
+    amount_override,
+    created_at,
+    updated_at
+)
+SELECT
+    profile.id,
+    definition.id,
+    0,
+    NULL,
+    CURRENT_TIMESTAMP(6),
+    CURRENT_TIMESTAMP(6)
+FROM reward_profiles profile
+JOIN reward_definitions definition
+    ON definition.code = REPLACE(profile.code, 'RP_', 'RD_')
+WHERE profile.code IN ('RP_EXP_10', 'RP_EXP_30');

--- a/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
@@ -2,6 +2,8 @@ package online.lifeasgame.migration;
 
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.output.MigrateResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -10,10 +12,13 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Testcontainers
+@DisplayName("Flyway migration history")
 class FlywayHistoryChecksumTest {
 
     @Container
@@ -22,60 +27,63 @@ class FlywayHistoryChecksumTest {
             .withUsername("lifeasgame")
             .withPassword("lifeasgame");
 
-    @Test
-    void secondMigrationIsNoOpAndKeepsVersionOneHistory() throws Exception {
-        Flyway flyway = Flyway.configure()
+    @Nested
+    @DisplayName("migration을 다시 실행할 때")
+    class MigrateAgain {
+
+        @Test
+        @DisplayName("두 번째 실행은 no-op이고 V1과 V2 checksum history를 유지한다")
+        void keepsMigrationHistory() throws Exception {
+            Flyway flyway = flyway();
+
+            MigrateResult first = flyway.migrate();
+            List<HistoryRow> firstHistory = successfulHistory();
+
+            MigrateResult second = flyway.migrate();
+            List<HistoryRow> secondHistory = successfulHistory();
+
+            assertThat(first.migrationsExecuted).isEqualTo(2);
+            assertThat(second.migrationsExecuted).isZero();
+            assertThat(secondHistory).isEqualTo(firstHistory);
+            assertThat(secondHistory).extracting(HistoryRow::version)
+                    .containsExactly("1", "2");
+            assertThat(secondHistory).allSatisfy(history -> {
+                assertThat(history.checksum()).isNotNull();
+                assertThat(history.success()).isTrue();
+            });
+        }
+    }
+
+    private Flyway flyway() {
+        return Flyway.configure()
                 .dataSource(MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword())
                 .locations("classpath:db/migration")
                 .baselineOnMigrate(false)
                 .load();
-
-        MigrateResult first = flyway.migrate();
-        HistoryRow firstHistory = versionOneHistory();
-
-        MigrateResult second = flyway.migrate();
-        HistoryRow secondHistory = versionOneHistory();
-
-        assertThat(first.migrationsExecuted).isEqualTo(1);
-        assertThat(second.migrationsExecuted).isZero();
-        assertThat(secondHistory).isEqualTo(firstHistory);
-        assertThat(secondHistory.version()).isEqualTo("1");
-        assertThat(secondHistory.checksum()).isNotNull();
-        assertThat(secondHistory.success()).isTrue();
-        assertThat(successfulVersionOneRows()).isEqualTo(1);
     }
 
-    private HistoryRow versionOneHistory() throws Exception {
+    private List<HistoryRow> successfulHistory() throws Exception {
         try (Connection connection = MYSQL.createConnection("");
              Statement statement = connection.createStatement();
              ResultSet resultSet = statement.executeQuery("""
                      SELECT installed_rank, version, description, type, script, checksum, success
                      FROM flyway_schema_history
-                     WHERE version = '1'
+                     WHERE success = TRUE
+                     ORDER BY installed_rank
                      """)) {
-            assertThat(resultSet.next()).isTrue();
-            return new HistoryRow(
-                    resultSet.getInt("installed_rank"),
-                    resultSet.getString("version"),
-                    resultSet.getString("description"),
-                    resultSet.getString("type"),
-                    resultSet.getString("script"),
-                    resultSet.getObject("checksum", Integer.class),
-                    resultSet.getBoolean("success")
-            );
-        }
-    }
-
-    private int successfulVersionOneRows() throws Exception {
-        try (Connection connection = MYSQL.createConnection("");
-             Statement statement = connection.createStatement();
-             ResultSet resultSet = statement.executeQuery("""
-                     SELECT COUNT(*)
-                     FROM flyway_schema_history
-                     WHERE version = '1' AND success = TRUE
-                     """)) {
-            assertThat(resultSet.next()).isTrue();
-            return resultSet.getInt(1);
+            List<HistoryRow> history = new ArrayList<>();
+            while (resultSet.next()) {
+                history.add(new HistoryRow(
+                        resultSet.getInt("installed_rank"),
+                        resultSet.getString("version"),
+                        resultSet.getString("description"),
+                        resultSet.getString("type"),
+                        resultSet.getString("script"),
+                        resultSet.getObject("checksum", Integer.class),
+                        resultSet.getBoolean("success")
+                ));
+            }
+            return history;
         }
     }
 

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -2,6 +2,8 @@ package online.lifeasgame.migration;
 
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.output.MigrateResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -17,6 +19,7 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Testcontainers
+@DisplayName("Flyway migration")
 class FlywayMigrationTest {
 
     @Container
@@ -25,16 +28,40 @@ class FlywayMigrationTest {
             .withUsername("lifeasgame")
             .withPassword("lifeasgame");
 
-    @Test
-    void cleanDatabaseMigratesToVersionOne() throws Exception {
-        Flyway flyway = flyway();
+    @Nested
+    @DisplayName("빈 MySQL 8 데이터베이스에 migration을 적용할 때")
+    class MigrateCleanDatabase {
 
-        MigrateResult result = flyway.migrate();
+        @Test
+        @DisplayName("V1과 V2가 적용되고 Reward seed profile을 조회할 수 있다")
+        void migratesSchemaAndSeedsRewardProfiles() throws Exception {
+            Flyway flyway = flyway();
 
-        assertThat(result.migrationsExecuted).isEqualTo(1);
-        assertThat(appliedVersions()).containsExactly("1");
-        assertThat(existingTables("users", "player", "quests", "items", "inventory_entries"))
-                .containsExactlyInAnyOrder("users", "player", "quests", "items", "inventory_entries");
+            MigrateResult result = flyway.migrate();
+
+            assertThat(result.migrationsExecuted).isEqualTo(2);
+            assertThat(appliedVersions()).containsExactly("1", "2");
+            assertThat(existingTables(
+                    "users",
+                    "player",
+                    "quests",
+                    "items",
+                    "inventory_entries",
+                    "reward_definitions",
+                    "reward_profiles",
+                    "reward_profile_lines"
+            )).containsExactlyInAnyOrder(
+                    "users",
+                    "player",
+                    "quests",
+                    "items",
+                    "inventory_entries",
+                    "reward_definitions",
+                    "reward_profiles",
+                    "reward_profile_lines"
+            );
+            assertThat(seedProfileCodes()).containsExactly("RP_EXP_10", "RP_EXP_30");
+        }
     }
 
     private Flyway flyway() {
@@ -83,6 +110,26 @@ class FlywayMigrationTest {
                 }
                 return tables;
             }
+        }
+    }
+
+    private Set<String> seedProfileCodes() throws Exception {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("""
+                     SELECT profile.code
+                     FROM reward_profiles profile
+                     JOIN reward_profile_lines line ON line.reward_profile_id = profile.id
+                     JOIN reward_definitions definition ON definition.id = line.reward_definition_id
+                     WHERE profile.status = 'ACTIVE'
+                       AND definition.reward_type = 'EXP'
+                     ORDER BY profile.code
+                     """)) {
+            Set<String> codes = new LinkedHashSet<>();
+            while (resultSet.next()) {
+                codes.add(resultSet.getString("code"));
+            }
+            return codes;
         }
     }
 }

--- a/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
@@ -1,6 +1,8 @@
 package online.lifeasgame.migration;
 
 import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -8,6 +10,8 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import online.lifeasgame.reward.application.RewardProfileReader;
+import online.lifeasgame.reward.application.RewardProfileQueryService;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -17,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 @SpringBootTest
 @ActiveProfiles({"test", "migration-test"})
+@DisplayName("V2 migration 이후 JPA schema validation")
 class JpaValidateAfterMigrationTest {
 
     @Container
@@ -39,13 +44,49 @@ class JpaValidateAfterMigrationTest {
     @Autowired
     private Flyway flyway;
 
-    @Test
-    void applicationContextLoadsWithJpaValidationAfterVersionOneMigration() {
-        assertThat(applicationContext).isNotNull();
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("1");
-        assertThat(applicationContext.getEnvironment().getProperty("spring.jpa.hibernate.ddl-auto"))
-                .isEqualTo("validate");
-        assertThat(applicationContext.getEnvironment().getProperty("spring.flyway.baseline-on-migrate", Boolean.class))
-                .isFalse();
+    @Autowired
+    private RewardProfileReader rewardProfileReader;
+
+    @Autowired
+    private RewardProfileQueryService rewardProfileQueryService;
+
+    @Nested
+    @DisplayName("V1과 V2가 적용된 schema로 ApplicationContext를 기동할 때")
+    class LoadApplicationContext {
+
+        @Test
+        @DisplayName("ddl-auto validate 상태로 정상 기동한다")
+        void loadsWithJpaValidation() {
+            assertThat(applicationContext).isNotNull();
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("2");
+            assertThat(applicationContext.getEnvironment().getProperty("spring.jpa.hibernate.ddl-auto"))
+                    .isEqualTo("validate");
+            assertThat(applicationContext.getEnvironment()
+                    .getProperty("spring.flyway.baseline-on-migrate", Boolean.class))
+                    .isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("V2 Reward seed profile을 조회할 때")
+    class LoadRewardSeedProfile {
+
+        @Test
+        @DisplayName("EntityGraph로 line과 RewardDefinition을 함께 조회한다")
+        void loadsLinesWithDefinitions() {
+            var profile = rewardProfileReader.getActiveByCodeOrThrow("RP_EXP_10");
+
+            assertThat(profile.getLines()).hasSize(1);
+            assertThat(profile.getLines().getFirst().getRewardDefinition().getCode())
+                    .isEqualTo("RD_EXP_10");
+        }
+
+        @Test
+        @DisplayName("DTO projection으로 활성 profile 요약을 조회한다")
+        void loadsActiveProfileSummariesWithProjection() {
+            assertThat(rewardProfileQueryService.listActiveProfiles())
+                    .extracting(summary -> summary.code())
+                    .containsExactly("RP_EXP_10", "RP_EXP_30");
+        }
     }
 }

--- a/src/test/java/online/lifeasgame/reward/application/RewardDefinitionReaderTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardDefinitionReaderTest.java
@@ -1,0 +1,63 @@
+package online.lifeasgame.reward.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.reward.domain.RewardDefinition;
+import online.lifeasgame.reward.domain.RewardType;
+import online.lifeasgame.reward.domain.error.RewardError;
+import online.lifeasgame.reward.domain.repository.RewardDefinitionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RewardDefinitionReader")
+class RewardDefinitionReaderTest {
+
+    @Mock
+    private RewardDefinitionRepository repository;
+
+    private RewardDefinitionReader reader;
+
+    @BeforeEach
+    void setUp() {
+        reader = new RewardDefinitionReader(repository);
+    }
+
+    @Nested
+    @DisplayName("RewardDefinition을 code로 조회할 때")
+    class GetByCode {
+
+        @Test
+        @DisplayName("존재하는 정의를 반환한다")
+        void returnsDefinition() {
+            RewardDefinition definition = RewardDefinition.create(
+                    "RD_EXP_10", "EXP 10", RewardType.EXP, 10L, null, true
+            );
+            given(repository.findByCode("RD_EXP_10")).willReturn(Optional.of(definition));
+
+            assertThat(reader.getByCodeOrThrow("RD_EXP_10")).isSameAs(definition);
+        }
+
+        @Test
+        @DisplayName("존재하지 않으면 REWARD_DEFINITION_NOT_FOUND 예외가 발생한다")
+        void throwsWhenDefinitionDoesNotExist() {
+            given(repository.findByCode("UNKNOWN")).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> reader.getByCodeOrThrow("UNKNOWN"))
+                    .isInstanceOfSatisfying(DomainException.class, exception ->
+                            assertThat(exception.getErrorCode())
+                                    .isEqualTo(RewardError.REWARD_DEFINITION_NOT_FOUND)
+                    );
+        }
+    }
+}

--- a/src/test/java/online/lifeasgame/reward/application/RewardProfileQueryServiceTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardProfileQueryServiceTest.java
@@ -1,0 +1,90 @@
+package online.lifeasgame.reward.application;
+
+import online.lifeasgame.reward.application.result.RewardProfileResult;
+import online.lifeasgame.reward.application.query.RewardProfileQueryRepository;
+import online.lifeasgame.reward.application.query.RewardProfileSummaryView;
+import online.lifeasgame.reward.domain.RewardDefinition;
+import online.lifeasgame.reward.domain.RewardProfile;
+import online.lifeasgame.reward.domain.RewardProfileStatus;
+import online.lifeasgame.reward.domain.RewardType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RewardProfileQueryService")
+class RewardProfileQueryServiceTest {
+
+    @Mock
+    private RewardProfileReader reader;
+
+    @Mock
+    private RewardProfileQueryRepository queryRepository;
+
+    private RewardProfileQueryService queryService;
+
+    @BeforeEach
+    void setUp() {
+        queryService = new RewardProfileQueryService(reader, queryRepository);
+    }
+
+    @Nested
+    @DisplayName("profile 상세를 조회할 때")
+    class GetProfileView {
+
+        @Test
+        @DisplayName("정렬된 line과 보상 정의를 함께 반환한다")
+        void returnsProfileWithOrderedLines() {
+            RewardProfile profile = profile("RP_EXP", "EXP Profile");
+            profile.addLine(expDefinition("RD_EXP_30", 30L), 20, null);
+            profile.addLine(expDefinition("RD_EXP_10", 10L), 10, null);
+            given(reader.getByCodeOrThrow("RP_EXP")).willReturn(profile);
+
+            RewardProfileResult.Detail result = queryService.getProfileView("RP_EXP");
+
+            assertThat(result.lines()).extracting(RewardProfileResult.Line::sortOrder)
+                    .containsExactly(10, 20);
+            assertThat(result.lines()).extracting(line -> line.rewardDefinition().code())
+                    .containsExactly("RD_EXP_10", "RD_EXP_30");
+        }
+    }
+
+    @Nested
+    @DisplayName("활성 profile 목록을 조회할 때")
+    class ListActiveProfiles {
+
+        @Test
+        @DisplayName("활성 profile 요약 목록을 반환한다")
+        void returnsActiveProfileSummaries() {
+            given(queryRepository.findActiveSummaries()).willReturn(List.of(
+                    new RewardProfileSummaryView(
+                            1L, "RP_EXP_10", "EXP 10 Profile", RewardProfileStatus.ACTIVE
+                    ),
+                    new RewardProfileSummaryView(
+                            2L, "RP_EXP_30", "EXP 30 Profile", RewardProfileStatus.ACTIVE
+                    )
+            ));
+
+            assertThat(queryService.listActiveProfiles())
+                    .extracting(RewardProfileResult.Summary::code)
+                    .containsExactly("RP_EXP_10", "RP_EXP_30");
+        }
+    }
+
+    private RewardProfile profile(String code, String name) {
+        return RewardProfile.create(code, name, RewardProfileStatus.ACTIVE);
+    }
+
+    private RewardDefinition expDefinition(String code, Long amount) {
+        return RewardDefinition.create(code, code, RewardType.EXP, amount, null, true);
+    }
+}

--- a/src/test/java/online/lifeasgame/reward/application/RewardProfileReaderTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardProfileReaderTest.java
@@ -1,0 +1,100 @@
+package online.lifeasgame.reward.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.reward.domain.RewardDefinition;
+import online.lifeasgame.reward.domain.RewardProfile;
+import online.lifeasgame.reward.domain.RewardProfileStatus;
+import online.lifeasgame.reward.domain.RewardType;
+import online.lifeasgame.reward.domain.error.RewardError;
+import online.lifeasgame.reward.domain.repository.RewardProfileRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RewardProfileReader")
+class RewardProfileReaderTest {
+
+    @Mock
+    private RewardProfileRepository repository;
+
+    private RewardProfileReader reader;
+
+    @BeforeEach
+    void setUp() {
+        reader = new RewardProfileReader(repository);
+    }
+
+    @Nested
+    @DisplayName("활성 RewardProfile을 code로 조회할 때")
+    class GetActiveProfileByCode {
+
+        @Test
+        @DisplayName("존재하는 활성 profile이면 line을 포함해 반환한다")
+        void returnsActiveProfileWithLines() {
+            RewardProfile profile = profile(RewardProfileStatus.ACTIVE);
+            profile.addLine(expDefinition(), 0, null);
+            given(repository.findByCode("RP_EXP_10")).willReturn(Optional.of(profile));
+
+            RewardProfile result = reader.getActiveByCodeOrThrow("RP_EXP_10");
+
+            assertThat(result).isSameAs(profile);
+            assertThat(result.getLines()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("비활성 profile이면 REWARD_PROFILE_INACTIVE 예외가 발생한다")
+        void throwsWhenProfileIsInactive() {
+            given(repository.findByCode("RP_EXP_10"))
+                    .willReturn(Optional.of(profile(RewardProfileStatus.INACTIVE)));
+
+            assertRewardError(
+                    () -> reader.getActiveByCodeOrThrow("RP_EXP_10"),
+                    RewardError.REWARD_PROFILE_INACTIVE
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("존재하지 않는 RewardProfile을 조회할 때")
+    class ProfileNotFound {
+
+        @Test
+        @DisplayName("REWARD_PROFILE_NOT_FOUND 예외가 발생한다")
+        void throwsNotFound() {
+            given(repository.findByCode("UNKNOWN")).willReturn(Optional.empty());
+
+            assertRewardError(
+                    () -> reader.getByCodeOrThrow("UNKNOWN"),
+                    RewardError.REWARD_PROFILE_NOT_FOUND
+            );
+        }
+    }
+
+    private RewardProfile profile(RewardProfileStatus status) {
+        return RewardProfile.create("RP_EXP_10", "EXP 10 Profile", status);
+    }
+
+    private RewardDefinition expDefinition() {
+        return RewardDefinition.create(
+                "RD_EXP_10", "EXP 10", RewardType.EXP, 10L, null, true
+        );
+    }
+
+    private void assertRewardError(Runnable action, RewardError error) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(error)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/reward/domain/RewardDefinitionTest.java
+++ b/src/test/java/online/lifeasgame/reward/domain/RewardDefinitionTest.java
@@ -1,0 +1,160 @@
+package online.lifeasgame.reward.domain;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.reward.domain.error.RewardError;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("RewardDefinition")
+class RewardDefinitionTest {
+
+    @Nested
+    @DisplayName("EXP 보상 정의를 생성할 때")
+    class CreateExpRewardDefinition {
+
+        @Test
+        @DisplayName("양수 amount와 itemId 없이 생성된다")
+        void createsWithAmountAndWithoutItemId() {
+            RewardDefinition definition = RewardDefinition.create(
+                    "RD_EXP_10", "EXP 10", RewardType.EXP, 10L, null, true
+            );
+
+            assertThat(definition.getRewardType()).isEqualTo(RewardType.EXP);
+            assertThat(definition.getAmount()).isEqualTo(10L);
+            assertThat(definition.getItemId()).isNull();
+            assertThat(definition.isActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("amount가 없으면 REWARD_AMOUNT_MUST_BE_POSITIVE 예외가 발생한다")
+        void throwsWhenAmountIsMissing() {
+            assertRewardError(
+                    () -> RewardDefinition.create(
+                            "RD_EXP", "EXP", RewardType.EXP, null, null, true
+                    ),
+                    RewardError.REWARD_AMOUNT_MUST_BE_POSITIVE
+            );
+        }
+
+        @Test
+        @DisplayName("itemId가 있으면 REWARD_EXP_ITEM_ID_NOT_ALLOWED 예외가 발생한다")
+        void throwsWhenItemIdExists() {
+            assertRewardError(
+                    () -> RewardDefinition.create(
+                            "RD_EXP", "EXP", RewardType.EXP, 10L, 1L, true
+                    ),
+                    RewardError.REWARD_EXP_ITEM_ID_NOT_ALLOWED
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("ITEM 보상 정의를 생성할 때")
+    class CreateItemRewardDefinition {
+
+        @Test
+        @DisplayName("itemId와 수량을 의미하는 amount로 생성된다")
+        void createsWithItemIdAndAmount() {
+            RewardDefinition definition = RewardDefinition.create(
+                    "RD_ITEM_1", "Item 1", RewardType.ITEM, 2L, 1L, true
+            );
+
+            assertThat(definition.getRewardType()).isEqualTo(RewardType.ITEM);
+            assertThat(definition.getAmount()).isEqualTo(2L);
+            assertThat(definition.getItemId()).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("itemId가 없으면 REWARD_ITEM_ID_REQUIRED 예외가 발생한다")
+        void throwsWhenItemIdIsMissing() {
+            assertRewardError(
+                    () -> RewardDefinition.create(
+                            "RD_ITEM", "Item", RewardType.ITEM, 1L, null, true
+                    ),
+                    RewardError.REWARD_ITEM_ID_REQUIRED
+            );
+        }
+
+        @Test
+        @DisplayName("수량이 양수가 아니면 REWARD_ITEM_QUANTITY_MUST_BE_POSITIVE 예외가 발생한다")
+        void throwsWhenAmountIsNotPositive() {
+            assertRewardError(
+                    () -> RewardDefinition.create(
+                            "RD_ITEM", "Item", RewardType.ITEM, 0L, 1L, true
+                    ),
+                    RewardError.REWARD_ITEM_QUANTITY_MUST_BE_POSITIVE
+            );
+        }
+
+        @Test
+        @DisplayName("itemId가 양수가 아니면 REWARD_ITEM_ID_MUST_BE_POSITIVE 예외가 발생한다")
+        void throwsWhenItemIdIsNotPositive() {
+            assertRewardError(
+                    () -> RewardDefinition.create(
+                            "RD_ITEM", "Item", RewardType.ITEM, 1L, 0L, true
+                    ),
+                    RewardError.REWARD_ITEM_ID_MUST_BE_POSITIVE
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("필수 정의 값을 검증할 때")
+    class ValidateRequiredDefinitionValues {
+
+        @Test
+        @DisplayName("code와 name의 앞뒤 공백을 제거해 저장한다")
+        void trimsCodeAndName() {
+            RewardDefinition definition = RewardDefinition.create(
+                    "  RD_EXP  ", "  EXP  ", RewardType.EXP, 1L, null, true
+            );
+
+            assertThat(definition.getCode()).isEqualTo("RD_EXP");
+            assertThat(definition.getName()).isEqualTo("EXP");
+        }
+
+        @Test
+        @DisplayName("code가 공백이면 REWARD_DEFINITION_CODE_REQUIRED 예외가 발생한다")
+        void throwsWhenCodeIsBlank() {
+            assertRewardError(
+                    () -> RewardDefinition.create(
+                            " ", "EXP", RewardType.EXP, 1L, null, true
+                    ),
+                    RewardError.REWARD_DEFINITION_CODE_REQUIRED
+            );
+        }
+
+        @Test
+        @DisplayName("name이 공백이면 REWARD_DEFINITION_NAME_REQUIRED 예외가 발생한다")
+        void throwsWhenNameIsBlank() {
+            assertRewardError(
+                    () -> RewardDefinition.create(
+                            "RD_EXP", " ", RewardType.EXP, 1L, null, true
+                    ),
+                    RewardError.REWARD_DEFINITION_NAME_REQUIRED
+            );
+        }
+
+        @Test
+        @DisplayName("rewardType이 없으면 REWARD_LINE_TYPE_REQUIRED 예외가 발생한다")
+        void throwsWhenRewardTypeIsMissing() {
+            assertRewardError(
+                    () -> RewardDefinition.create(
+                            "RD_EXP", "EXP", null, 1L, null, true
+                    ),
+                    RewardError.REWARD_LINE_TYPE_REQUIRED
+            );
+        }
+    }
+
+    private void assertRewardError(Runnable action, RewardError error) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(error)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/reward/domain/RewardProfileTest.java
+++ b/src/test/java/online/lifeasgame/reward/domain/RewardProfileTest.java
@@ -1,0 +1,178 @@
+package online.lifeasgame.reward.domain;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.reward.domain.error.RewardError;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("RewardProfile")
+class RewardProfileTest {
+
+    @Nested
+    @DisplayName("보상 라인을 추가할 때")
+    class AddRewardLine {
+
+        @Test
+        @DisplayName("EXP 라인을 profile에 포함한다")
+        void includesExpLine() {
+            RewardProfile profile = activeProfile();
+            RewardDefinition definition = expDefinition("RD_EXP_10", 10L);
+
+            RewardProfileLine line = profile.addLine(definition, 0, null);
+
+            assertThat(profile.getLines()).containsExactly(line);
+            assertThat(line.getRewardDefinition()).isSameAs(definition);
+            assertThat(line.effectiveAmount()).isEqualTo(10L);
+        }
+
+        @Test
+        @DisplayName("ITEM 라인을 profile에 포함한다")
+        void includesItemLine() {
+            RewardProfile profile = activeProfile();
+            RewardDefinition definition = RewardDefinition.create(
+                    "RD_ITEM_1", "Item 1", RewardType.ITEM, 1L, 1L, true
+            );
+
+            RewardProfileLine line = profile.addLine(definition, 0, 3L);
+
+            assertThat(line.getRewardDefinition().getRewardType()).isEqualTo(RewardType.ITEM);
+            assertThat(line.getAmountOverride()).isEqualTo(3L);
+            assertThat(line.effectiveAmount()).isEqualTo(3L);
+        }
+
+        @Test
+        @DisplayName("sortOrder 오름차순으로 line을 반환한다")
+        void returnsLinesOrderedBySortOrder() {
+            RewardProfile profile = activeProfile();
+            RewardProfileLine later = profile.addLine(expDefinition("RD_EXP_30", 30L), 20, null);
+            RewardProfileLine earlier = profile.addLine(expDefinition("RD_EXP_10", 10L), 10, null);
+
+            assertThat(profile.getLines()).containsExactly(earlier, later);
+        }
+
+        @Test
+        @DisplayName("같은 sortOrder를 추가하면 REWARD_LINE_SORT_ORDER_DUPLICATED 예외가 발생한다")
+        void throwsWhenSortOrderIsDuplicated() {
+            RewardProfile profile = activeProfile();
+            profile.addLine(expDefinition("RD_EXP_10", 10L), 0, null);
+
+            assertThatThrownBy(() ->
+                    profile.addLine(expDefinition("RD_EXP_30", 30L), 0, null)
+            ).isInstanceOfSatisfying(DomainException.class, exception ->
+                    assertThat(exception.getErrorCode())
+                            .isEqualTo(RewardError.REWARD_LINE_SORT_ORDER_DUPLICATED)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("잘못된 보상 라인을 추가할 때")
+    class AddInvalidRewardLine {
+
+        @Test
+        @DisplayName("RewardDefinition이 없으면 REWARD_LINE_TARGET_REQUIRED 예외가 발생한다")
+        void throwsWhenDefinitionIsMissing() {
+            assertRewardError(
+                    () -> activeProfile().addLine(null, 0, null),
+                    RewardError.REWARD_LINE_TARGET_REQUIRED
+            );
+        }
+
+        @Test
+        @DisplayName("sortOrder가 음수이면 REWARD_LINE_SORT_ORDER_MUST_BE_NON_NEGATIVE 예외가 발생한다")
+        void throwsWhenSortOrderIsNegative() {
+            assertRewardError(
+                    () -> activeProfile().addLine(expDefinition("RD_EXP", 1L), -1, null),
+                    RewardError.REWARD_LINE_SORT_ORDER_MUST_BE_NON_NEGATIVE
+            );
+        }
+
+        @Test
+        @DisplayName("override가 양수가 아니면 REWARD_AMOUNT_OVERRIDE_MUST_BE_POSITIVE 예외가 발생한다")
+        void throwsWhenAmountOverrideIsNotPositive() {
+            assertRewardError(
+                    () -> activeProfile().addLine(expDefinition("RD_EXP", 1L), 0, 0L),
+                    RewardError.REWARD_AMOUNT_OVERRIDE_MUST_BE_POSITIVE
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("profile 필수 값을 검증할 때")
+    class ValidateRequiredProfileValues {
+
+        @Test
+        @DisplayName("code와 name의 앞뒤 공백을 제거해 저장한다")
+        void trimsCodeAndName() {
+            RewardProfile profile = RewardProfile.create(
+                    "  RP_TEST  ", "  Test Profile  ", RewardProfileStatus.ACTIVE
+            );
+
+            assertThat(profile.getCode()).isEqualTo("RP_TEST");
+            assertThat(profile.getName()).isEqualTo("Test Profile");
+        }
+
+        @Test
+        @DisplayName("code가 공백이면 REWARD_PROFILE_CODE_REQUIRED 예외가 발생한다")
+        void throwsWhenCodeIsBlank() {
+            assertRewardError(
+                    () -> RewardProfile.create(" ", "Profile", RewardProfileStatus.ACTIVE),
+                    RewardError.REWARD_PROFILE_CODE_REQUIRED
+            );
+        }
+
+        @Test
+        @DisplayName("name이 공백이면 REWARD_PROFILE_NAME_REQUIRED 예외가 발생한다")
+        void throwsWhenNameIsBlank() {
+            assertRewardError(
+                    () -> RewardProfile.create("RP_TEST", " ", RewardProfileStatus.ACTIVE),
+                    RewardError.REWARD_PROFILE_NAME_REQUIRED
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("profile 활성 상태를 확인할 때")
+    class AssertActiveProfile {
+
+        @Test
+        @DisplayName("활성 profile이면 예외가 발생하지 않는다")
+        void doesNotThrowWhenProfileIsActive() {
+            assertThatCode(activeProfile()::assertActive).doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("비활성 profile이면 REWARD_PROFILE_INACTIVE 예외가 발생한다")
+        void throwsWhenProfileIsInactive() {
+            RewardProfile profile = RewardProfile.create(
+                    "RP_INACTIVE", "Inactive Profile", RewardProfileStatus.INACTIVE
+            );
+
+            assertThatThrownBy(profile::assertActive)
+                    .isInstanceOfSatisfying(DomainException.class, exception ->
+                            assertThat(exception.getErrorCode())
+                                    .isEqualTo(RewardError.REWARD_PROFILE_INACTIVE)
+                    );
+        }
+    }
+
+    private RewardProfile activeProfile() {
+        return RewardProfile.create("RP_TEST", "Test Profile", RewardProfileStatus.ACTIVE);
+    }
+
+    private RewardDefinition expDefinition(String code, Long amount) {
+        return RewardDefinition.create(code, code, RewardType.EXP, amount, null, true);
+    }
+
+    private void assertRewardError(Runnable action, RewardError error) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(error)
+                );
+    }
+}


### PR DESCRIPTION
## What

- RewardDefinition / RewardProfile 기반을 추가했습니다.
- EXP Reward와 ITEM Reward를 구분할 수 있는 최소 모델을 추가했습니다.
- RewardSettlement 구현 전 필요한 조회 기반을 준비했습니다.
- Reward 관련 테스트를 `@Nested` 기반의 읽히는 구조로 작성했습니다.

## Scope

- RewardDefinition
- RewardProfile
- RewardProfileLine
- RewardType
- Reward reader/query 기반
- Reward migration
- Reward definition/profile 테스트

## Out of Scope

- RewardSettlement 실행 로직
- Mailbox 전달 로직
- Inventory 반영 로직
- Quest 완료 로직 변경
- Achievement 판정
- Outbox 발행
- Saga 구현

## Test

- [ ] ./gradlew clean test
- [ ] ./gradlew build
- [ ] ./gradlew test --tests '*RewardDefinition*'
- [ ] ./gradlew test --tests '*RewardProfile*'

Closes #183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced reward definition and profile read/query capabilities with detail and active summary views.
  - Added support for EXP and item-based rewards, including profile line ordering and optional amount overrides.
  - Added active/inactive profile and reward-definition state handling.
- **Bug Fixes**
  - Strengthened validation with clear domain errors for missing/invalid inputs, inactive access, and invalid ordering/amounts.
- **Data**
  - Added V2 database schema with initial seeded EXP reward definitions and active profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->