### PR TITLE
[Reward] Add reward settlement foundation

### DIFF
--- a/src/main/java/online/lifeasgame/reward/application/RewardSettlementCreateAttempt.java
+++ b/src/main/java/online/lifeasgame/reward/application/RewardSettlementCreateAttempt.java
@@ -1,0 +1,29 @@
+package online.lifeasgame.reward.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.reward.domain.RewardProfile;
+import online.lifeasgame.reward.domain.RewardSettlement;
+import online.lifeasgame.reward.domain.RewardSettlementSourceType;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class RewardSettlementCreateAttempt {
+
+    private final RewardProfileReader profileReader;
+    private final RewardSettlementWriter settlementWriter;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public RewardSettlement create(
+            Long playerId,
+            RewardSettlementSourceType sourceType,
+            Long sourceId,
+            String rewardProfileCode
+    ) {
+        RewardProfile profile = profileReader.getActiveByCodeOrThrow(rewardProfileCode);
+        RewardSettlement settlement = RewardSettlement.create(playerId, sourceType, sourceId, profile);
+        return settlementWriter.saveAndFlush(settlement);
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/application/RewardSettlementCreateService.java
+++ b/src/main/java/online/lifeasgame/reward/application/RewardSettlementCreateService.java
@@ -1,0 +1,43 @@
+package online.lifeasgame.reward.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.reward.domain.RewardProfile;
+import online.lifeasgame.reward.domain.RewardSettlement;
+import online.lifeasgame.reward.domain.RewardSettlementSourceType;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RewardSettlementCreateService {
+
+    private final RewardSettlementReader settlementReader;
+    private final RewardProfileReader profileReader;
+    private final RewardSettlementWriter settlementWriter;
+
+    public RewardSettlement create(
+            Long playerId,
+            RewardSettlementSourceType sourceType,
+            Long sourceId,
+            String rewardProfileCode
+    ) {
+        return settlementReader.findByIdentity(playerId, sourceType, sourceId)
+                .orElseGet(() -> createNew(playerId, sourceType, sourceId, rewardProfileCode));
+    }
+
+    private RewardSettlement createNew(
+            Long playerId,
+            RewardSettlementSourceType sourceType,
+            Long sourceId,
+            String rewardProfileCode
+    ) {
+        RewardProfile profile = profileReader.getActiveByCodeOrThrow(rewardProfileCode);
+        RewardSettlement settlement = RewardSettlement.create(playerId, sourceType, sourceId, profile);
+        try {
+            return settlementWriter.saveAndFlush(settlement);
+        } catch (DataIntegrityViolationException exception) {
+            return settlementReader.findByIdentity(playerId, sourceType, sourceId)
+                    .orElseThrow(() -> exception);
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/application/RewardSettlementCreateService.java
+++ b/src/main/java/online/lifeasgame/reward/application/RewardSettlementCreateService.java
@@ -36,7 +36,7 @@ public class RewardSettlementCreateService {
         try {
             return settlementWriter.saveAndFlush(settlement);
         } catch (DataIntegrityViolationException exception) {
-            return settlementReader.findByIdentity(playerId, sourceType, sourceId)
+            return settlementReader.findByIdentityInNewTransaction(playerId, sourceType, sourceId)
                     .orElseThrow(() -> exception);
         }
     }

--- a/src/main/java/online/lifeasgame/reward/application/RewardSettlementCreateService.java
+++ b/src/main/java/online/lifeasgame/reward/application/RewardSettlementCreateService.java
@@ -1,7 +1,6 @@
 package online.lifeasgame.reward.application;
 
 import lombok.RequiredArgsConstructor;
-import online.lifeasgame.reward.domain.RewardProfile;
 import online.lifeasgame.reward.domain.RewardSettlement;
 import online.lifeasgame.reward.domain.RewardSettlementSourceType;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -12,8 +11,7 @@ import org.springframework.stereotype.Service;
 public class RewardSettlementCreateService {
 
     private final RewardSettlementReader settlementReader;
-    private final RewardProfileReader profileReader;
-    private final RewardSettlementWriter settlementWriter;
+    private final RewardSettlementCreateAttempt createAttempt;
 
     public RewardSettlement create(
             Long playerId,
@@ -31,10 +29,8 @@ public class RewardSettlementCreateService {
             Long sourceId,
             String rewardProfileCode
     ) {
-        RewardProfile profile = profileReader.getActiveByCodeOrThrow(rewardProfileCode);
-        RewardSettlement settlement = RewardSettlement.create(playerId, sourceType, sourceId, profile);
         try {
-            return settlementWriter.saveAndFlush(settlement);
+            return createAttempt.create(playerId, sourceType, sourceId, rewardProfileCode);
         } catch (DataIntegrityViolationException exception) {
             return settlementReader.findByIdentityInNewTransaction(playerId, sourceType, sourceId)
                     .orElseThrow(() -> exception);

--- a/src/main/java/online/lifeasgame/reward/application/RewardSettlementReader.java
+++ b/src/main/java/online/lifeasgame/reward/application/RewardSettlementReader.java
@@ -27,6 +27,15 @@ public class RewardSettlementReader {
         return repository.findByIdentity(playerId, sourceType, sourceId);
     }
 
+    @Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
+    public Optional<RewardSettlement> findByIdentityInNewTransaction(
+            Long playerId,
+            RewardSettlementSourceType sourceType,
+            Long sourceId
+    ) {
+        return repository.findByIdentity(playerId, sourceType, sourceId);
+    }
+
     public RewardSettlement getByIdentityOrThrow(
             Long playerId,
             RewardSettlementSourceType sourceType,

--- a/src/main/java/online/lifeasgame/reward/application/RewardSettlementReader.java
+++ b/src/main/java/online/lifeasgame/reward/application/RewardSettlementReader.java
@@ -1,0 +1,43 @@
+package online.lifeasgame.reward.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.reward.domain.RewardSettlement;
+import online.lifeasgame.reward.domain.RewardSettlementSourceType;
+import online.lifeasgame.reward.domain.error.RewardError;
+import online.lifeasgame.reward.domain.repository.RewardSettlementRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+public class RewardSettlementReader {
+
+    private final RewardSettlementRepository repository;
+
+    public Optional<RewardSettlement> findByIdentity(
+            Long playerId,
+            RewardSettlementSourceType sourceType,
+            Long sourceId
+    ) {
+        return repository.findByIdentity(playerId, sourceType, sourceId);
+    }
+
+    public RewardSettlement getByIdentityOrThrow(
+            Long playerId,
+            RewardSettlementSourceType sourceType,
+            Long sourceId
+    ) {
+        return findByIdentity(playerId, sourceType, sourceId)
+                .orElseThrow(() -> new DomainException(RewardError.REWARD_SETTLEMENT_NOT_FOUND));
+    }
+
+    public RewardSettlement getByIdOrThrow(Long id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new DomainException(RewardError.REWARD_SETTLEMENT_NOT_FOUND));
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/application/RewardSettlementWriter.java
+++ b/src/main/java/online/lifeasgame/reward/application/RewardSettlementWriter.java
@@ -4,8 +4,6 @@ import lombok.RequiredArgsConstructor;
 import online.lifeasgame.reward.domain.RewardSettlement;
 import online.lifeasgame.reward.domain.repository.RewardSettlementRepository;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -13,7 +11,6 @@ public class RewardSettlementWriter {
 
     private final RewardSettlementRepository repository;
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public RewardSettlement saveAndFlush(RewardSettlement settlement) {
         return repository.saveAndFlush(settlement);
     }

--- a/src/main/java/online/lifeasgame/reward/application/RewardSettlementWriter.java
+++ b/src/main/java/online/lifeasgame/reward/application/RewardSettlementWriter.java
@@ -1,0 +1,20 @@
+package online.lifeasgame.reward.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.reward.domain.RewardSettlement;
+import online.lifeasgame.reward.domain.repository.RewardSettlementRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class RewardSettlementWriter {
+
+    private final RewardSettlementRepository repository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public RewardSettlement saveAndFlush(RewardSettlement settlement) {
+        return repository.saveAndFlush(settlement);
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/domain/RewardSettlement.java
+++ b/src/main/java/online/lifeasgame/reward/domain/RewardSettlement.java
@@ -1,0 +1,161 @@
+package online.lifeasgame.reward.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import online.lifeasgame.core.annotation.AggregateRoot;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.error.ErrorCode;
+import online.lifeasgame.platform.persistence.jpa.AbstractTime;
+import online.lifeasgame.reward.domain.error.RewardError;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+@AggregateRoot
+@Table(
+        name = "reward_settlements",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_reward_settlement_source",
+                columnNames = {"player_id", "source_type", "source_id"}
+        )
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RewardSettlement extends AbstractTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "player_id", nullable = false)
+    private Long playerId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source_type", length = 40, nullable = false)
+    private RewardSettlementSourceType sourceType;
+
+    @Column(name = "source_id", nullable = false)
+    private Long sourceId;
+
+    @Column(name = "reward_profile_id", nullable = false)
+    private Long rewardProfileId;
+
+    @Column(name = "reward_profile_code", length = 80, nullable = false)
+    private String rewardProfileCode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    private RewardSettlementStatus status;
+
+    @OneToMany(mappedBy = "settlement", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("sortOrder ASC")
+    private List<RewardSettlementLine> lines = new ArrayList<>();
+
+    private RewardSettlement(
+            Long playerId,
+            RewardSettlementSourceType sourceType,
+            Long sourceId,
+            RewardProfile rewardProfile
+    ) {
+        validateIdentity(playerId, sourceType, sourceId);
+        validateProfile(rewardProfile);
+        this.playerId = playerId;
+        this.sourceType = sourceType;
+        this.sourceId = sourceId;
+        this.rewardProfileId = rewardProfile.getId();
+        this.rewardProfileCode = rewardProfile.getCode();
+        this.status = RewardSettlementStatus.PENDING;
+        rewardProfile.getLines().stream()
+                .map(line -> RewardSettlementLine.snapshot(this, line))
+                .forEach(lines::add);
+    }
+
+    public static RewardSettlement create(
+            Long playerId,
+            RewardSettlementSourceType sourceType,
+            Long sourceId,
+            RewardProfile rewardProfile
+    ) {
+        return new RewardSettlement(playerId, sourceType, sourceId, rewardProfile);
+    }
+
+    public List<RewardSettlementLine> getLines() {
+        return List.copyOf(lines);
+    }
+
+    public void markLineSucceeded(int sortOrder) {
+        findLine(sortOrder).succeed();
+        recalculateStatus();
+    }
+
+    public void markLineFailed(int sortOrder, ErrorCode errorCode) {
+        findLine(sortOrder).fail(errorCode);
+        recalculateStatus();
+    }
+
+    private RewardSettlementLine findLine(int sortOrder) {
+        return lines.stream()
+                .filter(line -> line.getSortOrder() == sortOrder)
+                .findFirst()
+                .orElseThrow(() -> new DomainException(RewardError.REWARD_SETTLEMENT_LINE_NOT_FOUND));
+    }
+
+    private void recalculateStatus() {
+        if (lines.stream().anyMatch(line -> line.getStatus() == RewardSettlementLineStatus.PENDING)) {
+            status = RewardSettlementStatus.PENDING;
+            return;
+        }
+        if (lines.stream().allMatch(line -> line.getStatus() == RewardSettlementLineStatus.SUCCEEDED)) {
+            status = RewardSettlementStatus.COMPLETED;
+            return;
+        }
+        if (lines.stream().allMatch(line -> line.getStatus() == RewardSettlementLineStatus.FAILED)) {
+            status = RewardSettlementStatus.FAILED;
+            return;
+        }
+        status = RewardSettlementStatus.PARTIAL_FAILED;
+    }
+
+    private static void validateIdentity(
+            Long playerId,
+            RewardSettlementSourceType sourceType,
+            Long sourceId
+    ) {
+        if (playerId == null || playerId <= 0) {
+            throw new DomainException(RewardError.REWARD_SETTLEMENT_PLAYER_ID_REQUIRED);
+        }
+        if (sourceType == null) {
+            throw new DomainException(RewardError.REWARD_SETTLEMENT_SOURCE_TYPE_REQUIRED);
+        }
+        if (sourceId == null || sourceId <= 0) {
+            throw new DomainException(RewardError.REWARD_SETTLEMENT_SOURCE_ID_REQUIRED);
+        }
+    }
+
+    private static void validateProfile(RewardProfile rewardProfile) {
+        if (rewardProfile == null) {
+            throw new DomainException(RewardError.REWARD_SETTLEMENT_PROFILE_REQUIRED);
+        }
+        rewardProfile.assertActive();
+        if (rewardProfile.getId() == null) {
+            throw new DomainException(RewardError.REWARD_SETTLEMENT_PROFILE_ID_REQUIRED);
+        }
+        if (rewardProfile.getLines().isEmpty()) {
+            throw new DomainException(RewardError.REWARD_SETTLEMENT_PROFILE_LINES_REQUIRED);
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/domain/RewardSettlementLine.java
+++ b/src/main/java/online/lifeasgame/reward/domain/RewardSettlementLine.java
@@ -1,0 +1,124 @@
+package online.lifeasgame.reward.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.error.ErrorCode;
+import online.lifeasgame.platform.persistence.jpa.AbstractTime;
+import online.lifeasgame.reward.domain.error.RewardError;
+
+@Getter
+@Entity
+@Table(
+        name = "reward_settlement_lines",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_reward_settlement_line_sort_order",
+                columnNames = {"reward_settlement_id", "sort_order"}
+        )
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RewardSettlementLine extends AbstractTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reward_settlement_id", nullable = false)
+    private RewardSettlement settlement;
+
+    @Column(name = "reward_definition_id", nullable = false)
+    private Long rewardDefinitionId;
+
+    @Column(name = "reward_definition_code", length = 80, nullable = false)
+    private String rewardDefinitionCode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reward_type", length = 20, nullable = false)
+    private RewardType rewardType;
+
+    @Column(nullable = false)
+    private long amount;
+
+    @Column(name = "item_id")
+    private Long itemId;
+
+    @Column(name = "sort_order", nullable = false)
+    private int sortOrder;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    private RewardSettlementLineStatus status;
+
+    @Column(name = "failure_code", length = 100)
+    private String failureCode;
+
+    private RewardSettlementLine(
+            RewardSettlement settlement,
+            RewardDefinition definition,
+            int sortOrder,
+            long amount
+    ) {
+        if (definition.getId() == null) {
+            throw new DomainException(RewardError.REWARD_SETTLEMENT_DEFINITION_ID_REQUIRED);
+        }
+        this.settlement = settlement;
+        this.rewardDefinitionId = definition.getId();
+        this.rewardDefinitionCode = definition.getCode();
+        this.rewardType = definition.getRewardType();
+        this.amount = amount;
+        this.itemId = definition.getItemId();
+        this.sortOrder = sortOrder;
+        this.status = RewardSettlementLineStatus.PENDING;
+    }
+
+    static RewardSettlementLine snapshot(
+            RewardSettlement settlement,
+            RewardProfileLine profileLine
+    ) {
+        return new RewardSettlementLine(
+                settlement,
+                profileLine.getRewardDefinition(),
+                profileLine.getSortOrder(),
+                profileLine.effectiveAmount()
+        );
+    }
+
+    void succeed() {
+        if (status == RewardSettlementLineStatus.SUCCEEDED) {
+            return;
+        }
+        if (status == RewardSettlementLineStatus.FAILED) {
+            throw new DomainException(RewardError.REWARD_SETTLEMENT_LINE_ALREADY_FAILED);
+        }
+        status = RewardSettlementLineStatus.SUCCEEDED;
+        failureCode = null;
+    }
+
+    void fail(ErrorCode errorCode) {
+        if (status == RewardSettlementLineStatus.SUCCEEDED) {
+            throw new DomainException(RewardError.REWARD_SETTLEMENT_SUCCEEDED_LINE_CANNOT_FAIL);
+        }
+        if (errorCode == null) {
+            throw new DomainException(RewardError.REWARD_SETTLEMENT_FAILURE_CODE_REQUIRED);
+        }
+        if (status == RewardSettlementLineStatus.FAILED) {
+            return;
+        }
+        status = RewardSettlementLineStatus.FAILED;
+        failureCode = errorCode.code();
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/domain/RewardSettlementLineStatus.java
+++ b/src/main/java/online/lifeasgame/reward/domain/RewardSettlementLineStatus.java
@@ -1,0 +1,7 @@
+package online.lifeasgame.reward.domain;
+
+public enum RewardSettlementLineStatus {
+    PENDING,
+    SUCCEEDED,
+    FAILED
+}

--- a/src/main/java/online/lifeasgame/reward/domain/RewardSettlementSourceType.java
+++ b/src/main/java/online/lifeasgame/reward/domain/RewardSettlementSourceType.java
@@ -1,0 +1,5 @@
+package online.lifeasgame.reward.domain;
+
+public enum RewardSettlementSourceType {
+    QUEST_COMPLETION
+}

--- a/src/main/java/online/lifeasgame/reward/domain/RewardSettlementStatus.java
+++ b/src/main/java/online/lifeasgame/reward/domain/RewardSettlementStatus.java
@@ -1,0 +1,8 @@
+package online.lifeasgame.reward.domain;
+
+public enum RewardSettlementStatus {
+    PENDING,
+    COMPLETED,
+    PARTIAL_FAILED,
+    FAILED
+}

--- a/src/main/java/online/lifeasgame/reward/domain/error/RewardError.java
+++ b/src/main/java/online/lifeasgame/reward/domain/error/RewardError.java
@@ -69,6 +69,42 @@ public enum RewardError implements ErrorCode {
     ),
     REWARD_AMOUNT_OVERRIDE_MUST_BE_POSITIVE(
             "RWD-400-AMOUNT-OVERRIDE-NOT-POSITIVE", "Reward amount override must be positive", 400
+    ),
+    REWARD_SETTLEMENT_NOT_FOUND(
+            "RWD-404-SETTLEMENT-NOT-FOUND", "Reward settlement not found", 404
+    ),
+    REWARD_SETTLEMENT_PLAYER_ID_REQUIRED(
+            "RWD-400-SETTLEMENT-PLAYER-ID-REQUIRED", "Reward settlement player id must be positive", 400
+    ),
+    REWARD_SETTLEMENT_SOURCE_TYPE_REQUIRED(
+            "RWD-400-SETTLEMENT-SOURCE-TYPE-REQUIRED", "Reward settlement source type is required", 400
+    ),
+    REWARD_SETTLEMENT_SOURCE_ID_REQUIRED(
+            "RWD-400-SETTLEMENT-SOURCE-ID-REQUIRED", "Reward settlement source id must be positive", 400
+    ),
+    REWARD_SETTLEMENT_PROFILE_REQUIRED(
+            "RWD-400-SETTLEMENT-PROFILE-REQUIRED", "Reward settlement requires a reward profile", 400
+    ),
+    REWARD_SETTLEMENT_PROFILE_ID_REQUIRED(
+            "RWD-400-SETTLEMENT-PROFILE-ID-REQUIRED", "Reward settlement requires a persisted reward profile", 400
+    ),
+    REWARD_SETTLEMENT_PROFILE_LINES_REQUIRED(
+            "RWD-400-SETTLEMENT-PROFILE-LINES-REQUIRED", "Reward settlement requires at least one profile line", 400
+    ),
+    REWARD_SETTLEMENT_DEFINITION_ID_REQUIRED(
+            "RWD-400-SETTLEMENT-DEFINITION-ID-REQUIRED", "Reward settlement line requires a persisted reward definition", 400
+    ),
+    REWARD_SETTLEMENT_LINE_NOT_FOUND(
+            "RWD-404-SETTLEMENT-LINE-NOT-FOUND", "Reward settlement line not found", 404
+    ),
+    REWARD_SETTLEMENT_LINE_ALREADY_FAILED(
+            "RWD-409-SETTLEMENT-LINE-ALREADY-FAILED", "Failed reward settlement line cannot succeed", 409
+    ),
+    REWARD_SETTLEMENT_SUCCEEDED_LINE_CANNOT_FAIL(
+            "RWD-409-SETTLEMENT-SUCCEEDED-LINE-CANNOT-FAIL", "Succeeded reward settlement line cannot fail", 409
+    ),
+    REWARD_SETTLEMENT_FAILURE_CODE_REQUIRED(
+            "RWD-400-SETTLEMENT-FAILURE-CODE-REQUIRED", "Failed reward settlement line requires an error code", 400
     );
 
     private final String code;

--- a/src/main/java/online/lifeasgame/reward/domain/repository/RewardSettlementRepository.java
+++ b/src/main/java/online/lifeasgame/reward/domain/repository/RewardSettlementRepository.java
@@ -1,0 +1,19 @@
+package online.lifeasgame.reward.domain.repository;
+
+import online.lifeasgame.reward.domain.RewardSettlement;
+import online.lifeasgame.reward.domain.RewardSettlementSourceType;
+
+import java.util.Optional;
+
+public interface RewardSettlementRepository {
+
+    RewardSettlement saveAndFlush(RewardSettlement settlement);
+
+    Optional<RewardSettlement> findById(Long id);
+
+    Optional<RewardSettlement> findByIdentity(
+            Long playerId,
+            RewardSettlementSourceType sourceType,
+            Long sourceId
+    );
+}

--- a/src/main/java/online/lifeasgame/reward/infra/JpaRewardSettlementRepository.java
+++ b/src/main/java/online/lifeasgame/reward/infra/JpaRewardSettlementRepository.java
@@ -1,0 +1,22 @@
+package online.lifeasgame.reward.infra;
+
+import online.lifeasgame.reward.domain.RewardSettlement;
+import online.lifeasgame.reward.domain.RewardSettlementSourceType;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface JpaRewardSettlementRepository extends JpaRepository<RewardSettlement, Long> {
+
+    @Override
+    @EntityGraph(attributePaths = "lines")
+    Optional<RewardSettlement> findById(Long id);
+
+    @EntityGraph(attributePaths = "lines")
+    Optional<RewardSettlement> findByPlayerIdAndSourceTypeAndSourceId(
+            Long playerId,
+            RewardSettlementSourceType sourceType,
+            Long sourceId
+    );
+}

--- a/src/main/java/online/lifeasgame/reward/infra/RewardSettlementRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/reward/infra/RewardSettlementRepositoryAdapter.java
@@ -1,0 +1,35 @@
+package online.lifeasgame.reward.infra;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.reward.domain.RewardSettlement;
+import online.lifeasgame.reward.domain.RewardSettlementSourceType;
+import online.lifeasgame.reward.domain.repository.RewardSettlementRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class RewardSettlementRepositoryAdapter implements RewardSettlementRepository {
+
+    private final JpaRewardSettlementRepository jpaRepository;
+
+    @Override
+    public RewardSettlement saveAndFlush(RewardSettlement settlement) {
+        return jpaRepository.saveAndFlush(settlement);
+    }
+
+    @Override
+    public Optional<RewardSettlement> findById(Long id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
+    public Optional<RewardSettlement> findByIdentity(
+            Long playerId,
+            RewardSettlementSourceType sourceType,
+            Long sourceId
+    ) {
+        return jpaRepository.findByPlayerIdAndSourceTypeAndSourceId(playerId, sourceType, sourceId);
+    }
+}

--- a/src/main/resources/db/migration/V3__reward_settlement_foundation.sql
+++ b/src/main/resources/db/migration/V3__reward_settlement_foundation.sql
@@ -1,0 +1,61 @@
+-- Reward settlement persistence foundation only.
+-- No EXP grant, item delivery, mailbox, quest completion, or retry behavior is executed here.
+
+CREATE TABLE reward_settlements (
+    created_at DATETIME(6) NOT NULL,
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    player_id BIGINT NOT NULL,
+    reward_profile_id BIGINT NOT NULL,
+    source_id BIGINT NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    reward_profile_code VARCHAR(80) NOT NULL,
+    source_type ENUM ('QUEST_COMPLETION') NOT NULL,
+    status ENUM ('COMPLETED','FAILED','PARTIAL_FAILED','PENDING') NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_reward_settlement_source UNIQUE (player_id, source_type, source_id),
+    CONSTRAINT ck_reward_settlement_player_id CHECK (player_id > 0),
+    CONSTRAINT ck_reward_settlement_profile_id CHECK (reward_profile_id > 0),
+    CONSTRAINT ck_reward_settlement_source_id CHECK (source_id > 0)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE INDEX idx_reward_settlement_profile
+    ON reward_settlements (reward_profile_id);
+
+CREATE TABLE reward_settlement_lines (
+    sort_order INTEGER NOT NULL,
+    amount BIGINT NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    item_id BIGINT,
+    reward_definition_id BIGINT NOT NULL,
+    reward_settlement_id BIGINT NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    failure_code VARCHAR(100),
+    reward_definition_code VARCHAR(80) NOT NULL,
+    reward_type ENUM ('EXP','ITEM') NOT NULL,
+    status ENUM ('FAILED','PENDING','SUCCEEDED') NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_reward_settlement_line_sort_order UNIQUE (reward_settlement_id, sort_order),
+    CONSTRAINT ck_reward_settlement_line_sort_order CHECK (sort_order >= 0),
+    CONSTRAINT ck_reward_settlement_line_amount CHECK (amount > 0),
+    CONSTRAINT ck_reward_settlement_line_payload CHECK (
+        (reward_type = 'EXP' AND item_id IS NULL)
+        OR (reward_type = 'ITEM' AND item_id IS NOT NULL AND item_id > 0)
+    ),
+    CONSTRAINT ck_reward_settlement_line_failure CHECK (
+        (status = 'FAILED' AND failure_code IS NOT NULL)
+        OR (status <> 'FAILED' AND failure_code IS NULL)
+    )
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE INDEX idx_reward_settlement_line_definition
+    ON reward_settlement_lines (reward_definition_id);
+
+ALTER TABLE reward_settlement_lines
+    ADD CONSTRAINT fk_reward_settlement_line_settlement
+    FOREIGN KEY (reward_settlement_id)
+    REFERENCES reward_settlements (id);

--- a/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
@@ -32,7 +32,7 @@ class FlywayHistoryChecksumTest {
     class MigrateAgain {
 
         @Test
-        @DisplayName("두 번째 실행은 no-op이고 V1과 V2 checksum history를 유지한다")
+        @DisplayName("두 번째 실행은 no-op이고 V1부터 V3까지 checksum history를 유지한다")
         void keepsMigrationHistory() throws Exception {
             Flyway flyway = flyway();
 
@@ -42,11 +42,11 @@ class FlywayHistoryChecksumTest {
             MigrateResult second = flyway.migrate();
             List<HistoryRow> secondHistory = successfulHistory();
 
-            assertThat(first.migrationsExecuted).isEqualTo(2);
+            assertThat(first.migrationsExecuted).isEqualTo(3);
             assertThat(second.migrationsExecuted).isZero();
             assertThat(secondHistory).isEqualTo(firstHistory);
             assertThat(secondHistory).extracting(HistoryRow::version)
-                    .containsExactly("1", "2");
+                    .containsExactly("1", "2", "3");
             assertThat(secondHistory).allSatisfy(history -> {
                 assertThat(history.checksum()).isNotNull();
                 assertThat(history.success()).isTrue();

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -11,12 +11,16 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Testcontainers
 @DisplayName("Flyway migration")
@@ -33,14 +37,14 @@ class FlywayMigrationTest {
     class MigrateCleanDatabase {
 
         @Test
-        @DisplayName("V1과 V2가 적용되고 Reward seed profile을 조회할 수 있다")
+        @DisplayName("V1부터 V3까지 적용되고 Settlement 테이블과 중복 방지 제약이 생성된다")
         void migratesSchemaAndSeedsRewardProfiles() throws Exception {
             Flyway flyway = flyway();
 
             MigrateResult result = flyway.migrate();
 
-            assertThat(result.migrationsExecuted).isEqualTo(2);
-            assertThat(appliedVersions()).containsExactly("1", "2");
+            assertThat(result.migrationsExecuted).isEqualTo(3);
+            assertThat(appliedVersions()).containsExactly("1", "2", "3");
             assertThat(existingTables(
                     "users",
                     "player",
@@ -49,7 +53,9 @@ class FlywayMigrationTest {
                     "inventory_entries",
                     "reward_definitions",
                     "reward_profiles",
-                    "reward_profile_lines"
+                    "reward_profile_lines",
+                    "reward_settlements",
+                    "reward_settlement_lines"
             )).containsExactlyInAnyOrder(
                     "users",
                     "player",
@@ -58,9 +64,22 @@ class FlywayMigrationTest {
                     "inventory_entries",
                     "reward_definitions",
                     "reward_profiles",
-                    "reward_profile_lines"
+                    "reward_profile_lines",
+                    "reward_settlements",
+                    "reward_settlement_lines"
             );
             assertThat(seedProfileCodes()).containsExactly("RP_EXP_10", "RP_EXP_30");
+            assertThat(uniqueIndexColumns("reward_settlements", "uq_reward_settlement_source"))
+                    .containsExactly("player_id", "source_type", "source_id");
+            assertThat(uniqueIndexColumns(
+                    "reward_settlement_lines",
+                    "uq_reward_settlement_line_sort_order"
+            )).containsExactly("reward_settlement_id", "sort_order");
+            insertSettlementIdentity();
+            assertThatThrownBy(FlywayMigrationTest.this::insertSettlementIdentity)
+                    .isInstanceOfSatisfying(SQLException.class, exception ->
+                            assertThat(exception.getSQLState()).startsWith("23")
+                    );
         }
     }
 
@@ -130,6 +149,56 @@ class FlywayMigrationTest {
                 codes.add(resultSet.getString("code"));
             }
             return codes;
+        }
+    }
+
+    private List<String> uniqueIndexColumns(String tableName, String indexName) throws Exception {
+        try (Connection connection = MYSQL.createConnection("");
+             var statement = connection.prepareStatement("""
+                     SELECT column_name
+                     FROM information_schema.statistics
+                     WHERE table_schema = DATABASE()
+                       AND table_name = ?
+                       AND index_name = ?
+                       AND non_unique = 0
+                     ORDER BY seq_in_index
+                     """)) {
+            statement.setString(1, tableName);
+            statement.setString(2, indexName);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                List<String> columns = new ArrayList<>();
+                while (resultSet.next()) {
+                    columns.add(resultSet.getString("column_name"));
+                }
+                return columns;
+            }
+        }
+    }
+
+    private void insertSettlementIdentity() throws SQLException {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement()) {
+            statement.executeUpdate("""
+                    INSERT INTO reward_settlements (
+                        player_id,
+                        source_type,
+                        source_id,
+                        reward_profile_id,
+                        reward_profile_code,
+                        status,
+                        created_at,
+                        updated_at
+                    ) VALUES (
+                        185,
+                        'QUEST_COMPLETION',
+                        185001,
+                        1,
+                        'RP_EXP_10',
+                        'PENDING',
+                        CURRENT_TIMESTAMP(6),
+                        CURRENT_TIMESTAMP(6)
+                    )
+                    """);
         }
     }
 }

--- a/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
@@ -12,6 +12,9 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import online.lifeasgame.reward.application.RewardProfileReader;
 import online.lifeasgame.reward.application.RewardProfileQueryService;
+import online.lifeasgame.reward.application.RewardSettlementCreateService;
+import online.lifeasgame.reward.application.RewardSettlementReader;
+import online.lifeasgame.reward.domain.RewardSettlementSourceType;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -21,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 @SpringBootTest
 @ActiveProfiles({"test", "migration-test"})
-@DisplayName("V2 migration 이후 JPA schema validation")
+@DisplayName("V3 migration 이후 JPA schema validation")
 class JpaValidateAfterMigrationTest {
 
     @Container
@@ -50,15 +53,21 @@ class JpaValidateAfterMigrationTest {
     @Autowired
     private RewardProfileQueryService rewardProfileQueryService;
 
+    @Autowired
+    private RewardSettlementCreateService rewardSettlementCreateService;
+
+    @Autowired
+    private RewardSettlementReader rewardSettlementReader;
+
     @Nested
-    @DisplayName("V1과 V2가 적용된 schema로 ApplicationContext를 기동할 때")
+    @DisplayName("V1부터 V3까지 적용된 schema로 ApplicationContext를 기동할 때")
     class LoadApplicationContext {
 
         @Test
         @DisplayName("ddl-auto validate 상태로 정상 기동한다")
         void loadsWithJpaValidation() {
             assertThat(applicationContext).isNotNull();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("2");
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("3");
             assertThat(applicationContext.getEnvironment().getProperty("spring.jpa.hibernate.ddl-auto"))
                     .isEqualTo("validate");
             assertThat(applicationContext.getEnvironment()
@@ -87,6 +96,35 @@ class JpaValidateAfterMigrationTest {
             assertThat(rewardProfileQueryService.listActiveProfiles())
                     .extracting(summary -> summary.code())
                     .containsExactly("RP_EXP_10", "RP_EXP_30");
+        }
+    }
+
+    @Nested
+    @DisplayName("V3 Settlement Aggregate를 저장하고 상세 조회할 때")
+    class PersistSettlementAggregate {
+
+        @Test
+        @DisplayName("Line을 함께 저장하고 같은 식별자의 재호출은 기존 Settlement를 반환한다")
+        void persistsAndReturnsExistingSettlement() {
+            var first = rewardSettlementCreateService.create(
+                    185L,
+                    RewardSettlementSourceType.QUEST_COMPLETION,
+                    185001L,
+                    "RP_EXP_10"
+            );
+            var second = rewardSettlementCreateService.create(
+                    185L,
+                    RewardSettlementSourceType.QUEST_COMPLETION,
+                    185001L,
+                    "RP_EXP_10"
+            );
+            var loaded = rewardSettlementReader.getByIdOrThrow(first.getId());
+
+            assertThat(second.getId()).isEqualTo(first.getId());
+            assertThat(loaded.getLines()).hasSize(1);
+            assertThat(loaded.getLines().getFirst().getRewardDefinitionCode())
+                    .isEqualTo("RD_EXP_10");
+            assertThat(loaded.getLines().getFirst().getAmount()).isEqualTo(10L);
         }
     }
 }

--- a/src/test/java/online/lifeasgame/reward/application/RewardSettlementConcurrencyTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardSettlementConcurrencyTest.java
@@ -50,13 +50,10 @@ class RewardSettlementConcurrencyTest {
     private PlatformTransactionManager transactionManager;
 
     @Autowired
-    private RewardProfileReader profileReader;
-
-    @Autowired
     private RewardSettlementReader settlementReader;
 
     @Autowired
-    private RewardSettlementWriter settlementWriter;
+    private RewardSettlementCreateAttempt createAttempt;
 
     @Autowired
     private RewardSettlementCreateService createService;
@@ -78,13 +75,12 @@ class RewardSettlementConcurrencyTest {
                 assertThat(settlementReader.findByIdentity(PLAYER_ID, SOURCE_TYPE, SOURCE_ID))
                         .isEmpty();
 
-                RewardSettlement winner = RewardSettlement.create(
+                RewardSettlement savedWinner = createAttempt.create(
                         PLAYER_ID,
                         SOURCE_TYPE,
                         SOURCE_ID,
-                        profileReader.getActiveByCodeOrThrow(PROFILE_CODE)
+                        PROFILE_CODE
                 );
-                RewardSettlement savedWinner = settlementWriter.saveAndFlush(winner);
 
                 boolean ordinaryReadStillMisses = settlementReader
                         .findByIdentity(PLAYER_ID, SOURCE_TYPE, SOURCE_ID)

--- a/src/test/java/online/lifeasgame/reward/application/RewardSettlementConcurrencyTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardSettlementConcurrencyTest.java
@@ -1,0 +1,148 @@
+package online.lifeasgame.reward.application;
+
+import online.lifeasgame.reward.domain.RewardSettlement;
+import online.lifeasgame.reward.domain.RewardSettlementSourceType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles({"test", "migration-test"})
+@DisplayName("RewardSettlement 동시 생성 복구")
+class RewardSettlementConcurrencyTest {
+
+    private static final Long PLAYER_ID = 185L;
+    private static final Long SOURCE_ID = 185002L;
+    private static final String PROFILE_CODE = "RP_EXP_10";
+    private static final RewardSettlementSourceType SOURCE_TYPE =
+            RewardSettlementSourceType.QUEST_COMPLETION;
+
+    @Container
+    private static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0.39")
+            .withDatabaseName("lifeasgame_settlement_concurrency")
+            .withUsername("lifeasgame")
+            .withPassword("lifeasgame");
+
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", MYSQL::getDriverClassName);
+    }
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @Autowired
+    private RewardProfileReader profileReader;
+
+    @Autowired
+    private RewardSettlementReader settlementReader;
+
+    @Autowired
+    private RewardSettlementWriter settlementWriter;
+
+    @Autowired
+    private RewardSettlementCreateService createService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Nested
+    @DisplayName("상위 REPEATABLE READ 트랜잭션이 최초 조회 snapshot을 유지할 때")
+    class RecoverAfterUniqueConflict {
+
+        @Test
+        @DisplayName("Unique 충돌 후 새 조회 트랜잭션에서 승자 Settlement를 반환한다")
+        void returnsWinnerFromNewReadTransaction() {
+            TransactionTemplate repeatableRead = new TransactionTemplate(transactionManager);
+            repeatableRead.setIsolationLevel(TransactionDefinition.ISOLATION_REPEATABLE_READ);
+
+            CompetitionResult result = repeatableRead.execute(status -> {
+                assertThat(settlementReader.findByIdentity(PLAYER_ID, SOURCE_TYPE, SOURCE_ID))
+                        .isEmpty();
+
+                RewardSettlement winner = RewardSettlement.create(
+                        PLAYER_ID,
+                        SOURCE_TYPE,
+                        SOURCE_ID,
+                        profileReader.getActiveByCodeOrThrow(PROFILE_CODE)
+                );
+                RewardSettlement savedWinner = settlementWriter.saveAndFlush(winner);
+
+                boolean ordinaryReadStillMisses = settlementReader
+                        .findByIdentity(PLAYER_ID, SOURCE_TYPE, SOURCE_ID)
+                        .isEmpty();
+                RewardSettlement recovered = createService.create(
+                        PLAYER_ID,
+                        SOURCE_TYPE,
+                        SOURCE_ID,
+                        PROFILE_CODE
+                );
+
+                return new CompetitionResult(
+                        savedWinner.getId(),
+                        recovered.getId(),
+                        savedWinner.getLines().size(),
+                        recovered.getLines().size(),
+                        ordinaryReadStillMisses
+                );
+            });
+
+            assertThat(result).isNotNull();
+            assertThat(result.ordinaryReadStillMisses()).isTrue();
+            assertThat(result.recoveredId()).isEqualTo(result.winnerId());
+            assertThat(result.winnerLineCount()).isEqualTo(1);
+            assertThat(result.recoveredLineCount()).isEqualTo(1);
+            assertThat(settlementRowCount()).isEqualTo(1);
+            assertThat(settlementLineRowCount()).isEqualTo(1);
+        }
+    }
+
+    private int settlementRowCount() {
+        return jdbcTemplate.queryForObject("""
+                SELECT COUNT(*)
+                FROM reward_settlements
+                WHERE player_id = ?
+                  AND source_type = ?
+                  AND source_id = ?
+                """, Integer.class, PLAYER_ID, SOURCE_TYPE.name(), SOURCE_ID);
+    }
+
+    private int settlementLineRowCount() {
+        return jdbcTemplate.queryForObject("""
+                SELECT COUNT(*)
+                FROM reward_settlement_lines line
+                JOIN reward_settlements settlement
+                  ON settlement.id = line.reward_settlement_id
+                WHERE settlement.player_id = ?
+                  AND settlement.source_type = ?
+                  AND settlement.source_id = ?
+                """, Integer.class, PLAYER_ID, SOURCE_TYPE.name(), SOURCE_ID);
+    }
+
+    private record CompetitionResult(
+            Long winnerId,
+            Long recoveredId,
+            int winnerLineCount,
+            int recoveredLineCount,
+            boolean ordinaryReadStillMisses
+    ) {
+    }
+}

--- a/src/test/java/online/lifeasgame/reward/application/RewardSettlementCreateServiceTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardSettlementCreateServiceTest.java
@@ -49,7 +49,9 @@ class RewardSettlementCreateServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new RewardSettlementCreateService(settlementReader, profileReader, settlementWriter);
+        RewardSettlementCreateAttempt createAttempt =
+                new RewardSettlementCreateAttempt(profileReader, settlementWriter);
+        service = new RewardSettlementCreateService(settlementReader, createAttempt);
     }
 
     @Nested

--- a/src/test/java/online/lifeasgame/reward/application/RewardSettlementCreateServiceTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardSettlementCreateServiceTest.java
@@ -1,0 +1,189 @@
+package online.lifeasgame.reward.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.reward.domain.RewardDefinition;
+import online.lifeasgame.reward.domain.RewardProfile;
+import online.lifeasgame.reward.domain.RewardProfileStatus;
+import online.lifeasgame.reward.domain.RewardSettlement;
+import online.lifeasgame.reward.domain.RewardSettlementSourceType;
+import online.lifeasgame.reward.domain.RewardType;
+import online.lifeasgame.reward.domain.error.RewardError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RewardSettlementCreateService")
+class RewardSettlementCreateServiceTest {
+
+    private static final Long PLAYER_ID = 1L;
+    private static final Long SOURCE_ID = 1000L;
+    private static final String PROFILE_CODE = "RP_EXP_10";
+
+    @Mock
+    private RewardSettlementReader settlementReader;
+
+    @Mock
+    private RewardProfileReader profileReader;
+
+    @Mock
+    private RewardSettlementWriter settlementWriter;
+
+    private RewardSettlementCreateService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new RewardSettlementCreateService(settlementReader, profileReader, settlementWriter);
+    }
+
+    @Nested
+    @DisplayName("활성 RewardProfile로 Settlement를 생성할 때")
+    class CreateNewSettlement {
+
+        @Test
+        @DisplayName("Profile Line 스냅샷을 한 번 저장한다")
+        void savesLineSnapshotsOnce() {
+            RewardProfile profile = activeProfile();
+            given(settlementReader.findByIdentity(PLAYER_ID, sourceType(), SOURCE_ID))
+                    .willReturn(Optional.empty());
+            given(profileReader.getActiveByCodeOrThrow(PROFILE_CODE)).willReturn(profile);
+            given(settlementWriter.saveAndFlush(any(RewardSettlement.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0, RewardSettlement.class));
+
+            RewardSettlement result = create();
+
+            assertThat(result.getLines()).hasSize(1);
+            assertThat(result.getLines().getFirst().getAmount()).isEqualTo(10L);
+            verify(settlementWriter).saveAndFlush(result);
+        }
+
+        @Test
+        @DisplayName("비활성 Profile이면 REWARD_PROFILE_INACTIVE 예외가 발생한다")
+        void rejectsInactiveProfile() {
+            given(settlementReader.findByIdentity(PLAYER_ID, sourceType(), SOURCE_ID))
+                    .willReturn(Optional.empty());
+            given(profileReader.getActiveByCodeOrThrow(PROFILE_CODE))
+                    .willThrow(new DomainException(RewardError.REWARD_PROFILE_INACTIVE));
+
+            assertRewardError(this::createSettlement, RewardError.REWARD_PROFILE_INACTIVE);
+            verify(settlementWriter, never()).saveAndFlush(any(RewardSettlement.class));
+        }
+
+        @Test
+        @DisplayName("Profile이 없으면 REWARD_PROFILE_NOT_FOUND 예외가 발생한다")
+        void rejectsMissingProfile() {
+            given(settlementReader.findByIdentity(PLAYER_ID, sourceType(), SOURCE_ID))
+                    .willReturn(Optional.empty());
+            given(profileReader.getActiveByCodeOrThrow(PROFILE_CODE))
+                    .willThrow(new DomainException(RewardError.REWARD_PROFILE_NOT_FOUND));
+
+            assertRewardError(this::createSettlement, RewardError.REWARD_PROFILE_NOT_FOUND);
+            verify(settlementWriter, never()).saveAndFlush(any(RewardSettlement.class));
+        }
+
+        private void createSettlement() {
+            create();
+        }
+    }
+
+    @Nested
+    @DisplayName("같은 정산 식별자로 다시 생성할 때")
+    class CreateExistingSettlement {
+
+        @Test
+        @DisplayName("새 Line을 만들지 않고 기존 Settlement를 반환한다")
+        void returnsExistingSettlement() {
+            RewardSettlement existing = settlement(activeProfile());
+            int originalLineCount = existing.getLines().size();
+            given(settlementReader.findByIdentity(PLAYER_ID, sourceType(), SOURCE_ID))
+                    .willReturn(Optional.of(existing));
+
+            RewardSettlement result = create();
+
+            assertThat(result).isSameAs(existing);
+            assertThat(result.getLines()).hasSize(originalLineCount);
+            verify(profileReader, never()).getActiveByCodeOrThrow(anyString());
+            verify(settlementWriter, never()).saveAndFlush(any(RewardSettlement.class));
+        }
+
+        @Test
+        @DisplayName("동시 생성 Unique 충돌 후 기존 Settlement를 다시 조회해 반환한다")
+        void returnsWinnerAfterUniqueConflict() {
+            RewardProfile profile = activeProfile();
+            RewardSettlement winner = settlement(profile);
+            given(settlementReader.findByIdentity(PLAYER_ID, sourceType(), SOURCE_ID))
+                    .willReturn(Optional.empty())
+                    .willReturn(Optional.of(winner));
+            given(profileReader.getActiveByCodeOrThrow(PROFILE_CODE)).willReturn(profile);
+            given(settlementWriter.saveAndFlush(any(RewardSettlement.class)))
+                    .willThrow(new DataIntegrityViolationException("duplicate settlement identity"));
+
+            RewardSettlement result = create();
+
+            assertThat(result).isSameAs(winner);
+        }
+
+        @Test
+        @DisplayName("Unique 충돌 뒤 기존 Settlement가 없으면 원래 저장 예외를 전파한다")
+        void rethrowsWhenConflictIsNotIdentityDuplicate() {
+            RewardProfile profile = activeProfile();
+            given(settlementReader.findByIdentity(PLAYER_ID, sourceType(), SOURCE_ID))
+                    .willReturn(Optional.empty());
+            given(profileReader.getActiveByCodeOrThrow(PROFILE_CODE)).willReturn(profile);
+            given(settlementWriter.saveAndFlush(any(RewardSettlement.class)))
+                    .willThrow(new DataIntegrityViolationException("other constraint"));
+
+            assertThatThrownBy(RewardSettlementCreateServiceTest.this::create)
+                    .isInstanceOf(DataIntegrityViolationException.class)
+                    .hasMessage("other constraint");
+        }
+    }
+
+    private RewardSettlement create() {
+        return service.create(PLAYER_ID, sourceType(), SOURCE_ID, PROFILE_CODE);
+    }
+
+    private RewardSettlement settlement(RewardProfile profile) {
+        return RewardSettlement.create(PLAYER_ID, sourceType(), SOURCE_ID, profile);
+    }
+
+    private RewardSettlementSourceType sourceType() {
+        return RewardSettlementSourceType.QUEST_COMPLETION;
+    }
+
+    private RewardProfile activeProfile() {
+        RewardProfile profile = RewardProfile.create(
+                PROFILE_CODE, "EXP 10 Profile", RewardProfileStatus.ACTIVE
+        );
+        ReflectionTestUtils.setField(profile, "id", 10L);
+        RewardDefinition definition = RewardDefinition.create(
+                "RD_EXP_10", "EXP 10", RewardType.EXP, 10L, null, true
+        );
+        ReflectionTestUtils.setField(definition, "id", 20L);
+        profile.addLine(definition, 0, null);
+        return profile;
+    }
+
+    private void assertRewardError(Runnable action, RewardError error) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(error)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/reward/application/RewardSettlementCreateServiceTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardSettlementCreateServiceTest.java
@@ -128,7 +128,8 @@ class RewardSettlementCreateServiceTest {
             RewardProfile profile = activeProfile();
             RewardSettlement winner = settlement(profile);
             given(settlementReader.findByIdentity(PLAYER_ID, sourceType(), SOURCE_ID))
-                    .willReturn(Optional.empty())
+                    .willReturn(Optional.empty());
+            given(settlementReader.findByIdentityInNewTransaction(PLAYER_ID, sourceType(), SOURCE_ID))
                     .willReturn(Optional.of(winner));
             given(profileReader.getActiveByCodeOrThrow(PROFILE_CODE)).willReturn(profile);
             given(settlementWriter.saveAndFlush(any(RewardSettlement.class)))
@@ -137,6 +138,8 @@ class RewardSettlementCreateServiceTest {
             RewardSettlement result = create();
 
             assertThat(result).isSameAs(winner);
+            verify(settlementReader)
+                    .findByIdentityInNewTransaction(PLAYER_ID, sourceType(), SOURCE_ID);
         }
 
         @Test
@@ -144,6 +147,8 @@ class RewardSettlementCreateServiceTest {
         void rethrowsWhenConflictIsNotIdentityDuplicate() {
             RewardProfile profile = activeProfile();
             given(settlementReader.findByIdentity(PLAYER_ID, sourceType(), SOURCE_ID))
+                    .willReturn(Optional.empty());
+            given(settlementReader.findByIdentityInNewTransaction(PLAYER_ID, sourceType(), SOURCE_ID))
                     .willReturn(Optional.empty());
             given(profileReader.getActiveByCodeOrThrow(PROFILE_CODE)).willReturn(profile);
             given(settlementWriter.saveAndFlush(any(RewardSettlement.class)))

--- a/src/test/java/online/lifeasgame/reward/domain/RewardSettlementTest.java
+++ b/src/test/java/online/lifeasgame/reward/domain/RewardSettlementTest.java
@@ -1,0 +1,250 @@
+package online.lifeasgame.reward.domain;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.reward.domain.error.RewardError;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("RewardSettlement")
+class RewardSettlementTest {
+
+    @Nested
+    @DisplayName("활성 RewardProfile로 정산을 생성할 때")
+    class CreateSettlement {
+
+        @Test
+        @DisplayName("Profile Line을 독립된 Settlement Line 스냅샷으로 생성한다")
+        void createsLineSnapshots() {
+            RewardProfile profile = profileWithExpAndItem();
+
+            RewardSettlement settlement = settlement(profile);
+
+            assertThat(settlement.getRewardProfileId()).isEqualTo(100L);
+            assertThat(settlement.getRewardProfileCode()).isEqualTo("RP_REWARD");
+            assertThat(settlement.getLines())
+                    .extracting(
+                            RewardSettlementLine::getRewardDefinitionCode,
+                            RewardSettlementLine::getRewardType,
+                            RewardSettlementLine::getAmount,
+                            RewardSettlementLine::getItemId,
+                            RewardSettlementLine::getSortOrder
+                    )
+                    .containsExactly(
+                            org.assertj.core.groups.Tuple.tuple("RD_EXP", RewardType.EXP, 10L, null, 0),
+                            org.assertj.core.groups.Tuple.tuple("RD_ITEM", RewardType.ITEM, 2L, 77L, 1)
+                    );
+            assertThat(settlement.getLines())
+                    .extracting(RewardSettlementLine::getStatus)
+                    .containsOnly(RewardSettlementLineStatus.PENDING);
+            assertThat(settlement.getStatus()).isEqualTo(RewardSettlementStatus.PENDING);
+        }
+
+        @Test
+        @DisplayName("amountOverride가 있으면 effectiveAmount를 스냅샷으로 저장한다")
+        void snapshotsEffectiveAmount() {
+            RewardProfile profile = persistedProfile("RP_OVERRIDE");
+            profile.addLine(persistedExpDefinition(1L, "RD_EXP_10", 10L), 0, 30L);
+
+            RewardSettlement settlement = settlement(profile);
+
+            assertThat(settlement.getLines().getFirst().getAmount()).isEqualTo(30L);
+        }
+
+        @Test
+        @DisplayName("원본 Profile과 Definition이 변경돼도 스냅샷 값은 유지된다")
+        void keepsSnapshotAfterSourceChanges() {
+            RewardProfile profile = persistedProfile("RP_SNAPSHOT");
+            RewardDefinition definition = persistedExpDefinition(1L, "RD_EXP_10", 10L);
+            profile.addLine(definition, 0, null);
+            RewardSettlement settlement = settlement(profile);
+
+            ReflectionTestUtils.setField(profile, "code", "RP_CHANGED");
+            ReflectionTestUtils.setField(definition, "code", "RD_CHANGED");
+            ReflectionTestUtils.setField(definition, "amount", 999L);
+
+            RewardSettlementLine line = settlement.getLines().getFirst();
+            assertThat(settlement.getRewardProfileCode()).isEqualTo("RP_SNAPSHOT");
+            assertThat(line.getRewardDefinitionCode()).isEqualTo("RD_EXP_10");
+            assertThat(line.getAmount()).isEqualTo(10L);
+        }
+
+        @Test
+        @DisplayName("Profile Line이 없으면 REWARD_SETTLEMENT_PROFILE_LINES_REQUIRED 예외가 발생한다")
+        void rejectsEmptyProfile() {
+            RewardProfile profile = persistedProfile("RP_EMPTY");
+
+            assertRewardError(
+                    () -> settlement(profile),
+                    RewardError.REWARD_SETTLEMENT_PROFILE_LINES_REQUIRED
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("Line 처리 결과를 반영할 때")
+    class UpdateLineResult {
+
+        @Test
+        @DisplayName("성공 처리한 Line은 SUCCEEDED가 되고 같은 성공 처리는 멱등이다")
+        void succeedsIdempotently() {
+            RewardSettlement settlement = settlement(profileWithExpAndItem());
+
+            settlement.markLineSucceeded(0);
+            settlement.markLineSucceeded(0);
+
+            assertThat(settlement.getLines().getFirst().getStatus())
+                    .isEqualTo(RewardSettlementLineStatus.SUCCEEDED);
+        }
+
+        @Test
+        @DisplayName("실패 처리한 Line은 FAILED와 ErrorCode를 저장한다")
+        void storesFailureCode() {
+            RewardSettlement settlement = settlement(profileWithExpAndItem());
+
+            settlement.markLineFailed(0, RewardError.REWARD_DEFINITION_NOT_FOUND);
+
+            RewardSettlementLine line = settlement.getLines().getFirst();
+            assertThat(line.getStatus()).isEqualTo(RewardSettlementLineStatus.FAILED);
+            assertThat(line.getFailureCode())
+                    .isEqualTo(RewardError.REWARD_DEFINITION_NOT_FOUND.code());
+        }
+
+        @Test
+        @DisplayName("성공한 Line을 실패 처리하면 도메인 예외가 발생한다")
+        void rejectsFailureAfterSuccess() {
+            RewardSettlement settlement = settlement(profileWithExpAndItem());
+            settlement.markLineSucceeded(0);
+
+            assertRewardError(
+                    () -> settlement.markLineFailed(0, RewardError.REWARD_DEFINITION_NOT_FOUND),
+                    RewardError.REWARD_SETTLEMENT_SUCCEEDED_LINE_CANNOT_FAIL
+            );
+        }
+
+        @Test
+        @DisplayName("실패한 Line을 성공 처리하면 도메인 예외가 발생한다")
+        void rejectsSuccessAfterFailure() {
+            RewardSettlement settlement = settlement(profileWithExpAndItem());
+            settlement.markLineFailed(0, RewardError.REWARD_DEFINITION_NOT_FOUND);
+
+            assertRewardError(
+                    () -> settlement.markLineSucceeded(0),
+                    RewardError.REWARD_SETTLEMENT_LINE_ALREADY_FAILED
+            );
+        }
+
+        @Test
+        @DisplayName("실패 ErrorCode가 없으면 도메인 예외가 발생한다")
+        void requiresFailureCode() {
+            RewardSettlement settlement = settlement(profileWithExpAndItem());
+
+            assertRewardError(
+                    () -> settlement.markLineFailed(0, null),
+                    RewardError.REWARD_SETTLEMENT_FAILURE_CODE_REQUIRED
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("Line 상태로 Settlement 상태를 계산할 때")
+    class CalculateSettlementStatus {
+
+        @Test
+        @DisplayName("모든 Line이 성공하면 COMPLETED가 된다")
+        void completesWhenAllLinesSucceed() {
+            RewardSettlement settlement = settlement(profileWithExpAndItem());
+
+            settlement.markLineSucceeded(0);
+            settlement.markLineSucceeded(1);
+
+            assertThat(settlement.getStatus()).isEqualTo(RewardSettlementStatus.COMPLETED);
+        }
+
+        @Test
+        @DisplayName("모든 Line이 실패하면 FAILED가 된다")
+        void failsWhenAllLinesFail() {
+            RewardSettlement settlement = settlement(profileWithExpAndItem());
+
+            settlement.markLineFailed(0, RewardError.REWARD_DEFINITION_NOT_FOUND);
+            settlement.markLineFailed(1, RewardError.REWARD_DEFINITION_NOT_FOUND);
+
+            assertThat(settlement.getStatus()).isEqualTo(RewardSettlementStatus.FAILED);
+        }
+
+        @Test
+        @DisplayName("성공과 실패 Line이 함께 있으면 PARTIAL_FAILED가 된다")
+        void partiallyFailsWhenResultsAreMixed() {
+            RewardSettlement settlement = settlement(profileWithExpAndItem());
+
+            settlement.markLineSucceeded(0);
+            settlement.markLineFailed(1, RewardError.REWARD_DEFINITION_NOT_FOUND);
+
+            assertThat(settlement.getStatus()).isEqualTo(RewardSettlementStatus.PARTIAL_FAILED);
+        }
+
+        @Test
+        @DisplayName("하나라도 Pending Line이 남으면 PENDING을 유지한다")
+        void remainsPendingWhileLineIsPending() {
+            RewardSettlement settlement = settlement(profileWithExpAndItem());
+
+            settlement.markLineSucceeded(0);
+
+            assertThat(settlement.getStatus()).isEqualTo(RewardSettlementStatus.PENDING);
+        }
+    }
+
+    private RewardSettlement settlement(RewardProfile profile) {
+        return RewardSettlement.create(
+                1L,
+                RewardSettlementSourceType.QUEST_COMPLETION,
+                1000L,
+                profile
+        );
+    }
+
+    private RewardProfile profileWithExpAndItem() {
+        RewardProfile profile = persistedProfile("RP_REWARD");
+        profile.addLine(persistedExpDefinition(1L, "RD_EXP", 10L), 0, null);
+        profile.addLine(persistedItemDefinition(2L, "RD_ITEM", 77L, 2L), 1, null);
+        return profile;
+    }
+
+    private RewardProfile persistedProfile(String code) {
+        RewardProfile profile = RewardProfile.create(code, code, RewardProfileStatus.ACTIVE);
+        ReflectionTestUtils.setField(profile, "id", 100L);
+        return profile;
+    }
+
+    private RewardDefinition persistedExpDefinition(Long id, String code, Long amount) {
+        RewardDefinition definition = RewardDefinition.create(
+                code, code, RewardType.EXP, amount, null, true
+        );
+        ReflectionTestUtils.setField(definition, "id", id);
+        return definition;
+    }
+
+    private RewardDefinition persistedItemDefinition(
+            Long id,
+            String code,
+            Long itemId,
+            Long quantity
+    ) {
+        RewardDefinition definition = RewardDefinition.create(
+                code, code, RewardType.ITEM, quantity, itemId, true
+        );
+        ReflectionTestUtils.setField(definition, "id", id);
+        return definition;
+    }
+
+    private void assertRewardError(Runnable action, RewardError error) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(error)
+                );
+    }
+}


### PR DESCRIPTION
## What

- RewardSettlement와 RewardSettlementLine 기반을 추가했습니다.
- 활성 RewardProfile에서 정산 Line 스냅샷을 생성하도록 구현했습니다.
- 동일 정산 식별자의 중복 생성 방지 기반을 추가했습니다.
- Line별 처리 상태와 Settlement 집계 상태를 추가했습니다.
- V3 Flyway migration과 관련 테스트를 추가했습니다.

## Scope

- RewardSettlement Aggregate
- RewardSettlementLine
- Reward Line snapshot
- Settlement idempotency
- Line/Settlement status
- Reward repository/reader/application service
- V3 migration
- Domain/application/migration tests

## Out of Scope

- 실제 EXP 지급
- Reward Mailbox 전달
- Inventory 반영
- Mailbox Claim
- Quest 완료 연결
- Achievement
- Outbox
- 자동 재시도
- 외부 공개 API
- Saga

## Test

- [ ] `./gradlew clean test`
- [ ] `./gradlew build`
- [ ] `./gradlew test --tests '*RewardSettlement*'`
- [ ] `./gradlew test --tests '*FlywayMigrationTest'`
- [ ] `./gradlew test --tests '*JpaValidateAfterMigrationTest'`
- [ ] `./gradlew test --tests '*FlywayHistoryChecksumTest'`

Closes #185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reward settlement creation backed by identity-based duplicate prevention and profile-driven reward line snapshots.
  * Introduced settlement and settlement-line status handling, including success/failure transitions with error codes.
  * Added persistence support for settlements and ordered reward lines, with new database schema for this feature.

* **Tests**
  * Expanded Flyway migration and JPA validation checks for the new schema.
  * Added unit and concurrency test coverage for reuse on duplicates and correct behavior under transactional isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->