### PR TITLE
[LifeLog] Add durable LifeLogRecorded facts

### DIFF
--- a/src/main/java/online/lifeasgame/core/support/IdGenerator.java
+++ b/src/main/java/online/lifeasgame/core/support/IdGenerator.java
@@ -8,4 +8,8 @@ public final class IdGenerator {
     public static String newTraceId() {
         return UUID.randomUUID().toString();
     }
+
+    public static String newEventId() {
+        return UUID.randomUUID().toString();
+    }
 }

--- a/src/main/java/online/lifeasgame/lifelog/application/CollectionLogService.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/CollectionLogService.java
@@ -2,13 +2,18 @@ package online.lifeasgame.lifelog.application;
 
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.core.event.DomainEventPublisher;
+import online.lifeasgame.core.support.IdGenerator;
 import online.lifeasgame.lifelog.application.command.CollectionCommand;
 import online.lifeasgame.lifelog.application.result.CollectionResult;
 import online.lifeasgame.lifelog.domain.*;
 import online.lifeasgame.lifelog.domain.event.CollectionLogged;
+import online.lifeasgame.lifelog.domain.event.LifeLogRecorded;
+import online.lifeasgame.lifelog.domain.event.LifeLogType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.util.List;
 
 @Service
@@ -18,6 +23,7 @@ public class CollectionLogService {
     private final CollectionLogReader collectionLogReader;
     private final CollectionLogWriter collectionLogWriter;
     private final DomainEventPublisher domainEventPublisher;
+    private final Clock clock;
 
     @Transactional
     public CollectionResult.Created create(Long playerId, CollectionCommand.Create command) {
@@ -35,14 +41,23 @@ public class CollectionLogService {
                 )
         );
 
-        domainEventPublisher.publish(
-                CollectionLogged.of(
+        Instant occurredAt = clock.instant();
+        domainEventPublisher.publishAll(List.of(
+                new CollectionLogged(
                         playerId,
                         saved.getId(),
                         saved.getCategory().name(),
-                        saved.getQuantity().value()
+                        saved.getQuantity().value(),
+                        occurredAt
+                ),
+                LifeLogRecorded.of(
+                        IdGenerator.newEventId(),
+                        playerId,
+                        saved.getId(),
+                        LifeLogType.COLLECTION,
+                        occurredAt
                 )
-        );
+        ));
 
         return new CollectionResult.Created(saved.getId());
     }

--- a/src/main/java/online/lifeasgame/lifelog/application/ExerciseLogService.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/ExerciseLogService.java
@@ -2,15 +2,20 @@ package online.lifeasgame.lifelog.application;
 
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.core.event.DomainEventPublisher;
+import online.lifeasgame.core.support.IdGenerator;
 import online.lifeasgame.lifelog.application.command.ExerciseCommand;
 import online.lifeasgame.lifelog.application.result.ExerciseResult;
 import online.lifeasgame.lifelog.domain.ExerciseCategory;
 import online.lifeasgame.lifelog.domain.ExerciseLog;
 import online.lifeasgame.lifelog.domain.ExerciseMetrics;
 import online.lifeasgame.lifelog.domain.event.ExerciseLogged;
+import online.lifeasgame.lifelog.domain.event.LifeLogRecorded;
+import online.lifeasgame.lifelog.domain.event.LifeLogType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.util.List;
 
 @Service
@@ -20,6 +25,7 @@ public class ExerciseLogService {
     private final ExerciseLogReader exerciseLogReader;
     private final ExerciseLogWriter exerciseLogWriter;
     private final DomainEventPublisher domainEventPublisher;
+    private final Clock clock;
 
     @Transactional
     public ExerciseResult.Created create(Long playerId, ExerciseCommand.Create command) {
@@ -33,16 +39,25 @@ public class ExerciseLogService {
                 )
         );
 
-        domainEventPublisher.publish(
-                ExerciseLogged.of(
+        Instant occurredAt = clock.instant();
+        domainEventPublisher.publishAll(List.of(
+                new ExerciseLogged(
                         playerId,
                         saved.getId(),
                         saved.getCategory().name(),
                         saved.getMetrics().durationMinutes(),
                         saved.getMetrics().distanceKm(),
-                        saved.getMetrics().calories()
+                        saved.getMetrics().calories(),
+                        occurredAt
+                ),
+                LifeLogRecorded.of(
+                        IdGenerator.newEventId(),
+                        playerId,
+                        saved.getId(),
+                        LifeLogType.EXERCISE,
+                        occurredAt
                 )
-        );
+        ));
 
         return new ExerciseResult.Created(saved.getId());
     }

--- a/src/main/java/online/lifeasgame/lifelog/application/MediaLogService.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/MediaLogService.java
@@ -2,13 +2,17 @@ package online.lifeasgame.lifelog.application;
 
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.core.event.DomainEventPublisher;
+import online.lifeasgame.core.support.IdGenerator;
 import online.lifeasgame.lifelog.application.command.MediaLogCommand;
 import online.lifeasgame.lifelog.application.result.MediaLogResult;
 import online.lifeasgame.lifelog.domain.*;
+import online.lifeasgame.lifelog.domain.event.LifeLogRecorded;
+import online.lifeasgame.lifelog.domain.event.LifeLogType;
 import online.lifeasgame.lifelog.domain.event.MediaLogAdvanced;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.util.List;
 
 @Service
@@ -18,6 +22,7 @@ public class MediaLogService {
     private final MediaLogReader mediaLogReader;
     private final MediaLogWriter mediaLogWriter;
     private final DomainEventPublisher domainEventPublisher;
+    private final Clock clock;
 
     @Transactional
     public MediaLogResult.Created create(Long playerId, MediaLogCommand.Create command) {
@@ -29,6 +34,16 @@ public class MediaLogService {
                         EpisodeProgress.of(command.currentEpisode(), command.totalEpisode()),
                         WatchStatus.parse(command.status()),
                         MediaTags.of(command.tags())
+                )
+        );
+
+        domainEventPublisher.publish(
+                LifeLogRecorded.of(
+                        IdGenerator.newEventId(),
+                        playerId,
+                        saved.getId(),
+                        LifeLogType.MEDIA,
+                        clock.instant()
                 )
         );
 

--- a/src/main/java/online/lifeasgame/lifelog/domain/event/LifeLogRecorded.java
+++ b/src/main/java/online/lifeasgame/lifelog/domain/event/LifeLogRecorded.java
@@ -1,0 +1,55 @@
+package online.lifeasgame.lifelog.domain.event;
+
+import online.lifeasgame.core.event.DomainEvent;
+import online.lifeasgame.core.guard.Guard;
+
+import java.time.Instant;
+
+public record LifeLogRecorded(
+        String eventId,
+        int eventVersion,
+        Long playerId,
+        Long lifeLogId,
+        LifeLogType lifeLogType,
+        Long primaryRoleId,
+        Instant occurredAt
+) implements DomainEvent {
+
+    public static final int EVENT_VERSION = 1;
+
+    public LifeLogRecorded {
+        eventId = Guard.notBlank(eventId, "eventId");
+        if (eventVersion != EVENT_VERSION) {
+            throw new IllegalArgumentException(
+                    "eventVersion must be " + EVENT_VERSION
+            );
+        }
+        Guard.notNull(playerId, "playerId");
+        Guard.notNull(lifeLogId, "lifeLogId");
+        Guard.notNull(lifeLogType, "lifeLogType");
+        if (primaryRoleId != null) {
+            throw new IllegalArgumentException(
+                    "primaryRoleId must be null until Role Domain is available"
+            );
+        }
+        Guard.notNull(occurredAt, "occurredAt");
+    }
+
+    public static LifeLogRecorded of(
+            String eventId,
+            Long playerId,
+            Long lifeLogId,
+            LifeLogType lifeLogType,
+            Instant occurredAt
+    ) {
+        return new LifeLogRecorded(
+                eventId,
+                EVENT_VERSION,
+                playerId,
+                lifeLogId,
+                lifeLogType,
+                null,
+                occurredAt
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/domain/event/LifeLogType.java
+++ b/src/main/java/online/lifeasgame/lifelog/domain/event/LifeLogType.java
@@ -1,0 +1,7 @@
+package online.lifeasgame.lifelog.domain.event;
+
+public enum LifeLogType {
+    COLLECTION,
+    EXERCISE,
+    MEDIA
+}

--- a/src/main/java/online/lifeasgame/platform/outbox/application/codec/OutboxEventCodecRegistry.java
+++ b/src/main/java/online/lifeasgame/platform/outbox/application/codec/OutboxEventCodecRegistry.java
@@ -8,9 +8,9 @@ import online.lifeasgame.core.event.DomainEvent;
 import online.lifeasgame.inventory.domain.event.InventoryItemAdded;
 import online.lifeasgame.lifelog.domain.event.CollectionLogged;
 import online.lifeasgame.lifelog.domain.event.ExerciseLogged;
+import online.lifeasgame.lifelog.domain.event.LifeLogRecorded;
 import online.lifeasgame.lifelog.domain.event.MediaLogAdvanced;
 import online.lifeasgame.platform.outbox.domain.error.OutboxError;
-import online.lifeasgame.quest.domain.event.QuestEvent;
 import online.lifeasgame.social.domain.event.ChatChannelDeactivated;
 import online.lifeasgame.user.domain.event.UserRegistered;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,6 +61,11 @@ public class OutboxEventCodecRegistry {
                 codec(
                         "lifelog.exercise-logged.v1",
                         ExerciseLogged.class,
+                        objectMapper
+                ),
+                codec(
+                        "lifelog.recorded.v1",
+                        LifeLogRecorded.class,
                         objectMapper
                 ),
                 codec(

--- a/src/test/java/online/lifeasgame/lifelog/application/LifeLogRecordedApplicationServiceTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/application/LifeLogRecordedApplicationServiceTest.java
@@ -1,0 +1,216 @@
+package online.lifeasgame.lifelog.application;
+
+import online.lifeasgame.core.event.DomainEvent;
+import online.lifeasgame.core.event.DomainEventPublisher;
+import online.lifeasgame.lifelog.application.command.CollectionCommand;
+import online.lifeasgame.lifelog.application.command.ExerciseCommand;
+import online.lifeasgame.lifelog.application.command.MediaLogCommand;
+import online.lifeasgame.lifelog.application.result.CollectionResult;
+import online.lifeasgame.lifelog.application.result.ExerciseResult;
+import online.lifeasgame.lifelog.application.result.MediaLogResult;
+import online.lifeasgame.lifelog.domain.CollectionCategory;
+import online.lifeasgame.lifelog.domain.CollectionLog;
+import online.lifeasgame.lifelog.domain.ExerciseCategory;
+import online.lifeasgame.lifelog.domain.ExerciseLog;
+import online.lifeasgame.lifelog.domain.ExerciseMetrics;
+import online.lifeasgame.lifelog.domain.MediaLog;
+import online.lifeasgame.lifelog.domain.Quantity;
+import online.lifeasgame.lifelog.domain.event.CollectionLogged;
+import online.lifeasgame.lifelog.domain.event.ExerciseLogged;
+import online.lifeasgame.lifelog.domain.event.LifeLogRecorded;
+import online.lifeasgame.lifelog.domain.event.LifeLogType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("LifeLogRecorded Application Service 발행")
+class LifeLogRecordedApplicationServiceTest {
+
+    private static final Long PLAYER_ID = 197L;
+    private static final Instant OCCURRED_AT =
+            Instant.parse("2026-07-24T10:00:00Z");
+    private static final Clock CLOCK =
+            Clock.fixed(OCCURRED_AT, ZoneOffset.UTC);
+
+    @Test
+    @DisplayName("Collection create는 저장 후 subtype Event와 Fact를 각각 한 번 발행한다")
+    void recordsCollectionCreate() {
+        CollectionLogReader reader = mock(CollectionLogReader.class);
+        CollectionLogWriter writer = mock(CollectionLogWriter.class);
+        RecordingPublisher publisher = new RecordingPublisher();
+        CollectionLog saved = mock(CollectionLog.class);
+        when(saved.getId()).thenReturn(101L);
+        when(saved.getCategory()).thenReturn(CollectionCategory.BOOK);
+        when(saved.getQuantity()).thenReturn(Quantity.of(2));
+        when(writer.create(any(CollectionLog.class))).thenReturn(saved);
+        CollectionLogService service = new CollectionLogService(
+                reader,
+                writer,
+                publisher,
+                CLOCK
+        );
+
+        CollectionResult.Created result = service.create(
+                PLAYER_ID,
+                new CollectionCommand.Create(
+                        "BOOK",
+                        "Private collection title",
+                        "Private original title",
+                        2,
+                        "Private condition",
+                        "Private source",
+                        Set.of("private-tag")
+                )
+        );
+
+        verify(writer).create(any(CollectionLog.class));
+        assertThat(result.id()).isEqualTo(101L);
+        assertThat(publisher.events())
+                .filteredOn(CollectionLogged.class::isInstance)
+                .singleElement()
+                .satisfies(event -> {
+                    CollectionLogged logged = (CollectionLogged) event;
+                    assertThat(logged.playerId()).isEqualTo(PLAYER_ID);
+                    assertThat(logged.collectionLogId()).isEqualTo(101L);
+                    assertThat(logged.occurredAt()).isEqualTo(OCCURRED_AT);
+                });
+        assertRecorded(
+                publisher.events(),
+                101L,
+                LifeLogType.COLLECTION
+        );
+        assertThat(publisher.events()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("Exercise create는 저장 후 subtype Event와 Fact를 각각 한 번 발행한다")
+    void recordsExerciseCreate() {
+        ExerciseLogReader reader = mock(ExerciseLogReader.class);
+        ExerciseLogWriter writer = mock(ExerciseLogWriter.class);
+        RecordingPublisher publisher = new RecordingPublisher();
+        ExerciseLog saved = mock(ExerciseLog.class);
+        when(saved.getId()).thenReturn(102L);
+        when(saved.getCategory()).thenReturn(ExerciseCategory.RUNNING);
+        when(saved.getMetrics()).thenReturn(ExerciseMetrics.of(30, 5.0, 250));
+        when(writer.create(any(ExerciseLog.class))).thenReturn(saved);
+        ExerciseLogService service = new ExerciseLogService(
+                reader,
+                writer,
+                publisher,
+                CLOCK
+        );
+
+        ExerciseResult.Created result = service.create(
+                PLAYER_ID,
+                new ExerciseCommand.Create(
+                        "RUNNING",
+                        30,
+                        5.0,
+                        250,
+                        LocalDate.of(2026, 7, 24),
+                        "Private exercise memo"
+                )
+        );
+
+        verify(writer).create(any(ExerciseLog.class));
+        assertThat(result.id()).isEqualTo(102L);
+        assertThat(publisher.events())
+                .filteredOn(ExerciseLogged.class::isInstance)
+                .singleElement()
+                .satisfies(event -> {
+                    ExerciseLogged logged = (ExerciseLogged) event;
+                    assertThat(logged.playerId()).isEqualTo(PLAYER_ID);
+                    assertThat(logged.exerciseLogId()).isEqualTo(102L);
+                    assertThat(logged.occurredAt()).isEqualTo(OCCURRED_AT);
+                });
+        assertRecorded(
+                publisher.events(),
+                102L,
+                LifeLogType.EXERCISE
+        );
+        assertThat(publisher.events()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("Media create는 저장 후 Fact를 정확히 한 번 발행한다")
+    void recordsMediaCreate() {
+        MediaLogReader reader = mock(MediaLogReader.class);
+        MediaLogWriter writer = mock(MediaLogWriter.class);
+        RecordingPublisher publisher = new RecordingPublisher();
+        MediaLog saved = mock(MediaLog.class);
+        when(saved.getId()).thenReturn(103L);
+        when(writer.create(any(MediaLog.class))).thenReturn(saved);
+        MediaLogService service = new MediaLogService(
+                reader,
+                writer,
+                publisher,
+                CLOCK
+        );
+
+        MediaLogResult.Created result = service.create(
+                PLAYER_ID,
+                new MediaLogCommand.Create(
+                        "MOVIE",
+                        "Private media title",
+                        "Private original title",
+                        0,
+                        1,
+                        "PLANNED",
+                        Set.of("private-tag")
+                )
+        );
+
+        verify(writer).create(any(MediaLog.class));
+        assertThat(result.id()).isEqualTo(103L);
+        assertRecorded(publisher.events(), 103L, LifeLogType.MEDIA);
+        assertThat(publisher.events()).hasSize(1);
+    }
+
+    private void assertRecorded(
+            List<DomainEvent> events,
+            Long lifeLogId,
+            LifeLogType type
+    ) {
+        assertThat(events)
+                .filteredOn(LifeLogRecorded.class::isInstance)
+                .singleElement()
+                .satisfies(event -> {
+                    LifeLogRecorded recorded = (LifeLogRecorded) event;
+                    assertThat(recorded.eventId()).isNotBlank();
+                    assertThat(recorded.eventVersion()).isEqualTo(1);
+                    assertThat(recorded.playerId()).isEqualTo(PLAYER_ID);
+                    assertThat(recorded.lifeLogId()).isEqualTo(lifeLogId);
+                    assertThat(recorded.lifeLogType()).isEqualTo(type);
+                    assertThat(recorded.primaryRoleId()).isNull();
+                    assertThat(recorded.occurredAt())
+                            .isEqualTo(OCCURRED_AT);
+                });
+    }
+
+    private static class RecordingPublisher implements DomainEventPublisher {
+
+        private final List<DomainEvent> events = new ArrayList<>();
+
+        @Override
+        public void publish(DomainEvent event) {
+            events.add(event);
+        }
+
+        List<DomainEvent> events() {
+            return List.copyOf(events);
+        }
+    }
+}

--- a/src/test/java/online/lifeasgame/lifelog/application/LifeLogRecordedOutboxIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/application/LifeLogRecordedOutboxIntegrationTest.java
@@ -1,0 +1,414 @@
+package online.lifeasgame.lifelog.application;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import online.lifeasgame.core.event.DomainEvent;
+import online.lifeasgame.lifelog.application.command.CollectionCommand;
+import online.lifeasgame.lifelog.application.command.ExerciseCommand;
+import online.lifeasgame.lifelog.application.command.MediaLogCommand;
+import online.lifeasgame.lifelog.domain.event.LifeLogRecorded;
+import online.lifeasgame.lifelog.domain.event.LifeLogType;
+import online.lifeasgame.platform.outbox.OutboxProperties;
+import online.lifeasgame.platform.outbox.application.OutboxRelayResult;
+import online.lifeasgame.platform.outbox.application.OutboxRelayScheduler;
+import online.lifeasgame.platform.outbox.application.OutboxRelayService;
+import online.lifeasgame.platform.outbox.application.codec.OutboxEventCodecRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.event.EventListener;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles({"test", "migration-test"})
+@Import({
+        LifeLogRecordedOutboxIntegrationTest.ClockConfiguration.class,
+        LifeLogRecordedOutboxIntegrationTest.ListenerConfiguration.class
+})
+@DisplayName("LifeLogRecorded MySQL Outbox")
+class LifeLogRecordedOutboxIntegrationTest {
+
+    private static final String ALIAS = "lifelog.recorded.v1";
+    private static final Long PLAYER_ID = 199L;
+    private static final Instant OCCURRED_AT =
+            Instant.parse("2026-07-24T11:00:00.123456Z");
+    private static final Set<String> PAYLOAD_FIELDS = Set.of(
+            "eventId",
+            "eventVersion",
+            "playerId",
+            "lifeLogId",
+            "lifeLogType",
+            "primaryRoleId",
+            "occurredAt"
+    );
+    private static final List<String> FORBIDDEN_FIELDS = List.of(
+            "title",
+            "originalTitle",
+            "memo",
+            "conditionNote",
+            "acquiredFrom",
+            "tags",
+            "photo",
+            "body",
+            "review",
+            "conversationText",
+            "category",
+            "duration",
+            "calories",
+            "episode"
+    );
+
+    @Container
+    private static final MySQLContainer<?> MYSQL =
+            new MySQLContainer<>("mysql:8.0.39")
+                    .withDatabaseName("lifeasgame_lifelog_recorded")
+                    .withUsername("lifeasgame")
+                    .withPassword("lifeasgame");
+
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add(
+                "spring.datasource.driver-class-name",
+                MYSQL::getDriverClassName
+        );
+        registry.add("app.outbox.enabled", () -> false);
+    }
+
+    @Autowired
+    private CollectionLogService collectionLogService;
+
+    @Autowired
+    private ExerciseLogService exerciseLogService;
+
+    @Autowired
+    private MediaLogService mediaLogService;
+
+    @Autowired
+    private OutboxRelayService relayService;
+
+    @Autowired
+    private OutboxEventCodecRegistry codecRegistry;
+
+    @Autowired
+    private OutboxProperties outboxProperties;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @Autowired
+    private LifeLogRecordedProbe probe;
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    private TransactionTemplate transactionTemplate;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.update("DELETE FROM collection_log_tags");
+        jdbcTemplate.update("DELETE FROM media_log_tags");
+        jdbcTemplate.update("DELETE FROM collection_logs");
+        jdbcTemplate.update("DELETE FROM exercise_logs");
+        jdbcTemplate.update("DELETE FROM media_logs");
+        jdbcTemplate.update("DELETE FROM outbox_events");
+        outboxProperties.setBatchSize(50);
+        outboxProperties.setMaxAttempts(3);
+        outboxProperties.setRetryDelayMs(0);
+        outboxProperties.setLeaseDurationMs(30_000);
+        outboxProperties.setInstanceId("lifelog-recorded-integration");
+        probe.reset();
+        transactionTemplate = new TransactionTemplate(transactionManager);
+    }
+
+    @Test
+    @DisplayName("Collection create commit은 Source와 대표 Fact를 한 건씩 저장한다")
+    void commitsCollectionAndFact() {
+        Long sourceId = collectionLogService.create(
+                PLAYER_ID,
+                collectionCommand()
+        ).id();
+
+        assertThat(count("collection_logs")).isEqualTo(1);
+        assertThat(countByAlias()).isEqualTo(1);
+        assertRecorded(sourceId, LifeLogType.COLLECTION);
+        assertThat(countByAlias("lifelog.collection-logged.v1"))
+                .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("Exercise create commit은 Source와 대표 Fact를 한 건씩 저장한다")
+    void commitsExerciseAndFact() {
+        Long sourceId = exerciseLogService.create(
+                PLAYER_ID,
+                exerciseCommand()
+        ).id();
+
+        assertThat(count("exercise_logs")).isEqualTo(1);
+        assertThat(countByAlias()).isEqualTo(1);
+        assertRecorded(sourceId, LifeLogType.EXERCISE);
+        assertThat(countByAlias("lifelog.exercise-logged.v1"))
+                .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("Media create commit은 Source와 대표 Fact를 한 건씩 저장한다")
+    void commitsMediaAndFact() {
+        Long sourceId = mediaLogService.create(
+                PLAYER_ID,
+                mediaCommand()
+        ).id();
+
+        assertThat(count("media_logs")).isEqualTo(1);
+        assertThat(countByAlias()).isEqualTo(1);
+        assertRecorded(sourceId, LifeLogType.MEDIA);
+        assertThat(count("outbox_events")).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("강제 rollback은 Source와 대표 Fact를 모두 제거한다")
+    void rollsBackSourceAndFactTogether() {
+        transactionTemplate.executeWithoutResult(status -> {
+            collectionLogService.create(PLAYER_ID, collectionCommand());
+            status.setRollbackOnly();
+        });
+
+        assertThat(count("collection_logs")).isZero();
+        assertThat(countByAlias()).isZero();
+        assertThat(count("outbox_events")).isZero();
+    }
+
+    @Test
+    @DisplayName("대표 Fact payload는 계약 필드만 포함하고 private subtype 값을 제외한다")
+    void keepsPayloadMinimal() throws Exception {
+        collectionLogService.create(PLAYER_ID, collectionCommand());
+        exerciseLogService.create(PLAYER_ID, exerciseCommand());
+        mediaLogService.create(PLAYER_ID, mediaCommand());
+
+        List<String> payloads = recordedPayloads();
+
+        assertThat(payloads).hasSize(3);
+        for (String payload : payloads) {
+            JsonNode json = objectMapper.readTree(payload);
+            Set<String> fields = new LinkedHashSet<>();
+            json.fieldNames().forEachRemaining(fields::add);
+            assertThat(fields).containsExactlyInAnyOrderElementsOf(
+                    PAYLOAD_FIELDS
+            );
+            assertThat(json.get("eventVersion").asInt()).isEqualTo(1);
+            assertThat(json.get("primaryRoleId").isNull()).isTrue();
+            assertThat(payload)
+                    .doesNotContain(LifeLogRecorded.class.getName())
+                    .doesNotContain(LifeLogRecorded.class.getSimpleName())
+                    .doesNotContain("Private collection title")
+                    .doesNotContain("Private original title")
+                    .doesNotContain("Private condition")
+                    .doesNotContain("Private source")
+                    .doesNotContain("Private exercise memo")
+                    .doesNotContain("Private media title")
+                    .doesNotContain("private-tag");
+            assertThat(FORBIDDEN_FIELDS).allSatisfy(
+                    field -> assertThat(json.has(field)).isFalse()
+            );
+        }
+    }
+
+    @Test
+    @DisplayName("Relay는 Codec으로 복원한 동일 LifeLogRecorded를 Listener에 전달한다")
+    void relaysDecodedEvent() {
+        mediaLogService.create(PLAYER_ID, mediaCommand());
+        LifeLogRecorded expected = onlyRecordedEvent();
+
+        OutboxRelayResult result = relayService.relayBatch();
+
+        assertThat(result.claimed()).isEqualTo(1);
+        assertThat(result.published()).isEqualTo(1);
+        assertThat(result.failed()).isZero();
+        assertThat(probe.events()).containsExactly(expected);
+    }
+
+    @Test
+    @DisplayName("통합 테스트에서는 Outbox Scheduler를 명시적으로 비활성화한다")
+    void disablesScheduler() {
+        assertThat(
+                applicationContext.getBeansOfType(
+                        OutboxRelayScheduler.class
+                )
+        ).isEmpty();
+    }
+
+    private CollectionCommand.Create collectionCommand() {
+        return new CollectionCommand.Create(
+                "BOOK",
+                "Private collection title",
+                "Private original title",
+                2,
+                "Private condition",
+                "Private source",
+                Set.of("private-tag")
+        );
+    }
+
+    private ExerciseCommand.Create exerciseCommand() {
+        return new ExerciseCommand.Create(
+                "RUNNING",
+                30,
+                5.0,
+                250,
+                LocalDate.of(2026, 7, 24),
+                "Private exercise memo"
+        );
+    }
+
+    private MediaLogCommand.Create mediaCommand() {
+        return new MediaLogCommand.Create(
+                "MOVIE",
+                "Private media title",
+                "Private original title",
+                0,
+                1,
+                "PLANNED",
+                Set.of("private-tag")
+        );
+    }
+
+    private void assertRecorded(Long sourceId, LifeLogType type) {
+        LifeLogRecorded event = onlyRecordedEvent();
+        assertThat(event.eventId()).isNotBlank();
+        assertThat(event.eventVersion()).isEqualTo(1);
+        assertThat(event.playerId()).isEqualTo(PLAYER_ID);
+        assertThat(event.lifeLogId()).isEqualTo(sourceId);
+        assertThat(event.lifeLogType()).isEqualTo(type);
+        assertThat(event.primaryRoleId()).isNull();
+        assertThat(event.occurredAt()).isEqualTo(OCCURRED_AT);
+    }
+
+    private LifeLogRecorded onlyRecordedEvent() {
+        List<LifeLogRecorded> events = jdbcTemplate.query(
+                """
+                SELECT event_type, payload
+                FROM outbox_events
+                WHERE event_type = ?
+                """,
+                (resultSet, rowNum) -> {
+                    DomainEvent decoded = codecRegistry.decode(
+                            resultSet.getString("event_type"),
+                            resultSet.getString("payload")
+                    );
+                    return (LifeLogRecorded) decoded;
+                },
+                ALIAS
+        );
+        assertThat(events).hasSize(1);
+        return events.getFirst();
+    }
+
+    private List<String> recordedPayloads() {
+        return jdbcTemplate.queryForList(
+                """
+                SELECT payload
+                FROM outbox_events
+                WHERE event_type = ?
+                ORDER BY id
+                """,
+                String.class,
+                ALIAS
+        );
+    }
+
+    private int count(String table) {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM " + table,
+                Integer.class
+        );
+    }
+
+    private int countByAlias() {
+        return countByAlias(ALIAS);
+    }
+
+    private int countByAlias(String alias) {
+        return jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM outbox_events
+                WHERE event_type = ?
+                """,
+                Integer.class,
+                alias
+        );
+    }
+
+    @TestConfiguration
+    static class ClockConfiguration {
+
+        @Bean
+        @Primary
+        Clock lifeLogRecordedTestClock() {
+            return Clock.fixed(OCCURRED_AT, ZoneOffset.UTC);
+        }
+    }
+
+    @TestConfiguration
+    static class ListenerConfiguration {
+
+        @Bean
+        LifeLogRecordedProbe lifeLogRecordedProbe() {
+            return new LifeLogRecordedProbe();
+        }
+    }
+
+    static class LifeLogRecordedProbe {
+
+        private final List<LifeLogRecorded> events =
+                new CopyOnWriteArrayList<>();
+
+        @EventListener
+        public void on(LifeLogRecorded event) {
+            events.add(event);
+        }
+
+        List<LifeLogRecorded> events() {
+            return List.copyOf(events);
+        }
+
+        void reset() {
+            events.clear();
+        }
+    }
+}

--- a/src/test/java/online/lifeasgame/lifelog/domain/event/LifeLogRecordedTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/domain/event/LifeLogRecordedTest.java
@@ -1,0 +1,110 @@
+package online.lifeasgame.lifelog.domain.event;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("LifeLogRecorded 계약")
+class LifeLogRecordedTest {
+
+    private static final Instant OCCURRED_AT =
+            Instant.parse("2026-07-24T09:00:00Z");
+
+    @Test
+    @DisplayName("Factory는 v1과 null primaryRoleId를 고정한다")
+    void createsVersionOneWithoutPrimaryRole() {
+        LifeLogRecorded event = LifeLogRecorded.of(
+                "event-199",
+                197L,
+                199L,
+                LifeLogType.COLLECTION,
+                OCCURRED_AT
+        );
+
+        assertThat(event.eventId()).isEqualTo("event-199");
+        assertThat(event.eventVersion())
+                .isEqualTo(LifeLogRecorded.EVENT_VERSION);
+        assertThat(event.playerId()).isEqualTo(197L);
+        assertThat(event.lifeLogId()).isEqualTo(199L);
+        assertThat(event.lifeLogType()).isEqualTo(LifeLogType.COLLECTION);
+        assertThat(event.primaryRoleId()).isNull();
+        assertThat(event.occurredAt()).isEqualTo(OCCURRED_AT);
+    }
+
+    @Test
+    @DisplayName("필수 필드와 Event version을 검증한다")
+    void validatesContract() {
+        assertThatThrownBy(() -> new LifeLogRecorded(
+                " ",
+                1,
+                197L,
+                199L,
+                LifeLogType.EXERCISE,
+                null,
+                OCCURRED_AT
+        )).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new LifeLogRecorded(
+                "event-199",
+                2,
+                197L,
+                199L,
+                LifeLogType.EXERCISE,
+                null,
+                OCCURRED_AT
+        )).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new LifeLogRecorded(
+                "event-199",
+                1,
+                null,
+                199L,
+                LifeLogType.EXERCISE,
+                null,
+                OCCURRED_AT
+        )).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new LifeLogRecorded(
+                "event-199",
+                1,
+                197L,
+                null,
+                LifeLogType.EXERCISE,
+                null,
+                OCCURRED_AT
+        )).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new LifeLogRecorded(
+                "event-199",
+                1,
+                197L,
+                199L,
+                null,
+                null,
+                OCCURRED_AT
+        )).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new LifeLogRecorded(
+                "event-199",
+                1,
+                197L,
+                199L,
+                LifeLogType.EXERCISE,
+                null,
+                null
+        )).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("Role Domain 전에는 primaryRoleId 입력을 거부한다")
+    void rejectsPrimaryRoleId() {
+        assertThatThrownBy(() -> new LifeLogRecorded(
+                "event-199",
+                1,
+                197L,
+                199L,
+                LifeLogType.MEDIA,
+                31L,
+                OCCURRED_AT
+        )).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/online/lifeasgame/platform/outbox/application/codec/LifeLogRecordedCodecTest.java
+++ b/src/test/java/online/lifeasgame/platform/outbox/application/codec/LifeLogRecordedCodecTest.java
@@ -1,0 +1,76 @@
+package online.lifeasgame.platform.outbox.application.codec;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import online.lifeasgame.lifelog.domain.event.LifeLogRecorded;
+import online.lifeasgame.lifelog.domain.event.LifeLogType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("LifeLogRecorded Outbox Codec")
+class LifeLogRecordedCodecTest {
+
+    private static final Instant OCCURRED_AT =
+            Instant.parse("2026-07-24T09:15:30.123456Z");
+
+    private OutboxEventCodecRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        ObjectMapper objectMapper = JsonMapper.builder()
+                .addModule(new JavaTimeModule())
+                .build();
+        registry = new OutboxEventCodecRegistry(objectMapper);
+    }
+
+    @Test
+    @DisplayName("stable alias와 모든 필드를 그대로 round-trip한다")
+    void roundTripsEveryField() {
+        LifeLogRecorded source = LifeLogRecorded.of(
+                "d05c05d8-75a8-436d-b2f6-e0d63107927d",
+                197L,
+                199L,
+                LifeLogType.MEDIA,
+                OCCURRED_AT
+        );
+
+        OutboxEventEnvelope envelope = registry.encode(source);
+        LifeLogRecorded decoded = (LifeLogRecorded) registry.decode(
+                envelope.eventType(),
+                envelope.payload()
+        );
+
+        assertThat(envelope.eventType()).isEqualTo("lifelog.recorded.v1");
+        assertThat(envelope.occurredAt()).isEqualTo(OCCURRED_AT);
+        assertThat(decoded).isEqualTo(source);
+        assertThat(decoded.eventVersion()).isEqualTo(1);
+        assertThat(decoded.primaryRoleId()).isNull();
+    }
+
+    @Test
+    @DisplayName("Alias와 payload에 Java class name을 노출하지 않는다")
+    void doesNotExposeJavaClassName() {
+        LifeLogRecorded event = LifeLogRecorded.of(
+                "839d32ae-c695-4bb0-9d48-65372ac78e99",
+                197L,
+                199L,
+                LifeLogType.COLLECTION,
+                OCCURRED_AT
+        );
+
+        OutboxEventEnvelope envelope = registry.encode(event);
+
+        assertThat(envelope.eventType())
+                .doesNotContain(LifeLogRecorded.class.getSimpleName())
+                .doesNotContain(LifeLogRecorded.class.getName());
+        assertThat(envelope.payload())
+                .doesNotContain(LifeLogRecorded.class.getSimpleName())
+                .doesNotContain(LifeLogRecorded.class.getName());
+    }
+}

--- a/src/test/java/online/lifeasgame/platform/outbox/application/codec/OutboxEventCodecRegistryTest.java
+++ b/src/test/java/online/lifeasgame/platform/outbox/application/codec/OutboxEventCodecRegistryTest.java
@@ -12,6 +12,8 @@ import online.lifeasgame.economy.domain.event.EconomyEventType;
 import online.lifeasgame.inventory.domain.event.InventoryItemAdded;
 import online.lifeasgame.lifelog.domain.event.CollectionLogged;
 import online.lifeasgame.lifelog.domain.event.ExerciseLogged;
+import online.lifeasgame.lifelog.domain.event.LifeLogRecorded;
+import online.lifeasgame.lifelog.domain.event.LifeLogType;
 import online.lifeasgame.lifelog.domain.event.MediaLogAdvanced;
 import online.lifeasgame.platform.outbox.domain.error.OutboxError;
 import online.lifeasgame.quest.domain.event.QuestEvent;
@@ -86,6 +88,15 @@ class OutboxEventCodecRegistryTest {
                             250,
                             OCCURRED_AT
                     ),
+                    new LifeLogRecorded(
+                            "2a294fd2-1e08-49b9-a9f2-a3a4e3c17cb6",
+                            1,
+                            197L,
+                            52L,
+                            LifeLogType.EXERCISE,
+                            null,
+                            OCCURRED_AT
+                    ),
                     new MediaLogAdvanced(
                             197L,
                             61L,
@@ -132,6 +143,8 @@ class OutboxEventCodecRegistryTest {
                     .isEqualTo("player.registered.v1");
             assertThat(registry.aliasFor(PlayerLeveledUp.class))
                     .isEqualTo("player.leveled-up.v1");
+            assertThat(registry.aliasFor(LifeLogRecorded.class))
+                    .isEqualTo("lifelog.recorded.v1");
             assertThat(registry.aliasFor(QuestEvent.class))
                     .isEqualTo("quest.event.v1");
             assertThat(registry.aliasFor(EconomyEvent.class))


### PR DESCRIPTION
## What

- Collection, Exercise, Media 생성에서 공통 `LifeLogRecorded` Fact를 추가했습니다.
- 원본 저장과 Outbox append를 같은 Transaction으로 결합했습니다.
- `lifelog.recorded.v1` Stable Alias와 Codec을 추가했습니다.
- Event payload를 Source 식별용 최소 메타데이터로 제한했습니다.
- 기존 subtype Event와 Quest Trigger 의미를 유지했습니다.

## Event Contract

```text
LifeLogRecorded
- eventId
- eventVersion
- playerId
- lifeLogId
- lifeLogType
- primaryRoleId
- occurredAt
```

## Transaction

```text
LifeLog Source Create
→ LifeLogRecorded Outbox Append
→ Commit
```

Source Rollback 시 Outbox도 함께 Rollback됩니다.

## Test

- [ ] `./gradlew clean test`
- [ ] `./gradlew build`
- [ ] Codec round-trip
- [ ] Collection/Exercise/Media Fact append
- [ ] Commit/Rollback 원자성
- [ ] Payload private text 제외
- [ ] 기존 subtype Event 회귀
- [ ] V1~V8 checksum / JPA validate

## Out of Scope

- Quick Record Public API
- Idempotency-Key / Replay
- Role / Person 연결
- Timeline / Home
- Quest Definition / Seed
- RewardSettlement 연결
- Achievement
- Frontend

Closes #199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added unified life-log recording for collection, exercise, and media activities.
  - Recorded entries now include a unique identifier, activity type, and occurrence timestamp.
  - Added support for delivering and processing recorded life-log events consistently across the platform.

- **Reliability**
  - Life-log records and their activity events are saved together, reducing inconsistent data when operations fail.
  - Added validation to ensure recorded event details remain complete and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->