### PR TITLE
[Reward] Process EXP reward settlements

### DIFF
--- a/src/main/java/online/lifeasgame/character/application/PlayerExpGrantService.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerExpGrantService.java
@@ -1,0 +1,32 @@
+package online.lifeasgame.character.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.domain.Player;
+import online.lifeasgame.character.domain.service.LevelingPolicy;
+import online.lifeasgame.core.event.DomainEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PlayerExpGrantService {
+
+    private final PlayerReader playerReader;
+    private final LevelingPolicy levelingPolicy;
+    private final DomainEventPublisher domainEventPublisher;
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public Player.GainResult grantExp(Long playerId, long amount) {
+        Player player = playerReader.getByIdForUpdateOrThrow(playerId);
+        return grantExp(player, amount);
+    }
+
+    Player.GainResult grantExp(Player player, long amount) {
+        Player.GainResult result = player.gainExp(amount, levelingPolicy);
+
+        domainEventPublisher.publishAll(player.pullEvents());
+
+        return result;
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/PlayerReader.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerReader.java
@@ -21,6 +21,12 @@ class PlayerReader {
                 .orElseThrow(() -> new DomainException(PlayerError.PLAYER_NOT_FOUND));
     }
 
+    @Transactional(propagation = Propagation.MANDATORY)
+    public Player getByIdForUpdateOrThrow(Long playerId) {
+        return repository.findByIdForUpdate(playerId)
+                .orElseThrow(() -> new DomainException(PlayerError.PLAYER_NOT_FOUND));
+    }
+
     public void assertExistsById(Long playerId) {
         if (!repository.existsById(playerId)) {
             throw new DomainException(PlayerError.PLAYER_NOT_FOUND);

--- a/src/main/java/online/lifeasgame/character/application/PlayerRewardExpGrantService.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerRewardExpGrantService.java
@@ -1,0 +1,67 @@
+package online.lifeasgame.character.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.application.growth.PlayerGrowthChangeReader;
+import online.lifeasgame.character.application.growth.PlayerGrowthChangeWriter;
+import online.lifeasgame.character.application.internal.PlayerGrowthApi;
+import online.lifeasgame.character.domain.Player;
+import online.lifeasgame.character.domain.growth.PlayerGrowthChange;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class PlayerRewardExpGrantService implements PlayerGrowthApi {
+
+    private final PlayerReader playerReader;
+    private final PlayerExpGrantService playerExpGrantService;
+    private final PlayerGrowthChangeReader growthChangeReader;
+    private final PlayerGrowthChangeWriter growthChangeWriter;
+
+    @Override
+    @Transactional(propagation = Propagation.MANDATORY)
+    public PlayerGrowthGrantResult grantRewardExp(
+            Long playerId,
+            Long rewardLineId,
+            long amount
+    ) {
+        Player player = playerReader.getByIdForUpdateOrThrow(playerId);
+        Optional<PlayerGrowthChange> existing = growthChangeReader.findByRewardLineId(rewardLineId);
+        if (existing.isPresent()) {
+            PlayerGrowthChange change = existing.get();
+            change.assertMatches(playerId, rewardLineId, amount);
+            return toResult(change, true);
+        }
+
+        Player.GainResult gainResult = playerExpGrantService.grantExp(player, amount);
+        PlayerGrowthChange change = PlayerGrowthChange.rewardExp(playerId, rewardLineId, gainResult);
+        PlayerGrowthChange saved = growthChangeWriter.saveAndFlush(change);
+        return toResult(saved, false);
+    }
+
+    @Override
+    @Transactional(readOnly = true, propagation = Propagation.MANDATORY)
+    public Optional<PlayerGrowthGrantResult> findRewardExpGrant(Long rewardLineId) {
+        return growthChangeReader.findByRewardLineId(rewardLineId)
+                .map(change -> toResult(change, true));
+    }
+
+    private PlayerGrowthGrantResult toResult(PlayerGrowthChange change, boolean replayed) {
+        return new PlayerGrowthGrantResult(
+                change.getId(),
+                change.getPlayerId(),
+                change.getRewardLineId(),
+                change.getRequestedExp(),
+                change.getAppliedExp(),
+                change.getLeftoverExp(),
+                change.getBeforeLevel(),
+                change.getAfterLevel(),
+                change.getBeforeTotalExp(),
+                change.getAfterTotalExp(),
+                replayed
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/PlayerService.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import online.lifeasgame.character.application.command.PlayerCommand;
 import online.lifeasgame.character.application.result.PlayerResult;
 import online.lifeasgame.character.domain.*;
-import online.lifeasgame.character.domain.service.LevelingPolicy;
 import online.lifeasgame.core.event.DomainEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,7 +15,7 @@ public class PlayerService {
     private final PlayerWriter playerWriter;
     private final PlayerReader playerReader;
     private final PlayerTitleReader playerTitleReader;
-    private final LevelingPolicy levelingPolicy;
+    private final PlayerExpGrantService playerExpGrantService;
     private final DomainEventPublisher domainEventPublisher;
 
     @Transactional
@@ -58,13 +57,7 @@ public class PlayerService {
 
     @Transactional
     public PlayerResult.ExpGranted grantExp(Long playerId, long exp) {
-        Player player = playerReader.getByIdOrThrow(playerId);
-
-        Player.GainResult gainResult = player.gainExp(exp, levelingPolicy);
-
-        domainEventPublisher.publishAll(player.pullEvents());
-
-        return PlayerResult.ExpGranted.from(playerId, gainResult);
+        return PlayerResult.ExpGranted.from(playerId, playerExpGrantService.grantExp(playerId, exp));
     }
 
     @Transactional

--- a/src/main/java/online/lifeasgame/character/application/growth/PlayerGrowthChangeReader.java
+++ b/src/main/java/online/lifeasgame/character/application/growth/PlayerGrowthChangeReader.java
@@ -1,0 +1,22 @@
+package online.lifeasgame.character.application.growth;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.domain.growth.PlayerGrowthChange;
+import online.lifeasgame.character.domain.growth.repository.PlayerGrowthChangeRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.MANDATORY)
+public class PlayerGrowthChangeReader {
+
+    private final PlayerGrowthChangeRepository repository;
+
+    public Optional<PlayerGrowthChange> findByRewardLineId(Long rewardLineId) {
+        return repository.findByRewardLineId(rewardLineId);
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/growth/PlayerGrowthChangeWriter.java
+++ b/src/main/java/online/lifeasgame/character/application/growth/PlayerGrowthChangeWriter.java
@@ -1,0 +1,20 @@
+package online.lifeasgame.character.application.growth;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.domain.growth.PlayerGrowthChange;
+import online.lifeasgame.character.domain.growth.repository.PlayerGrowthChangeRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.MANDATORY)
+public class PlayerGrowthChangeWriter {
+
+    private final PlayerGrowthChangeRepository repository;
+
+    public PlayerGrowthChange saveAndFlush(PlayerGrowthChange change) {
+        return repository.saveAndFlush(change);
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/internal/PlayerGrowthApi.java
+++ b/src/main/java/online/lifeasgame/character/application/internal/PlayerGrowthApi.java
@@ -1,0 +1,25 @@
+package online.lifeasgame.character.application.internal;
+
+import java.util.Optional;
+
+public interface PlayerGrowthApi {
+
+    PlayerGrowthGrantResult grantRewardExp(Long playerId, Long rewardLineId, long amount);
+
+    Optional<PlayerGrowthGrantResult> findRewardExpGrant(Long rewardLineId);
+
+    record PlayerGrowthGrantResult(
+            Long growthChangeId,
+            Long playerId,
+            Long rewardLineId,
+            long requestedExp,
+            long appliedExp,
+            long leftoverExp,
+            int beforeLevel,
+            int afterLevel,
+            long beforeTotalExp,
+            long afterTotalExp,
+            boolean replayed
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/character/domain/Experience.java
+++ b/src/main/java/online/lifeasgame/character/domain/Experience.java
@@ -5,7 +5,8 @@ import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import online.lifeasgame.core.guard.Guard;
+import online.lifeasgame.character.domain.error.PlayerError;
+import online.lifeasgame.core.error.DomainException;
 
 @Embeddable
 @EqualsAndHashCode
@@ -16,7 +17,9 @@ public class Experience {
     private long value;
 
     private Experience(long v) {
-        Guard.minValue(v, 0, "exp");
+        if (v < 0) {
+            throw new DomainException(PlayerError.PLAYER_EXP_MUST_NOT_BE_NEGATIVE);
+        }
         this.value = v;
     }
 
@@ -29,7 +32,13 @@ public class Experience {
     }
 
     public Experience plus(long delta) {
-        Guard.minValue(delta, 0, "delta");
-        return new Experience(value + delta);
+        if (delta < 0) {
+            throw new DomainException(PlayerError.PLAYER_EXP_MUST_NOT_BE_NEGATIVE);
+        }
+        try {
+            return new Experience(Math.addExact(value, delta));
+        } catch (ArithmeticException exception) {
+            throw new DomainException(PlayerError.PLAYER_EXP_OVERFLOW, null, exception);
+        }
     }
 }

--- a/src/main/java/online/lifeasgame/character/domain/Player.java
+++ b/src/main/java/online/lifeasgame/character/domain/Player.java
@@ -106,8 +106,12 @@ public class Player extends AbstractTime {
     }
 
     public GainResult gainExp(long amount, LevelingPolicy leveling) {
-        Guard.minValue(amount, 1, "exp delta");
-        Guard.notNull(leveling, "leveling");
+        if (amount < 1) {
+            throw new DomainException(PlayerError.PLAYER_EXP_AMOUNT_MUST_BE_POSITIVE);
+        }
+        if (leveling == null) {
+            throw new DomainException(PlayerError.PLAYER_LEVELING_POLICY_REQUIRED);
+        }
 
         long beforeTotal = this.exp.value();
         int beforeLv = this.level.value();
@@ -135,6 +139,7 @@ public class Player extends AbstractTime {
         return new GainResult(
                 amount, applied, leftover,
                 beforeLv, afterLv,
+                beforeTotal,
                 this.exp.value(),
                 p.expIntoLevel(), p.expToNext(), p.capForLevel(), p.progressRatio()
         );
@@ -253,6 +258,7 @@ public class Player extends AbstractTime {
             long leftoverExp,
             int beforeLevel,
             int afterLevel,
+            long beforeTotalExp,
             long totalExp,
             long expIntoLevel,
             long expToNext,

--- a/src/main/java/online/lifeasgame/character/domain/error/PlayerError.java
+++ b/src/main/java/online/lifeasgame/character/domain/error/PlayerError.java
@@ -10,6 +10,27 @@ public enum PlayerError implements ErrorCode {
     INVALID_HP("PLR-400-INVALID-HP", "Invalid hpDelta", 400),
     INVALID_MP_CAPACITY("PLR-400-INVALID-MP-CAP", "Invalid mpDelta capacity", 400),
     INVALID_MP("PLR-400-INVALID-MP", "Invalid mpDelta", 400),
+    PLAYER_EXP_AMOUNT_MUST_BE_POSITIVE(
+            "PLR-400-EXP-AMOUNT-NOT-POSITIVE", "Experience grant amount must be positive", 400
+    ),
+    PLAYER_EXP_MUST_NOT_BE_NEGATIVE(
+            "PLR-400-EXP-NEGATIVE", "Experience must not be negative", 400
+    ),
+    PLAYER_LEVELING_POLICY_REQUIRED(
+            "PLR-400-LEVELING-POLICY-REQUIRED", "Leveling policy is required", 400
+    ),
+    PLAYER_EXP_OVERFLOW(
+            "PLR-400-EXP-OVERFLOW", "Experience exceeds the supported range", 400
+    ),
+    PLAYER_GROWTH_REWARD_LINE_ID_REQUIRED(
+            "PLR-400-GROWTH-REWARD-LINE-ID-REQUIRED", "Growth change requires a positive reward line id", 400
+    ),
+    PLAYER_GROWTH_CHANGE_INVALID(
+            "PLR-400-GROWTH-CHANGE-INVALID", "Player growth change is invalid", 400
+    ),
+    PLAYER_GROWTH_CHANGE_INCONSISTENT(
+            "PLR-409-GROWTH-CHANGE-INCONSISTENT", "Player growth change conflicts with its reward line", 409
+    ),
     INVALID_TITLE("PLR-400-INVALID-TITLE", "Invalid title", 400),
     INVALID_STATUS_EFFECT_CODE("PLR-400-INVALID-STATUS-EFFECT", "Invalid status effect", 400);
 

--- a/src/main/java/online/lifeasgame/character/domain/growth/PlayerGrowthChange.java
+++ b/src/main/java/online/lifeasgame/character/domain/growth/PlayerGrowthChange.java
@@ -1,0 +1,119 @@
+package online.lifeasgame.character.domain.growth;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import online.lifeasgame.character.domain.Player;
+import online.lifeasgame.character.domain.error.PlayerError;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.platform.persistence.jpa.AbstractTime;
+
+@Getter
+@Entity
+@Table(
+        name = "player_growth_changes",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_player_growth_change_reward_line",
+                columnNames = "reward_line_id"
+        )
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlayerGrowthChange extends AbstractTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "player_id", nullable = false)
+    private Long playerId;
+
+    @Column(name = "reward_line_id", nullable = false)
+    private Long rewardLineId;
+
+    @Column(name = "requested_exp", nullable = false)
+    private long requestedExp;
+
+    @Column(name = "applied_exp", nullable = false)
+    private long appliedExp;
+
+    @Column(name = "leftover_exp", nullable = false)
+    private long leftoverExp;
+
+    @Column(name = "before_level", nullable = false)
+    private int beforeLevel;
+
+    @Column(name = "after_level", nullable = false)
+    private int afterLevel;
+
+    @Column(name = "before_total_exp", nullable = false)
+    private long beforeTotalExp;
+
+    @Column(name = "after_total_exp", nullable = false)
+    private long afterTotalExp;
+
+    private PlayerGrowthChange(
+            Long playerId,
+            Long rewardLineId,
+            Player.GainResult result
+    ) {
+        validate(playerId, rewardLineId, result);
+        this.playerId = playerId;
+        this.rewardLineId = rewardLineId;
+        this.requestedExp = result.requestedExp();
+        this.appliedExp = result.appliedExp();
+        this.leftoverExp = result.leftoverExp();
+        this.beforeLevel = result.beforeLevel();
+        this.afterLevel = result.afterLevel();
+        this.beforeTotalExp = result.beforeTotalExp();
+        this.afterTotalExp = result.totalExp();
+    }
+
+    public static PlayerGrowthChange rewardExp(
+            Long playerId,
+            Long rewardLineId,
+            Player.GainResult result
+    ) {
+        return new PlayerGrowthChange(playerId, rewardLineId, result);
+    }
+
+    public void assertMatches(Long playerId, Long rewardLineId, long requestedExp) {
+        if (!this.playerId.equals(playerId)
+                || !this.rewardLineId.equals(rewardLineId)
+                || this.requestedExp != requestedExp) {
+            throw new DomainException(PlayerError.PLAYER_GROWTH_CHANGE_INCONSISTENT);
+        }
+    }
+
+    private static void validate(Long playerId, Long rewardLineId, Player.GainResult result) {
+        if (playerId == null || playerId <= 0 || result == null) {
+            throw new DomainException(PlayerError.PLAYER_GROWTH_CHANGE_INVALID);
+        }
+        if (rewardLineId == null || rewardLineId <= 0) {
+            throw new DomainException(PlayerError.PLAYER_GROWTH_REWARD_LINE_ID_REQUIRED);
+        }
+        boolean invalidAmounts;
+        try {
+            invalidAmounts = result.requestedExp() <= 0
+                    || result.appliedExp() < 0
+                    || result.leftoverExp() < 0
+                    || Math.addExact(result.appliedExp(), result.leftoverExp()) != result.requestedExp()
+                    || Math.subtractExact(result.totalExp(), result.beforeTotalExp()) != result.appliedExp();
+        } catch (ArithmeticException exception) {
+            throw new DomainException(PlayerError.PLAYER_GROWTH_CHANGE_INVALID, null, exception);
+        }
+        if (invalidAmounts
+                || result.beforeLevel() < 1
+                || result.afterLevel() < result.beforeLevel()
+                || result.beforeTotalExp() < 0
+                || result.totalExp() < result.beforeTotalExp()) {
+            throw new DomainException(PlayerError.PLAYER_GROWTH_CHANGE_INVALID);
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/character/domain/growth/repository/PlayerGrowthChangeRepository.java
+++ b/src/main/java/online/lifeasgame/character/domain/growth/repository/PlayerGrowthChangeRepository.java
@@ -1,0 +1,12 @@
+package online.lifeasgame.character.domain.growth.repository;
+
+import online.lifeasgame.character.domain.growth.PlayerGrowthChange;
+
+import java.util.Optional;
+
+public interface PlayerGrowthChangeRepository {
+
+    PlayerGrowthChange saveAndFlush(PlayerGrowthChange change);
+
+    Optional<PlayerGrowthChange> findByRewardLineId(Long rewardLineId);
+}

--- a/src/main/java/online/lifeasgame/character/domain/repository/PlayerRepository.java
+++ b/src/main/java/online/lifeasgame/character/domain/repository/PlayerRepository.java
@@ -11,6 +11,8 @@ public interface PlayerRepository {
 
     Optional<Player> findById(Long playerId);
 
+    Optional<Player> findByIdForUpdate(Long playerId);
+
     boolean existsById(Long playerId);
 
     Optional<Player> findByUserId(Long userId);

--- a/src/main/java/online/lifeasgame/character/infra/JpaPlayerRepository.java
+++ b/src/main/java/online/lifeasgame/character/infra/JpaPlayerRepository.java
@@ -1,11 +1,20 @@
 package online.lifeasgame.character.infra;
 
+import jakarta.persistence.LockModeType;
 import online.lifeasgame.character.domain.Player;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface JpaPlayerRepository extends JpaRepository<Player, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select player from Player player where player.id = :playerId")
+    Optional<Player> findByIdForUpdate(@Param("playerId") Long playerId);
+
     boolean existsByUserId(Long userId);
 
     Optional<Player> findByUserId(Long userId);

--- a/src/main/java/online/lifeasgame/character/infra/PlayerRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/character/infra/PlayerRepositoryAdapter.java
@@ -29,6 +29,11 @@ public class PlayerRepositoryAdapter implements PlayerRepository {
     }
 
     @Override
+    public Optional<Player> findByIdForUpdate(Long playerId) {
+        return jpa.findByIdForUpdate(playerId);
+    }
+
+    @Override
     public boolean existsById(Long playerId) {
         return jpa.existsById(playerId);
     }

--- a/src/main/java/online/lifeasgame/character/infra/growth/JpaPlayerGrowthChangeRepository.java
+++ b/src/main/java/online/lifeasgame/character/infra/growth/JpaPlayerGrowthChangeRepository.java
@@ -1,0 +1,11 @@
+package online.lifeasgame.character.infra.growth;
+
+import online.lifeasgame.character.domain.growth.PlayerGrowthChange;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface JpaPlayerGrowthChangeRepository extends JpaRepository<PlayerGrowthChange, Long> {
+
+    Optional<PlayerGrowthChange> findByRewardLineId(Long rewardLineId);
+}

--- a/src/main/java/online/lifeasgame/character/infra/growth/PlayerGrowthChangeRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/character/infra/growth/PlayerGrowthChangeRepositoryAdapter.java
@@ -1,0 +1,25 @@
+package online.lifeasgame.character.infra.growth;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.domain.growth.PlayerGrowthChange;
+import online.lifeasgame.character.domain.growth.repository.PlayerGrowthChangeRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class PlayerGrowthChangeRepositoryAdapter implements PlayerGrowthChangeRepository {
+
+    private final JpaPlayerGrowthChangeRepository jpaRepository;
+
+    @Override
+    public PlayerGrowthChange saveAndFlush(PlayerGrowthChange change) {
+        return jpaRepository.saveAndFlush(change);
+    }
+
+    @Override
+    public Optional<PlayerGrowthChange> findByRewardLineId(Long rewardLineId) {
+        return jpaRepository.findByRewardLineId(rewardLineId);
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/application/RewardSettlementExpProcessAttempt.java
+++ b/src/main/java/online/lifeasgame/reward/application/RewardSettlementExpProcessAttempt.java
@@ -1,0 +1,87 @@
+package online.lifeasgame.reward.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.application.internal.PlayerGrowthApi;
+import online.lifeasgame.character.application.internal.PlayerGrowthApi.PlayerGrowthGrantResult;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.reward.application.result.RewardSettlementExpProcessResult;
+import online.lifeasgame.reward.domain.RewardSettlement;
+import online.lifeasgame.reward.domain.RewardSettlementLine;
+import online.lifeasgame.reward.domain.error.RewardError;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class RewardSettlementExpProcessAttempt {
+
+    private final RewardSettlementReader settlementReader;
+    private final RewardSettlementWriter settlementWriter;
+    private final PlayerGrowthApi playerGrowthApi;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public RewardSettlementExpProcessResult process(Long settlementId, Long lineId) {
+        RewardSettlement settlement = settlementReader.getByIdForUpdateOrThrow(settlementId);
+        RewardSettlementLine line = settlement.getLineByIdOrThrow(lineId);
+
+        if (!line.isExpProcessingRequired()) {
+            PlayerGrowthGrantResult replay = playerGrowthApi.findRewardExpGrant(lineId)
+                    .orElseThrow(() -> new DomainException(
+                            RewardError.REWARD_SETTLEMENT_EXP_GROWTH_INCONSISTENT
+                    ));
+            assertMatches(settlement, line, replay);
+            return toResult(settlement, line, replay);
+        }
+
+        PlayerGrowthGrantResult grantResult = playerGrowthApi.grantRewardExp(
+                settlement.getPlayerId(),
+                line.getId(),
+                line.getAmount()
+        );
+        assertMatches(settlement, line, grantResult);
+        if (grantResult.replayed()) {
+            throw new DomainException(RewardError.REWARD_SETTLEMENT_EXP_GROWTH_INCONSISTENT);
+        }
+
+        settlement.markExpLineSucceeded(lineId);
+        settlementWriter.saveAndFlush(settlement);
+
+        return toResult(settlement, line, grantResult);
+    }
+
+    private void assertMatches(
+            RewardSettlement settlement,
+            RewardSettlementLine line,
+            PlayerGrowthGrantResult result
+    ) {
+        if (!settlement.getPlayerId().equals(result.playerId())
+                || !line.getId().equals(result.rewardLineId())
+                || line.getAmount() != result.requestedExp()) {
+            throw new DomainException(RewardError.REWARD_SETTLEMENT_EXP_GROWTH_INCONSISTENT);
+        }
+    }
+
+    private RewardSettlementExpProcessResult toResult(
+            RewardSettlement settlement,
+            RewardSettlementLine line,
+            PlayerGrowthGrantResult result
+    ) {
+        return new RewardSettlementExpProcessResult(
+                settlement.getId(),
+                line.getId(),
+                settlement.getPlayerId(),
+                line.getStatus(),
+                settlement.getStatus(),
+                result.requestedExp(),
+                result.appliedExp(),
+                result.leftoverExp(),
+                result.beforeLevel(),
+                result.afterLevel(),
+                result.beforeTotalExp(),
+                result.afterTotalExp(),
+                result.replayed(),
+                result.growthChangeId()
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/application/RewardSettlementExpProcessService.java
+++ b/src/main/java/online/lifeasgame/reward/application/RewardSettlementExpProcessService.java
@@ -1,0 +1,28 @@
+package online.lifeasgame.reward.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.reward.application.result.RewardSettlementExpProcessResult;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RewardSettlementExpProcessService {
+
+    private final RewardSettlementExpProcessAttempt processAttempt;
+    private final RewardSettlementLineFailureRecorder failureRecorder;
+    private final RewardSettlementExpReplayRecovery replayRecovery;
+
+    public RewardSettlementExpProcessResult process(Long settlementId, Long lineId) {
+        try {
+            return processAttempt.process(settlementId, lineId);
+        } catch (DomainException exception) {
+            failureRecorder.record(settlementId, lineId, exception.getErrorCode());
+            throw exception;
+        } catch (DataIntegrityViolationException exception) {
+            return replayRecovery.findCompletedReplay(settlementId, lineId)
+                    .orElseThrow(() -> exception);
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/application/RewardSettlementExpReplayRecovery.java
+++ b/src/main/java/online/lifeasgame/reward/application/RewardSettlementExpReplayRecovery.java
@@ -1,0 +1,62 @@
+package online.lifeasgame.reward.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.application.internal.PlayerGrowthApi;
+import online.lifeasgame.character.application.internal.PlayerGrowthApi.PlayerGrowthGrantResult;
+import online.lifeasgame.reward.application.result.RewardSettlementExpProcessResult;
+import online.lifeasgame.reward.domain.RewardSettlement;
+import online.lifeasgame.reward.domain.RewardSettlementLine;
+import online.lifeasgame.reward.domain.RewardSettlementLineStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class RewardSettlementExpReplayRecovery {
+
+    private final RewardSettlementReader settlementReader;
+    private final PlayerGrowthApi playerGrowthApi;
+
+    @Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
+    public Optional<RewardSettlementExpProcessResult> findCompletedReplay(
+            Long settlementId,
+            Long lineId
+    ) {
+        RewardSettlement settlement = settlementReader.getByIdOrThrow(settlementId);
+        RewardSettlementLine line = settlement.getLineByIdOrThrow(lineId);
+        if (line.getStatus() != RewardSettlementLineStatus.SUCCEEDED) {
+            return Optional.empty();
+        }
+        return playerGrowthApi.findRewardExpGrant(lineId)
+                .filter(result -> matches(settlement, line, result))
+                .map(result -> new RewardSettlementExpProcessResult(
+                        settlement.getId(),
+                        line.getId(),
+                        settlement.getPlayerId(),
+                        line.getStatus(),
+                        settlement.getStatus(),
+                        result.requestedExp(),
+                        result.appliedExp(),
+                        result.leftoverExp(),
+                        result.beforeLevel(),
+                        result.afterLevel(),
+                        result.beforeTotalExp(),
+                        result.afterTotalExp(),
+                        true,
+                        result.growthChangeId()
+                ));
+    }
+
+    private boolean matches(
+            RewardSettlement settlement,
+            RewardSettlementLine line,
+            PlayerGrowthGrantResult result
+    ) {
+        return settlement.getPlayerId().equals(result.playerId())
+                && line.getId().equals(result.rewardLineId())
+                && line.getAmount() == result.requestedExp();
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/application/RewardSettlementLineFailureRecorder.java
+++ b/src/main/java/online/lifeasgame/reward/application/RewardSettlementLineFailureRecorder.java
@@ -1,0 +1,22 @@
+package online.lifeasgame.reward.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.ErrorCode;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class RewardSettlementLineFailureRecorder {
+
+    private final RewardSettlementReader settlementReader;
+    private final RewardSettlementWriter settlementWriter;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void record(Long settlementId, Long lineId, ErrorCode errorCode) {
+        settlementReader.findByIdForUpdate(settlementId)
+                .filter(settlement -> settlement.markLineFailedIfPending(lineId, errorCode))
+                .ifPresent(settlementWriter::saveAndFlush);
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/application/RewardSettlementReader.java
+++ b/src/main/java/online/lifeasgame/reward/application/RewardSettlementReader.java
@@ -49,4 +49,15 @@ public class RewardSettlementReader {
         return repository.findById(id)
                 .orElseThrow(() -> new DomainException(RewardError.REWARD_SETTLEMENT_NOT_FOUND));
     }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public RewardSettlement getByIdForUpdateOrThrow(Long id) {
+        return findByIdForUpdate(id)
+                .orElseThrow(() -> new DomainException(RewardError.REWARD_SETTLEMENT_NOT_FOUND));
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public Optional<RewardSettlement> findByIdForUpdate(Long id) {
+        return repository.findByIdForUpdate(id);
+    }
 }

--- a/src/main/java/online/lifeasgame/reward/application/result/RewardSettlementExpProcessResult.java
+++ b/src/main/java/online/lifeasgame/reward/application/result/RewardSettlementExpProcessResult.java
@@ -1,0 +1,22 @@
+package online.lifeasgame.reward.application.result;
+
+import online.lifeasgame.reward.domain.RewardSettlementLineStatus;
+import online.lifeasgame.reward.domain.RewardSettlementStatus;
+
+public record RewardSettlementExpProcessResult(
+        Long settlementId,
+        Long lineId,
+        Long playerId,
+        RewardSettlementLineStatus lineStatus,
+        RewardSettlementStatus settlementStatus,
+        long requestedExp,
+        long appliedExp,
+        long leftoverExp,
+        int beforeLevel,
+        int afterLevel,
+        long beforeTotalExp,
+        long afterTotalExp,
+        boolean replayed,
+        Long growthChangeId
+) {
+}

--- a/src/main/java/online/lifeasgame/reward/domain/RewardSettlement.java
+++ b/src/main/java/online/lifeasgame/reward/domain/RewardSettlement.java
@@ -102,14 +102,47 @@ public class RewardSettlement extends AbstractTime {
         recalculateStatus();
     }
 
+    public void markExpLineSucceeded(Long lineId) {
+        findLineById(lineId).succeedExp();
+        recalculateStatus();
+    }
+
     public void markLineFailed(int sortOrder, ErrorCode errorCode) {
         findLine(sortOrder).fail(errorCode);
         recalculateStatus();
     }
 
+    public boolean markLineFailedIfPending(Long lineId, ErrorCode errorCode) {
+        return lines.stream()
+                .filter(line -> line.getId() != null && line.getId().equals(lineId))
+                .filter(RewardSettlementLine::isPending)
+                .findFirst()
+                .map(line -> {
+                    line.fail(errorCode);
+                    recalculateStatus();
+                    return true;
+                })
+                .orElse(false);
+    }
+
+    public RewardSettlementLine getLineOrThrow(int sortOrder) {
+        return findLine(sortOrder);
+    }
+
+    public RewardSettlementLine getLineByIdOrThrow(Long lineId) {
+        return findLineById(lineId);
+    }
+
     private RewardSettlementLine findLine(int sortOrder) {
         return lines.stream()
                 .filter(line -> line.getSortOrder() == sortOrder)
+                .findFirst()
+                .orElseThrow(() -> new DomainException(RewardError.REWARD_SETTLEMENT_LINE_NOT_FOUND));
+    }
+
+    private RewardSettlementLine findLineById(Long lineId) {
+        return lines.stream()
+                .filter(line -> line.getId() != null && line.getId().equals(lineId))
                 .findFirst()
                 .orElseThrow(() -> new DomainException(RewardError.REWARD_SETTLEMENT_LINE_NOT_FOUND));
     }

--- a/src/main/java/online/lifeasgame/reward/domain/RewardSettlementLine.java
+++ b/src/main/java/online/lifeasgame/reward/domain/RewardSettlementLine.java
@@ -108,6 +108,23 @@ public class RewardSettlementLine extends AbstractTime {
         failureCode = null;
     }
 
+    void succeedExp() {
+        assertExp();
+        succeed();
+    }
+
+    public boolean isExpProcessingRequired() {
+        assertExp();
+        if (status == RewardSettlementLineStatus.FAILED) {
+            throw new DomainException(RewardError.REWARD_SETTLEMENT_LINE_ALREADY_FAILED);
+        }
+        return status == RewardSettlementLineStatus.PENDING;
+    }
+
+    boolean isPending() {
+        return status == RewardSettlementLineStatus.PENDING;
+    }
+
     void fail(ErrorCode errorCode) {
         if (status == RewardSettlementLineStatus.SUCCEEDED) {
             throw new DomainException(RewardError.REWARD_SETTLEMENT_SUCCEEDED_LINE_CANNOT_FAIL);
@@ -121,4 +138,11 @@ public class RewardSettlementLine extends AbstractTime {
         status = RewardSettlementLineStatus.FAILED;
         failureCode = errorCode.code();
     }
+
+    private void assertExp() {
+        if (rewardType != RewardType.EXP) {
+            throw new DomainException(RewardError.REWARD_SETTLEMENT_LINE_NOT_EXP);
+        }
+    }
+
 }

--- a/src/main/java/online/lifeasgame/reward/domain/error/RewardError.java
+++ b/src/main/java/online/lifeasgame/reward/domain/error/RewardError.java
@@ -97,6 +97,9 @@ public enum RewardError implements ErrorCode {
     REWARD_SETTLEMENT_LINE_NOT_FOUND(
             "RWD-404-SETTLEMENT-LINE-NOT-FOUND", "Reward settlement line not found", 404
     ),
+    REWARD_SETTLEMENT_LINE_NOT_EXP(
+            "RWD-409-SETTLEMENT-LINE-NOT-EXP", "Reward settlement line is not an EXP reward", 409
+    ),
     REWARD_SETTLEMENT_LINE_ALREADY_FAILED(
             "RWD-409-SETTLEMENT-LINE-ALREADY-FAILED", "Failed reward settlement line cannot succeed", 409
     ),
@@ -105,6 +108,9 @@ public enum RewardError implements ErrorCode {
     ),
     REWARD_SETTLEMENT_FAILURE_CODE_REQUIRED(
             "RWD-400-SETTLEMENT-FAILURE-CODE-REQUIRED", "Failed reward settlement line requires an error code", 400
+    ),
+    REWARD_SETTLEMENT_EXP_GROWTH_INCONSISTENT(
+            "RWD-409-SETTLEMENT-EXP-GROWTH-INCONSISTENT", "EXP line and player growth change are inconsistent", 409
     );
 
     private final String code;

--- a/src/main/java/online/lifeasgame/reward/domain/repository/RewardSettlementRepository.java
+++ b/src/main/java/online/lifeasgame/reward/domain/repository/RewardSettlementRepository.java
@@ -11,6 +11,8 @@ public interface RewardSettlementRepository {
 
     Optional<RewardSettlement> findById(Long id);
 
+    Optional<RewardSettlement> findByIdForUpdate(Long id);
+
     Optional<RewardSettlement> findByIdentity(
             Long playerId,
             RewardSettlementSourceType sourceType,

--- a/src/main/java/online/lifeasgame/reward/infra/JpaRewardSettlementRepository.java
+++ b/src/main/java/online/lifeasgame/reward/infra/JpaRewardSettlementRepository.java
@@ -2,8 +2,12 @@ package online.lifeasgame.reward.infra;
 
 import online.lifeasgame.reward.domain.RewardSettlement;
 import online.lifeasgame.reward.domain.RewardSettlementSourceType;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -12,6 +16,11 @@ public interface JpaRewardSettlementRepository extends JpaRepository<RewardSettl
     @Override
     @EntityGraph(attributePaths = "lines")
     Optional<RewardSettlement> findById(Long id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @EntityGraph(attributePaths = "lines")
+    @Query("select settlement from RewardSettlement settlement where settlement.id = :settlementId")
+    Optional<RewardSettlement> findByIdForUpdate(@Param("settlementId") Long settlementId);
 
     @EntityGraph(attributePaths = "lines")
     Optional<RewardSettlement> findByPlayerIdAndSourceTypeAndSourceId(

--- a/src/main/java/online/lifeasgame/reward/infra/RewardSettlementRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/reward/infra/RewardSettlementRepositoryAdapter.java
@@ -25,6 +25,11 @@ public class RewardSettlementRepositoryAdapter implements RewardSettlementReposi
     }
 
     @Override
+    public Optional<RewardSettlement> findByIdForUpdate(Long id) {
+        return jpaRepository.findByIdForUpdate(id);
+    }
+
+    @Override
     public Optional<RewardSettlement> findByIdentity(
             Long playerId,
             RewardSettlementSourceType sourceType,

--- a/src/main/resources/db/migration/V4__player_growth_change.sql
+++ b/src/main/resources/db/migration/V4__player_growth_change.sql
@@ -1,0 +1,37 @@
+CREATE TABLE player_growth_changes (
+    before_level INTEGER NOT NULL,
+    after_level INTEGER NOT NULL,
+    applied_exp BIGINT NOT NULL,
+    before_total_exp BIGINT NOT NULL,
+    after_total_exp BIGINT NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    leftover_exp BIGINT NOT NULL,
+    player_id BIGINT NOT NULL,
+    requested_exp BIGINT NOT NULL,
+    reward_line_id BIGINT NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_player_growth_change_reward_line UNIQUE (reward_line_id),
+    CONSTRAINT ck_player_growth_change_player CHECK (player_id > 0),
+    CONSTRAINT ck_player_growth_change_reward_line CHECK (reward_line_id > 0),
+    CONSTRAINT ck_player_growth_change_requested_exp CHECK (requested_exp > 0),
+    CONSTRAINT ck_player_growth_change_applied_exp CHECK (applied_exp >= 0),
+    CONSTRAINT ck_player_growth_change_leftover_exp CHECK (leftover_exp >= 0),
+    CONSTRAINT ck_player_growth_change_exp_sum CHECK (requested_exp = applied_exp + leftover_exp),
+    CONSTRAINT ck_player_growth_change_levels CHECK (
+        before_level > 0 AND after_level >= before_level
+    ),
+    CONSTRAINT ck_player_growth_change_totals CHECK (
+        before_total_exp >= 0
+        AND after_total_exp >= before_total_exp
+        AND after_total_exp - before_total_exp = applied_exp
+    ),
+    CONSTRAINT fk_player_growth_change_player
+        FOREIGN KEY (player_id) REFERENCES player (id)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE INDEX idx_player_growth_change_player
+    ON player_growth_changes (player_id);

--- a/src/test/java/online/lifeasgame/character/application/PlayerExpGrantServiceTest.java
+++ b/src/test/java/online/lifeasgame/character/application/PlayerExpGrantServiceTest.java
@@ -1,0 +1,84 @@
+package online.lifeasgame.character.application;
+
+import online.lifeasgame.character.domain.GenderType;
+import online.lifeasgame.character.domain.LevelingPolicyParameters;
+import online.lifeasgame.character.domain.Name;
+import online.lifeasgame.character.domain.Player;
+import online.lifeasgame.character.domain.event.PlayerLeveledUp;
+import online.lifeasgame.character.domain.service.LevelingPolicy;
+import online.lifeasgame.character.domain.service.PrecomputedLevelingPolicy;
+import online.lifeasgame.core.event.DomainEvent;
+import online.lifeasgame.core.event.DomainEventPublisher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PlayerExpGrantService")
+class PlayerExpGrantServiceTest {
+
+    @Mock
+    private PlayerReader playerReader;
+
+    @Mock
+    private DomainEventPublisher domainEventPublisher;
+
+    private PlayerExpGrantService service;
+
+    @BeforeEach
+    void setUp() {
+        LevelingPolicy levelingPolicy = new PrecomputedLevelingPolicy(new LevelingPolicyParameters(
+                3,
+                100L,
+                List.of(new LevelingPolicyParameters.Bracket(1, 3, 1.0, 0L))
+        ));
+        service = new PlayerExpGrantService(playerReader, levelingPolicy, domainEventPublisher);
+    }
+
+    @Nested
+    @DisplayName("Player EXP를 지급할 때")
+    class GrantExperience {
+
+        @Test
+        @DisplayName("Player를 잠금 조회하고 지급 결과와 Level Up 이벤트를 발행한다")
+        void locksPlayerAndPublishesLevelUpEvent() {
+            Player player = player();
+            given(playerReader.getByIdForUpdateOrThrow(1L)).willReturn(player);
+
+            var result = service.grantExp(1L, 100L);
+
+            assertThat(result.appliedExp()).isEqualTo(100L);
+            assertThat(result.beforeLevel()).isEqualTo(1);
+            assertThat(result.afterLevel()).isEqualTo(2);
+            assertThat(result.totalExp()).isEqualTo(100L);
+            verify(playerReader).getByIdForUpdateOrThrow(1L);
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<Collection<? extends DomainEvent>> events =
+                    ArgumentCaptor.forClass(Collection.class);
+            verify(domainEventPublisher).publishAll(events.capture());
+            assertThat(events.getValue())
+                    .singleElement()
+                    .isInstanceOf(PlayerLeveledUp.class);
+        }
+    }
+
+    private Player player() {
+        Player player = Player.linkStart(10L, Name.of("테스터"), GenderType.MALE);
+        ReflectionTestUtils.setField(player, "id", 1L);
+        return player;
+    }
+}

--- a/src/test/java/online/lifeasgame/character/application/PlayerRewardExpGrantServiceTest.java
+++ b/src/test/java/online/lifeasgame/character/application/PlayerRewardExpGrantServiceTest.java
@@ -1,0 +1,143 @@
+package online.lifeasgame.character.application;
+
+import online.lifeasgame.character.application.growth.PlayerGrowthChangeReader;
+import online.lifeasgame.character.application.growth.PlayerGrowthChangeWriter;
+import online.lifeasgame.character.domain.GenderType;
+import online.lifeasgame.character.domain.Name;
+import online.lifeasgame.character.domain.Player;
+import online.lifeasgame.character.domain.error.PlayerError;
+import online.lifeasgame.character.domain.growth.PlayerGrowthChange;
+import online.lifeasgame.core.error.DomainException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PlayerRewardExpGrantService")
+class PlayerRewardExpGrantServiceTest {
+
+    @Mock
+    private PlayerReader playerReader;
+
+    @Mock
+    private PlayerExpGrantService playerExpGrantService;
+
+    @Mock
+    private PlayerGrowthChangeReader growthChangeReader;
+
+    @Mock
+    private PlayerGrowthChangeWriter growthChangeWriter;
+
+    private PlayerRewardExpGrantService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PlayerRewardExpGrantService(
+                playerReader,
+                playerExpGrantService,
+                growthChangeReader,
+                growthChangeWriter
+        );
+    }
+
+    @Nested
+    @DisplayName("Reward EXP를 최초 지급할 때")
+    class GrantFirstTime {
+
+        @Test
+        @DisplayName("Player lock 후 ledger를 확인하고 EXP와 GrowthChange를 함께 반영한다")
+        void locksPlayerAndCreatesGrowthChange() {
+            Player player = player();
+            Player.GainResult gainResult = gainResult();
+            given(playerReader.getByIdForUpdateOrThrow(1L)).willReturn(player);
+            given(growthChangeReader.findByRewardLineId(10L)).willReturn(Optional.empty());
+            given(playerExpGrantService.grantExp(player, 30L)).willReturn(gainResult);
+            given(growthChangeWriter.saveAndFlush(org.mockito.ArgumentMatchers.any()))
+                    .willAnswer(invocation -> {
+                        PlayerGrowthChange change = invocation.getArgument(0);
+                        ReflectionTestUtils.setField(change, "id", 100L);
+                        return change;
+                    });
+
+            var result = service.grantRewardExp(1L, 10L, 30L);
+
+            assertThat(result.growthChangeId()).isEqualTo(100L);
+            assertThat(result.rewardLineId()).isEqualTo(10L);
+            assertThat(result.appliedExp()).isEqualTo(30L);
+            assertThat(result.beforeTotalExp()).isZero();
+            assertThat(result.afterTotalExp()).isEqualTo(30L);
+            assertThat(result.replayed()).isFalse();
+
+            InOrder order = inOrder(playerReader, growthChangeReader, playerExpGrantService, growthChangeWriter);
+            order.verify(playerReader).getByIdForUpdateOrThrow(1L);
+            order.verify(growthChangeReader).findByRewardLineId(10L);
+            order.verify(playerExpGrantService).grantExp(player, 30L);
+            order.verify(growthChangeWriter).saveAndFlush(org.mockito.ArgumentMatchers.any());
+        }
+    }
+
+    @Nested
+    @DisplayName("같은 rewardLineId를 replay할 때")
+    class ReplayRewardLine {
+
+        @Test
+        @DisplayName("기존 GrowthChange 결과를 반환하고 EXP와 이벤트 경로를 다시 호출하지 않는다")
+        void returnsExistingGrowthChange() {
+            Player player = player();
+            PlayerGrowthChange existing = PlayerGrowthChange.rewardExp(1L, 10L, gainResult());
+            ReflectionTestUtils.setField(existing, "id", 100L);
+            given(playerReader.getByIdForUpdateOrThrow(1L)).willReturn(player);
+            given(growthChangeReader.findByRewardLineId(10L)).willReturn(Optional.of(existing));
+
+            var result = service.grantRewardExp(1L, 10L, 30L);
+
+            assertThat(result.growthChangeId()).isEqualTo(100L);
+            assertThat(result.replayed()).isTrue();
+            verify(playerExpGrantService, never()).grantExp(player, 30L);
+            verify(growthChangeWriter, never()).saveAndFlush(existing);
+        }
+
+        @Test
+        @DisplayName("기존 GrowthChange의 Player나 요청량이 다르면 invariant error로 중단한다")
+        void rejectsInconsistentReplay() {
+            Player player = player();
+            PlayerGrowthChange existing = PlayerGrowthChange.rewardExp(1L, 10L, gainResult());
+            given(playerReader.getByIdForUpdateOrThrow(1L)).willReturn(player);
+            given(growthChangeReader.findByRewardLineId(10L)).willReturn(Optional.of(existing));
+
+            assertThatThrownBy(() -> service.grantRewardExp(1L, 10L, 20L))
+                    .isInstanceOfSatisfying(DomainException.class, exception ->
+                            assertThat(exception.getErrorCode())
+                                    .isEqualTo(PlayerError.PLAYER_GROWTH_CHANGE_INCONSISTENT)
+                    );
+            verify(playerExpGrantService, never()).grantExp(player, 20L);
+        }
+    }
+
+    private Player player() {
+        Player player = Player.linkStart(10L, Name.of("테스터"), GenderType.MALE);
+        ReflectionTestUtils.setField(player, "id", 1L);
+        return player;
+    }
+
+    private Player.GainResult gainResult() {
+        return new Player.GainResult(
+                30L, 30L, 0L, 1, 1, 0L, 30L, 30L, 70L, 100L, 0.3
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/character/application/PlayerServiceExpGrantTest.java
+++ b/src/test/java/online/lifeasgame/character/application/PlayerServiceExpGrantTest.java
@@ -1,0 +1,70 @@
+package online.lifeasgame.character.application;
+
+import online.lifeasgame.character.domain.Player;
+import online.lifeasgame.core.event.DomainEventPublisher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PlayerService EXP API")
+class PlayerServiceExpGrantTest {
+
+    @Mock
+    private PlayerWriter playerWriter;
+
+    @Mock
+    private PlayerReader playerReader;
+
+    @Mock
+    private PlayerTitleReader playerTitleReader;
+
+    @Mock
+    private PlayerExpGrantService playerExpGrantService;
+
+    @Mock
+    private DomainEventPublisher domainEventPublisher;
+
+    private PlayerService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PlayerService(
+                playerWriter,
+                playerReader,
+                playerTitleReader,
+                playerExpGrantService,
+                domainEventPublisher
+        );
+    }
+
+    @Nested
+    @DisplayName("기존 Admin EXP 지급 기능을 호출할 때")
+    class GrantExperience {
+
+        @Test
+        @DisplayName("행동 서비스에 위임하고 기존 ExpGranted 계약으로 반환한다")
+        void delegatesAndKeepsResultContract() {
+            given(playerExpGrantService.grantExp(1L, 30L)).willReturn(new Player.GainResult(
+                    30L, 30L, 0L, 1, 1, 0L, 30L, 30L, 70L, 100L, 0.3
+            ));
+
+            var result = service.grantExp(1L, 30L);
+
+            assertThat(result.playerId()).isEqualTo(1L);
+            assertThat(result.requestedExp()).isEqualTo(30L);
+            assertThat(result.appliedExp()).isEqualTo(30L);
+            assertThat(result.level()).isEqualTo(1);
+            assertThat(result.totalExp()).isEqualTo(30L);
+            verify(playerExpGrantService).grantExp(1L, 30L);
+        }
+    }
+}

--- a/src/test/java/online/lifeasgame/character/domain/PlayerExperienceTest.java
+++ b/src/test/java/online/lifeasgame/character/domain/PlayerExperienceTest.java
@@ -1,0 +1,125 @@
+package online.lifeasgame.character.domain;
+
+import online.lifeasgame.character.domain.error.PlayerError;
+import online.lifeasgame.character.domain.event.PlayerLeveledUp;
+import online.lifeasgame.character.domain.service.PrecomputedLevelingPolicy;
+import online.lifeasgame.core.error.DomainException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Player EXP 도메인")
+class PlayerExperienceTest {
+
+    @Nested
+    @DisplayName("EXP 값을 검증할 때")
+    class ValidateExperience {
+
+        @Test
+        @DisplayName("음수 총 EXP는 PlayerError 기반 DomainException으로 거부한다")
+        void rejectsNegativeTotalExp() {
+            assertPlayerError(() -> Experience.of(-1L), PlayerError.PLAYER_EXP_MUST_NOT_BE_NEGATIVE);
+        }
+
+        @Test
+        @DisplayName("음수 증가량은 PlayerError 기반 DomainException으로 거부한다")
+        void rejectsNegativeDelta() {
+            Experience experience = Experience.of(10L);
+
+            assertPlayerError(() -> experience.plus(-1L), PlayerError.PLAYER_EXP_MUST_NOT_BE_NEGATIVE);
+        }
+
+        @Test
+        @DisplayName("총 EXP 오버플로는 PlayerError 기반 DomainException으로 변환한다")
+        void rejectsOverflow() {
+            Experience experience = Experience.of(Long.MAX_VALUE);
+
+            assertPlayerError(() -> experience.plus(1L), PlayerError.PLAYER_EXP_OVERFLOW);
+        }
+    }
+
+    @Nested
+    @DisplayName("Player에게 EXP를 지급할 때")
+    class GainExperience {
+
+        @Test
+        @DisplayName("0 이하 지급량을 PlayerError로 거부한다")
+        void rejectsNonPositiveAmount() {
+            Player player = player();
+
+            assertPlayerError(
+                    () -> player.gainExp(0L, levelingPolicy()),
+                    PlayerError.PLAYER_EXP_AMOUNT_MUST_BE_POSITIVE
+            );
+        }
+
+        @Test
+        @DisplayName("LevelingPolicy가 없으면 PlayerError로 거부한다")
+        void requiresLevelingPolicy() {
+            Player player = player();
+
+            assertPlayerError(
+                    () -> player.gainExp(10L, null),
+                    PlayerError.PLAYER_LEVELING_POLICY_REQUIRED
+            );
+        }
+
+        @Test
+        @DisplayName("레벨 경계를 넘으면 결과와 기존 PlayerLeveledUp 이벤트를 생성한다")
+        void createsLevelUpResultAndEvent() {
+            Player player = player();
+
+            Player.GainResult result = player.gainExp(100L, levelingPolicy());
+
+            assertThat(result.beforeLevel()).isEqualTo(1);
+            assertThat(result.afterLevel()).isEqualTo(2);
+            assertThat(result.appliedExp()).isEqualTo(100L);
+            assertThat(result.totalExp()).isEqualTo(100L);
+            assertThat(player.pullEvents())
+                    .singleElement()
+                    .isInstanceOfSatisfying(PlayerLeveledUp.class, event -> {
+                        assertThat(event.playerId()).isEqualTo(1L);
+                        assertThat(event.beforeLevel()).isEqualTo(1);
+                        assertThat(event.afterLevel()).isEqualTo(2);
+                    });
+        }
+
+        @Test
+        @DisplayName("max level 상한까지만 적용하고 남은 EXP를 반환한다")
+        void capsAtMaxLevelAndReturnsLeftover() {
+            Player player = player();
+
+            Player.GainResult result = player.gainExp(300L, levelingPolicy());
+
+            assertThat(result.appliedExp()).isEqualTo(201L);
+            assertThat(result.leftoverExp()).isEqualTo(99L);
+            assertThat(result.afterLevel()).isEqualTo(3);
+            assertThat(result.totalExp()).isEqualTo(201L);
+        }
+    }
+
+    private Player player() {
+        Player player = Player.linkStart(10L, Name.of("테스터"), GenderType.MALE);
+        ReflectionTestUtils.setField(player, "id", 1L);
+        return player;
+    }
+
+    private PrecomputedLevelingPolicy levelingPolicy() {
+        return new PrecomputedLevelingPolicy(new LevelingPolicyParameters(
+                3,
+                100L,
+                java.util.List.of(new LevelingPolicyParameters.Bracket(1, 3, 1.0, 0L))
+        ));
+    }
+
+    private void assertPlayerError(Runnable action, PlayerError error) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(error)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/character/domain/growth/PlayerGrowthChangeTest.java
+++ b/src/test/java/online/lifeasgame/character/domain/growth/PlayerGrowthChangeTest.java
@@ -1,0 +1,97 @@
+package online.lifeasgame.character.domain.growth;
+
+import online.lifeasgame.character.domain.Player;
+import online.lifeasgame.character.domain.error.PlayerError;
+import online.lifeasgame.core.error.DomainException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("PlayerGrowthChange")
+class PlayerGrowthChangeTest {
+
+    @Nested
+    @DisplayName("Reward EXP 성장 변경을 생성할 때")
+    class CreateRewardGrowthChange {
+
+        @Test
+        @DisplayName("Player와 rewardLine 및 EXP 적용 결과를 스냅샷으로 보존한다")
+        void createsSnapshot() {
+            PlayerGrowthChange change = PlayerGrowthChange.rewardExp(1L, 10L, validResult());
+
+            assertThat(change.getPlayerId()).isEqualTo(1L);
+            assertThat(change.getRewardLineId()).isEqualTo(10L);
+            assertThat(change.getRequestedExp()).isEqualTo(30L);
+            assertThat(change.getAppliedExp()).isEqualTo(30L);
+            assertThat(change.getBeforeTotalExp()).isZero();
+            assertThat(change.getAfterTotalExp()).isEqualTo(30L);
+        }
+
+        @Test
+        @DisplayName("rewardLineId가 없거나 양수가 아니면 PlayerError로 거부한다")
+        void requiresPositiveRewardLineId() {
+            assertPlayerError(
+                    () -> PlayerGrowthChange.rewardExp(1L, 0L, validResult()),
+                    PlayerError.PLAYER_GROWTH_REWARD_LINE_ID_REQUIRED
+            );
+        }
+
+        @Test
+        @DisplayName("지급량 합계가 맞지 않으면 안정된 PlayerError로 거부한다")
+        void rejectsInvalidAmountConsistency() {
+            Player.GainResult invalid = new Player.GainResult(
+                    30L, 20L, 5L, 1, 1, 0L, 20L, 20L, 80L, 100L, 0.2
+            );
+
+            assertPlayerError(
+                    () -> PlayerGrowthChange.rewardExp(1L, 10L, invalid),
+                    PlayerError.PLAYER_GROWTH_CHANGE_INVALID
+            );
+        }
+
+        @Test
+        @DisplayName("레벨 또는 총 EXP 정합성이 맞지 않으면 안정된 PlayerError로 거부한다")
+        void rejectsInvalidLevelAndTotalConsistency() {
+            Player.GainResult invalid = new Player.GainResult(
+                    30L, 30L, 0L, 2, 1, 0L, 20L, 20L, 80L, 100L, 0.2
+            );
+
+            assertPlayerError(
+                    () -> PlayerGrowthChange.rewardExp(1L, 10L, invalid),
+                    PlayerError.PLAYER_GROWTH_CHANGE_INVALID
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("기존 GrowthChange를 replay할 때")
+    class ValidateReplayIdentity {
+
+        @Test
+        @DisplayName("Player, rewardLine, 요청 EXP가 다르면 invariant error로 중단한다")
+        void rejectsDifferentIdentity() {
+            PlayerGrowthChange change = PlayerGrowthChange.rewardExp(1L, 10L, validResult());
+
+            assertPlayerError(
+                    () -> change.assertMatches(2L, 10L, 30L),
+                    PlayerError.PLAYER_GROWTH_CHANGE_INCONSISTENT
+            );
+        }
+    }
+
+    private Player.GainResult validResult() {
+        return new Player.GainResult(
+                30L, 30L, 0L, 1, 1, 0L, 30L, 30L, 70L, 100L, 0.3
+        );
+    }
+
+    private void assertPlayerError(Runnable action, PlayerError error) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(error)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
@@ -32,7 +32,7 @@ class FlywayHistoryChecksumTest {
     class MigrateAgain {
 
         @Test
-        @DisplayName("두 번째 실행은 no-op이고 V1부터 V3까지 checksum history를 유지한다")
+        @DisplayName("두 번째 실행은 no-op이고 V1부터 V4까지 checksum history를 유지한다")
         void keepsMigrationHistory() throws Exception {
             Flyway flyway = flyway();
 
@@ -42,11 +42,11 @@ class FlywayHistoryChecksumTest {
             MigrateResult second = flyway.migrate();
             List<HistoryRow> secondHistory = successfulHistory();
 
-            assertThat(first.migrationsExecuted).isEqualTo(3);
+            assertThat(first.migrationsExecuted).isEqualTo(4);
             assertThat(second.migrationsExecuted).isZero();
             assertThat(secondHistory).isEqualTo(firstHistory);
             assertThat(secondHistory).extracting(HistoryRow::version)
-                    .containsExactly("1", "2", "3");
+                    .containsExactly("1", "2", "3", "4");
             assertThat(secondHistory).allSatisfy(history -> {
                 assertThat(history.checksum()).isNotNull();
                 assertThat(history.success()).isTrue();

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -37,14 +37,14 @@ class FlywayMigrationTest {
     class MigrateCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V3까지 적용되고 Settlement 테이블과 중복 방지 제약이 생성된다")
+        @DisplayName("V1부터 V4까지 적용되고 Settlement와 GrowthChange 중복 방지 제약이 생성된다")
         void migratesSchemaAndSeedsRewardProfiles() throws Exception {
             Flyway flyway = flyway();
 
             MigrateResult result = flyway.migrate();
 
-            assertThat(result.migrationsExecuted).isEqualTo(3);
-            assertThat(appliedVersions()).containsExactly("1", "2", "3");
+            assertThat(result.migrationsExecuted).isEqualTo(4);
+            assertThat(appliedVersions()).containsExactly("1", "2", "3", "4");
             assertThat(existingTables(
                     "users",
                     "player",
@@ -55,7 +55,8 @@ class FlywayMigrationTest {
                     "reward_profiles",
                     "reward_profile_lines",
                     "reward_settlements",
-                    "reward_settlement_lines"
+                    "reward_settlement_lines",
+                    "player_growth_changes"
             )).containsExactlyInAnyOrder(
                     "users",
                     "player",
@@ -66,7 +67,8 @@ class FlywayMigrationTest {
                     "reward_profiles",
                     "reward_profile_lines",
                     "reward_settlements",
-                    "reward_settlement_lines"
+                    "reward_settlement_lines",
+                    "player_growth_changes"
             );
             assertThat(seedProfileCodes()).containsExactly("RP_EXP_10", "RP_EXP_30");
             assertThat(uniqueIndexColumns("reward_settlements", "uq_reward_settlement_source"))
@@ -75,6 +77,10 @@ class FlywayMigrationTest {
                     "reward_settlement_lines",
                     "uq_reward_settlement_line_sort_order"
             )).containsExactly("reward_settlement_id", "sort_order");
+            assertThat(uniqueIndexColumns(
+                    "player_growth_changes",
+                    "uq_player_growth_change_reward_line"
+            )).containsExactly("reward_line_id");
             insertSettlementIdentity();
             assertThatThrownBy(FlywayMigrationTest.this::insertSettlementIdentity)
                     .isInstanceOfSatisfying(SQLException.class, exception ->

--- a/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
@@ -1,5 +1,6 @@
 package online.lifeasgame.migration;
 
+import online.lifeasgame.reward.application.result.RewardProfileResult;
 import org.flywaydb.core.Flyway;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -24,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 @SpringBootTest
 @ActiveProfiles({"test", "migration-test"})
-@DisplayName("V3 migration 이후 JPA schema validation")
+@DisplayName("V4 migration 이후 JPA schema validation")
 class JpaValidateAfterMigrationTest {
 
     @Container
@@ -60,14 +61,14 @@ class JpaValidateAfterMigrationTest {
     private RewardSettlementReader rewardSettlementReader;
 
     @Nested
-    @DisplayName("V1부터 V3까지 적용된 schema로 ApplicationContext를 기동할 때")
+    @DisplayName("V1부터 V4까지 적용된 schema로 ApplicationContext를 기동할 때")
     class LoadApplicationContext {
 
         @Test
         @DisplayName("ddl-auto validate 상태로 정상 기동한다")
         void loadsWithJpaValidation() {
             assertThat(applicationContext).isNotNull();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("3");
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("4");
             assertThat(applicationContext.getEnvironment().getProperty("spring.jpa.hibernate.ddl-auto"))
                     .isEqualTo("validate");
             assertThat(applicationContext.getEnvironment()
@@ -94,7 +95,7 @@ class JpaValidateAfterMigrationTest {
         @DisplayName("DTO projection으로 활성 profile 요약을 조회한다")
         void loadsActiveProfileSummariesWithProjection() {
             assertThat(rewardProfileQueryService.listActiveProfiles())
-                    .extracting(summary -> summary.code())
+                    .extracting(RewardProfileResult.Summary::code)
                     .containsExactly("RP_EXP_10", "RP_EXP_30");
         }
     }

--- a/src/test/java/online/lifeasgame/reward/application/RewardSettlementExpProcessAttemptTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardSettlementExpProcessAttemptTest.java
@@ -1,0 +1,237 @@
+package online.lifeasgame.reward.application;
+
+import online.lifeasgame.character.application.internal.PlayerGrowthApi;
+import online.lifeasgame.character.application.internal.PlayerGrowthApi.PlayerGrowthGrantResult;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.reward.domain.RewardDefinition;
+import online.lifeasgame.reward.domain.RewardProfile;
+import online.lifeasgame.reward.domain.RewardProfileStatus;
+import online.lifeasgame.reward.domain.RewardSettlement;
+import online.lifeasgame.reward.domain.RewardSettlementLineStatus;
+import online.lifeasgame.reward.domain.RewardSettlementSourceType;
+import online.lifeasgame.reward.domain.RewardSettlementStatus;
+import online.lifeasgame.reward.domain.RewardType;
+import online.lifeasgame.reward.domain.error.RewardError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RewardSettlementExpProcessAttempt")
+class RewardSettlementExpProcessAttemptTest {
+
+    @Mock
+    private RewardSettlementReader settlementReader;
+
+    @Mock
+    private RewardSettlementWriter settlementWriter;
+
+    @Mock
+    private PlayerGrowthApi playerGrowthApi;
+
+    private RewardSettlementExpProcessAttempt attempt;
+
+    @BeforeEach
+    void setUp() {
+        attempt = new RewardSettlementExpProcessAttempt(
+                settlementReader,
+                settlementWriter,
+                playerGrowthApi
+        );
+    }
+
+    @Nested
+    @DisplayName("PENDING EXP Line을 처리할 때")
+    class ProcessPendingLine {
+
+        @Test
+        @DisplayName("Player EXP 지급과 Line 성공을 하나의 시도로 반영한다")
+        void grantsExpAndSucceedsLine() {
+            RewardSettlement settlement = settlementWithExpOnly();
+            given(settlementReader.getByIdForUpdateOrThrow(100L)).willReturn(settlement);
+            given(playerGrowthApi.grantRewardExp(1L, 1000L, 10L)).willReturn(grantResult(false));
+            given(settlementWriter.saveAndFlush(settlement)).willReturn(settlement);
+
+            var result = attempt.process(100L, 1000L);
+
+            assertThat(result.settlementId()).isEqualTo(100L);
+            assertThat(result.lineStatus()).isEqualTo(RewardSettlementLineStatus.SUCCEEDED);
+            assertThat(result.appliedExp()).isEqualTo(10L);
+            assertThat(result.beforeLevel()).isEqualTo(1);
+            assertThat(result.afterLevel()).isEqualTo(1);
+            assertThat(result.beforeTotalExp()).isZero();
+            assertThat(result.afterTotalExp()).isEqualTo(10L);
+            assertThat(result.settlementStatus()).isEqualTo(RewardSettlementStatus.COMPLETED);
+            assertThat(result.replayed()).isFalse();
+            assertThat(result.growthChangeId()).isEqualTo(500L);
+            verify(settlementWriter).saveAndFlush(settlement);
+        }
+
+        @Test
+        @DisplayName("다른 PENDING Line이 남아 있으면 Settlement는 PENDING을 유지한다")
+        void keepsSettlementPending() {
+            RewardSettlement settlement = settlementWithExpAndItem();
+            given(settlementReader.getByIdForUpdateOrThrow(100L)).willReturn(settlement);
+            given(playerGrowthApi.grantRewardExp(1L, 1000L, 10L)).willReturn(grantResult(false));
+            given(settlementWriter.saveAndFlush(settlement)).willReturn(settlement);
+
+            var result = attempt.process(100L, 1000L);
+
+            assertThat(result.settlementStatus()).isEqualTo(RewardSettlementStatus.PENDING);
+        }
+
+        @Test
+        @DisplayName("PENDING Line에 기존 GrowthChange가 있으면 invariant error로 중단한다")
+        void rejectsGrowthReplayForPendingLine() {
+            RewardSettlement settlement = settlementWithExpOnly();
+            given(settlementReader.getByIdForUpdateOrThrow(100L)).willReturn(settlement);
+            given(playerGrowthApi.grantRewardExp(1L, 1000L, 10L)).willReturn(grantResult(true));
+
+            assertRewardError(
+                    () -> attempt.process(100L, 1000L),
+                    RewardError.REWARD_SETTLEMENT_EXP_GROWTH_INCONSISTENT
+            );
+            assertThat(settlement.getLineByIdOrThrow(1000L).getStatus())
+                    .isEqualTo(RewardSettlementLineStatus.PENDING);
+            verify(settlementWriter, never()).saveAndFlush(settlement);
+        }
+    }
+
+    @Nested
+    @DisplayName("처리할 수 없는 Line을 요청할 때")
+    class RejectInvalidLine {
+
+        @Test
+        @DisplayName("ITEM Line은 RewardError로 거부하고 Player API를 호출하지 않는다")
+        void rejectsItemLine() {
+            RewardSettlement settlement = settlementWithExpAndItem();
+            given(settlementReader.getByIdForUpdateOrThrow(100L)).willReturn(settlement);
+
+            assertRewardError(
+                    () -> attempt.process(100L, 1001L),
+                    RewardError.REWARD_SETTLEMENT_LINE_NOT_EXP
+            );
+            verify(playerGrowthApi, never()).grantRewardExp(1L, 1001L, 2L);
+        }
+
+        @Test
+        @DisplayName("FAILED Line은 자동 재처리를 거부한다")
+        void rejectsFailedLine() {
+            RewardSettlement settlement = settlementWithExpOnly();
+            settlement.markLineFailed(0, RewardError.REWARD_DEFINITION_NOT_FOUND);
+            given(settlementReader.getByIdForUpdateOrThrow(100L)).willReturn(settlement);
+
+            assertRewardError(
+                    () -> attempt.process(100L, 1000L),
+                    RewardError.REWARD_SETTLEMENT_LINE_ALREADY_FAILED
+            );
+            verify(playerGrowthApi, never()).grantRewardExp(1L, 1000L, 10L);
+        }
+    }
+
+    @Nested
+    @DisplayName("이미 SUCCEEDED인 EXP Line을 다시 요청할 때")
+    class ProcessSucceededLine {
+
+        @Test
+        @DisplayName("Player API를 호출하지 않고 저장된 기존 결과를 반환한다")
+        void returnsExistingResultWithoutGrant() {
+            RewardSettlement settlement = settlementWithExpOnly();
+            settlement.markExpLineSucceeded(1000L);
+            given(settlementReader.getByIdForUpdateOrThrow(100L)).willReturn(settlement);
+            given(playerGrowthApi.findRewardExpGrant(1000L)).willReturn(
+                    java.util.Optional.of(grantResult(true))
+            );
+
+            var result = attempt.process(100L, 1000L);
+
+            assertThat(result.replayed()).isTrue();
+            assertThat(result.appliedExp()).isEqualTo(10L);
+            assertThat(result.settlementStatus()).isEqualTo(RewardSettlementStatus.COMPLETED);
+            verify(playerGrowthApi, never()).grantRewardExp(1L, 1000L, 10L);
+            verify(settlementWriter, never()).saveAndFlush(settlement);
+        }
+
+        @Test
+        @DisplayName("SUCCEEDED Line에 GrowthChange가 없으면 invariant error로 중단한다")
+        void rejectsMissingGrowthChange() {
+            RewardSettlement settlement = settlementWithExpOnly();
+            settlement.markExpLineSucceeded(1000L);
+            given(settlementReader.getByIdForUpdateOrThrow(100L)).willReturn(settlement);
+            given(playerGrowthApi.findRewardExpGrant(1000L)).willReturn(java.util.Optional.empty());
+
+            assertRewardError(
+                    () -> attempt.process(100L, 1000L),
+                    RewardError.REWARD_SETTLEMENT_EXP_GROWTH_INCONSISTENT
+            );
+            verify(playerGrowthApi, never()).grantRewardExp(1L, 1000L, 10L);
+        }
+    }
+
+    private PlayerGrowthGrantResult grantResult(boolean replayed) {
+        return new PlayerGrowthGrantResult(
+                500L, 1L, 1000L, 10L, 10L, 0L,
+                1, 1, 0L, 10L, replayed
+        );
+    }
+
+    private RewardSettlement settlementWithExpOnly() {
+        RewardProfile profile = profile();
+        profile.addLine(expDefinition(), 0, null);
+        return settlement(profile);
+    }
+
+    private RewardSettlement settlementWithExpAndItem() {
+        RewardProfile profile = profile();
+        profile.addLine(expDefinition(), 0, null);
+        RewardDefinition item = RewardDefinition.create(
+                "RD_ITEM", "Item", RewardType.ITEM, 2L, 77L, true
+        );
+        ReflectionTestUtils.setField(item, "id", 3L);
+        profile.addLine(item, 1, null);
+        return settlement(profile);
+    }
+
+    private RewardProfile profile() {
+        RewardProfile profile = RewardProfile.create("RP", "Profile", RewardProfileStatus.ACTIVE);
+        ReflectionTestUtils.setField(profile, "id", 2L);
+        return profile;
+    }
+
+    private RewardDefinition expDefinition() {
+        RewardDefinition definition = RewardDefinition.create(
+                "RD_EXP", "EXP", RewardType.EXP, 10L, null, true
+        );
+        ReflectionTestUtils.setField(definition, "id", 1L);
+        return definition;
+    }
+
+    private RewardSettlement settlement(RewardProfile profile) {
+        RewardSettlement settlement = RewardSettlement.create(
+                1L, RewardSettlementSourceType.QUEST_COMPLETION, 10L, profile
+        );
+        ReflectionTestUtils.setField(settlement, "id", 100L);
+        for (int index = 0; index < settlement.getLines().size(); index++) {
+            ReflectionTestUtils.setField(settlement.getLines().get(index), "id", 1000L + index);
+        }
+        return settlement;
+    }
+
+    private void assertRewardError(Runnable action, RewardError error) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(error)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/reward/application/RewardSettlementExpProcessConcurrencyTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardSettlementExpProcessConcurrencyTest.java
@@ -1,0 +1,413 @@
+package online.lifeasgame.reward.application;
+
+import online.lifeasgame.character.domain.error.PlayerError;
+import online.lifeasgame.character.domain.event.PlayerLeveledUp;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.reward.application.result.RewardSettlementExpProcessResult;
+import online.lifeasgame.reward.domain.RewardSettlement;
+import online.lifeasgame.reward.domain.RewardSettlementLineStatus;
+import online.lifeasgame.reward.domain.RewardSettlementSourceType;
+import online.lifeasgame.reward.domain.RewardSettlementStatus;
+import online.lifeasgame.reward.domain.error.RewardError;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doThrow;
+
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles({"test", "migration-test"})
+@Import(RewardSettlementExpProcessConcurrencyTest.EventProbeConfig.class)
+@DisplayName("RewardSettlement EXP 처리 MySQL 동시성")
+class RewardSettlementExpProcessConcurrencyTest {
+
+    private static final long PLAYER_ID = 187001L;
+    private static final RewardSettlementSourceType SOURCE_TYPE =
+            RewardSettlementSourceType.QUEST_COMPLETION;
+
+    @Container
+    private static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0.39")
+            .withDatabaseName("lifeasgame_exp_reward_concurrency")
+            .withUsername("lifeasgame")
+            .withPassword("lifeasgame");
+
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", MYSQL::getDriverClassName);
+    }
+
+    @Autowired
+    private RewardSettlementCreateService createService;
+
+    @Autowired
+    private RewardSettlementExpProcessService processService;
+
+    @Autowired
+    private RewardSettlementLineFailureRecorder failureRecorder;
+
+    @MockitoSpyBean
+    private RewardSettlementWriter settlementWriter;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private LevelUpCommitProbe levelUpCommitProbe;
+
+    private ExecutorService executor;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.update("DELETE FROM player_growth_changes");
+        jdbcTemplate.update("DELETE FROM reward_settlement_lines");
+        jdbcTemplate.update("DELETE FROM reward_settlements");
+        jdbcTemplate.update("DELETE FROM player WHERE id = ?", PLAYER_ID);
+        levelUpCommitProbe.reset();
+        executor = Executors.newFixedThreadPool(2);
+    }
+
+    @AfterEach
+    void tearDown() throws InterruptedException {
+        executor.shutdownNow();
+        assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Nested
+    @DisplayName("같은 EXP Line에 두 요청이 동시에 도착할 때")
+    class ProcessSameLineConcurrently {
+
+        @Test
+        @DisplayName("Player EXP와 GrowthChange는 한 번만 반영되고 두 결과는 success/replay가 된다")
+        void grantsExactlyOnce() throws Exception {
+            insertPlayer(0L);
+            RewardSettlement settlement = createSettlement(187101L, "RP_EXP_10");
+            Long lineId = settlement.getLines().getFirst().getId();
+
+            List<RewardSettlementExpProcessResult> results = runConcurrently(
+                    () -> processService.process(settlement.getId(), lineId),
+                    () -> processService.process(settlement.getId(), lineId)
+            );
+
+            assertThat(playerExp()).isEqualTo(10L);
+            assertThat(growthChangeCount()).isEqualTo(1);
+            assertThat(growthChangeCountByRewardLine(lineId)).isEqualTo(1);
+            assertThat(lineStatus(lineId)).isEqualTo(RewardSettlementLineStatus.SUCCEEDED.name());
+            assertThat(settlementStatus(settlement.getId()))
+                    .isEqualTo(RewardSettlementStatus.COMPLETED.name());
+            assertThat(results).extracting(RewardSettlementExpProcessResult::replayed)
+                    .containsExactlyInAnyOrder(false, true);
+            assertThat(results).extracting(RewardSettlementExpProcessResult::growthChangeId)
+                    .doesNotContainNull()
+                    .containsOnly(results.getFirst().growthChangeId());
+            assertThat(settlementRowCount()).isEqualTo(1);
+            assertThat(settlementLineRowCount()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("서로 다른 EXP Line이 같은 Player를 동시에 변경할 때")
+    class ProcessDifferentLinesForSamePlayer {
+
+        @Test
+        @DisplayName("Settlement 다음 Player 잠금 순서로 두 지급을 모두 반영하고 lost update가 없다")
+        void preventsLostUpdate() throws Exception {
+            insertPlayer(0L);
+            RewardSettlement first = createSettlement(187201L, "RP_EXP_10");
+            RewardSettlement second = createSettlement(187202L, "RP_EXP_30");
+            Long firstLineId = first.getLines().getFirst().getId();
+            Long secondLineId = second.getLines().getFirst().getId();
+
+            List<RewardSettlementExpProcessResult> results = runConcurrently(
+                    () -> processService.process(first.getId(), firstLineId),
+                    () -> processService.process(second.getId(), secondLineId)
+            );
+
+            assertThat(playerExp()).isEqualTo(40L);
+            assertThat(growthChangeCount()).isEqualTo(2);
+            assertThat(results).extracting(RewardSettlementExpProcessResult::appliedExp)
+                    .containsExactlyInAnyOrder(10L, 30L);
+            assertThat(results).extracting(RewardSettlementExpProcessResult::replayed)
+                    .containsOnly(false);
+            assertThat(lineStatus(firstLineId)).isEqualTo(RewardSettlementLineStatus.SUCCEEDED.name());
+            assertThat(lineStatus(secondLineId)).isEqualTo(RewardSettlementLineStatus.SUCCEEDED.name());
+        }
+    }
+
+    @Nested
+    @DisplayName("최초 성공 응답을 잃고 같은 command를 다시 실행할 때")
+    class ReplayCommittedResponse {
+
+        @Test
+        @DisplayName("기존 GrowthChange를 반환하고 EXP와 Level Up event를 다시 적용하지 않는다")
+        void replaysWithoutMutationOrDuplicateEvent() {
+            insertPlayer(95L);
+            RewardSettlement settlement = createSettlement(187301L, "RP_EXP_10");
+            Long lineId = settlement.getLines().getFirst().getId();
+
+            RewardSettlementExpProcessResult first =
+                    processService.process(settlement.getId(), lineId);
+            RewardSettlementExpProcessResult replay =
+                    processService.process(settlement.getId(), lineId);
+
+            assertThat(first.replayed()).isFalse();
+            assertThat(replay.replayed()).isTrue();
+            assertThat(replay.growthChangeId()).isEqualTo(first.growthChangeId());
+            assertThat(playerExp()).isEqualTo(105L);
+            assertThat(playerLevel()).isEqualTo(2);
+            assertThat(growthChangeCount()).isEqualTo(1);
+            assertThat(levelUpCommitProbe.count()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("성공 attempt 중 예상하지 못한 RuntimeException이 발생할 때")
+    class RollBackUnexpectedFailure {
+
+        @Test
+        @DisplayName("Player와 GrowthChange를 rollback하고 Line PENDING 및 Level Up 미발행을 유지한다")
+        void rollsBackAllAtomicChanges() {
+            insertPlayer(95L);
+            RewardSettlement settlement = createSettlement(187401L, "RP_EXP_10");
+            Long lineId = settlement.getLines().getFirst().getId();
+            doThrow(new RuntimeException("forced after growth flush"))
+                    .when(settlementWriter)
+                    .saveAndFlush(argThat(candidate -> settlement.getId().equals(candidate.getId())));
+
+            assertThatThrownBy(() -> processService.process(settlement.getId(), lineId))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("forced after growth flush");
+
+            assertThat(playerExp()).isEqualTo(95L);
+            assertThat(playerLevel()).isEqualTo(1);
+            assertThat(growthChangeCount()).isZero();
+            assertThat(lineStatus(lineId)).isEqualTo(RewardSettlementLineStatus.PENDING.name());
+            assertThat(levelUpCommitProbe.count()).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("알려진 DomainException으로 성공 attempt가 rollback될 때")
+    class RecordKnownFailure {
+
+        @Test
+        @DisplayName("Player가 없으면 GrowthChange 없이 Line FAILED와 안정된 failureCode만 commit한다")
+        void recordsPlayerNotFound() {
+            RewardSettlement settlement = createSettlement(187501L, "RP_EXP_10");
+            Long lineId = settlement.getLines().getFirst().getId();
+
+            assertThatThrownBy(() -> processService.process(settlement.getId(), lineId))
+                    .isInstanceOfSatisfying(DomainException.class, exception ->
+                            assertThat(exception.getErrorCode()).isEqualTo(PlayerError.PLAYER_NOT_FOUND)
+                    );
+
+            assertThat(growthChangeCount()).isZero();
+            assertThat(lineStatus(lineId)).isEqualTo(RewardSettlementLineStatus.FAILED.name());
+            assertThat(lineFailureCode(lineId)).isEqualTo(PlayerError.PLAYER_NOT_FOUND.code());
+        }
+
+        @Test
+        @DisplayName("ITEM Line을 EXP processor로 호출하면 known failure로 기록한다")
+        void recordsWrongRewardType() {
+            insertPlayer(0L);
+            RewardSettlement settlement = createSettlement(187502L, "RP_EXP_10");
+            Long lineId = settlement.getLines().getFirst().getId();
+            jdbcTemplate.update("""
+                    UPDATE reward_settlement_lines
+                    SET reward_type = 'ITEM', item_id = 77
+                    WHERE id = ?
+                    """, lineId);
+
+            assertThatThrownBy(() -> processService.process(settlement.getId(), lineId))
+                    .isInstanceOfSatisfying(DomainException.class, exception ->
+                            assertThat(exception.getErrorCode())
+                                    .isEqualTo(RewardError.REWARD_SETTLEMENT_LINE_NOT_EXP)
+                    );
+
+            assertThat(playerExp()).isZero();
+            assertThat(growthChangeCount()).isZero();
+            assertThat(lineStatus(lineId)).isEqualTo(RewardSettlementLineStatus.FAILED.name());
+            assertThat(lineFailureCode(lineId))
+                    .isEqualTo(RewardError.REWARD_SETTLEMENT_LINE_NOT_EXP.code());
+        }
+
+        @Test
+        @DisplayName("늦은 failure recorder는 이미 SUCCEEDED인 Line을 덮어쓰지 않는다")
+        void doesNotOverwriteSucceededLine() {
+            insertPlayer(0L);
+            RewardSettlement settlement = createSettlement(187503L, "RP_EXP_10");
+            Long lineId = settlement.getLines().getFirst().getId();
+            processService.process(settlement.getId(), lineId);
+
+            failureRecorder.record(
+                    settlement.getId(),
+                    lineId,
+                    PlayerError.PLAYER_GROWTH_CHANGE_INCONSISTENT
+            );
+
+            assertThat(lineStatus(lineId)).isEqualTo(RewardSettlementLineStatus.SUCCEEDED.name());
+            assertThat(lineFailureCode(lineId)).isNull();
+            assertThat(playerExp()).isEqualTo(10L);
+            assertThat(growthChangeCount()).isEqualTo(1);
+        }
+    }
+
+    private RewardSettlement createSettlement(long sourceId, String profileCode) {
+        return createService.create(PLAYER_ID, SOURCE_TYPE, sourceId, profileCode);
+    }
+
+    private void insertPlayer(long exp) {
+        int level = exp >= 100 ? 2 : 1;
+        jdbcTemplate.update("""
+                INSERT INTO player (
+                    id, user_id, name, gender, level, exp,
+                    hp_cur, hp_cap, mp_cur, mp_cap,
+                    str_stat, agi_stat, dex_stat, int_stat, vit_stat, luc_stat,
+                    extra_stats, status_effects, version, created_at, updated_at
+                ) VALUES (
+                    ?, ?, 'Reward Tester', 'male', ?, ?,
+                    100, 100, 50, 50,
+                    1, 1, 1, 1, 1, 1,
+                    JSON_OBJECT(), '[]', 0, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
+                )
+                """, PLAYER_ID, PLAYER_ID + 100000L, level, exp);
+    }
+
+    private List<RewardSettlementExpProcessResult> runConcurrently(
+            CheckedSupplier first,
+            CheckedSupplier second
+    ) throws Exception {
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        Future<RewardSettlementExpProcessResult> firstFuture = executor.submit(() -> {
+            ready.countDown();
+            start.await();
+            return first.get();
+        });
+        Future<RewardSettlementExpProcessResult> secondFuture = executor.submit(() -> {
+            ready.countDown();
+            start.await();
+            return second.get();
+        });
+        assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+        start.countDown();
+        return List.of(
+                firstFuture.get(Duration.ofSeconds(20).toMillis(), TimeUnit.MILLISECONDS),
+                secondFuture.get(Duration.ofSeconds(20).toMillis(), TimeUnit.MILLISECONDS)
+        );
+    }
+
+    private long playerExp() {
+        return jdbcTemplate.queryForObject(
+                "SELECT exp FROM player WHERE id = ?", Long.class, PLAYER_ID
+        );
+    }
+
+    private int playerLevel() {
+        return jdbcTemplate.queryForObject(
+                "SELECT level FROM player WHERE id = ?", Integer.class, PLAYER_ID
+        );
+    }
+
+    private int growthChangeCount() {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM player_growth_changes", Integer.class
+        );
+    }
+
+    private int growthChangeCountByRewardLine(Long lineId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM player_growth_changes WHERE reward_line_id = ?",
+                Integer.class,
+                lineId
+        );
+    }
+
+    private String lineStatus(Long lineId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT status FROM reward_settlement_lines WHERE id = ?", String.class, lineId
+        );
+    }
+
+    private String lineFailureCode(Long lineId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT failure_code FROM reward_settlement_lines WHERE id = ?", String.class, lineId
+        );
+    }
+
+    private String settlementStatus(Long settlementId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT status FROM reward_settlements WHERE id = ?", String.class, settlementId
+        );
+    }
+
+    private int settlementRowCount() {
+        return jdbcTemplate.queryForObject("SELECT COUNT(*) FROM reward_settlements", Integer.class);
+    }
+
+    private int settlementLineRowCount() {
+        return jdbcTemplate.queryForObject("SELECT COUNT(*) FROM reward_settlement_lines", Integer.class);
+    }
+
+    @FunctionalInterface
+    private interface CheckedSupplier {
+        RewardSettlementExpProcessResult get();
+    }
+
+    static final class LevelUpCommitProbe {
+        private final AtomicInteger count = new AtomicInteger();
+
+        @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+        public void on(PlayerLeveledUp event) {
+            count.incrementAndGet();
+        }
+
+        int count() {
+            return count.get();
+        }
+
+        void reset() {
+            count.set(0);
+        }
+    }
+
+    @TestConfiguration
+    static class EventProbeConfig {
+        @Bean
+        LevelUpCommitProbe levelUpCommitProbe() {
+            return new LevelUpCommitProbe();
+        }
+    }
+}

--- a/src/test/java/online/lifeasgame/reward/application/RewardSettlementExpProcessServiceTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardSettlementExpProcessServiceTest.java
@@ -1,0 +1,109 @@
+package online.lifeasgame.reward.application;
+
+import online.lifeasgame.character.domain.error.PlayerError;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.reward.application.result.RewardSettlementExpProcessResult;
+import online.lifeasgame.reward.domain.RewardSettlementLineStatus;
+import online.lifeasgame.reward.domain.RewardSettlementStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RewardSettlementExpProcessService")
+class RewardSettlementExpProcessServiceTest {
+
+    @Mock
+    private RewardSettlementExpProcessAttempt processAttempt;
+
+    @Mock
+    private RewardSettlementLineFailureRecorder failureRecorder;
+
+    @Mock
+    private RewardSettlementExpReplayRecovery replayRecovery;
+
+    private RewardSettlementExpProcessService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new RewardSettlementExpProcessService(processAttempt, failureRecorder, replayRecovery);
+    }
+
+    @Nested
+    @DisplayName("성공 attempt 결과를 처리할 때")
+    class HandleSuccess {
+
+        @Test
+        @DisplayName("성공 결과를 그대로 반환하고 실패 기록은 호출하지 않는다")
+        void returnsSuccess() {
+            RewardSettlementExpProcessResult expected = new RewardSettlementExpProcessResult(
+                    1L, 10L, 100L,
+                    RewardSettlementLineStatus.SUCCEEDED, RewardSettlementStatus.COMPLETED,
+                    10L, 10L, 0L, 1, 1, 0L, 10L, false, 50L
+            );
+            given(processAttempt.process(1L, 10L)).willReturn(expected);
+
+            RewardSettlementExpProcessResult result = service.process(1L, 10L);
+
+            assertThat(result).isEqualTo(expected);
+            verify(failureRecorder, never()).record(1L, 10L, PlayerError.PLAYER_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("성공 attempt가 실패할 때")
+    class HandleFailure {
+
+        @Test
+        @DisplayName("알려진 DomainException은 rollback 이후 별도 실패 기록을 남기고 재전파한다")
+        void recordsKnownDomainFailure() {
+            DomainException exception = new DomainException(PlayerError.PLAYER_NOT_FOUND);
+            given(processAttempt.process(1L, 10L)).willThrow(exception);
+
+            assertThatThrownBy(() -> service.process(1L, 10L)).isSameAs(exception);
+            verify(failureRecorder).record(1L, 10L, PlayerError.PLAYER_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("예상하지 못한 RuntimeException은 실패로 확정하지 않고 그대로 전파한다")
+        void propagatesUnexpectedFailureWithoutRecording() {
+            RuntimeException exception = new RuntimeException("unexpected");
+            given(processAttempt.process(1L, 10L)).willThrow(exception);
+
+            assertThatThrownBy(() -> service.process(1L, 10L)).isSameAs(exception);
+            verify(failureRecorder, never()).record(1L, 10L, PlayerError.PLAYER_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("GrowthChange unique 충돌은 rollback 후 fresh transaction replay로 복구한다")
+        void recoversUniqueConflictWithFreshReplay() {
+            DataIntegrityViolationException exception =
+                    new DataIntegrityViolationException("duplicate reward line");
+            RewardSettlementExpProcessResult replay = new RewardSettlementExpProcessResult(
+                    1L, 10L, 100L,
+                    RewardSettlementLineStatus.SUCCEEDED, RewardSettlementStatus.COMPLETED,
+                    10L, 10L, 0L, 1, 1, 0L, 10L, true, 50L
+            );
+            given(processAttempt.process(1L, 10L)).willThrow(exception);
+            given(replayRecovery.findCompletedReplay(1L, 10L)).willReturn(Optional.of(replay));
+
+            RewardSettlementExpProcessResult result = service.process(1L, 10L);
+
+            assertThat(result).isEqualTo(replay);
+            verify(failureRecorder, never()).record(1L, 10L, PlayerError.PLAYER_NOT_FOUND);
+        }
+    }
+}

--- a/src/test/java/online/lifeasgame/reward/domain/RewardSettlementTest.java
+++ b/src/test/java/online/lifeasgame/reward/domain/RewardSettlementTest.java
@@ -86,6 +86,66 @@ class RewardSettlementTest {
     }
 
     @Nested
+    @DisplayName("EXP Line 처리 가능 여부를 확인할 때")
+    class ValidateExpLineProcessing {
+
+        @Test
+        @DisplayName("PENDING EXP Line은 처리가 필요하다")
+        void requiresPendingExpProcessing() {
+            RewardSettlement settlement = settlement(profileWithExpAndItem());
+
+            assertThat(settlement.getLineOrThrow(0).isExpProcessingRequired()).isTrue();
+        }
+
+        @Test
+        @DisplayName("ITEM Line은 EXP processor에서 처리할 수 없다")
+        void rejectsItemLine() {
+            RewardSettlement settlement = settlement(profileWithExpAndItem());
+
+            assertRewardError(
+                    () -> settlement.getLineOrThrow(1).isExpProcessingRequired(),
+                    RewardError.REWARD_SETTLEMENT_LINE_NOT_EXP
+            );
+        }
+
+        @Test
+        @DisplayName("SUCCEEDED EXP Line은 기존 결과를 유지하고 재처리하지 않는다")
+        void skipsSucceededExpLine() {
+            RewardSettlement settlement = settlement(profileWithExpAndItem());
+            settlement.markExpLineSucceeded(1000L);
+
+            boolean processingRequired = settlement.getLineOrThrow(0).isExpProcessingRequired();
+
+            assertThat(processingRequired).isFalse();
+            assertThat(settlement.getLineByIdOrThrow(1000L).getStatus())
+                    .isEqualTo(RewardSettlementLineStatus.SUCCEEDED);
+        }
+
+        @Test
+        @DisplayName("FAILED EXP Line은 자동 재처리할 수 없다")
+        void rejectsFailedExpLine() {
+            RewardSettlement settlement = settlement(profileWithExpAndItem());
+            settlement.markLineFailed(0, RewardError.REWARD_DEFINITION_NOT_FOUND);
+
+            assertRewardError(
+                    () -> settlement.getLineOrThrow(0).isExpProcessingRequired(),
+                    RewardError.REWARD_SETTLEMENT_LINE_ALREADY_FAILED
+            );
+        }
+
+        @Test
+        @DisplayName("다른 Settlement의 lineId는 소유 Line으로 조회하지 않는다")
+        void rejectsForeignLineId() {
+            RewardSettlement settlement = settlement(profileWithExpAndItem());
+
+            assertRewardError(
+                    () -> settlement.getLineByIdOrThrow(9999L),
+                    RewardError.REWARD_SETTLEMENT_LINE_NOT_FOUND
+            );
+        }
+    }
+
+    @Nested
     @DisplayName("Line 처리 결과를 반영할 때")
     class UpdateLineResult {
 
@@ -199,12 +259,16 @@ class RewardSettlementTest {
     }
 
     private RewardSettlement settlement(RewardProfile profile) {
-        return RewardSettlement.create(
+        RewardSettlement settlement = RewardSettlement.create(
                 1L,
                 RewardSettlementSourceType.QUEST_COMPLETION,
                 1000L,
                 profile
         );
+        for (int index = 0; index < settlement.getLines().size(); index++) {
+            ReflectionTestUtils.setField(settlement.getLines().get(index), "id", 1000L + index);
+        }
+        return settlement;
     }
 
     private RewardProfile profileWithExpAndItem() {


### PR DESCRIPTION
## What

- PENDING EXP RewardSettlementLine을 Player EXP에 반영했습니다.
- rewardLineId unique PlayerGrowthChange ledger를 추가했습니다.
- Player EXP, GrowthChange, Line SUCCEEDED를 하나의 transaction으로 처리했습니다.
- duplicate/replay/concurrent 요청에서 EXP가 한 번만 지급되도록 했습니다.
- 알려진 Domain failure는 별도 transaction으로 Line failureCode를 기록합니다.
- 기존 Player EXP API와 Level Up event 흐름을 유지했습니다.

## Scope

- EXP Reward Line processor
- PlayerGrowthChange ledger
- Character PlayerGrowthApi
- Player EXP lock
- Settlement/Player atomic transaction
- failure recorder
- Flyway migration
- MySQL concurrency tests
- directly touched Player EXP validation refactor

## Out of Scope

- RP_NONE / 0 Line Settlement remediation
- FAILED Line retry command/worker
- ITEM Reward
- Reward Mailbox
- Inventory / Claim
- Quest completion integration
- Achievement
- Outbox
- public Reward API

## Test

- [ ] `./gradlew clean test`
- [ ] `./gradlew build`
- [ ] EXP processor tests
- [ ] PlayerGrowthChange tests
- [ ] MySQL same-line concurrency
- [ ] MySQL different-lines same-player concurrency
- [ ] rollback/failure recording tests
- [ ] Flyway/JPA validate/checksum tests

Closes #187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added EXP reward settlement processing with support for successful grants, replays, and failure tracking.
  * Added idempotent EXP grants tied to reward lines, preventing duplicate experience awards.
  * Added detailed EXP results, including applied/leftover experience and level changes.
  * Added safeguards for invalid amounts, overflow, inconsistent grants, and unsupported reward types.
* **Bug Fixes**
  * Improved concurrent processing to prevent lost updates and duplicate level-up effects.
* **Tests**
  * Added coverage for validation, replay behavior, migration updates, rollback handling, and concurrent processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->