### PR TITLE
[Reward] Support RP_NONE and retry preparation

### DIFF
--- a/src/main/java/online/lifeasgame/reward/application/RewardSettlementLineRetryPreparationService.java
+++ b/src/main/java/online/lifeasgame/reward/application/RewardSettlementLineRetryPreparationService.java
@@ -1,0 +1,34 @@
+package online.lifeasgame.reward.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.reward.application.result.RewardSettlementLineRetryPreparationResult;
+import online.lifeasgame.reward.domain.RewardSettlement;
+import online.lifeasgame.reward.domain.RewardSettlementLine;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RewardSettlementLineRetryPreparationService {
+
+    private final RewardSettlementReader settlementReader;
+    private final RewardSettlementWriter settlementWriter;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public RewardSettlementLineRetryPreparationResult prepare(Long settlementId, Long lineId) {
+        RewardSettlement settlement = settlementReader.getByIdForUpdateOrThrow(settlementId);
+        boolean changed = settlement.prepareLineRetry(lineId);
+        if (changed) {
+            settlementWriter.saveAndFlush(settlement);
+        }
+        RewardSettlementLine line = settlement.getLineByIdOrThrow(lineId);
+        return new RewardSettlementLineRetryPreparationResult(
+                settlement.getId(),
+                line.getId(),
+                line.getStatus(),
+                settlement.getStatus(),
+                changed
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/application/result/RewardSettlementLineRetryPreparationResult.java
+++ b/src/main/java/online/lifeasgame/reward/application/result/RewardSettlementLineRetryPreparationResult.java
@@ -1,0 +1,13 @@
+package online.lifeasgame.reward.application.result;
+
+import online.lifeasgame.reward.domain.RewardSettlementLineStatus;
+import online.lifeasgame.reward.domain.RewardSettlementStatus;
+
+public record RewardSettlementLineRetryPreparationResult(
+        Long settlementId,
+        Long lineId,
+        RewardSettlementLineStatus lineStatus,
+        RewardSettlementStatus settlementStatus,
+        boolean changed
+) {
+}

--- a/src/main/java/online/lifeasgame/reward/domain/RewardSettlement.java
+++ b/src/main/java/online/lifeasgame/reward/domain/RewardSettlement.java
@@ -78,10 +78,10 @@ public class RewardSettlement extends AbstractTime {
         this.sourceId = sourceId;
         this.rewardProfileId = rewardProfile.getId();
         this.rewardProfileCode = rewardProfile.getCode();
-        this.status = RewardSettlementStatus.PENDING;
         rewardProfile.getLines().stream()
                 .map(line -> RewardSettlementLine.snapshot(this, line))
                 .forEach(lines::add);
+        recalculateStatus();
     }
 
     public static RewardSettlement create(
@@ -123,6 +123,14 @@ public class RewardSettlement extends AbstractTime {
                     return true;
                 })
                 .orElse(false);
+    }
+
+    public boolean prepareLineRetry(Long lineId) {
+        boolean changed = findLineById(lineId).prepareRetry();
+        if (changed) {
+            recalculateStatus();
+        }
+        return changed;
     }
 
     public RewardSettlementLine getLineOrThrow(int sortOrder) {
@@ -186,9 +194,6 @@ public class RewardSettlement extends AbstractTime {
         rewardProfile.assertActive();
         if (rewardProfile.getId() == null) {
             throw new DomainException(RewardError.REWARD_SETTLEMENT_PROFILE_ID_REQUIRED);
-        }
-        if (rewardProfile.getLines().isEmpty()) {
-            throw new DomainException(RewardError.REWARD_SETTLEMENT_PROFILE_LINES_REQUIRED);
         }
     }
 }

--- a/src/main/java/online/lifeasgame/reward/domain/RewardSettlementLine.java
+++ b/src/main/java/online/lifeasgame/reward/domain/RewardSettlementLine.java
@@ -139,6 +139,20 @@ public class RewardSettlementLine extends AbstractTime {
         failureCode = errorCode.code();
     }
 
+    boolean prepareRetry() {
+        if (status == RewardSettlementLineStatus.PENDING) {
+            return false;
+        }
+        if (status == RewardSettlementLineStatus.SUCCEEDED) {
+            throw new DomainException(
+                    RewardError.REWARD_SETTLEMENT_SUCCEEDED_LINE_CANNOT_RETRY
+            );
+        }
+        status = RewardSettlementLineStatus.PENDING;
+        failureCode = null;
+        return true;
+    }
+
     private void assertExp() {
         if (rewardType != RewardType.EXP) {
             throw new DomainException(RewardError.REWARD_SETTLEMENT_LINE_NOT_EXP);

--- a/src/main/java/online/lifeasgame/reward/domain/error/RewardError.java
+++ b/src/main/java/online/lifeasgame/reward/domain/error/RewardError.java
@@ -88,9 +88,6 @@ public enum RewardError implements ErrorCode {
     REWARD_SETTLEMENT_PROFILE_ID_REQUIRED(
             "RWD-400-SETTLEMENT-PROFILE-ID-REQUIRED", "Reward settlement requires a persisted reward profile", 400
     ),
-    REWARD_SETTLEMENT_PROFILE_LINES_REQUIRED(
-            "RWD-400-SETTLEMENT-PROFILE-LINES-REQUIRED", "Reward settlement requires at least one profile line", 400
-    ),
     REWARD_SETTLEMENT_DEFINITION_ID_REQUIRED(
             "RWD-400-SETTLEMENT-DEFINITION-ID-REQUIRED", "Reward settlement line requires a persisted reward definition", 400
     ),
@@ -105,6 +102,9 @@ public enum RewardError implements ErrorCode {
     ),
     REWARD_SETTLEMENT_SUCCEEDED_LINE_CANNOT_FAIL(
             "RWD-409-SETTLEMENT-SUCCEEDED-LINE-CANNOT-FAIL", "Succeeded reward settlement line cannot fail", 409
+    ),
+    REWARD_SETTLEMENT_SUCCEEDED_LINE_CANNOT_RETRY(
+            "RWD-409-SETTLEMENT-SUCCEEDED-LINE-CANNOT-RETRY", "Succeeded reward settlement line cannot retry", 409
     ),
     REWARD_SETTLEMENT_FAILURE_CODE_REQUIRED(
             "RWD-400-SETTLEMENT-FAILURE-CODE-REQUIRED", "Failed reward settlement line requires an error code", 400

--- a/src/main/resources/db/migration/V5__reward_none_profile.sql
+++ b/src/main/resources/db/migration/V5__reward_none_profile.sql
@@ -1,0 +1,6 @@
+-- A reward-free completion still uses the settlement lifecycle with an empty active profile.
+INSERT INTO reward_profiles (
+    code, name, status, created_at, updated_at
+) VALUES (
+    'RP_NONE', 'No Reward Profile', 'ACTIVE', CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
+);

--- a/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
@@ -32,7 +32,7 @@ class FlywayHistoryChecksumTest {
     class MigrateAgain {
 
         @Test
-        @DisplayName("두 번째 실행은 no-op이고 V1부터 V4까지 checksum history를 유지한다")
+        @DisplayName("두 번째 실행은 no-op이고 V1부터 V5까지 checksum history를 유지한다")
         void keepsMigrationHistory() throws Exception {
             Flyway flyway = flyway();
 
@@ -42,11 +42,11 @@ class FlywayHistoryChecksumTest {
             MigrateResult second = flyway.migrate();
             List<HistoryRow> secondHistory = successfulHistory();
 
-            assertThat(first.migrationsExecuted).isEqualTo(4);
+            assertThat(first.migrationsExecuted).isEqualTo(5);
             assertThat(second.migrationsExecuted).isZero();
             assertThat(secondHistory).isEqualTo(firstHistory);
             assertThat(secondHistory).extracting(HistoryRow::version)
-                    .containsExactly("1", "2", "3", "4");
+                    .containsExactly("1", "2", "3", "4", "5");
             assertThat(secondHistory).allSatisfy(history -> {
                 assertThat(history.checksum()).isNotNull();
                 assertThat(history.success()).isTrue();

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -37,14 +37,14 @@ class FlywayMigrationTest {
     class MigrateCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V4까지 적용되고 Settlement와 GrowthChange 중복 방지 제약이 생성된다")
+        @DisplayName("V1부터 V5까지 적용되고 RP_NONE과 중복 방지 제약이 생성된다")
         void migratesSchemaAndSeedsRewardProfiles() throws Exception {
             Flyway flyway = flyway();
 
             MigrateResult result = flyway.migrate();
 
-            assertThat(result.migrationsExecuted).isEqualTo(4);
-            assertThat(appliedVersions()).containsExactly("1", "2", "3", "4");
+            assertThat(result.migrationsExecuted).isEqualTo(5);
+            assertThat(appliedVersions()).containsExactly("1", "2", "3", "4", "5");
             assertThat(existingTables(
                     "users",
                     "player",
@@ -71,6 +71,7 @@ class FlywayMigrationTest {
                     "player_growth_changes"
             );
             assertThat(seedProfileCodes()).containsExactly("RP_EXP_10", "RP_EXP_30");
+            assertThat(noRewardProfile()).isEqualTo(new NoRewardProfile("ACTIVE", 0));
             assertThat(uniqueIndexColumns("reward_settlements", "uq_reward_settlement_source"))
                     .containsExactly("player_id", "source_type", "source_id");
             assertThat(uniqueIndexColumns(
@@ -158,6 +159,26 @@ class FlywayMigrationTest {
         }
     }
 
+    private NoRewardProfile noRewardProfile() throws Exception {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("""
+                     SELECT profile.status, COUNT(line.id) AS line_count
+                     FROM reward_profiles profile
+                     LEFT JOIN reward_profile_lines line ON line.reward_profile_id = profile.id
+                     WHERE profile.code = 'RP_NONE'
+                     GROUP BY profile.id, profile.status
+                     """)) {
+            assertThat(resultSet.next()).isTrue();
+            NoRewardProfile result = new NoRewardProfile(
+                    resultSet.getString("status"),
+                    resultSet.getInt("line_count")
+            );
+            assertThat(resultSet.next()).isFalse();
+            return result;
+        }
+    }
+
     private List<String> uniqueIndexColumns(String tableName, String indexName) throws Exception {
         try (Connection connection = MYSQL.createConnection("");
              var statement = connection.prepareStatement("""
@@ -206,5 +227,8 @@ class FlywayMigrationTest {
                     )
                     """);
         }
+    }
+
+    private record NoRewardProfile(String status, int lineCount) {
     }
 }

--- a/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 @SpringBootTest
 @ActiveProfiles({"test", "migration-test"})
-@DisplayName("V4 migration 이후 JPA schema validation")
+@DisplayName("V5 migration 이후 JPA schema validation")
 class JpaValidateAfterMigrationTest {
 
     @Container
@@ -61,14 +61,14 @@ class JpaValidateAfterMigrationTest {
     private RewardSettlementReader rewardSettlementReader;
 
     @Nested
-    @DisplayName("V1부터 V4까지 적용된 schema로 ApplicationContext를 기동할 때")
+    @DisplayName("V1부터 V5까지 적용된 schema로 ApplicationContext를 기동할 때")
     class LoadApplicationContext {
 
         @Test
         @DisplayName("ddl-auto validate 상태로 정상 기동한다")
         void loadsWithJpaValidation() {
             assertThat(applicationContext).isNotNull();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("4");
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("5");
             assertThat(applicationContext.getEnvironment().getProperty("spring.jpa.hibernate.ddl-auto"))
                     .isEqualTo("validate");
             assertThat(applicationContext.getEnvironment()
@@ -92,11 +92,20 @@ class JpaValidateAfterMigrationTest {
         }
 
         @Test
+        @DisplayName("V5 RP_NONE은 ACTIVE 상태이고 Line이 없다")
+        void loadsNoRewardProfileWithoutLines() {
+            var profile = rewardProfileReader.getActiveByCodeOrThrow("RP_NONE");
+
+            assertThat(profile.isActive()).isTrue();
+            assertThat(profile.getLines()).isEmpty();
+        }
+
+        @Test
         @DisplayName("DTO projection으로 활성 profile 요약을 조회한다")
         void loadsActiveProfileSummariesWithProjection() {
             assertThat(rewardProfileQueryService.listActiveProfiles())
                     .extracting(RewardProfileResult.Summary::code)
-                    .containsExactly("RP_EXP_10", "RP_EXP_30");
+                    .containsExactly("RP_EXP_10", "RP_EXP_30", "RP_NONE");
         }
     }
 

--- a/src/test/java/online/lifeasgame/reward/application/RewardSettlementCreateServiceTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardSettlementCreateServiceTest.java
@@ -6,6 +6,7 @@ import online.lifeasgame.reward.domain.RewardProfile;
 import online.lifeasgame.reward.domain.RewardProfileStatus;
 import online.lifeasgame.reward.domain.RewardSettlement;
 import online.lifeasgame.reward.domain.RewardSettlementSourceType;
+import online.lifeasgame.reward.domain.RewardSettlementStatus;
 import online.lifeasgame.reward.domain.RewardType;
 import online.lifeasgame.reward.domain.error.RewardError;
 import org.junit.jupiter.api.BeforeEach;
@@ -72,6 +73,26 @@ class RewardSettlementCreateServiceTest {
 
             assertThat(result.getLines()).hasSize(1);
             assertThat(result.getLines().getFirst().getAmount()).isEqualTo(10L);
+            verify(settlementWriter).saveAndFlush(result);
+        }
+
+        @Test
+        @DisplayName("RP_NONE은 Line 없이 COMPLETED Settlement로 저장한다")
+        void savesCompletedSettlementForNoRewardProfile() {
+            RewardProfile profile = activeEmptyProfile();
+            given(settlementReader.findByIdentity(PLAYER_ID, sourceType(), SOURCE_ID))
+                    .willReturn(Optional.empty());
+            given(profileReader.getActiveByCodeOrThrow("RP_NONE")).willReturn(profile);
+            given(settlementWriter.saveAndFlush(any(RewardSettlement.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0, RewardSettlement.class));
+
+            RewardSettlement result = service.create(
+                    PLAYER_ID, sourceType(), SOURCE_ID, "RP_NONE"
+            );
+
+            assertThat(result.getRewardProfileCode()).isEqualTo("RP_NONE");
+            assertThat(result.getLines()).isEmpty();
+            assertThat(result.getStatus()).isEqualTo(RewardSettlementStatus.COMPLETED);
             verify(settlementWriter).saveAndFlush(result);
         }
 
@@ -184,6 +205,14 @@ class RewardSettlementCreateServiceTest {
         );
         ReflectionTestUtils.setField(definition, "id", 20L);
         profile.addLine(definition, 0, null);
+        return profile;
+    }
+
+    private RewardProfile activeEmptyProfile() {
+        RewardProfile profile = RewardProfile.create(
+                "RP_NONE", "No Reward Profile", RewardProfileStatus.ACTIVE
+        );
+        ReflectionTestUtils.setField(profile, "id", 30L);
         return profile;
     }
 

--- a/src/test/java/online/lifeasgame/reward/application/RewardSettlementExpProcessConcurrencyTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardSettlementExpProcessConcurrencyTest.java
@@ -4,6 +4,7 @@ import online.lifeasgame.character.domain.error.PlayerError;
 import online.lifeasgame.character.domain.event.PlayerLeveledUp;
 import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.reward.application.result.RewardSettlementExpProcessResult;
+import online.lifeasgame.reward.application.result.RewardSettlementLineRetryPreparationResult;
 import online.lifeasgame.reward.domain.RewardSettlement;
 import online.lifeasgame.reward.domain.RewardSettlementLineStatus;
 import online.lifeasgame.reward.domain.RewardSettlementSourceType;
@@ -77,6 +78,9 @@ class RewardSettlementExpProcessConcurrencyTest {
 
     @Autowired
     private RewardSettlementLineFailureRecorder failureRecorder;
+
+    @Autowired
+    private RewardSettlementLineRetryPreparationService retryPreparationService;
 
     @MockitoSpyBean
     private RewardSettlementWriter settlementWriter;
@@ -284,6 +288,88 @@ class RewardSettlementExpProcessConcurrencyTest {
         }
     }
 
+    @Nested
+    @DisplayName("RP_NONE으로 무보상 Settlement를 생성할 때")
+    class CreateNoRewardSettlement {
+
+        @Test
+        @DisplayName("Line 없이 즉시 COMPLETED가 되고 같은 Source 재호출은 기존 행을 반환한다")
+        void completesAndReplaysWithoutLines() {
+            RewardSettlement first = createSettlement(189001L, "RP_NONE");
+            RewardSettlement replay = createSettlement(189001L, "RP_NONE");
+
+            assertThat(first.getLines()).isEmpty();
+            assertThat(first.getStatus()).isEqualTo(RewardSettlementStatus.COMPLETED);
+            assertThat(replay.getId()).isEqualTo(first.getId());
+            assertThat(replay.getLines()).isEmpty();
+            assertThat(replay.getStatus()).isEqualTo(RewardSettlementStatus.COMPLETED);
+            assertThat(settlementRowCount()).isEqualTo(1);
+            assertThat(settlementLineRowCount()).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("알려진 실패를 명시적으로 Retry 준비할 때")
+    class PrepareKnownFailureRetry {
+
+        @Test
+        @DisplayName("FAILED를 PENDING으로 영속화한 뒤 명시적 processor 호출에서 EXP를 한 번 지급한다")
+        void preparesThenProcessesExactlyOnce() {
+            RewardSettlement settlement = createSettlement(189101L, "RP_EXP_10");
+            Long lineId = settlement.getLines().getFirst().getId();
+            assertThatThrownBy(() -> processService.process(settlement.getId(), lineId))
+                    .isInstanceOfSatisfying(DomainException.class, exception ->
+                            assertThat(exception.getErrorCode()).isEqualTo(PlayerError.PLAYER_NOT_FOUND)
+                    );
+            insertPlayer(0L);
+
+            RewardSettlementLineRetryPreparationResult prepared =
+                    retryPreparationService.prepare(settlement.getId(), lineId);
+
+            assertThat(prepared.changed()).isTrue();
+            assertThat(lineStatus(lineId)).isEqualTo(RewardSettlementLineStatus.PENDING.name());
+            assertThat(lineFailureCode(lineId)).isNull();
+            assertThat(settlementStatus(settlement.getId()))
+                    .isEqualTo(RewardSettlementStatus.PENDING.name());
+            assertThat(playerExp()).isZero();
+            assertThat(growthChangeCount()).isZero();
+
+            RewardSettlementExpProcessResult processed =
+                    processService.process(settlement.getId(), lineId);
+
+            assertThat(processed.replayed()).isFalse();
+            assertThat(playerExp()).isEqualTo(10L);
+            assertThat(growthChangeCount()).isEqualTo(1);
+            assertThat(growthChangeCountByRewardLine(lineId)).isEqualTo(1);
+            assertThat(lineStatus(lineId)).isEqualTo(RewardSettlementLineStatus.SUCCEEDED.name());
+            assertThat(settlementStatus(settlement.getId()))
+                    .isEqualTo(RewardSettlementStatus.COMPLETED.name());
+        }
+
+        @Test
+        @DisplayName("같은 FAILED Line의 두 동시 요청은 한 번만 변경하고 최종 PENDING을 유지한다")
+        void preparesSameFailedLineConcurrently() throws Exception {
+            RewardSettlement settlement = createSettlement(189102L, "RP_EXP_10");
+            Long lineId = settlement.getLines().getFirst().getId();
+            assertThatThrownBy(() -> processService.process(settlement.getId(), lineId))
+                    .isInstanceOf(DomainException.class);
+
+            List<RewardSettlementLineRetryPreparationResult> results = runConcurrently(
+                    () -> retryPreparationService.prepare(settlement.getId(), lineId),
+                    () -> retryPreparationService.prepare(settlement.getId(), lineId)
+            );
+
+            assertThat(results)
+                    .extracting(RewardSettlementLineRetryPreparationResult::changed)
+                    .containsExactlyInAnyOrder(true, false);
+            assertThat(lineStatus(lineId)).isEqualTo(RewardSettlementLineStatus.PENDING.name());
+            assertThat(lineFailureCode(lineId)).isNull();
+            assertThat(settlementStatus(settlement.getId()))
+                    .isEqualTo(RewardSettlementStatus.PENDING.name());
+            assertThat(growthChangeCount()).isZero();
+        }
+    }
+
     private RewardSettlement createSettlement(long sourceId, String profileCode) {
         return createService.create(PLAYER_ID, SOURCE_TYPE, sourceId, profileCode);
     }
@@ -305,18 +391,18 @@ class RewardSettlementExpProcessConcurrencyTest {
                 """, PLAYER_ID, PLAYER_ID + 100000L, level, exp);
     }
 
-    private List<RewardSettlementExpProcessResult> runConcurrently(
-            CheckedSupplier first,
-            CheckedSupplier second
+    private <T> List<T> runConcurrently(
+            CheckedSupplier<T> first,
+            CheckedSupplier<T> second
     ) throws Exception {
         CountDownLatch ready = new CountDownLatch(2);
         CountDownLatch start = new CountDownLatch(1);
-        Future<RewardSettlementExpProcessResult> firstFuture = executor.submit(() -> {
+        Future<T> firstFuture = executor.submit(() -> {
             ready.countDown();
             start.await();
             return first.get();
         });
-        Future<RewardSettlementExpProcessResult> secondFuture = executor.submit(() -> {
+        Future<T> secondFuture = executor.submit(() -> {
             ready.countDown();
             start.await();
             return second.get();
@@ -382,8 +468,8 @@ class RewardSettlementExpProcessConcurrencyTest {
     }
 
     @FunctionalInterface
-    private interface CheckedSupplier {
-        RewardSettlementExpProcessResult get();
+    private interface CheckedSupplier<T> {
+        T get();
     }
 
     static final class LevelUpCommitProbe {

--- a/src/test/java/online/lifeasgame/reward/application/RewardSettlementLineRetryPreparationServiceTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardSettlementLineRetryPreparationServiceTest.java
@@ -1,0 +1,172 @@
+package online.lifeasgame.reward.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.reward.application.result.RewardSettlementLineRetryPreparationResult;
+import online.lifeasgame.reward.domain.RewardDefinition;
+import online.lifeasgame.reward.domain.RewardProfile;
+import online.lifeasgame.reward.domain.RewardProfileStatus;
+import online.lifeasgame.reward.domain.RewardSettlement;
+import online.lifeasgame.reward.domain.RewardSettlementLineStatus;
+import online.lifeasgame.reward.domain.RewardSettlementSourceType;
+import online.lifeasgame.reward.domain.RewardSettlementStatus;
+import online.lifeasgame.reward.domain.RewardType;
+import online.lifeasgame.reward.domain.error.RewardError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RewardSettlementLineRetryPreparationService")
+class RewardSettlementLineRetryPreparationServiceTest {
+
+    private static final Long SETTLEMENT_ID = 189L;
+    private static final Long LINE_ID = 1890L;
+
+    @Mock
+    private RewardSettlementReader settlementReader;
+
+    @Mock
+    private RewardSettlementWriter settlementWriter;
+
+    private RewardSettlementLineRetryPreparationService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new RewardSettlementLineRetryPreparationService(
+                settlementReader, settlementWriter
+        );
+    }
+
+    @Nested
+    @DisplayName("FAILED Line의 재시도를 준비할 때")
+    class PrepareFailedLine {
+
+        @Test
+        @DisplayName("Settlement를 잠금 조회하고 변경 상태를 flush한다")
+        void locksAndFlushesChangedSettlement() {
+            RewardSettlement settlement = settlement();
+            settlement.markLineFailed(0, RewardError.REWARD_DEFINITION_NOT_FOUND);
+            given(settlementReader.getByIdForUpdateOrThrow(SETTLEMENT_ID))
+                    .willReturn(settlement);
+
+            RewardSettlementLineRetryPreparationResult result =
+                    service.prepare(SETTLEMENT_ID, LINE_ID);
+
+            assertThat(result.settlementId()).isEqualTo(SETTLEMENT_ID);
+            assertThat(result.lineId()).isEqualTo(LINE_ID);
+            assertThat(result.lineStatus()).isEqualTo(RewardSettlementLineStatus.PENDING);
+            assertThat(result.settlementStatus()).isEqualTo(RewardSettlementStatus.PENDING);
+            assertThat(result.changed()).isTrue();
+            assertThat(settlement.getLineByIdOrThrow(LINE_ID).getFailureCode()).isNull();
+            verify(settlementReader).getByIdForUpdateOrThrow(SETTLEMENT_ID);
+            verify(settlementWriter).saveAndFlush(settlement);
+        }
+    }
+
+    @Nested
+    @DisplayName("PENDING Line의 재시도를 준비할 때")
+    class PreparePendingLine {
+
+        @Test
+        @DisplayName("no-op 결과를 반환하고 저장하지 않는다")
+        void returnsNoOpWithoutSave() {
+            RewardSettlement settlement = settlement();
+            given(settlementReader.getByIdForUpdateOrThrow(SETTLEMENT_ID))
+                    .willReturn(settlement);
+
+            RewardSettlementLineRetryPreparationResult result =
+                    service.prepare(SETTLEMENT_ID, LINE_ID);
+
+            assertThat(result.lineStatus()).isEqualTo(RewardSettlementLineStatus.PENDING);
+            assertThat(result.settlementStatus()).isEqualTo(RewardSettlementStatus.PENDING);
+            assertThat(result.changed()).isFalse();
+            verify(settlementWriter, never()).saveAndFlush(settlement);
+        }
+    }
+
+    @Nested
+    @DisplayName("재시도 대상을 검증할 때")
+    class ValidateRetryTarget {
+
+        @Test
+        @DisplayName("Settlement가 없으면 안정된 DomainException을 전파한다")
+        void propagatesMissingSettlementError() {
+            given(settlementReader.getByIdForUpdateOrThrow(SETTLEMENT_ID))
+                    .willThrow(new DomainException(RewardError.REWARD_SETTLEMENT_NOT_FOUND));
+
+            assertRewardError(
+                    () -> service.prepare(SETTLEMENT_ID, LINE_ID),
+                    RewardError.REWARD_SETTLEMENT_NOT_FOUND
+            );
+            verify(settlementWriter, never()).saveAndFlush(org.mockito.ArgumentMatchers.any());
+        }
+
+        @Test
+        @DisplayName("Settlement에 속하지 않은 Line이면 저장하지 않는다")
+        void rejectsMissingLine() {
+            RewardSettlement settlement = settlement();
+            given(settlementReader.getByIdForUpdateOrThrow(SETTLEMENT_ID))
+                    .willReturn(settlement);
+
+            assertRewardError(
+                    () -> service.prepare(SETTLEMENT_ID, 9999L),
+                    RewardError.REWARD_SETTLEMENT_LINE_NOT_FOUND
+            );
+            verify(settlementWriter, never()).saveAndFlush(settlement);
+        }
+
+        @Test
+        @DisplayName("SUCCEEDED Line이면 저장하지 않고 Retry 거부 예외를 전파한다")
+        void rejectsSucceededLine() {
+            RewardSettlement settlement = settlement();
+            settlement.markLineSucceeded(0);
+            given(settlementReader.getByIdForUpdateOrThrow(SETTLEMENT_ID))
+                    .willReturn(settlement);
+
+            assertRewardError(
+                    () -> service.prepare(SETTLEMENT_ID, LINE_ID),
+                    RewardError.REWARD_SETTLEMENT_SUCCEEDED_LINE_CANNOT_RETRY
+            );
+            verify(settlementWriter, never()).saveAndFlush(settlement);
+        }
+    }
+
+    private RewardSettlement settlement() {
+        RewardProfile profile = RewardProfile.create(
+                "RP_EXP_10", "EXP 10 Profile", RewardProfileStatus.ACTIVE
+        );
+        ReflectionTestUtils.setField(profile, "id", 10L);
+        RewardDefinition definition = RewardDefinition.create(
+                "RD_EXP_10", "EXP 10", RewardType.EXP, 10L, null, true
+        );
+        ReflectionTestUtils.setField(definition, "id", 20L);
+        profile.addLine(definition, 0, null);
+        RewardSettlement settlement = RewardSettlement.create(
+                1L,
+                RewardSettlementSourceType.QUEST_COMPLETION,
+                18900L,
+                profile
+        );
+        ReflectionTestUtils.setField(settlement, "id", SETTLEMENT_ID);
+        ReflectionTestUtils.setField(settlement.getLines().getFirst(), "id", LINE_ID);
+        return settlement;
+    }
+
+    private void assertRewardError(Runnable action, RewardError error) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(error)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/reward/domain/RewardSettlementTest.java
+++ b/src/test/java/online/lifeasgame/reward/domain/RewardSettlementTest.java
@@ -74,14 +74,95 @@ class RewardSettlementTest {
         }
 
         @Test
-        @DisplayName("Profile Line이 없으면 REWARD_SETTLEMENT_PROFILE_LINES_REQUIRED 예외가 발생한다")
-        void rejectsEmptyProfile() {
-            RewardProfile profile = persistedProfile("RP_EMPTY");
+        @DisplayName("Profile Line이 없으면 빈 Line과 COMPLETED 상태로 생성한다")
+        void createsCompletedSettlementForEmptyProfile() {
+            RewardProfile profile = persistedProfile("RP_NONE");
+
+            RewardSettlement settlement = settlement(profile);
+
+            assertThat(settlement.getRewardProfileId()).isEqualTo(100L);
+            assertThat(settlement.getRewardProfileCode()).isEqualTo("RP_NONE");
+            assertThat(settlement.getLines()).isEmpty();
+            assertThat(settlement.getStatus()).isEqualTo(RewardSettlementStatus.COMPLETED);
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 Line의 재시도를 준비할 때")
+    class PrepareLineRetry {
+
+        @Test
+        @DisplayName("FAILED Line을 PENDING으로 바꾸고 failureCode를 제거한다")
+        void preparesFailedLine() {
+            RewardSettlement settlement = settlement(profileWithExpAndItem());
+            settlement.markLineFailed(0, RewardError.REWARD_DEFINITION_NOT_FOUND);
+
+            boolean changed = settlement.prepareLineRetry(1000L);
+
+            RewardSettlementLine line = settlement.getLineByIdOrThrow(1000L);
+            assertThat(changed).isTrue();
+            assertThat(line.getStatus()).isEqualTo(RewardSettlementLineStatus.PENDING);
+            assertThat(line.getFailureCode()).isNull();
+            assertThat(settlement.getStatus()).isEqualTo(RewardSettlementStatus.PENDING);
+        }
+
+        @Test
+        @DisplayName("PENDING Line 재호출은 상태를 변경하지 않는다")
+        void keepsPendingLine() {
+            RewardSettlement settlement = settlement(profileWithExpAndItem());
+
+            boolean changed = settlement.prepareLineRetry(1000L);
+
+            assertThat(changed).isFalse();
+            assertThat(settlement.getLineByIdOrThrow(1000L).getStatus())
+                    .isEqualTo(RewardSettlementLineStatus.PENDING);
+            assertThat(settlement.getStatus()).isEqualTo(RewardSettlementStatus.PENDING);
+        }
+
+        @Test
+        @DisplayName("SUCCEEDED Line은 재시도를 준비할 수 없다")
+        void rejectsSucceededLine() {
+            RewardSettlement settlement = settlement(profileWithExpAndItem());
+            settlement.markLineSucceeded(0);
 
             assertRewardError(
-                    () -> settlement(profile),
-                    RewardError.REWARD_SETTLEMENT_PROFILE_LINES_REQUIRED
+                    () -> settlement.prepareLineRetry(1000L),
+                    RewardError.REWARD_SETTLEMENT_SUCCEEDED_LINE_CANNOT_RETRY
             );
+        }
+
+        @Test
+        @DisplayName("부분 실패의 대상 Line만 PENDING으로 바꾸고 부모 상태를 재계산한다")
+        void recalculatesPartialFailure() {
+            RewardSettlement settlement = settlement(profileWithExpAndItem());
+            settlement.markLineSucceeded(0);
+            settlement.markLineFailed(1, RewardError.REWARD_DEFINITION_NOT_FOUND);
+            assertThat(settlement.getStatus()).isEqualTo(RewardSettlementStatus.PARTIAL_FAILED);
+
+            settlement.prepareLineRetry(1001L);
+
+            assertThat(settlement.getLineByIdOrThrow(1000L).getStatus())
+                    .isEqualTo(RewardSettlementLineStatus.SUCCEEDED);
+            assertThat(settlement.getLineByIdOrThrow(1001L).getStatus())
+                    .isEqualTo(RewardSettlementLineStatus.PENDING);
+            assertThat(settlement.getStatus()).isEqualTo(RewardSettlementStatus.PENDING);
+        }
+
+        @Test
+        @DisplayName("전체 실패에서 한 Line을 준비하면 부모 상태가 PENDING이 된다")
+        void recalculatesTotalFailure() {
+            RewardSettlement settlement = settlement(profileWithExpAndItem());
+            settlement.markLineFailed(0, RewardError.REWARD_DEFINITION_NOT_FOUND);
+            settlement.markLineFailed(1, RewardError.REWARD_DEFINITION_NOT_FOUND);
+            assertThat(settlement.getStatus()).isEqualTo(RewardSettlementStatus.FAILED);
+
+            settlement.prepareLineRetry(1000L);
+
+            assertThat(settlement.getLineByIdOrThrow(1000L).getStatus())
+                    .isEqualTo(RewardSettlementLineStatus.PENDING);
+            assertThat(settlement.getLineByIdOrThrow(1001L).getStatus())
+                    .isEqualTo(RewardSettlementLineStatus.FAILED);
+            assertThat(settlement.getStatus()).isEqualTo(RewardSettlementStatus.PENDING);
         }
     }
 


### PR DESCRIPTION
## What

- 활성 무보상 Reward Profile `RP_NONE`을 추가했습니다.
- Line이 없는 Reward Profile로 Settlement를 생성할 수 있도록 변경했습니다.
- 0 Line Settlement가 생성 즉시 `COMPLETED`가 되도록 했습니다.
- 실패한 Reward Line을 명시적으로 `PENDING`으로 되돌리는 Retry Preparation을 추가했습니다.
- Retry 준비 시 `failureCode`를 제거하고 부모 Settlement 상태를 재계산합니다.
- PENDING 재호출은 멱등 처리하고 SUCCEEDED Line Retry는 거부합니다.

## Transaction / Lock

- Retry Preparation은 별도 Transaction에서 실행합니다.
- Settlement를 `PESSIMISTIC_WRITE`로 먼저 잠급니다.
- 다른 Aggregate를 변경하거나 잠그지 않습니다.
- Retry Preparation은 Reward Processor를 자동 실행하지 않습니다.

## Migration

- `V5__reward_none_profile.sql`
- `RP_NONE`은 ACTIVE이며 Profile Line을 가지지 않습니다.
- 기존 V1~V4 Migration은 수정하지 않았습니다.

## Test

- [ ] `./gradlew clean test`
- [ ] `./gradlew build`
- [ ] RP_NONE Seed / 0 Line 검증
- [ ] 0 Line Settlement 즉시 COMPLETED
- [ ] 동일 Source 생성 멱등성
- [ ] FAILED → PENDING
- [ ] failureCode 제거
- [ ] 부모 Settlement 상태 재계산
- [ ] PENDING Retry no-op
- [ ] SUCCEEDED Retry 거부
- [ ] Flyway V1~V5 / checksum / JPA validate
- [ ] 기존 EXP exact-once 회귀

## Out of Scope

- 자동 Retry Worker / Scheduler
- Retry 횟수 / Backoff / DLQ
- ITEM Reward
- Reward Mailbox
- Inventory / Claim
- Quest 연동
- Achievement
- Outbox
- Public Reward API
- InternalApi HTTP 전환

Closes #189