### PR TITLE
[Database] Cut over local and production profiles to Flyway

### DIFF
--- a/docs/database/flyway_baseline_runbook.md
+++ b/docs/database/flyway_baseline_runbook.md
@@ -4,13 +4,69 @@
 
 `V1__baseline_current_schema.sql`은 빈 MySQL 8 데이터베이스를 위한 clean-install 전용 스키마이다. 기존 운영 데이터베이스에는 V1 SQL을 실행하지 않는다.
 
-- 애플리케이션 공통 설정은 `spring.flyway.enabled=false` 및 `spring.flyway.baseline-on-migrate=false`를 유지한다.
-- 운영 baseline은 승인된 작업 시간에 운영자가 명시적으로 한 번 수행한다. 애플리케이션 시작 과정에서 baseline 또는 migration을 실행하지 않는다.
+- Flyway만 local/prod schema 변경 권위를 가진다. Hibernate는 `ddl-auto=validate`로 mapping 일치 여부만 확인한다.
+- 공통 설정은 `spring.flyway.enabled=false`, `locations=classpath:db/migration`, `baseline-on-migrate=false`이다.
+- local은 Flyway가 활성화되고 prod는 `FLYWAY_ENABLED` 환경변수로 명시적으로 활성화한다.
+- 운영 baseline은 `FLYWAY_ENABLED=false` 상태의 승인된 작업 시간에 운영자가 명시적으로 한 번 수행한다. 애플리케이션 코드가 baseline을 수행하지 않는다.
 - `baselineOnMigrate`를 켜서 비어 있지 않은 스키마를 자동 baseline하지 않는다.
 - V1과 운영 스키마가 의미상 다르면 baseline을 기록하지 않는다.
-- 현재 `application-local.yml`과 `application-prod.yml`의 `ddl-auto`는 이 작업 범위에서 변경하지 않는다. 따라서 비교 작업 중에는 애플리케이션 인스턴스가 대상 복제본 스키마를 변경하지 않도록 격리한다.
+- local/prod에서 `ddl-auto=update`, `create`, `create-drop`을 사용하지 않는다.
 
-## 1. 변경 동결과 full backup
+## 실제 Profile 설정
+
+| Profile | Flyway | Hibernate | 자동 baseline |
+|---|---|---|---|
+| 공통 | `enabled=false` | `ddl-auto=none` | 금지 |
+| local | `enabled=true` | `ddl-auto=validate` | 금지 |
+| prod | `enabled=${FLYWAY_ENABLED:false}` | `ddl-auto=validate` | 금지 |
+
+모든 Profile의 Flyway location은 `classpath:db/migration`이며 `baseline-on-migrate=false`이다. 기존 `DB_URL`, `DB_USERNAME`, `DB_PASSWORD` datasource 환경변수 계약은 그대로 사용한다.
+
+## Local 신규 DB
+
+1. 빈 MySQL 8 database를 생성한다.
+2. `local` Profile로 애플리케이션을 기동한다.
+3. Flyway가 V1부터 최신 version까지 순서대로 적용한다.
+4. Flyway 완료 후 Hibernate `validate`가 Entity mapping과 schema 일치를 확인한다.
+5. `flyway_schema_history`의 version, checksum, success를 확인한다.
+
+빈 DB가 아닌데 history가 없다면 local 기동은 실패해야 한다. 이 실패를 피하려고 `baseline-on-migrate=true`로 바꾸지 않는다.
+
+## Local 기존 DB
+
+다음 두 경로 중 하나만 선택한다.
+
+### 경로 A: 백업 후 재생성
+
+1. 필요한 local 데이터를 백업한다.
+2. database를 재생성한다.
+3. `local` Profile을 기동해 V1부터 최신 migration을 적용한다.
+4. 필요한 데이터를 호환성을 확인하며 복원한다.
+
+### 경로 B: semantic diff 후 명시적 baseline
+
+1. 기존 local database를 백업한다.
+2. 아래 운영 절차와 같은 기준으로 V1과 semantic diff를 수행한다.
+3. V1과 의미상 동등한 경우에만 Flyway CLI/API의 명시적 `baseline`으로 version 1 marker를 만든다.
+4. `local` Profile을 기동해 V2 이상을 적용하고 Hibernate `validate`를 통과시킨다.
+
+애플리케이션 설정을 통한 자동 baseline이나 `flyway_schema_history` 직접 INSERT는 허용하지 않는다.
+
+## Production Cutover 순서
+
+다음 순서를 바꾸지 않는다.
+
+```text
+FLYWAY_ENABLED=false
+→ backup 및 restore 검증
+→ V1 semantic diff
+→ version 1 explicit baseline
+→ 격리 clone에서 V2+ migration 및 validate 검증
+→ DBA/애플리케이션 담당자 승인
+→ FLYWAY_ENABLED=true
+```
+
+## 운영 1. 변경 동결과 full backup
 
 1. DBA, 애플리케이션 담당자, 변경 승인자를 지정하고 작업 시간을 승인받는다.
 2. schema 변경과 배포를 동결한다.
@@ -27,7 +83,7 @@ mysqldump --single-transaction --routines --triggers --events \
 
 비밀번호는 명령행 인자로 전달하지 말고 승인된 option file 또는 secret 주입 방식을 사용한다.
 
-## 2. schema dump 확보
+## 운영 2. schema dump 확보
 
 데이터를 제외한 운영 schema를 별도 파일로 추출한다.
 
@@ -53,7 +109,7 @@ WHERE constraint_schema = DATABASE()
 ORDER BY table_name, constraint_name;
 ```
 
-## 3. V1과 semantic diff
+## 운영 3. V1과 semantic diff
 
 1. 같은 MySQL 8 minor/설정의 빈 임시 DB에 V1을 적용한다. 운영 DB에는 적용하지 않는다.
 2. 임시 DB의 `SHOW CREATE TABLE`과 `information_schema` 결과를 운영 dump와 비교한다.
@@ -72,7 +128,7 @@ ORDER BY table_name, constraint_name;
 - character set/collation 및 JSON/TEXT 계열 타입
 - generated column, trigger, view, routine처럼 JPA inventory에 드러나지 않는 운영 객체
 
-## 4. diff 승인 기준
+## 운영 4. diff 승인 기준
 
 다음 조건을 모두 만족해야 baseline을 승인한다.
 
@@ -86,7 +142,7 @@ ORDER BY table_name, constraint_name;
 
 하나라도 충족하지 않으면 baseline을 기록하지 않는다. 먼저 별도 승인된 정합화 작업을 설계하며 V1을 운영에 실행해 차이를 덮지 않는다.
 
-## 5. version 1 수동 baseline 기록
+## 운영 5. version 1 수동 baseline 기록
 
 애플리케이션을 중지하거나 DB schema 작업이 발생하지 않도록 격리한 뒤, 승인된 Flyway CLI/운영 도구의 명시적 `baseline` 명령을 사용한다. 아래 값은 예시이며 URL과 credential은 secret 관리 경로에서 주입한다.
 
@@ -115,9 +171,9 @@ ORDER BY installed_rank;
 - type은 baseline marker임을 나타낸다.
 - success는 참이다.
 - V1 DDL로 생성·변경된 운영 객체가 없다.
-- `baseline-on-migrate=false`와 애플리케이션의 `spring.flyway.enabled=false`가 그대로다.
+- `baseline-on-migrate=false`와 `FLYWAY_ENABLED=false`가 그대로다.
 
-## 6. V2 이상 dry-run
+## 운영 6. clone에서 V2 이상 검증
 
 V2 이상의 migration은 운영에 직접 시험하지 않는다.
 
@@ -135,13 +191,25 @@ flyway -url='<clone-jdbc-url>' validate
 flyway -url='<clone-jdbc-url>' -dryRunOutput='<approved-path>/V2-plus.sql' migrate
 ```
 
-## 7. 장애 및 rollback
+clone 검증에서는 V2부터 최신 version까지 적용된 뒤 운영과 같은 Hibernate `ddl-auto=validate`로 애플리케이션 Context가 정상 기동하는지 확인한다. Reward seed, unique/FK/check constraint와 Flyway history도 함께 검증한다.
+
+## 운영 7. Production Flyway 활성화
+
+1. backup/restore, semantic diff, explicit baseline, clone 검증 산출물의 최종 승인을 확인한다.
+2. 운영 DB의 version 1 baseline marker와 checksum/history 상태를 다시 확인한다.
+3. 배포 환경에 `FLYWAY_ENABLED=true`를 명시한다.
+4. 애플리케이션 기동 시 Flyway가 V2부터 최신 version까지 적용하고, 완료 후 Hibernate `validate`가 실행되는지 로그와 history로 확인한다.
+5. migration 또는 validation이 실패하면 애플리케이션 기동 실패를 정상 안전 동작으로 간주하고 우회 기동하지 않는다.
+
+`FLYWAY_ENABLED`를 생략하면 기본값은 `false`이다. 애플리케이션이 baseline을 자동 생성하는 경로는 없으며, 운영자가 사전에 만든 version 1 marker만을 신뢰한다.
+
+## 운영 8. 장애 및 rollback
 
 baseline 기록 단계에서 V1은 실행되지 않으므로 애플리케이션 table rollback은 없어야 한다.
 
 - baseline 명령 실패: 애플리케이션 재기동을 중지하고 history table 상태와 Flyway 로그를 보존한다. 부분 history를 임의 수정하거나 재시도하지 말고 DBA가 원인을 판정한다.
 - 잘못된 DB에 기록: 즉시 작업을 중단하고 영향 범위를 확인한다. history row/table 삭제는 감사 기록과 승인 후에만 수행한다.
-- baseline 후 애플리케이션 장애: Flyway 자동 실행은 꺼진 상태를 유지하고 이전 애플리케이션 버전으로 되돌린다. schema가 바뀌지 않았는지 checksum/schema dump로 확인한다.
+- baseline 또는 활성화 후 애플리케이션 장애: `FLYWAY_ENABLED=false`로 되돌리고 이전 애플리케이션 버전으로 복구한다. schema가 바뀌지 않았는지 checksum/schema dump로 확인한다.
 - V2 이상 장애: migration별로 사전 승인된 compensating SQL을 사용하거나, 안전한 forward fix가 불가능하면 서비스를 중지하고 검증된 full backup 및 binlog/GTID 지점으로 복구한다. history row만 삭제해 성공을 가장하지 않는다.
 
 복구 완료 후 schema dump, row count/정합성, Flyway history, 애플리케이션 smoke test를 다시 확인하고 incident 기록에 첨부한다.

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -7,11 +7,16 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true
     show-sql: false
+
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: false
 
 lifeasgame:
   jwt:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -6,7 +6,12 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
+
+  flyway:
+    enabled: ${FLYWAY_ENABLED:false}
+    locations: classpath:db/migration
+    baseline-on-migrate: false
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,6 +51,7 @@ spring:
 
   flyway:
     enabled: false
+    locations: classpath:db/migration
     baseline-on-migrate: false
 
   jackson:

--- a/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
@@ -1,0 +1,283 @@
+package online.lifeasgame.migration;
+
+import online.lifeasgame.LifeasgameApplication;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.output.MigrateResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+@DisplayName("Flyway explicit baseline")
+class FlywayExplicitBaselineTest {
+
+    @Container
+    private static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0.39")
+            .withDatabaseName("lifeasgame_explicit_baseline")
+            .withUsername("lifeasgame")
+            .withPassword("lifeasgame");
+
+    @Nested
+    @DisplayName("V1 상당 schema가 있지만 Flyway history가 없을 때")
+    class RejectAutomaticBaseline {
+
+        @Test
+        @DisplayName("baselineOnMigrate false는 migrate를 거부하고 marker를 만들지 않는다")
+        void rejectsMigrationWithoutHistory() throws Exception {
+            String jdbcUrl = createV1EquivalentDatabase();
+            Flyway flyway = migrationFlyway(jdbcUrl);
+
+            assertThatThrownBy(flyway::migrate)
+                    .isInstanceOf(FlywayException.class)
+                    .hasMessageContaining("non-empty schema")
+                    .hasMessageContaining("baseline");
+
+            assertThat(tableCount(jdbcUrl, "flyway_schema_history")).isZero();
+            assertThat(tableCount(jdbcUrl, "reward_profiles")).isZero();
+            assertThat(userCount(jdbcUrl)).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("V1 상당 schema에 version 1 baseline을 명시적으로 기록할 때")
+    class ApplyExplicitBaseline {
+
+        @Test
+        @DisplayName("V1을 재실행하지 않고 V2부터 V5까지 적용한 뒤 JPA validate를 통과한다")
+        void migratesFromVersionTwoAndValidatesJpa() throws Exception {
+            String jdbcUrl = createV1EquivalentDatabase();
+            Flyway flyway = migrationFlyway(jdbcUrl);
+
+            flyway.baseline();
+            MigrateResult migrateResult = flyway.migrate();
+            List<HistoryRow> history = successfulHistory(jdbcUrl);
+
+            assertThat(migrateResult.migrationsExecuted).isEqualTo(4);
+            assertThat(history).extracting(HistoryRow::version)
+                    .containsExactly("1", "2", "3", "4", "5");
+            assertThat(history.getFirst().type()).isEqualTo("BASELINE");
+            assertThat(history.getFirst().script())
+                    .isEqualTo("baseline current production schema");
+            assertThat(history.getFirst().checksum()).isNull();
+            assertThat(history.subList(1, history.size()))
+                    .extracting(HistoryRow::type)
+                    .containsOnly("SQL");
+            assertThat(history.subList(1, history.size()))
+                    .extracting(HistoryRow::script)
+                    .containsExactly(
+                            "V2__reward_definition_foundation.sql",
+                            "V3__reward_settlement_foundation.sql",
+                            "V4__player_growth_change.sql",
+                            "V5__reward_none_profile.sql"
+                    );
+            assertThat(history.subList(1, history.size()))
+                    .allSatisfy(row -> assertThat(row.checksum()).isNotNull());
+            assertThat(history).allSatisfy(row -> assertThat(row.success()).isTrue());
+            assertThat(userCount(jdbcUrl)).isEqualTo(1);
+            assertThat(noRewardProfile(jdbcUrl))
+                    .isEqualTo(new NoRewardProfile("ACTIVE", 0));
+            assertThat(uniqueIndexColumns(
+                    jdbcUrl,
+                    "reward_settlements",
+                    "uq_reward_settlement_source"
+            )).containsExactly("player_id", "source_type", "source_id");
+
+            try (ConfigurableApplicationContext context = startValidationContext(jdbcUrl)) {
+                assertThat(context.isActive()).isTrue();
+                assertThat(context.getEnvironment().getProperty(
+                        "spring.jpa.hibernate.ddl-auto"
+                )).isEqualTo("validate");
+                assertThat(context.getBean(Flyway.class).info().current().getVersion().getVersion())
+                        .isEqualTo("5");
+            }
+        }
+    }
+
+    private String createV1EquivalentDatabase() throws Exception {
+        String jdbcUrl = MYSQL.getJdbcUrl();
+        Flyway.configure()
+                .dataSource(jdbcUrl, MYSQL.getUsername(), MYSQL.getPassword())
+                .cleanDisabled(false)
+                .load()
+                .clean();
+        DriverManagerDataSource dataSource = new DriverManagerDataSource(
+                jdbcUrl, MYSQL.getUsername(), MYSQL.getPassword()
+        );
+        new ResourceDatabasePopulator(new ClassPathResource(
+                "db/migration/V1__baseline_current_schema.sql"
+        )).execute(dataSource);
+        try (Connection connection = DriverManager.getConnection(
+                jdbcUrl, MYSQL.getUsername(), MYSQL.getPassword()
+        ); Statement statement = connection.createStatement()) {
+            statement.executeUpdate("""
+                    INSERT INTO users (
+                        id, email, password_hash, nickname, status, created_at, updated_at
+                    ) VALUES (
+                        191, 'baseline@example.com', 'hash', 'baseline', 'ACTIVE',
+                        CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
+                    )
+                    """);
+        }
+        return jdbcUrl;
+    }
+
+    private Flyway migrationFlyway(String jdbcUrl) {
+        return Flyway.configure()
+                .dataSource(jdbcUrl, MYSQL.getUsername(), MYSQL.getPassword())
+                .locations("classpath:db/migration")
+                .baselineOnMigrate(false)
+                .baselineVersion("1")
+                .baselineDescription("baseline current production schema")
+                .load();
+    }
+
+    private ConfigurableApplicationContext startValidationContext(String jdbcUrl) {
+        return new SpringApplicationBuilder(LifeasgameApplication.class)
+                .web(WebApplicationType.SERVLET)
+                .registerShutdownHook(false)
+                .run(
+                        "--spring.profiles.active=test,migration-test",
+                        "--spring.datasource.url=" + jdbcUrl,
+                        "--spring.datasource.username=" + MYSQL.getUsername(),
+                        "--spring.datasource.password=" + MYSQL.getPassword(),
+                        "--spring.datasource.driver-class-name=" + MYSQL.getDriverClassName(),
+                        "--server.port=0",
+                        "--spring.main.banner-mode=off"
+                );
+    }
+
+    private int tableCount(String jdbcUrl, String tableName) throws Exception {
+        try (Connection connection = DriverManager.getConnection(
+                jdbcUrl, MYSQL.getUsername(), MYSQL.getPassword()
+        ); var statement = connection.prepareStatement("""
+                SELECT COUNT(*)
+                FROM information_schema.tables
+                WHERE table_schema = DATABASE()
+                  AND table_name = ?
+                """)) {
+            statement.setString(1, tableName);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                resultSet.next();
+                return resultSet.getInt(1);
+            }
+        }
+    }
+
+    private int userCount(String jdbcUrl) throws Exception {
+        try (Connection connection = DriverManager.getConnection(
+                jdbcUrl, MYSQL.getUsername(), MYSQL.getPassword()
+        ); Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("""
+                     SELECT COUNT(*)
+                     FROM users
+                     WHERE id = 191
+                       AND email = 'baseline@example.com'
+                     """)) {
+            resultSet.next();
+            return resultSet.getInt(1);
+        }
+    }
+
+    private List<HistoryRow> successfulHistory(String jdbcUrl) throws Exception {
+        try (Connection connection = DriverManager.getConnection(
+                jdbcUrl, MYSQL.getUsername(), MYSQL.getPassword()
+        ); Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("""
+                     SELECT version, type, script, checksum, success
+                     FROM flyway_schema_history
+                     WHERE success = TRUE
+                     ORDER BY installed_rank
+                     """)) {
+            List<HistoryRow> history = new ArrayList<>();
+            while (resultSet.next()) {
+                history.add(new HistoryRow(
+                        resultSet.getString("version"),
+                        resultSet.getString("type"),
+                        resultSet.getString("script"),
+                        resultSet.getObject("checksum", Integer.class),
+                        resultSet.getBoolean("success")
+                ));
+            }
+            return history;
+        }
+    }
+
+    private NoRewardProfile noRewardProfile(String jdbcUrl) throws Exception {
+        try (Connection connection = DriverManager.getConnection(
+                jdbcUrl, MYSQL.getUsername(), MYSQL.getPassword()
+        ); Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("""
+                     SELECT profile.status, COUNT(line.id) AS line_count
+                     FROM reward_profiles profile
+                     LEFT JOIN reward_profile_lines line ON line.reward_profile_id = profile.id
+                     WHERE profile.code = 'RP_NONE'
+                     GROUP BY profile.id, profile.status
+                     """)) {
+            assertThat(resultSet.next()).isTrue();
+            return new NoRewardProfile(
+                    resultSet.getString("status"),
+                    resultSet.getInt("line_count")
+            );
+        }
+    }
+
+    private List<String> uniqueIndexColumns(
+            String jdbcUrl,
+            String tableName,
+            String indexName
+    ) throws Exception {
+        try (Connection connection = DriverManager.getConnection(
+                jdbcUrl, MYSQL.getUsername(), MYSQL.getPassword()
+        ); var statement = connection.prepareStatement("""
+                SELECT column_name
+                FROM information_schema.statistics
+                WHERE table_schema = DATABASE()
+                  AND table_name = ?
+                  AND index_name = ?
+                  AND non_unique = 0
+                ORDER BY seq_in_index
+                """)) {
+            statement.setString(1, tableName);
+            statement.setString(2, indexName);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                List<String> columns = new ArrayList<>();
+                while (resultSet.next()) {
+                    columns.add(resultSet.getString("column_name"));
+                }
+                return columns;
+            }
+        }
+    }
+
+    private record HistoryRow(
+            String version,
+            String type,
+            String script,
+            Integer checksum,
+            boolean success
+    ) {
+    }
+
+    private record NoRewardProfile(String status, int lineCount) {
+    }
+}

--- a/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
@@ -1,0 +1,282 @@
+package online.lifeasgame.migration;
+
+import online.lifeasgame.LifeasgameApplication;
+import org.flywaydb.core.Flyway;
+import org.hibernate.tool.schema.spi.SchemaManagementException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+@Testcontainers
+@SpringBootTest(properties = {
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect"
+})
+@ActiveProfiles("local")
+@DisplayName("Flyway profile cutover")
+class FlywayProfileCutoverTest {
+
+    @Container
+    private static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0.39")
+            .withDatabaseName("lifeasgame_profile_cutover")
+            .withUsername("lifeasgame")
+            .withPassword("lifeasgame");
+
+    @Container
+    private static final MySQLContainer<?> FLYWAY_DISABLED_MYSQL =
+            new MySQLContainer<>("mysql:8.0.39")
+                    .withDatabaseName("lifeasgame_flyway_disabled")
+                    .withUsername("lifeasgame")
+                    .withPassword("lifeasgame");
+
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", MYSQL::getDriverClassName);
+    }
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Autowired
+    private Flyway flyway;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Nested
+    @DisplayName("공통과 배포 Profile 설정을 해석할 때")
+    class ResolveProfileProperties {
+
+        @Test
+        @DisplayName("공통 기본값은 Flyway 비활성, Hibernate none, 자동 baseline 금지다")
+        void keepsConservativeCommonDefaults() throws IOException {
+            ConfigurableEnvironment environment = environment(null, Map.of());
+
+            assertThat(environment.getProperty("spring.flyway.enabled", Boolean.class)).isFalse();
+            assertThat(environment.getProperty("spring.flyway.locations"))
+                    .isEqualTo("classpath:db/migration");
+            assertThat(environment.getProperty(
+                    "spring.flyway.baseline-on-migrate", Boolean.class
+            )).isFalse();
+            assertThat(environment.getProperty("spring.jpa.hibernate.ddl-auto"))
+                    .isEqualTo("none");
+        }
+
+        @Test
+        @DisplayName("local은 Flyway 활성과 Hibernate validate를 사용한다")
+        void enablesFlywayForLocal() throws IOException {
+            ConfigurableEnvironment environment = environment("local", Map.of());
+
+            assertThat(environment.getProperty("spring.flyway.enabled", Boolean.class)).isTrue();
+            assertThat(environment.getProperty("spring.flyway.locations"))
+                    .isEqualTo("classpath:db/migration");
+            assertThat(environment.getProperty(
+                    "spring.flyway.baseline-on-migrate", Boolean.class
+            )).isFalse();
+            assertThat(environment.getProperty("spring.jpa.hibernate.ddl-auto"))
+                    .isEqualTo("validate");
+        }
+
+        @Test
+        @DisplayName("prod는 기본 비활성이며 FLYWAY_ENABLED로만 활성화된다")
+        void gatesProductionFlywayWithEnvironmentVariable() throws IOException {
+            ConfigurableEnvironment disabled = environment("prod", Map.of());
+            ConfigurableEnvironment enabled = environment(
+                    "prod", Map.of("FLYWAY_ENABLED", "true")
+            );
+
+            assertThat(disabled.getProperty("spring.flyway.enabled", Boolean.class)).isFalse();
+            assertThat(enabled.getProperty("spring.flyway.enabled", Boolean.class)).isTrue();
+            assertThat(enabled.getProperty("spring.flyway.locations"))
+                    .isEqualTo("classpath:db/migration");
+            assertThat(enabled.getProperty(
+                    "spring.flyway.baseline-on-migrate", Boolean.class
+            )).isFalse();
+            assertThat(enabled.getProperty("spring.jpa.hibernate.ddl-auto"))
+                    .isEqualTo("validate");
+        }
+
+        @Test
+        @DisplayName("기존 datasource 환경변수 계약을 유지한다")
+        void keepsDatasourceEnvironmentContract() throws IOException {
+            ConfigurableEnvironment environment = environment(null, Map.of(
+                    "DB_URL", "jdbc:mysql://localhost:3306/lifeasgame",
+                    "DB_USERNAME", "lifeasgame",
+                    "DB_PASSWORD", "secret"
+            ));
+
+            assertThat(environment.getProperty("spring.datasource.url"))
+                    .isEqualTo("jdbc:mysql://localhost:3306/lifeasgame");
+            assertThat(environment.getProperty("spring.datasource.username"))
+                    .isEqualTo("lifeasgame");
+            assertThat(environment.getProperty("spring.datasource.password"))
+                    .isEqualTo("secret");
+        }
+    }
+
+    @Nested
+    @DisplayName("빈 MySQL을 local Profile로 기동할 때")
+    class StartLocalWithCleanDatabase {
+
+        @Test
+        @DisplayName("V1부터 V5까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
+        void migratesThenValidates() {
+            ConfigurableEnvironment environment =
+                    (ConfigurableEnvironment) applicationContext.getEnvironment();
+
+            assertThat(applicationContext).isNotNull();
+            assertThat(environment.getProperty("spring.flyway.enabled", Boolean.class)).isTrue();
+            assertThat(environment.getProperty("spring.jpa.hibernate.ddl-auto"))
+                    .isEqualTo("validate");
+            assertThat(environment.getProperty(
+                    "spring.flyway.baseline-on-migrate", Boolean.class
+            )).isFalse();
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("5");
+            assertThat(appliedMigrationCount()).isEqualTo(5);
+        }
+    }
+
+    @Nested
+    @DisplayName("Flyway가 비활성인 prod-equivalent 빈 DB를 기동할 때")
+    class StartProductionWithFlywayDisabled {
+
+        @Test
+        @DisplayName("migration과 Hibernate update 없이 validate 실패로 기동을 중단한다")
+        void failsValidationWithoutCreatingSchema() throws Exception {
+            String jdbcUrl = FLYWAY_DISABLED_MYSQL.getJdbcUrl();
+
+            Throwable thrown = catchThrowable(() -> new SpringApplicationBuilder(
+                    LifeasgameApplication.class
+            )
+                    .web(WebApplicationType.NONE)
+                    .registerShutdownHook(false)
+                    .run(
+                            "--spring.profiles.active=prod",
+                            "--FLYWAY_ENABLED=false",
+                            "--spring.datasource.url=" + jdbcUrl,
+                            "--spring.datasource.username=" + FLYWAY_DISABLED_MYSQL.getUsername(),
+                            "--spring.datasource.password=" + FLYWAY_DISABLED_MYSQL.getPassword(),
+                            "--spring.datasource.driver-class-name="
+                                    + FLYWAY_DISABLED_MYSQL.getDriverClassName(),
+                            "--spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect",
+                            "--lifeasgame.jwt.secret=test-secret-key-must-be-at-least-32-characters-long",
+                            "--spring.main.banner-mode=off"
+                    ));
+
+            assertThat(rootCause(thrown))
+                    .isInstanceOf(SchemaManagementException.class)
+                    .hasMessageContaining("Schema-validation: missing table");
+            assertThat(tableCount(jdbcUrl, "flyway_schema_history")).isZero();
+            assertThat(schemaTableCount()).isZero();
+        }
+    }
+
+    private int appliedMigrationCount() {
+        return jdbcTemplate.queryForObject("""
+                SELECT COUNT(*)
+                FROM flyway_schema_history
+                WHERE success = TRUE
+                """, Integer.class);
+    }
+
+    private ConfigurableEnvironment environment(
+            String profile,
+            Map<String, Object> overrides
+    ) throws IOException {
+        MockEnvironment environment = new MockEnvironment();
+        addYamlFirst(environment, "application.yml", "common");
+        if (profile != null) {
+            addYamlFirst(environment, "application-" + profile + ".yml", profile);
+        }
+        if (!overrides.isEmpty()) {
+            environment.getPropertySources().addFirst(
+                    new MapPropertySource("overrides", overrides)
+            );
+        }
+        return environment;
+    }
+
+    private void addYamlFirst(
+            ConfigurableEnvironment environment,
+            String path,
+            String name
+    ) throws IOException {
+        YamlPropertySourceLoader loader = new YamlPropertySourceLoader();
+        for (PropertySource<?> source : loader.load(name, new ClassPathResource(path))) {
+            environment.getPropertySources().addFirst(source);
+        }
+    }
+
+    private int tableCount(String jdbcUrl, String tableName) throws Exception {
+        try (Connection connection = DriverManager.getConnection(
+                jdbcUrl,
+                FLYWAY_DISABLED_MYSQL.getUsername(),
+                FLYWAY_DISABLED_MYSQL.getPassword()
+        ); var statement = connection.prepareStatement("""
+                SELECT COUNT(*)
+                FROM information_schema.tables
+                WHERE table_schema = DATABASE()
+                  AND table_name = ?
+                """)) {
+            statement.setString(1, tableName);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                resultSet.next();
+                return resultSet.getInt(1);
+            }
+        }
+    }
+
+    private int schemaTableCount() throws Exception {
+        try (Connection connection = FLYWAY_DISABLED_MYSQL.createConnection("");
+             var statement = connection.prepareStatement("""
+                     SELECT COUNT(*)
+                     FROM information_schema.tables
+                     WHERE table_schema = ?
+                     """)) {
+            statement.setString(1, FLYWAY_DISABLED_MYSQL.getDatabaseName());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                resultSet.next();
+                return resultSet.getInt(1);
+            }
+        }
+    }
+
+    private Throwable rootCause(Throwable throwable) {
+        assertThat(throwable).isNotNull();
+        Throwable current = throwable;
+        while (current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current;
+    }
+}


### PR DESCRIPTION
## What

- local Profile을 Flyway 기반으로 전환했습니다.
- local의 Hibernate `ddl-auto`를 `validate`로 변경했습니다.
- production의 Hibernate 자동 schema update를 제거했습니다.
- production Flyway를 `FLYWAY_ENABLED` 환경변수 기반 opt-in으로 구성했습니다.
- 모든 환경에서 `baseline-on-migrate=false`를 유지했습니다.
- local 신규/기존 DB 및 production baseline 절차를 Runbook에 반영했습니다.

## Safety

- 기존 V1~V5 Migration은 수정하지 않았습니다.
- 비어 있지 않은 DB를 자동 baseline하지 않습니다.
- production baseline은 애플리케이션 시작 과정에서 수행하지 않습니다.
- Flyway가 비활성인 production에서도 Hibernate가 DDL을 변경하지 않습니다.

## Test

- [ ] `./gradlew clean test`
- [ ] `./gradlew build`
- [ ] 빈 MySQL clean install
- [ ] local Flyway + Hibernate validate
- [ ] non-empty DB 자동 baseline 거부
- [ ] explicit version 1 baseline 후 V2+ 적용
- [ ] prod Flyway disabled gate
- [ ] V1~V5 checksum 유지
- [ ] Reward 회귀 테스트

## Out of Scope

- 실제 production baseline
- 운영 secret/credential
- 신규 Migration
- Quest/Outbox/Mailbox
- CI/CD 전면 개편

Closes #191 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Flyway now manages database schema changes, with Hibernate limited to schema validation.
  * Local environments automatically run migrations; production requires explicit `FLYWAY_ENABLED=true`.
  * Automatic baselining is disabled to prevent unintended schema changes.

* **Documentation**
  * Updated the operations runbook with migration, validation, activation, rollback, and incident procedures.

* **Tests**
  * Added coverage for explicit baselines, profile-based activation, migration execution, schema validation, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->