### PR TITLE
[LifeLog] Add idempotent quick record API

### DIFF
--- a/src/main/java/online/lifeasgame/lifelog/application/CollectionLogService.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/CollectionLogService.java
@@ -59,7 +59,7 @@ public class CollectionLogService {
                 )
         ));
 
-        return new CollectionResult.Created(saved.getId());
+        return new CollectionResult.Created(saved.getId(), occurredAt);
     }
 
     @Transactional

--- a/src/main/java/online/lifeasgame/lifelog/application/ExerciseLogService.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/ExerciseLogService.java
@@ -59,7 +59,7 @@ public class ExerciseLogService {
                 )
         ));
 
-        return new ExerciseResult.Created(saved.getId());
+        return new ExerciseResult.Created(saved.getId(), occurredAt);
     }
 
     @Transactional

--- a/src/main/java/online/lifeasgame/lifelog/application/MediaLogService.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/MediaLogService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
+import java.time.Instant;
 import java.util.List;
 
 @Service
@@ -37,17 +38,18 @@ public class MediaLogService {
                 )
         );
 
+        Instant recordedAt = clock.instant();
         domainEventPublisher.publish(
                 LifeLogRecorded.of(
                         IdGenerator.newEventId(),
                         playerId,
                         saved.getId(),
                         LifeLogType.MEDIA,
-                        clock.instant()
+                        recordedAt
                 )
         );
 
-        return new MediaLogResult.Created(saved.getId());
+        return new MediaLogResult.Created(saved.getId(), recordedAt);
     }
 
     @Transactional

--- a/src/main/java/online/lifeasgame/lifelog/application/result/CollectionResult.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/result/CollectionResult.java
@@ -10,7 +10,10 @@ public final class CollectionResult {
     private CollectionResult() {
     }
 
-    public record Created(Long id) {
+    public record Created(
+            Long id,
+            Instant recordedAt
+    ) {
     }
 
     public record Info(

--- a/src/main/java/online/lifeasgame/lifelog/application/result/ExerciseResult.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/result/ExerciseResult.java
@@ -10,7 +10,10 @@ public final class ExerciseResult {
     private ExerciseResult() {
     }
 
-    public record Created(Long id) {
+    public record Created(
+            Long id,
+            Instant recordedAt
+    ) {
     }
 
     public record Info(

--- a/src/main/java/online/lifeasgame/lifelog/application/result/MediaLogResult.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/result/MediaLogResult.java
@@ -11,7 +11,10 @@ public final class MediaLogResult {
     private MediaLogResult() {
     }
 
-    public record Created(Long id) {
+    public record Created(
+            Long id,
+            Instant recordedAt
+    ) {
     }
 
     public record Info(

--- a/src/main/java/online/lifeasgame/lifelog/quick/api/QuickRecordController.java
+++ b/src/main/java/online/lifeasgame/lifelog/quick/api/QuickRecordController.java
@@ -1,0 +1,54 @@
+package online.lifeasgame.lifelog.quick.api;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.response.ApiResponse;
+import online.lifeasgame.lifelog.quick.application.QuickRecordFacade;
+import online.lifeasgame.lifelog.quick.application.QuickRecordResult;
+import online.lifeasgame.lifelog.quick.domain.error.QuickRecordError;
+import online.lifeasgame.platform.web.response.ApiResponses;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/lifelogs")
+public class QuickRecordController implements QuickRecordSpecV1 {
+
+    private final QuickRecordFacade quickRecordFacade;
+
+    @Override
+    @PostMapping("/quick-record")
+    public ResponseEntity<ApiResponse<QuickRecordResponse.Recorded>> record(
+            @RequestHeader(
+                    value = "Idempotency-Key",
+                    required = false
+            )
+            String idempotencyKey,
+            @Valid @RequestBody QuickRecordRequest.Create request
+    ) {
+        if (idempotencyKey == null || idempotencyKey.isBlank()) {
+            throw new DomainException(
+                    QuickRecordError.IDEMPOTENCY_KEY_REQUIRED
+            );
+        }
+        QuickRecordResult.Recorded result = quickRecordFacade.record(
+                idempotencyKey,
+                QuickRecordWebMapper.toCommand(request)
+        );
+        QuickRecordResponse.Recorded response =
+                QuickRecordWebMapper.toResponse(result);
+
+        if (result.replay()) {
+            return ApiResponses.ok(response);
+        }
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.onCreateSuccess(response));
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/quick/api/QuickRecordRequest.java
+++ b/src/main/java/online/lifeasgame/lifelog/quick/api/QuickRecordRequest.java
@@ -1,0 +1,21 @@
+package online.lifeasgame.lifelog.quick.api;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import online.lifeasgame.lifelog.api.player.request.PlayerCollectionRequest;
+import online.lifeasgame.lifelog.api.player.request.PlayerExerciseRequest;
+import online.lifeasgame.lifelog.api.player.request.PlayerMediaLogRequest;
+
+public final class QuickRecordRequest {
+
+    private QuickRecordRequest() {
+    }
+
+    public record Create(
+            @NotBlank String type,
+            @Valid PlayerCollectionRequest.Create collection,
+            @Valid PlayerExerciseRequest.Create exercise,
+            @Valid PlayerMediaLogRequest.Create media
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/quick/api/QuickRecordResponse.java
+++ b/src/main/java/online/lifeasgame/lifelog/quick/api/QuickRecordResponse.java
@@ -1,0 +1,17 @@
+package online.lifeasgame.lifelog.quick.api;
+
+import java.time.Instant;
+
+public final class QuickRecordResponse {
+
+    private QuickRecordResponse() {
+    }
+
+    public record Recorded(
+            String sourceType,
+            Long sourceId,
+            Instant recordedAt,
+            boolean replay
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/quick/api/QuickRecordSpecV1.java
+++ b/src/main/java/online/lifeasgame/lifelog/quick/api/QuickRecordSpecV1.java
@@ -1,0 +1,23 @@
+package online.lifeasgame.lifelog.quick.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import online.lifeasgame.core.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@Tag(name = "Quick Record API V1 (Player)")
+public interface QuickRecordSpecV1 {
+
+    @Operation(summary = "기존 LifeLog subtype을 빠르게 기록")
+    ResponseEntity<ApiResponse<QuickRecordResponse.Recorded>> record(
+            @RequestHeader(
+                    value = "Idempotency-Key",
+                    required = false
+            )
+            String idempotencyKey,
+            @Valid @RequestBody QuickRecordRequest.Create request
+    );
+}

--- a/src/main/java/online/lifeasgame/lifelog/quick/api/QuickRecordWebMapper.java
+++ b/src/main/java/online/lifeasgame/lifelog/quick/api/QuickRecordWebMapper.java
@@ -1,0 +1,47 @@
+package online.lifeasgame.lifelog.quick.api;
+
+import online.lifeasgame.lifelog.api.player.mapper.PlayerCollectionWebMapper;
+import online.lifeasgame.lifelog.api.player.mapper.PlayerExerciseWebMapper;
+import online.lifeasgame.lifelog.api.player.mapper.PlayerMediaLogWebMapper;
+import online.lifeasgame.lifelog.quick.application.QuickRecordCommand;
+import online.lifeasgame.lifelog.quick.application.QuickRecordResult;
+
+public final class QuickRecordWebMapper {
+
+    private QuickRecordWebMapper() {
+    }
+
+    public static QuickRecordCommand.Create toCommand(
+            QuickRecordRequest.Create request
+    ) {
+        return new QuickRecordCommand.Create(
+                request.type(),
+                request.collection() == null
+                        ? null
+                        : PlayerCollectionWebMapper.toCreateCommand(
+                                request.collection()
+                        ),
+                request.exercise() == null
+                        ? null
+                        : PlayerExerciseWebMapper.toCreateCommand(
+                                request.exercise()
+                        ),
+                request.media() == null
+                        ? null
+                        : PlayerMediaLogWebMapper.toCreateCommand(
+                                request.media()
+                        )
+        );
+    }
+
+    public static QuickRecordResponse.Recorded toResponse(
+            QuickRecordResult.Recorded result
+    ) {
+        return new QuickRecordResponse.Recorded(
+                result.sourceType().name(),
+                result.sourceId(),
+                result.recordedAt(),
+                result.replay()
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/quick/application/QuickRecordCommand.java
+++ b/src/main/java/online/lifeasgame/lifelog/quick/application/QuickRecordCommand.java
@@ -1,0 +1,142 @@
+package online.lifeasgame.lifelog.quick.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.lifelog.application.command.CollectionCommand;
+import online.lifeasgame.lifelog.application.command.ExerciseCommand;
+import online.lifeasgame.lifelog.application.command.MediaLogCommand;
+import online.lifeasgame.lifelog.domain.event.LifeLogType;
+import online.lifeasgame.lifelog.quick.domain.error.QuickRecordError;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
+
+public final class QuickRecordCommand {
+
+    private QuickRecordCommand() {
+    }
+
+    public record Create(
+            String type,
+            CollectionCommand.Create collection,
+            ExerciseCommand.Create exercise,
+            MediaLogCommand.Create media
+    ) {
+        public Create {
+            collection = copy(collection);
+            exercise = copy(exercise);
+            media = copy(media);
+        }
+
+        public Selected selected() {
+            LifeLogType selectedType = parseType(type);
+            int payloadCount = (collection == null ? 0 : 1)
+                    + (exercise == null ? 0 : 1)
+                    + (media == null ? 0 : 1);
+            if (payloadCount != 1
+                    || selectedType == LifeLogType.COLLECTION
+                    && collection == null
+                    || selectedType == LifeLogType.EXERCISE
+                    && exercise == null
+                    || selectedType == LifeLogType.MEDIA
+                    && media == null) {
+                throw invalid();
+            }
+            return new Selected(
+                    selectedType,
+                    collection,
+                    exercise,
+                    media
+            );
+        }
+    }
+
+    public record Selected(
+            LifeLogType type,
+            CollectionCommand.Create collection,
+            ExerciseCommand.Create exercise,
+            MediaLogCommand.Create media
+    ) {
+    }
+
+    private static LifeLogType parseType(String raw) {
+        if (raw == null || raw.isBlank()) {
+            throw invalid();
+        }
+        try {
+            return LifeLogType.valueOf(
+                    raw.trim().toUpperCase(Locale.ROOT)
+            );
+        } catch (IllegalArgumentException exception) {
+            throw new DomainException(
+                    QuickRecordError.INVALID_REQUEST,
+                    null,
+                    exception
+            );
+        }
+    }
+
+    private static CollectionCommand.Create copy(
+            CollectionCommand.Create value
+    ) {
+        if (value == null) {
+            return null;
+        }
+        return new CollectionCommand.Create(
+                value.category(),
+                value.title(),
+                value.originalTitle(),
+                value.quantity(),
+                value.conditionNote(),
+                value.acquiredFrom(),
+                copyTags(value.tags())
+        );
+    }
+
+    private static ExerciseCommand.Create copy(
+            ExerciseCommand.Create value
+    ) {
+        if (value == null) {
+            return null;
+        }
+        return new ExerciseCommand.Create(
+                value.category(),
+                value.durationMinutes(),
+                value.distanceKm(),
+                value.calories(),
+                value.exercisedOn(),
+                value.memo()
+        );
+    }
+
+    private static MediaLogCommand.Create copy(
+            MediaLogCommand.Create value
+    ) {
+        if (value == null) {
+            return null;
+        }
+        return new MediaLogCommand.Create(
+                value.category(),
+                value.title(),
+                value.originalTitle(),
+                value.currentEpisode(),
+                value.totalEpisode(),
+                value.status(),
+                copyTags(value.tags())
+        );
+    }
+
+    private static Set<String> copyTags(Set<String> values) {
+        if (values == null) {
+            return null;
+        }
+        return Collections.unmodifiableSet(
+                new LinkedHashSet<>(values)
+        );
+    }
+
+    private static DomainException invalid() {
+        return new DomainException(QuickRecordError.INVALID_REQUEST);
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/quick/application/QuickRecordFacade.java
+++ b/src/main/java/online/lifeasgame/lifelog/quick/application/QuickRecordFacade.java
@@ -1,0 +1,24 @@
+package online.lifeasgame.lifelog.quick.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class QuickRecordFacade {
+
+    private final CurrentPlayerAccessor currentPlayerAccessor;
+    private final QuickRecordService quickRecordService;
+
+    public QuickRecordResult.Recorded record(
+            String idempotencyKey,
+            QuickRecordCommand.Create command
+    ) {
+        return quickRecordService.record(
+                currentPlayerAccessor.currentPlayerIdOrThrow(),
+                idempotencyKey,
+                command
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/quick/application/QuickRecordRequestHasher.java
+++ b/src/main/java/online/lifeasgame/lifelog/quick/application/QuickRecordRequestHasher.java
@@ -1,0 +1,222 @@
+package online.lifeasgame.lifelog.quick.application;
+
+import online.lifeasgame.lifelog.application.command.CollectionCommand;
+import online.lifeasgame.lifelog.application.command.ExerciseCommand;
+import online.lifeasgame.lifelog.application.command.MediaLogCommand;
+import online.lifeasgame.lifelog.domain.CollectionCategory;
+import online.lifeasgame.lifelog.domain.ExerciseCategory;
+import online.lifeasgame.lifelog.domain.MediaCategory;
+import online.lifeasgame.lifelog.domain.WatchStatus;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDate;
+import java.util.HexFormat;
+import java.util.Locale;
+import java.util.Set;
+import java.util.TreeSet;
+
+@Component
+public class QuickRecordRequestHasher {
+
+    public String hash(QuickRecordCommand.Selected selected) {
+        StringBuilder canonical = new StringBuilder();
+        appendText(canonical, "type", selected.type().name());
+        switch (selected.type()) {
+            case COLLECTION ->
+                    appendCollection(canonical, selected.collection());
+            case EXERCISE ->
+                    appendExercise(canonical, selected.exercise());
+            case MEDIA -> appendMedia(canonical, selected.media());
+        }
+        return sha256(canonical.toString());
+    }
+
+    private void appendCollection(
+            StringBuilder target,
+            CollectionCommand.Create value
+    ) {
+        appendText(
+                target,
+                "category",
+                CollectionCategory.parse(value.category()).name()
+        );
+        appendRequiredText(target, "title", value.title());
+        appendOptionalText(
+                target,
+                "originalTitle",
+                value.originalTitle()
+        );
+        appendNumber(target, "quantity", value.quantity());
+        appendOptionalText(
+                target,
+                "conditionNote",
+                value.conditionNote()
+        );
+        appendOptionalText(
+                target,
+                "acquiredFrom",
+                value.acquiredFrom()
+        );
+        appendTags(target, value.tags());
+    }
+
+    private void appendExercise(
+            StringBuilder target,
+            ExerciseCommand.Create value
+    ) {
+        appendText(
+                target,
+                "category",
+                ExerciseCategory.parse(value.category()).name()
+        );
+        appendNumber(
+                target,
+                "durationMinutes",
+                value.durationMinutes()
+        );
+        appendNumber(target, "distanceKm", value.distanceKm());
+        appendNumber(target, "calories", value.calories());
+        appendDate(target, "exercisedOn", value.exercisedOn());
+        appendOptionalText(target, "memo", value.memo());
+    }
+
+    private void appendMedia(
+            StringBuilder target,
+            MediaLogCommand.Create value
+    ) {
+        appendText(
+                target,
+                "category",
+                MediaCategory.parse(value.category()).name()
+        );
+        appendRequiredText(target, "title", value.title());
+        appendOptionalText(
+                target,
+                "originalTitle",
+                value.originalTitle()
+        );
+        appendNumber(
+                target,
+                "currentEpisode",
+                value.currentEpisode()
+        );
+        appendNumber(target, "totalEpisode", value.totalEpisode());
+        appendText(
+                target,
+                "status",
+                WatchStatus.parse(value.status()).name()
+        );
+        appendTags(target, value.tags());
+    }
+
+    private void appendTags(StringBuilder target, Set<String> values) {
+        TreeSet<String> normalized = new TreeSet<>();
+        if (values != null) {
+            values.stream()
+                    .filter(value ->
+                            value != null && !value.isBlank()
+                    )
+                    .map(value ->
+                            value.trim().toLowerCase(Locale.ROOT)
+                    )
+                    .forEach(normalized::add);
+        }
+        appendNumber(target, "tagCount", normalized.size());
+        normalized.forEach(tag -> appendText(target, "tag", tag));
+    }
+
+    private void appendRequiredText(
+            StringBuilder target,
+            String key,
+            String value
+    ) {
+        if (value == null) {
+            appendMissing(target, key);
+            return;
+        }
+        appendText(target, key, value.trim());
+    }
+
+    private void appendOptionalText(
+            StringBuilder target,
+            String key,
+            String value
+    ) {
+        if (value == null || value.isBlank()) {
+            appendMissing(target, key);
+            return;
+        }
+        appendText(target, key, value.trim());
+    }
+
+    private void appendDate(
+            StringBuilder target,
+            String key,
+            LocalDate value
+    ) {
+        if (value == null) {
+            appendMissing(target, key);
+            return;
+        }
+        appendText(target, key, value.toString());
+    }
+
+    private void appendNumber(
+            StringBuilder target,
+            String key,
+            Number value
+    ) {
+        if (value == null) {
+            appendMissing(target, key);
+            return;
+        }
+        String text = value.toString();
+        appendKey(target, key);
+        target.append("number:")
+                .append(text.length())
+                .append(':')
+                .append(text)
+                .append(';');
+    }
+
+    private void appendMissing(StringBuilder target, String key) {
+        appendKey(target, key);
+        target.append("missing;");
+    }
+
+    private void appendText(
+            StringBuilder target,
+            String key,
+            String value
+    ) {
+        appendKey(target, key);
+        target.append("text:")
+                .append(value.length())
+                .append(':')
+                .append(value)
+                .append(';');
+    }
+
+    private void appendKey(StringBuilder target, String key) {
+        target.append(key.length())
+                .append(':')
+                .append(key)
+                .append('=');
+    }
+
+    private String sha256(String canonical) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(canonical.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException(
+                    "SHA-256 is not available",
+                    exception
+            );
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/quick/application/QuickRecordResult.java
+++ b/src/main/java/online/lifeasgame/lifelog/quick/application/QuickRecordResult.java
@@ -1,0 +1,31 @@
+package online.lifeasgame.lifelog.quick.application;
+
+import online.lifeasgame.lifelog.domain.event.LifeLogType;
+import online.lifeasgame.lifelog.quick.domain.QuickRecordRequestReceipt;
+
+import java.time.Instant;
+
+public final class QuickRecordResult {
+
+    private QuickRecordResult() {
+    }
+
+    public record Recorded(
+            LifeLogType sourceType,
+            Long sourceId,
+            Instant recordedAt,
+            boolean replay
+    ) {
+        public static Recorded from(
+                QuickRecordRequestReceipt.StoredResult result,
+                boolean replay
+        ) {
+            return new Recorded(
+                    result.sourceType(),
+                    result.sourceId(),
+                    result.recordedAt(),
+                    replay
+            );
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/quick/application/QuickRecordService.java
+++ b/src/main/java/online/lifeasgame/lifelog/quick/application/QuickRecordService.java
@@ -1,0 +1,135 @@
+package online.lifeasgame.lifelog.quick.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.lifelog.application.CollectionLogService;
+import online.lifeasgame.lifelog.application.ExerciseLogService;
+import online.lifeasgame.lifelog.application.MediaLogService;
+import online.lifeasgame.lifelog.application.result.CollectionResult;
+import online.lifeasgame.lifelog.application.result.ExerciseResult;
+import online.lifeasgame.lifelog.application.result.MediaLogResult;
+import online.lifeasgame.lifelog.domain.event.LifeLogType;
+import online.lifeasgame.lifelog.quick.domain.QuickRecordRequestReceipt;
+import online.lifeasgame.lifelog.quick.domain.error.QuickRecordError;
+import online.lifeasgame.lifelog.quick.domain.repository.QuickRecordRequestReceiptRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+public class QuickRecordService {
+
+    private final CollectionLogService collectionLogService;
+    private final ExerciseLogService exerciseLogService;
+    private final MediaLogService mediaLogService;
+    private final QuickRecordRequestReceiptRepository receiptRepository;
+    private final QuickRecordRequestHasher requestHasher;
+    private final Clock clock;
+
+    @Transactional
+    public QuickRecordResult.Recorded record(
+            Long playerId,
+            String idempotencyKey,
+            QuickRecordCommand.Create command
+    ) {
+        if (playerId == null || playerId <= 0 || command == null) {
+            throw invalid();
+        }
+        String normalizedKey =
+                QuickRecordRequestReceipt.normalizeIdempotencyKey(
+                        idempotencyKey
+                );
+        QuickRecordCommand.Selected selected = command.selected();
+        String requestHash = requestHasher.hash(selected);
+        Instant reservedAt = clock.instant();
+
+        receiptRepository.reserve(
+                playerId,
+                normalizedKey,
+                requestHash,
+                reservedAt
+        );
+        QuickRecordRequestReceipt receipt = receiptRepository
+                .findByIdentityForUpdate(playerId, normalizedKey)
+                .orElseThrow(QuickRecordService::invalid);
+        receipt.assertRequestHash(requestHash);
+
+        if (receipt.isCompleted()) {
+            return QuickRecordResult.Recorded.from(
+                    receipt.replay(requestHash),
+                    true
+            );
+        }
+
+        SourceSnapshot source = createSource(playerId, selected);
+        receipt.complete(
+                source.sourceType(),
+                source.sourceId(),
+                source.recordedAt()
+        );
+        receiptRepository.saveAndFlush(receipt);
+
+        return QuickRecordResult.Recorded.from(
+                receipt.storedResult(),
+                false
+        );
+    }
+
+    private SourceSnapshot createSource(
+            Long playerId,
+            QuickRecordCommand.Selected selected
+    ) {
+        return switch (selected.type()) {
+            case COLLECTION -> {
+                CollectionResult.Created created =
+                        collectionLogService.create(
+                                playerId,
+                                selected.collection()
+                        );
+                yield new SourceSnapshot(
+                        LifeLogType.COLLECTION,
+                        created.id(),
+                        created.recordedAt()
+                );
+            }
+            case EXERCISE -> {
+                ExerciseResult.Created created =
+                        exerciseLogService.create(
+                                playerId,
+                                selected.exercise()
+                        );
+                yield new SourceSnapshot(
+                        LifeLogType.EXERCISE,
+                        created.id(),
+                        created.recordedAt()
+                );
+            }
+            case MEDIA -> {
+                MediaLogResult.Created created =
+                        mediaLogService.create(
+                                playerId,
+                                selected.media()
+                        );
+                yield new SourceSnapshot(
+                        LifeLogType.MEDIA,
+                        created.id(),
+                        created.recordedAt()
+                );
+            }
+        };
+    }
+
+    private static DomainException invalid() {
+        return new DomainException(QuickRecordError.INVALID_REQUEST);
+    }
+
+    private record SourceSnapshot(
+            LifeLogType sourceType,
+            Long sourceId,
+            Instant recordedAt
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/quick/domain/QuickRecordRequestReceipt.java
+++ b/src/main/java/online/lifeasgame/lifelog/quick/domain/QuickRecordRequestReceipt.java
@@ -1,0 +1,168 @@
+package online.lifeasgame.lifelog.quick.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.guard.Guard;
+import online.lifeasgame.lifelog.domain.event.LifeLogType;
+import online.lifeasgame.lifelog.quick.domain.error.QuickRecordError;
+import online.lifeasgame.platform.persistence.jpa.AbstractTime;
+
+import java.time.Instant;
+
+@Getter
+@Entity
+@Table(
+        name = "quick_record_request_receipts",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_quick_record_request_receipt_identity",
+                columnNames = {"player_id", "idempotency_key"}
+        )
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuickRecordRequestReceipt extends AbstractTime {
+
+    public static final int IDEMPOTENCY_KEY_MAX_LENGTH = 128;
+    public static final int REQUEST_HASH_LENGTH = 64;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "player_id", nullable = false)
+    private Long playerId;
+
+    @Column(
+            name = "idempotency_key",
+            nullable = false,
+            length = IDEMPOTENCY_KEY_MAX_LENGTH
+    )
+    private String idempotencyKey;
+
+    @Column(
+            name = "request_hash",
+            nullable = false,
+            length = REQUEST_HASH_LENGTH,
+            columnDefinition = "CHAR(64)"
+    )
+    private String requestHash;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source_type", length = 20)
+    private LifeLogType sourceType;
+
+    @Column(name = "source_id")
+    private Long sourceId;
+
+    @Column(name = "recorded_at")
+    private Instant recordedAt;
+
+    private QuickRecordRequestReceipt(
+            Long playerId,
+            String idempotencyKey,
+            String requestHash
+    ) {
+        this.playerId = Guard.notNull(playerId, "playerId");
+        Guard.minValue(playerId, 1L, "playerId");
+        this.idempotencyKey = normalizeIdempotencyKey(idempotencyKey);
+        this.requestHash = requireHash(requestHash);
+    }
+
+    public static QuickRecordRequestReceipt reserve(
+            Long playerId,
+            String idempotencyKey,
+            String requestHash
+    ) {
+        return new QuickRecordRequestReceipt(
+                playerId,
+                idempotencyKey,
+                requestHash
+        );
+    }
+
+    public static String normalizeIdempotencyKey(String value) {
+        if (value == null || value.isBlank()) {
+            throw new DomainException(
+                    QuickRecordError.IDEMPOTENCY_KEY_REQUIRED
+            );
+        }
+        String normalized = value.trim();
+        if (normalized.length() > IDEMPOTENCY_KEY_MAX_LENGTH) {
+            throw invalid();
+        }
+        return normalized;
+    }
+
+    public void assertRequestHash(String candidate) {
+        if (!requestHash.equals(requireHash(candidate))) {
+            throw new DomainException(
+                    QuickRecordError.IDEMPOTENCY_KEY_PAYLOAD_CONFLICT
+            );
+        }
+    }
+
+    public boolean isCompleted() {
+        return sourceType != null
+                && sourceId != null
+                && recordedAt != null;
+    }
+
+    public void complete(
+            LifeLogType sourceType,
+            Long sourceId,
+            Instant recordedAt
+    ) {
+        if (isCompleted()
+                || sourceType == null
+                || sourceId == null
+                || sourceId <= 0
+                || recordedAt == null) {
+            throw invalid();
+        }
+        this.sourceType = sourceType;
+        this.sourceId = sourceId;
+        this.recordedAt = recordedAt;
+    }
+
+    public StoredResult replay(String candidateHash) {
+        assertRequestHash(candidateHash);
+        return storedResult();
+    }
+
+    public StoredResult storedResult() {
+        if (!isCompleted()) {
+            throw invalid();
+        }
+        return new StoredResult(sourceType, sourceId, recordedAt);
+    }
+
+    private static String requireHash(String value) {
+        if (value == null
+                || value.length() != REQUEST_HASH_LENGTH
+                || !value.matches("[0-9a-f]{64}")) {
+            throw invalid();
+        }
+        return value;
+    }
+
+    private static DomainException invalid() {
+        return new DomainException(QuickRecordError.INVALID_REQUEST);
+    }
+
+    public record StoredResult(
+            LifeLogType sourceType,
+            Long sourceId,
+            Instant recordedAt
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/quick/domain/error/QuickRecordError.java
+++ b/src/main/java/online/lifeasgame/lifelog/quick/domain/error/QuickRecordError.java
@@ -1,0 +1,46 @@
+package online.lifeasgame.lifelog.quick.domain.error;
+
+import online.lifeasgame.core.error.ErrorCode;
+
+public enum QuickRecordError implements ErrorCode {
+    INVALID_REQUEST(
+            "LIF-400-INVALID-QUICK-RECORD",
+            "Invalid quick record request",
+            400
+    ),
+    IDEMPOTENCY_KEY_REQUIRED(
+            "IDEM-400-KEY-REQUIRED",
+            "Idempotency-Key is required",
+            400
+    ),
+    IDEMPOTENCY_KEY_PAYLOAD_CONFLICT(
+            "IDEM-409-KEY-PAYLOAD-CONFLICT",
+            "Idempotency-Key was already used for a different request",
+            409
+    );
+
+    private final String code;
+    private final String message;
+    private final int status;
+
+    QuickRecordError(String code, String message, int status) {
+        this.code = code;
+        this.message = message;
+        this.status = status;
+    }
+
+    @Override
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public int status() {
+        return status;
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/quick/domain/repository/QuickRecordRequestReceiptRepository.java
+++ b/src/main/java/online/lifeasgame/lifelog/quick/domain/repository/QuickRecordRequestReceiptRepository.java
@@ -1,0 +1,25 @@
+package online.lifeasgame.lifelog.quick.domain.repository;
+
+import online.lifeasgame.lifelog.quick.domain.QuickRecordRequestReceipt;
+
+import java.time.Instant;
+import java.util.Optional;
+
+public interface QuickRecordRequestReceiptRepository {
+
+    void reserve(
+            Long playerId,
+            String idempotencyKey,
+            String requestHash,
+            Instant reservedAt
+    );
+
+    Optional<QuickRecordRequestReceipt> findByIdentityForUpdate(
+            Long playerId,
+            String idempotencyKey
+    );
+
+    QuickRecordRequestReceipt saveAndFlush(
+            QuickRecordRequestReceipt receipt
+    );
+}

--- a/src/main/java/online/lifeasgame/lifelog/quick/infra/JpaQuickRecordRequestReceiptRepository.java
+++ b/src/main/java/online/lifeasgame/lifelog/quick/infra/JpaQuickRecordRequestReceiptRepository.java
@@ -1,0 +1,47 @@
+package online.lifeasgame.lifelog.quick.infra;
+
+import jakarta.persistence.LockModeType;
+import online.lifeasgame.lifelog.quick.domain.QuickRecordRequestReceipt;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.util.Optional;
+
+public interface JpaQuickRecordRequestReceiptRepository
+        extends JpaRepository<QuickRecordRequestReceipt, Long> {
+
+    @Modifying
+    @Query(value = """
+            INSERT INTO quick_record_request_receipts (
+                player_id,
+                idempotency_key,
+                request_hash,
+                created_at,
+                updated_at
+            ) VALUES (
+                :playerId,
+                :idempotencyKey,
+                :requestHash,
+                :reservedAt,
+                :reservedAt
+            )
+            ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id)
+            """, nativeQuery = true)
+    int reserve(
+            @Param("playerId") Long playerId,
+            @Param("idempotencyKey") String idempotencyKey,
+            @Param("requestHash") String requestHash,
+            @Param("reservedAt") Instant reservedAt
+    );
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<QuickRecordRequestReceipt>
+    findByPlayerIdAndIdempotencyKey(
+            Long playerId,
+            String idempotencyKey
+    );
+}

--- a/src/main/java/online/lifeasgame/lifelog/quick/infra/QuickRecordRequestReceiptRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/lifelog/quick/infra/QuickRecordRequestReceiptRepositoryAdapter.java
@@ -1,0 +1,50 @@
+package online.lifeasgame.lifelog.quick.infra;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.lifelog.quick.domain.QuickRecordRequestReceipt;
+import online.lifeasgame.lifelog.quick.domain.repository.QuickRecordRequestReceiptRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class QuickRecordRequestReceiptRepositoryAdapter
+        implements QuickRecordRequestReceiptRepository {
+
+    private final JpaQuickRecordRequestReceiptRepository jpaRepository;
+
+    @Override
+    public void reserve(
+            Long playerId,
+            String idempotencyKey,
+            String requestHash,
+            Instant reservedAt
+    ) {
+        jpaRepository.reserve(
+                playerId,
+                idempotencyKey,
+                requestHash,
+                reservedAt
+        );
+    }
+
+    @Override
+    public Optional<QuickRecordRequestReceipt> findByIdentityForUpdate(
+            Long playerId,
+            String idempotencyKey
+    ) {
+        return jpaRepository.findByPlayerIdAndIdempotencyKey(
+                playerId,
+                idempotencyKey
+        );
+    }
+
+    @Override
+    public QuickRecordRequestReceipt saveAndFlush(
+            QuickRecordRequestReceipt receipt
+    ) {
+        return jpaRepository.saveAndFlush(receipt);
+    }
+}

--- a/src/main/java/online/lifeasgame/system/bootstrap/security/SecurityConfig.java
+++ b/src/main/java/online/lifeasgame/system/bootstrap/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package online.lifeasgame.system.bootstrap.security;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.platform.security.jwt.JwtAuthenticationFilter;
 import online.lifeasgame.platform.security.jwt.JwtProvider;
@@ -29,6 +30,12 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(c -> c.configurationSource(corsConfigurationSource()))
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exceptions -> exceptions
+                        .authenticationEntryPoint((request, response, cause) ->
+                                response.sendError(
+                                        HttpServletResponse.SC_UNAUTHORIZED
+                                )
+                        ))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.POST,
                                 "/api/v1/auth/login",

--- a/src/main/resources/db/migration/V9__quick_lifelog_record.sql
+++ b/src/main/resources/db/migration/V9__quick_lifelog_record.sql
@@ -1,0 +1,33 @@
+CREATE TABLE quick_record_request_receipts (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    player_id BIGINT NOT NULL,
+    idempotency_key VARCHAR(128) NOT NULL,
+    request_hash CHAR(64) NOT NULL,
+    source_type VARCHAR(20) NULL,
+    source_id BIGINT NULL,
+    recorded_at DATETIME(6) NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_quick_record_request_receipt_identity
+        UNIQUE (player_id, idempotency_key),
+    CONSTRAINT ck_quick_record_request_receipt_player
+        CHECK (player_id > 0),
+    CONSTRAINT ck_quick_record_request_receipt_key
+        CHECK (CHAR_LENGTH(TRIM(idempotency_key)) > 0),
+    CONSTRAINT ck_quick_record_request_receipt_result CHECK (
+        (
+            source_type IS NULL
+            AND source_id IS NULL
+            AND recorded_at IS NULL
+        )
+        OR
+        (
+            source_type IS NOT NULL
+            AND source_id IS NOT NULL
+            AND recorded_at IS NOT NULL
+        )
+    )
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_0900_ai_ci;

--- a/src/test/java/online/lifeasgame/lifelog/quick/api/QuickRecordControllerTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/quick/api/QuickRecordControllerTest.java
@@ -1,0 +1,331 @@
+package online.lifeasgame.lifelog.quick.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.lifelog.api.player.request.PlayerCollectionRequest;
+import online.lifeasgame.lifelog.api.player.request.PlayerExerciseRequest;
+import online.lifeasgame.lifelog.domain.event.LifeLogType;
+import online.lifeasgame.lifelog.quick.application.QuickRecordFacade;
+import online.lifeasgame.lifelog.quick.application.QuickRecordResult;
+import online.lifeasgame.lifelog.quick.domain.error.QuickRecordError;
+import online.lifeasgame.platform.security.jwt.JwtPrincipal;
+import online.lifeasgame.platform.security.jwt.JwtProvider;
+import online.lifeasgame.platform.web.error.docs.ErrorDocLinker;
+import online.lifeasgame.support.WebMvcTestConfig;
+import online.lifeasgame.system.bootstrap.error.handler.AppErrorProperties;
+import online.lifeasgame.system.bootstrap.security.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = QuickRecordController.class)
+@Import({
+        SecurityConfig.class,
+        WebMvcTestConfig.class
+})
+@DisplayName("POST /api/v1/lifelogs/quick-record")
+class QuickRecordControllerTest {
+
+    private static final Instant RECORDED_AT =
+            Instant.parse("2026-07-24T15:00:00Z");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private QuickRecordFacade quickRecordFacade;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private AppErrorProperties appErrorProperties;
+
+    @MockitoBean
+    private ErrorDocLinker errorDocLinker;
+
+    @Test
+    @DisplayName("인증이 없으면 401이다")
+    void requiresAuthentication() throws Exception {
+        mockMvc.perform(request("key-201", collectionRequest(), false))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Idempotency-Key가 없으면 400이다")
+    void requiresIdempotencyKey() throws Exception {
+        mockMvc.perform(request(null, collectionRequest(), true))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code")
+                        .value("IDEM-400-KEY-REQUIRED"));
+    }
+
+    @Test
+    @DisplayName("선택 subtype의 기존 Request validation을 적용한다")
+    void validatesNestedSubtypeRequest() throws Exception {
+        QuickRecordRequest.Create invalid =
+                new QuickRecordRequest.Create(
+                        "COLLECTION",
+                        new PlayerCollectionRequest.Create(
+                                "BOOK",
+                                "title",
+                                null,
+                                0,
+                                null,
+                                null,
+                                Set.of()
+                        ),
+                        null,
+                        null
+                );
+
+        mockMvc.perform(request("invalid-subtype", invalid, true))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("REQ-VALIDATION"));
+    }
+
+    @Test
+    @DisplayName("type과 payload 불일치는 400이다")
+    void rejectsMismatchedTypeAndPayload() throws Exception {
+        QuickRecordRequest.Create invalid =
+                new QuickRecordRequest.Create(
+                        "COLLECTION",
+                        null,
+                        exercisePayload(),
+                        null
+                );
+        mockInvalid("mismatch-key");
+
+        mockMvc.perform(request("mismatch-key", invalid, true))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code")
+                        .value("LIF-400-INVALID-QUICK-RECORD"));
+    }
+
+    @Test
+    @DisplayName("두 subtype payload 동시 입력은 400이다")
+    void rejectsMultiplePayloads() throws Exception {
+        QuickRecordRequest.Create invalid =
+                new QuickRecordRequest.Create(
+                        "COLLECTION",
+                        collectionPayload(),
+                        exercisePayload(),
+                        null
+                );
+        mockInvalid("multiple-key");
+
+        mockMvc.perform(request("multiple-key", invalid, true))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code")
+                        .value("LIF-400-INVALID-QUICK-RECORD"));
+    }
+
+    @Test
+    @DisplayName("subtype payload가 없으면 400이다")
+    void rejectsMissingPayload() throws Exception {
+        QuickRecordRequest.Create invalid =
+                new QuickRecordRequest.Create(
+                        "MEDIA",
+                        null,
+                        null,
+                        null
+                );
+        mockInvalid("missing-payload-key");
+
+        mockMvc.perform(request(
+                        "missing-payload-key",
+                        invalid,
+                        true
+                ))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code")
+                        .value("LIF-400-INVALID-QUICK-RECORD"));
+    }
+
+    @Test
+    @DisplayName("최초 생성은 실제 Source snapshot과 201을 반환한다")
+    void returnsCreatedSource() throws Exception {
+        when(quickRecordFacade.record(
+                eq("created-key"),
+                argThat(command -> command.collection() != null)
+        )).thenReturn(result(false));
+
+        mockMvc.perform(request(
+                        "created-key",
+                        collectionRequest(),
+                        true
+                ))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.code").value("COMMON-201"))
+                .andExpect(jsonPath("$.result.sourceType")
+                        .value("COLLECTION"))
+                .andExpect(jsonPath("$.result.sourceId").value(31))
+                .andExpect(jsonPath("$.result.recordedAt")
+                        .value("2026-07-24T15:00:00Z"))
+                .andExpect(jsonPath("$.result.replay").value(false))
+                .andExpect(jsonPath("$.result.sourceEventId")
+                        .doesNotExist())
+                .andExpect(jsonPath("$.result.lifeLogId")
+                        .doesNotExist());
+    }
+
+    @Test
+    @DisplayName("동일 요청 replay는 저장된 Source snapshot과 200을 반환한다")
+    void returnsReplay() throws Exception {
+        when(quickRecordFacade.record(
+                eq("replay-key"),
+                argThat(command -> command.collection() != null)
+        )).thenReturn(result(true));
+
+        mockMvc.perform(request(
+                        "replay-key",
+                        collectionRequest(),
+                        true
+                ))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("COMMON-200"))
+                .andExpect(jsonPath("$.result.sourceType")
+                        .value("COLLECTION"))
+                .andExpect(jsonPath("$.result.sourceId").value(31))
+                .andExpect(jsonPath("$.result.recordedAt")
+                        .value("2026-07-24T15:00:00Z"))
+                .andExpect(jsonPath("$.result.replay").value(true));
+    }
+
+    @Test
+    @DisplayName("다른 payload conflict는 기존 Source나 private 값을 노출하지 않는다")
+    void returnsConflictWithoutSensitiveResult() throws Exception {
+        when(quickRecordFacade.record(
+                eq("conflict-key"),
+                argThat(command -> true)
+        )).thenThrow(new DomainException(
+                QuickRecordError.IDEMPOTENCY_KEY_PAYLOAD_CONFLICT
+        ));
+
+        mockMvc.perform(request(
+                        "conflict-key",
+                        collectionRequest(),
+                        true
+                ))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code")
+                        .value("IDEM-409-KEY-PAYLOAD-CONFLICT"))
+                .andExpect(content().string(
+                        org.hamcrest.Matchers.not(
+                                org.hamcrest.Matchers.containsString(
+                                        "Private collection title"
+                                )
+                        )
+                ))
+                .andExpect(content().string(
+                        org.hamcrest.Matchers.not(
+                                org.hamcrest.Matchers.containsString(
+                                        "sourceId"
+                                )
+                        )
+                ));
+    }
+
+    private void mockInvalid(String key) {
+        when(quickRecordFacade.record(
+                eq(key),
+                argThat(command -> true)
+        )).thenThrow(new DomainException(
+                QuickRecordError.INVALID_REQUEST
+        ));
+    }
+
+    private MockHttpServletRequestBuilder request(
+            String idempotencyKey,
+            QuickRecordRequest.Create request,
+            boolean authenticated
+    ) throws Exception {
+        MockHttpServletRequestBuilder builder = post(
+                "/api/v1/lifelogs/quick-record"
+        )
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request));
+        if (idempotencyKey != null) {
+            builder.header("Idempotency-Key", idempotencyKey);
+        }
+        if (authenticated) {
+            builder.with(authentication(
+                    new UsernamePasswordAuthenticationToken(
+                            new JwtPrincipal(201L, 201001L),
+                            null,
+                            List.of(new SimpleGrantedAuthority(
+                                    "ROLE_USER"
+                            ))
+                    )
+            ));
+            builder.header("Authorization", "Bearer test-token");
+        }
+        return builder;
+    }
+
+    private QuickRecordRequest.Create collectionRequest() {
+        return new QuickRecordRequest.Create(
+                "COLLECTION",
+                collectionPayload(),
+                null,
+                null
+        );
+    }
+
+    private PlayerCollectionRequest.Create collectionPayload() {
+        return new PlayerCollectionRequest.Create(
+                "BOOK",
+                "Private collection title",
+                null,
+                1,
+                null,
+                null,
+                Set.of("private-tag")
+        );
+    }
+
+    private PlayerExerciseRequest.Create exercisePayload() {
+        return new PlayerExerciseRequest.Create(
+                "RUNNING",
+                30,
+                5.0,
+                250,
+                LocalDate.of(2026, 7, 24),
+                null
+        );
+    }
+
+    private QuickRecordResult.Recorded result(boolean replay) {
+        return new QuickRecordResult.Recorded(
+                LifeLogType.COLLECTION,
+                31L,
+                RECORDED_AT,
+                replay
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/lifelog/quick/application/QuickRecordRequestHasherTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/quick/application/QuickRecordRequestHasherTest.java
@@ -1,0 +1,209 @@
+package online.lifeasgame.lifelog.quick.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.lifelog.application.command.CollectionCommand;
+import online.lifeasgame.lifelog.application.command.ExerciseCommand;
+import online.lifeasgame.lifelog.application.command.MediaLogCommand;
+import online.lifeasgame.lifelog.domain.event.LifeLogType;
+import online.lifeasgame.lifelog.quick.domain.error.QuickRecordError;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("QuickRecord request selection과 canonical hash")
+class QuickRecordRequestHasherTest {
+
+    private final QuickRecordRequestHasher hasher =
+            new QuickRecordRequestHasher();
+
+    @Test
+    @DisplayName("type과 일치하는 payload 하나만 선택한다")
+    void selectsExactlyOneMatchingPayload() {
+        QuickRecordCommand.Selected selected = new QuickRecordCommand.Create(
+                " collection ",
+                collection("title", Set.of("tag")),
+                null,
+                null
+        ).selected();
+
+        assertThat(selected.type()).isEqualTo(LifeLogType.COLLECTION);
+        assertThat(selected.collection()).isNotNull();
+        assertThat(selected.exercise()).isNull();
+        assertThat(selected.media()).isNull();
+    }
+
+    @Test
+    @DisplayName("payload 없음, 복수 payload, type 불일치를 모두 거부한다")
+    void rejectsInvalidPayloadShape() {
+        assertInvalid(new QuickRecordCommand.Create(
+                "COLLECTION", null, null, null
+        ));
+        assertInvalid(new QuickRecordCommand.Create(
+                "COLLECTION",
+                collection("title", Set.of()),
+                exercise(),
+                null
+        ));
+        assertInvalid(new QuickRecordCommand.Create(
+                "COLLECTION", null, exercise(), null
+        ));
+        assertInvalid(new QuickRecordCommand.Create(
+                "DIARY",
+                collection("title", Set.of()),
+                null,
+                null
+        ));
+    }
+
+    @Test
+    @DisplayName("공백, enum 표기, tags 순서와 중복 정규화 후 hash가 같다")
+    void normalizesCollectionPayload() {
+        Set<String> firstTags = new LinkedHashSet<>();
+        firstTags.add(" Daily ");
+        firstTags.add("BOOK");
+        Set<String> secondTags = new LinkedHashSet<>();
+        secondTags.add("book");
+        secondTags.add("daily");
+        secondTags.add("DAILY");
+
+        String first = hash(new QuickRecordCommand.Create(
+                " collection ",
+                new CollectionCommand.Create(
+                        " book ",
+                        "  title  ",
+                        "   ",
+                        1,
+                        " condition ",
+                        " source ",
+                        firstTags
+                ),
+                null,
+                null
+        ));
+        String second = hash(new QuickRecordCommand.Create(
+                "COLLECTION",
+                new CollectionCommand.Create(
+                        "BOOK",
+                        "title",
+                        null,
+                        1,
+                        "condition",
+                        "source",
+                        secondTags
+                ),
+                null,
+                null
+        ));
+
+        assertThat(first)
+                .hasSize(64)
+                .matches("[0-9a-f]{64}")
+                .isEqualTo(second);
+    }
+
+    @Test
+    @DisplayName("선택된 subtype payload 전체가 hash에 반영된다")
+    void hashesAllSelectedPayloadFields() {
+        String collection = hash(new QuickRecordCommand.Create(
+                "COLLECTION",
+                collection("title", Set.of("tag")),
+                null,
+                null
+        ));
+        String changedCollection = hash(new QuickRecordCommand.Create(
+                "COLLECTION",
+                collection("changed", Set.of("tag")),
+                null,
+                null
+        ));
+        String exercise = hash(new QuickRecordCommand.Create(
+                "EXERCISE", null, exercise(), null
+        ));
+        String media = hash(new QuickRecordCommand.Create(
+                "MEDIA", null, null, media()
+        ));
+
+        assertThat(Set.of(
+                collection,
+                changedCollection,
+                exercise,
+                media
+        )).hasSize(4);
+    }
+
+    @Test
+    @DisplayName("길이 prefix가 필드 경계와 구분자 충돌을 방지한다")
+    void preventsFieldBoundaryCollisions() {
+        String first = hash(new QuickRecordCommand.Create(
+                "COLLECTION",
+                collection("a;4:tags=text:1:b", Set.of("c")),
+                null,
+                null
+        ));
+        String second = hash(new QuickRecordCommand.Create(
+                "COLLECTION",
+                collection("a", Set.of("b;4:tags=text:1:c")),
+                null,
+                null
+        ));
+
+        assertThat(first).isNotEqualTo(second);
+    }
+
+    private String hash(QuickRecordCommand.Create command) {
+        return hasher.hash(command.selected());
+    }
+
+    private void assertInvalid(QuickRecordCommand.Create command) {
+        assertThatThrownBy(command::selected)
+                .isInstanceOfSatisfying(
+                        DomainException.class,
+                        exception -> assertThat(exception.getErrorCode())
+                                .isEqualTo(QuickRecordError.INVALID_REQUEST)
+                );
+    }
+
+    private CollectionCommand.Create collection(
+            String title,
+            Set<String> tags
+    ) {
+        return new CollectionCommand.Create(
+                "BOOK",
+                title,
+                null,
+                1,
+                null,
+                null,
+                tags
+        );
+    }
+
+    private ExerciseCommand.Create exercise() {
+        return new ExerciseCommand.Create(
+                "RUNNING",
+                30,
+                5.0,
+                250,
+                LocalDate.of(2026, 7, 24),
+                "memo"
+        );
+    }
+
+    private MediaLogCommand.Create media() {
+        return new MediaLogCommand.Create(
+                "MOVIE",
+                "title",
+                null,
+                0,
+                1,
+                "PLANNED",
+                Set.of("tag")
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/lifelog/quick/application/QuickRecordServiceIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/quick/application/QuickRecordServiceIntegrationTest.java
@@ -1,0 +1,750 @@
+package online.lifeasgame.lifelog.quick.application;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.event.DomainEvent;
+import online.lifeasgame.core.event.DomainEventPublisher;
+import online.lifeasgame.lifelog.application.command.CollectionCommand;
+import online.lifeasgame.lifelog.application.command.ExerciseCommand;
+import online.lifeasgame.lifelog.application.command.MediaLogCommand;
+import online.lifeasgame.lifelog.domain.event.LifeLogType;
+import online.lifeasgame.lifelog.quick.domain.QuickRecordRequestReceipt;
+import online.lifeasgame.lifelog.quick.domain.error.QuickRecordError;
+import online.lifeasgame.lifelog.quick.domain.repository.QuickRecordRequestReceiptRepository;
+import online.lifeasgame.platform.outbox.application.OutboxRelayScheduler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles({"test", "migration-test"})
+@Import(QuickRecordServiceIntegrationTest.QuickRecordTestConfiguration.class)
+@DisplayName("QuickRecord MySQL subtype dispatch와 멱등성")
+class QuickRecordServiceIntegrationTest {
+
+    private static final String RECORDED_ALIAS = "lifelog.recorded.v1";
+    private static final String COLLECTION_ALIAS =
+            "lifelog.collection-logged.v1";
+    private static final String EXERCISE_ALIAS =
+            "lifelog.exercise-logged.v1";
+    private static final String MEDIA_ADVANCED_ALIAS =
+            "lifelog.media-advanced.v1";
+    private static final Long PLAYER_ID = 201001L;
+    private static final Long OTHER_PLAYER_ID = 201002L;
+    private static final Instant RECORDED_AT =
+            Instant.parse("2026-07-24T14:00:00.123456Z");
+
+    @Container
+    private static final MySQLContainer<?> MYSQL =
+            new MySQLContainer<>("mysql:8.0.39")
+                    .withDatabaseName("lifeasgame_quick_record")
+                    .withUsername("lifeasgame")
+                    .withPassword("lifeasgame");
+
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add(
+                "spring.datasource.driver-class-name",
+                MYSQL::getDriverClassName
+        );
+        registry.add("app.outbox.enabled", () -> false);
+    }
+
+    @Autowired
+    private QuickRecordService quickRecordService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private FailingDomainEventPublisher eventPublisher;
+
+    @Autowired
+    private FailingQuickRecordReceiptRepository receiptRepository;
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    private ExecutorService executor;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.update("DELETE FROM quick_record_request_receipts");
+        jdbcTemplate.update("DELETE FROM collection_log_tags");
+        jdbcTemplate.update("DELETE FROM media_log_tags");
+        jdbcTemplate.update("DELETE FROM collection_logs");
+        jdbcTemplate.update("DELETE FROM exercise_logs");
+        jdbcTemplate.update("DELETE FROM media_logs");
+        jdbcTemplate.update("DELETE FROM outbox_events");
+        eventPublisher.reset();
+        receiptRepository.reset();
+        executor = Executors.newFixedThreadPool(2);
+    }
+
+    @AfterEach
+    void tearDown() throws InterruptedException {
+        executor.shutdownNow();
+        assertThat(executor.awaitTermination(5, TimeUnit.SECONDS))
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("Collection Quick Record는 기존 Source와 두 기존 Event만 저장한다")
+    void dispatchesCollectionCreate() throws Exception {
+        QuickRecordResult.Recorded result = quickRecordService.record(
+                PLAYER_ID,
+                "collection-first",
+                collectionCommand("Private collection title")
+        );
+
+        assertFirstResult(result, LifeLogType.COLLECTION);
+        assertThat(count("collection_logs")).isEqualTo(1);
+        assertThat(count("collection_log_tags")).isEqualTo(2);
+        assertThat(count("exercise_logs")).isZero();
+        assertThat(count("media_logs")).isZero();
+        assertThat(receiptCount()).isEqualTo(1);
+        assertThat(outboxCount(RECORDED_ALIAS)).isEqualTo(1);
+        assertThat(outboxCount(COLLECTION_ALIAS)).isEqualTo(1);
+        assertThat(outboxCount()).isEqualTo(2);
+        assertRecordedPayload(result);
+        assertThat(storedReceipt()).isEqualTo(
+                new StoredReceipt(
+                        LifeLogType.COLLECTION.name(),
+                        result.sourceId(),
+                        RECORDED_AT
+                )
+        );
+        assertThat(tableExists("quick_lifelog_entries")).isFalse();
+    }
+
+    @Test
+    @DisplayName("Exercise Quick Record는 기존 Source와 두 기존 Event만 저장한다")
+    void dispatchesExerciseCreate() throws Exception {
+        QuickRecordResult.Recorded result = quickRecordService.record(
+                PLAYER_ID,
+                "exercise-first",
+                exerciseCommand(30)
+        );
+
+        assertFirstResult(result, LifeLogType.EXERCISE);
+        assertThat(count("collection_logs")).isZero();
+        assertThat(count("exercise_logs")).isEqualTo(1);
+        assertThat(count("media_logs")).isZero();
+        assertThat(receiptCount()).isEqualTo(1);
+        assertThat(outboxCount(RECORDED_ALIAS)).isEqualTo(1);
+        assertThat(outboxCount(EXERCISE_ALIAS)).isEqualTo(1);
+        assertThat(outboxCount()).isEqualTo(2);
+        assertRecordedPayload(result);
+    }
+
+    @Test
+    @DisplayName("Media Quick Record는 기존 create 계약의 LifeLogRecorded만 저장한다")
+    void dispatchesMediaCreate() throws Exception {
+        QuickRecordResult.Recorded result = quickRecordService.record(
+                PLAYER_ID,
+                "media-first",
+                mediaCommand("Private media title")
+        );
+
+        assertFirstResult(result, LifeLogType.MEDIA);
+        assertThat(count("collection_logs")).isZero();
+        assertThat(count("exercise_logs")).isZero();
+        assertThat(count("media_logs")).isEqualTo(1);
+        assertThat(count("media_log_tags")).isEqualTo(1);
+        assertThat(receiptCount()).isEqualTo(1);
+        assertThat(outboxCount(RECORDED_ALIAS)).isEqualTo(1);
+        assertThat(outboxCount(MEDIA_ADVANCED_ALIAS)).isZero();
+        assertThat(outboxCount()).isEqualTo(1);
+        assertRecordedPayload(result);
+    }
+
+    @Test
+    @DisplayName("동일 key와 payload 순차 replay는 subtype create와 Event를 반복하지 않는다")
+    void replaysSequentially() {
+        QuickRecordCommand.Create command =
+                collectionCommand("Replay collection");
+        QuickRecordResult.Recorded first = quickRecordService.record(
+                PLAYER_ID,
+                " replay-key ",
+                command
+        );
+        QuickRecordResult.Recorded replay = quickRecordService.record(
+                PLAYER_ID,
+                "replay-key",
+                command
+        );
+
+        assertThat(first.replay()).isFalse();
+        assertThat(replay.replay()).isTrue();
+        assertSameSnapshot(first, replay);
+        assertThat(count("collection_logs")).isEqualTo(1);
+        assertThat(receiptCount()).isEqualTo(1);
+        assertThat(outboxCount(RECORDED_ALIAS)).isEqualTo(1);
+        assertThat(outboxCount(COLLECTION_ALIAS)).isEqualTo(1);
+        assertThat(outboxCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("동일 key의 다른 payload와 다른 subtype은 기존 Source를 보존하고 409다")
+    void conflictsSequentially() {
+        QuickRecordResult.Recorded winner = quickRecordService.record(
+                PLAYER_ID,
+                "conflict-key",
+                collectionCommand("Winner collection")
+        );
+        StoredReceipt before = storedReceipt();
+
+        assertConflict(() -> quickRecordService.record(
+                PLAYER_ID,
+                "conflict-key",
+                collectionCommand("Changed collection")
+        ));
+        assertConflict(() -> quickRecordService.record(
+                PLAYER_ID,
+                "conflict-key",
+                mediaCommand("Other subtype")
+        ));
+
+        assertThat(storedReceipt()).isEqualTo(before);
+        assertThat(storedReceipt().sourceId())
+                .isEqualTo(winner.sourceId());
+        assertThat(storedCollectionTitle())
+                .isEqualTo("Winner collection");
+        assertThat(count("collection_logs")).isEqualTo(1);
+        assertThat(count("media_logs")).isZero();
+        assertThat(receiptCount()).isEqualTo(1);
+        assertThat(outboxCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("다른 Player는 같은 key로 독립 Source를 생성한다")
+    void scopesKeyByPlayer() {
+        QuickRecordResult.Recorded first = quickRecordService.record(
+                PLAYER_ID,
+                "shared-key",
+                mediaCommand("First player")
+        );
+        QuickRecordResult.Recorded second = quickRecordService.record(
+                OTHER_PLAYER_ID,
+                "shared-key",
+                mediaCommand("Second player")
+        );
+
+        assertThat(first.sourceId()).isNotEqualTo(second.sourceId());
+        assertThat(count("media_logs")).isEqualTo(2);
+        assertThat(receiptCount()).isEqualTo(2);
+        assertThat(outboxCount(RECORDED_ALIAS)).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("같은 key와 payload 동시 요청은 Source 1건과 replay 1건을 만든다")
+    void serializesSamePayloadConcurrently() throws Exception {
+        QuickRecordCommand.Create command =
+                mediaCommand("Concurrent same media");
+
+        List<QuickRecordResult.Recorded> results = runConcurrently(
+                () -> quickRecordService.record(
+                        PLAYER_ID,
+                        "concurrent-same",
+                        command
+                ),
+                () -> quickRecordService.record(
+                        PLAYER_ID,
+                        "concurrent-same",
+                        command
+                )
+        );
+
+        assertThat(results)
+                .extracting(QuickRecordResult.Recorded::replay)
+                .containsExactlyInAnyOrder(false, true);
+        assertSameSnapshot(results.getFirst(), results.getLast());
+        assertThat(count("media_logs")).isEqualTo(1);
+        assertThat(receiptCount()).isEqualTo(1);
+        assertThat(outboxCount(RECORDED_ALIAS)).isEqualTo(1);
+        assertThat(outboxCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("같은 key와 다른 payload 동시 요청은 승자 Source만 남긴다")
+    void conflictsDifferentPayloadConcurrently() throws Exception {
+        List<ConcurrentOutcome> outcomes = runConcurrently(
+                () -> capture(() -> quickRecordService.record(
+                        PLAYER_ID,
+                        "concurrent-conflict",
+                        collectionCommand("Concurrent first")
+                )),
+                () -> capture(() -> quickRecordService.record(
+                        PLAYER_ID,
+                        "concurrent-conflict",
+                        collectionCommand("Concurrent second")
+                ))
+        );
+
+        assertThat(outcomes)
+                .filteredOn(outcome -> outcome.result() != null)
+                .singleElement()
+                .satisfies(outcome ->
+                        assertThat(outcome.result().replay()).isFalse()
+                );
+        assertThat(outcomes)
+                .filteredOn(outcome -> outcome.error() != null)
+                .singleElement()
+                .satisfies(outcome ->
+                        assertThat(outcome.error().getErrorCode())
+                                .isEqualTo(
+                                        QuickRecordError
+                                                .IDEMPOTENCY_KEY_PAYLOAD_CONFLICT
+                                )
+                );
+        assertThat(storedCollectionTitle())
+                .isIn("Concurrent first", "Concurrent second");
+        assertThat(count("collection_logs")).isEqualTo(1);
+        assertThat(receiptCount()).isEqualTo(1);
+        assertThat(outboxCount(RECORDED_ALIAS)).isEqualTo(1);
+        assertThat(outboxCount(COLLECTION_ALIAS)).isEqualTo(1);
+        assertThat(outboxCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("기존 subtype validation 실패는 예약 Receipt까지 rollback한다")
+    void rollsBackSubtypeValidationFailure() {
+        assertThatThrownBy(() -> quickRecordService.record(
+                PLAYER_ID,
+                "validation-failure",
+                exerciseCommand(0)
+        )).isInstanceOf(IllegalStateException.class);
+
+        assertNoQuickRecordMutation();
+    }
+
+    @Test
+    @DisplayName("Receipt result 저장 실패는 subtype과 기존 Event를 함께 rollback한다")
+    void rollsBackReceiptFailure() {
+        receiptRepository.failNextCompletion();
+
+        assertThatThrownBy(() -> quickRecordService.record(
+                PLAYER_ID,
+                "receipt-failure",
+                collectionCommand("Receipt rollback")
+        )).isInstanceOf(IllegalStateException.class)
+                .hasMessage("forced receipt failure");
+
+        assertNoQuickRecordMutation();
+    }
+
+    @Test
+    @DisplayName("Outbox append 실패는 subtype과 Receipt를 함께 rollback한다")
+    void rollsBackOutboxFailure() {
+        eventPublisher.failNext();
+
+        assertThatThrownBy(() -> quickRecordService.record(
+                PLAYER_ID,
+                "outbox-failure",
+                mediaCommand("Outbox rollback")
+        )).isInstanceOf(IllegalStateException.class)
+                .hasMessage("forced outbox failure");
+
+        assertNoQuickRecordMutation();
+    }
+
+    @Test
+    @DisplayName("통합 테스트 profile은 Outbox Scheduler를 비활성화한다")
+    void disablesScheduler() {
+        assertThat(applicationContext.getBeansOfType(
+                OutboxRelayScheduler.class
+        )).isEmpty();
+    }
+
+    private QuickRecordCommand.Create collectionCommand(String title) {
+        return new QuickRecordCommand.Create(
+                "COLLECTION",
+                new CollectionCommand.Create(
+                        "BOOK",
+                        title,
+                        "Private original",
+                        1,
+                        "Private condition",
+                        "Private source",
+                        Set.of(" Daily ", "BOOK")
+                ),
+                null,
+                null
+        );
+    }
+
+    private QuickRecordCommand.Create exerciseCommand(
+            int durationMinutes
+    ) {
+        return new QuickRecordCommand.Create(
+                "EXERCISE",
+                null,
+                new ExerciseCommand.Create(
+                        "RUNNING",
+                        durationMinutes,
+                        5.0,
+                        250,
+                        LocalDate.of(2026, 7, 24),
+                        "Private memo"
+                ),
+                null
+        );
+    }
+
+    private QuickRecordCommand.Create mediaCommand(String title) {
+        return new QuickRecordCommand.Create(
+                "MEDIA",
+                null,
+                null,
+                new MediaLogCommand.Create(
+                        "MOVIE",
+                        title,
+                        "Private original",
+                        0,
+                        1,
+                        "PLANNED",
+                        Set.of("private-tag")
+                )
+        );
+    }
+
+    private void assertFirstResult(
+            QuickRecordResult.Recorded result,
+            LifeLogType type
+    ) {
+        assertThat(result.sourceType()).isEqualTo(type);
+        assertThat(result.sourceId()).isPositive();
+        assertThat(result.recordedAt()).isEqualTo(RECORDED_AT);
+        assertThat(result.replay()).isFalse();
+    }
+
+    private void assertSameSnapshot(
+            QuickRecordResult.Recorded first,
+            QuickRecordResult.Recorded second
+    ) {
+        assertThat(second.sourceType()).isEqualTo(first.sourceType());
+        assertThat(second.sourceId()).isEqualTo(first.sourceId());
+        assertThat(second.recordedAt()).isEqualTo(first.recordedAt());
+    }
+
+    private void assertConflict(Callable<?> call) {
+        assertThatThrownBy(call::call)
+                .isInstanceOfSatisfying(
+                        DomainException.class,
+                        exception -> {
+                            assertThat(exception.getErrorCode())
+                                    .isEqualTo(
+                                            QuickRecordError
+                                                    .IDEMPOTENCY_KEY_PAYLOAD_CONFLICT
+                                    );
+                            assertThat(exception.detail()).isNull();
+                        }
+                );
+    }
+
+    private void assertNoQuickRecordMutation() {
+        assertThat(count("collection_logs")).isZero();
+        assertThat(count("exercise_logs")).isZero();
+        assertThat(count("media_logs")).isZero();
+        assertThat(receiptCount()).isZero();
+        assertThat(outboxCount()).isZero();
+    }
+
+    private ConcurrentOutcome capture(
+            Callable<QuickRecordResult.Recorded> call
+    ) {
+        try {
+            return new ConcurrentOutcome(call.call(), null);
+        } catch (DomainException exception) {
+            return new ConcurrentOutcome(null, exception);
+        } catch (Exception exception) {
+            throw new IllegalStateException(exception);
+        }
+    }
+
+    private <T> List<T> runConcurrently(
+            Callable<T> first,
+            Callable<T> second
+    ) throws Exception {
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        Future<T> firstFuture = executor.submit(() -> {
+            ready.countDown();
+            start.await();
+            return first.call();
+        });
+        Future<T> secondFuture = executor.submit(() -> {
+            ready.countDown();
+            start.await();
+            return second.call();
+        });
+        assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+        start.countDown();
+        return List.of(
+                firstFuture.get(20, TimeUnit.SECONDS),
+                secondFuture.get(20, TimeUnit.SECONDS)
+        );
+    }
+
+    private void assertRecordedPayload(
+            QuickRecordResult.Recorded result
+    ) throws Exception {
+        String payload = jdbcTemplate.queryForObject(
+                """
+                SELECT payload
+                FROM outbox_events
+                WHERE event_type = ?
+                """,
+                String.class,
+                RECORDED_ALIAS
+        );
+        JsonNode json = objectMapper.readTree(payload);
+        assertThat(json.get("playerId").asLong()).isEqualTo(PLAYER_ID);
+        assertThat(json.get("lifeLogId").asLong())
+                .isEqualTo(result.sourceId());
+        assertThat(json.get("lifeLogType").asText())
+                .isEqualTo(result.sourceType().name());
+        assertThat(json.get("occurredAt").asText())
+                .isEqualTo(RECORDED_AT.toString());
+    }
+
+    private int count(String table) {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM " + table,
+                Integer.class
+        );
+    }
+
+    private int receiptCount() {
+        return count("quick_record_request_receipts");
+    }
+
+    private int outboxCount() {
+        return count("outbox_events");
+    }
+
+    private int outboxCount(String alias) {
+        return jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM outbox_events
+                WHERE event_type = ?
+                """,
+                Integer.class,
+                alias
+        );
+    }
+
+    private String storedCollectionTitle() {
+        return jdbcTemplate.queryForObject(
+                "SELECT title_value FROM collection_logs",
+                String.class
+        );
+    }
+
+    private StoredReceipt storedReceipt() {
+        return jdbcTemplate.queryForObject(
+                """
+                SELECT source_type, source_id, recorded_at
+                FROM quick_record_request_receipts
+                """,
+                (resultSet, rowNum) -> new StoredReceipt(
+                        resultSet.getString("source_type"),
+                        resultSet.getLong("source_id"),
+                        resultSet.getObject(
+                                        "recorded_at",
+                                        LocalDateTime.class
+                                )
+                                .toInstant(ZoneOffset.UTC)
+                )
+        );
+    }
+
+    private boolean tableExists(String table) {
+        return jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*) > 0
+                FROM information_schema.tables
+                WHERE table_schema = DATABASE()
+                  AND table_name = ?
+                """,
+                Boolean.class,
+                table
+        );
+    }
+
+    private record StoredReceipt(
+            String sourceType,
+            Long sourceId,
+            Instant recordedAt
+    ) {
+    }
+
+    private record ConcurrentOutcome(
+            QuickRecordResult.Recorded result,
+            DomainException error
+    ) {
+    }
+
+    @TestConfiguration
+    static class QuickRecordTestConfiguration {
+
+        @Bean
+        @Primary
+        Clock quickRecordTestClock() {
+            return Clock.fixed(RECORDED_AT, ZoneOffset.UTC);
+        }
+
+        @Bean
+        @Primary
+        FailingDomainEventPublisher quickRecordEventPublisher(
+                @Qualifier("transactionalOutboxDomainEventPublisher")
+                DomainEventPublisher delegate
+        ) {
+            return new FailingDomainEventPublisher(delegate);
+        }
+
+        @Bean
+        @Primary
+        FailingQuickRecordReceiptRepository
+        quickRecordReceiptRepository(
+                @Qualifier("quickRecordRequestReceiptRepositoryAdapter")
+                QuickRecordRequestReceiptRepository delegate
+        ) {
+            return new FailingQuickRecordReceiptRepository(delegate);
+        }
+    }
+
+    static class FailingDomainEventPublisher
+            implements DomainEventPublisher {
+
+        private final DomainEventPublisher delegate;
+        private final AtomicBoolean failNext = new AtomicBoolean();
+
+        FailingDomainEventPublisher(DomainEventPublisher delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void publish(DomainEvent event) {
+            if (failNext.getAndSet(false)) {
+                throw new IllegalStateException(
+                        "forced outbox failure"
+                );
+            }
+            delegate.publish(event);
+        }
+
+        void failNext() {
+            failNext.set(true);
+        }
+
+        void reset() {
+            failNext.set(false);
+        }
+    }
+
+    static class FailingQuickRecordReceiptRepository
+            implements QuickRecordRequestReceiptRepository {
+
+        private final QuickRecordRequestReceiptRepository delegate;
+        private final AtomicBoolean failNextCompletion =
+                new AtomicBoolean();
+
+        FailingQuickRecordReceiptRepository(
+                QuickRecordRequestReceiptRepository delegate
+        ) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void reserve(
+                Long playerId,
+                String idempotencyKey,
+                String requestHash,
+                Instant reservedAt
+        ) {
+            delegate.reserve(
+                    playerId,
+                    idempotencyKey,
+                    requestHash,
+                    reservedAt
+            );
+        }
+
+        @Override
+        public Optional<QuickRecordRequestReceipt>
+        findByIdentityForUpdate(
+                Long playerId,
+                String idempotencyKey
+        ) {
+            return delegate.findByIdentityForUpdate(
+                    playerId,
+                    idempotencyKey
+            );
+        }
+
+        @Override
+        public QuickRecordRequestReceipt saveAndFlush(
+                QuickRecordRequestReceipt receipt
+        ) {
+            if (failNextCompletion.getAndSet(false)) {
+                throw new IllegalStateException(
+                        "forced receipt failure"
+                );
+            }
+            return delegate.saveAndFlush(receipt);
+        }
+
+        void failNextCompletion() {
+            failNextCompletion.set(true);
+        }
+
+        void reset() {
+            failNextCompletion.set(false);
+        }
+    }
+}

--- a/src/test/java/online/lifeasgame/lifelog/quick/domain/QuickRecordRequestReceiptTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/quick/domain/QuickRecordRequestReceiptTest.java
@@ -1,0 +1,99 @@
+package online.lifeasgame.lifelog.quick.domain;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.lifelog.domain.event.LifeLogType;
+import online.lifeasgame.lifelog.quick.domain.error.QuickRecordError;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("QuickRecordRequestReceipt")
+class QuickRecordRequestReceiptTest {
+
+    private static final String HASH = "a".repeat(64);
+    private static final Instant RECORDED_AT =
+            Instant.parse("2026-07-24T13:00:00Z");
+
+    @Test
+    @DisplayName("동일 hash replay는 실제 Source snapshot을 반환한다")
+    void replaysStoredSource() {
+        QuickRecordRequestReceipt receipt =
+                QuickRecordRequestReceipt.reserve(
+                        201L,
+                        " key-201 ",
+                        HASH
+                );
+        receipt.complete(
+                LifeLogType.MEDIA,
+                31L,
+                RECORDED_AT
+        );
+
+        QuickRecordRequestReceipt.StoredResult replay =
+                receipt.replay(HASH);
+
+        assertThat(receipt.getIdempotencyKey()).isEqualTo("key-201");
+        assertThat(replay.sourceType()).isEqualTo(LifeLogType.MEDIA);
+        assertThat(replay.sourceId()).isEqualTo(31L);
+        assertThat(replay.recordedAt()).isEqualTo(RECORDED_AT);
+    }
+
+    @Test
+    @DisplayName("다른 hash는 저장 결과를 노출하지 않고 conflict로 거부한다")
+    void rejectsDifferentPayloadHash() {
+        QuickRecordRequestReceipt receipt =
+                QuickRecordRequestReceipt.reserve(
+                        201L,
+                        "key-201",
+                        HASH
+                );
+        receipt.complete(
+                LifeLogType.EXERCISE,
+                31L,
+                RECORDED_AT
+        );
+
+        assertThatThrownBy(() -> receipt.replay("b".repeat(64)))
+                .isInstanceOfSatisfying(
+                        DomainException.class,
+                        exception -> {
+                            assertThat(exception.getErrorCode())
+                                    .isEqualTo(
+                                            QuickRecordError
+                                                    .IDEMPOTENCY_KEY_PAYLOAD_CONFLICT
+                                    );
+                            assertThat(exception.detail()).isNull();
+                        }
+                );
+    }
+
+    @Test
+    @DisplayName("Idempotency-Key 필수와 DB column 길이를 검증한다")
+    void validatesIdempotencyKey() {
+        assertThatThrownBy(() ->
+                QuickRecordRequestReceipt.normalizeIdempotencyKey(" ")
+        ).isInstanceOfSatisfying(
+                DomainException.class,
+                exception -> assertThat(exception.getErrorCode())
+                        .isEqualTo(
+                                QuickRecordError.IDEMPOTENCY_KEY_REQUIRED
+                        )
+        );
+        assertThatThrownBy(() ->
+                QuickRecordRequestReceipt.normalizeIdempotencyKey(
+                        "a".repeat(
+                                QuickRecordRequestReceipt
+                                        .IDEMPOTENCY_KEY_MAX_LENGTH + 1
+                        )
+                )
+        ).isInstanceOfSatisfying(
+                DomainException.class,
+                exception -> assertThat(exception.getErrorCode())
+                        .isEqualTo(QuickRecordError.INVALID_REQUEST)
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
@@ -63,7 +63,7 @@ class FlywayExplicitBaselineTest {
     class ApplyExplicitBaseline {
 
         @Test
-        @DisplayName("V1을 재실행하지 않고 V2부터 V8까지 적용한 뒤 JPA validate를 통과한다")
+        @DisplayName("V1을 재실행하지 않고 V2부터 V9까지 적용한 뒤 JPA validate를 통과한다")
         void migratesFromVersionTwoAndValidatesJpa() throws Exception {
             String jdbcUrl = createV1EquivalentDatabase();
             Flyway flyway = migrationFlyway(jdbcUrl);
@@ -72,9 +72,12 @@ class FlywayExplicitBaselineTest {
             MigrateResult migrateResult = flyway.migrate();
             List<HistoryRow> history = successfulHistory(jdbcUrl);
 
-            assertThat(migrateResult.migrationsExecuted).isEqualTo(7);
+            assertThat(migrateResult.migrationsExecuted).isEqualTo(8);
             assertThat(history).extracting(HistoryRow::version)
-                    .containsExactly("1", "2", "3", "4", "5", "6", "7", "8");
+                    .containsExactly(
+                            "1", "2", "3", "4", "5",
+                            "6", "7", "8", "9"
+                    );
             assertThat(history.getFirst().type()).isEqualTo("BASELINE");
             assertThat(history.getFirst().script())
                     .isEqualTo("baseline current production schema");
@@ -91,7 +94,8 @@ class FlywayExplicitBaselineTest {
                             "V5__reward_none_profile.sql",
                             "V6__quest_state_contract.sql",
                             "V7__quest_signal_receipt.sql",
-                            "V8__transactional_outbox.sql"
+                            "V8__transactional_outbox.sql",
+                            "V9__quick_lifelog_record.sql"
                     );
             assertThat(history.subList(1, history.size()))
                     .allSatisfy(row -> assertThat(row.checksum()).isNotNull());
@@ -111,7 +115,7 @@ class FlywayExplicitBaselineTest {
                         "spring.jpa.hibernate.ddl-auto"
                 )).isEqualTo("validate");
                 assertThat(context.getBean(Flyway.class).info().current().getVersion().getVersion())
-                        .isEqualTo("8");
+                        .isEqualTo("9");
             }
         }
     }

--- a/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
@@ -32,7 +32,7 @@ class FlywayHistoryChecksumTest {
     class MigrateAgain {
 
         @Test
-        @DisplayName("두 번째 실행은 no-op이고 V1부터 V8까지 checksum history를 유지한다")
+        @DisplayName("두 번째 실행은 no-op이고 V1부터 V9까지 checksum history를 유지한다")
         void keepsMigrationHistory() throws Exception {
             Flyway flyway = flyway();
 
@@ -42,11 +42,14 @@ class FlywayHistoryChecksumTest {
             MigrateResult second = flyway.migrate();
             List<HistoryRow> secondHistory = successfulHistory();
 
-            assertThat(first.migrationsExecuted).isEqualTo(8);
+            assertThat(first.migrationsExecuted).isEqualTo(9);
             assertThat(second.migrationsExecuted).isZero();
             assertThat(secondHistory).isEqualTo(firstHistory);
             assertThat(secondHistory).extracting(HistoryRow::version)
-                    .containsExactly("1", "2", "3", "4", "5", "6", "7", "8");
+                    .containsExactly(
+                            "1", "2", "3", "4", "5",
+                            "6", "7", "8", "9"
+                    );
             assertThat(secondHistory).allSatisfy(history -> {
                 assertThat(history.checksum()).isNotNull();
                 assertThat(history.success()).isTrue();

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -37,15 +37,18 @@ class FlywayMigrationTest {
     class MigrateCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V8까지 적용되고 Outbox 조회 제약과 Index가 생성된다")
+        @DisplayName("V1부터 V9까지 적용되고 Quick Record Receipt unique가 생성된다")
         void migratesSchemaAndSeedsRewardProfiles() throws Exception {
             Flyway flyway = flyway();
 
             MigrateResult result = flyway.migrate();
 
-            assertThat(result.migrationsExecuted).isEqualTo(8);
+            assertThat(result.migrationsExecuted).isEqualTo(9);
             assertThat(appliedVersions())
-                    .containsExactly("1", "2", "3", "4", "5", "6", "7", "8");
+                    .containsExactly(
+                            "1", "2", "3", "4", "5",
+                            "6", "7", "8", "9"
+                    );
             assertThat(existingTables(
                     "users",
                     "player",
@@ -59,7 +62,8 @@ class FlywayMigrationTest {
                     "reward_settlement_lines",
                     "player_growth_changes",
                     "quest_signal_receipts",
-                    "outbox_events"
+                    "outbox_events",
+                    "quick_record_request_receipts"
             )).containsExactlyInAnyOrder(
                     "users",
                     "player",
@@ -73,8 +77,14 @@ class FlywayMigrationTest {
                     "reward_settlement_lines",
                     "player_growth_changes",
                     "quest_signal_receipts",
-                    "outbox_events"
+                    "outbox_events",
+                    "quick_record_request_receipts"
             );
+            assertThat(existingTables(
+                    "quick_lifelog_entries",
+                    "quick_lifelog_entry_tags",
+                    "quick_lifelog_request_receipts"
+            )).isEmpty();
             assertThat(seedProfileCodes()).containsExactly("RP_EXP_10", "RP_EXP_30");
             assertThat(noRewardProfile()).isEqualTo(new NoRewardProfile("ACTIVE", 0));
             assertThat(uniqueIndexColumns("reward_settlements", "uq_reward_settlement_source"))
@@ -111,6 +121,10 @@ class FlywayMigrationTest {
                     "outbox_events",
                     "idx_outbox_event_lease"
             )).containsExactly("status", "locked_at");
+            assertThat(uniqueIndexColumns(
+                    "quick_record_request_receipts",
+                    "uq_quick_record_request_receipt_identity"
+            )).containsExactly("player_id", "idempotency_key");
             insertSettlementIdentity();
             assertThatThrownBy(FlywayMigrationTest.this::insertSettlementIdentity)
                     .isInstanceOfSatisfying(SQLException.class, exception ->

--- a/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
-import java.sql.Statement;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -150,7 +149,7 @@ class FlywayProfileCutoverTest {
     class StartLocalWithCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V8까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
+        @DisplayName("V1부터 V9까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
         void migratesThenValidates() {
             ConfigurableEnvironment environment =
                     (ConfigurableEnvironment) applicationContext.getEnvironment();
@@ -162,8 +161,8 @@ class FlywayProfileCutoverTest {
             assertThat(environment.getProperty(
                     "spring.flyway.baseline-on-migrate", Boolean.class
             )).isFalse();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("8");
-            assertThat(appliedMigrationCount()).isEqualTo(8);
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("9");
+            assertThat(appliedMigrationCount()).isEqualTo(9);
         }
     }
 

--- a/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 @SpringBootTest
 @ActiveProfiles({"test", "migration-test"})
-@DisplayName("V8 migration 이후 JPA schema validation")
+@DisplayName("V9 migration 이후 JPA schema validation")
 class JpaValidateAfterMigrationTest {
 
     @Container
@@ -61,14 +61,14 @@ class JpaValidateAfterMigrationTest {
     private RewardSettlementReader rewardSettlementReader;
 
     @Nested
-    @DisplayName("V1부터 V8까지 적용된 schema로 ApplicationContext를 기동할 때")
+    @DisplayName("V1부터 V9까지 적용된 schema로 ApplicationContext를 기동할 때")
     class LoadApplicationContext {
 
         @Test
         @DisplayName("ddl-auto validate 상태로 정상 기동한다")
         void loadsWithJpaValidation() {
             assertThat(applicationContext).isNotNull();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("8");
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("9");
             assertThat(applicationContext.getEnvironment().getProperty("spring.jpa.hibernate.ddl-auto"))
                     .isEqualTo("validate");
             assertThat(applicationContext.getEnvironment()


### PR DESCRIPTION
## What

- `POST /api/v1/lifelogs/quick-record` 쓰기 API를 추가했습니다.
- `(playerId, Idempotency-Key)` 기준 영구 멱등 Receipt를 추가했습니다.
- QuickLifeLogEntry, Receipt, LifeLogRecorded Outbox를 같은 Transaction으로 처리합니다.
- 동일 요청 replay와 다른 payload conflict를 구분합니다.
- 동시 요청에서도 Source와 Event가 한 번만 생성되도록 MySQL unique 경계를 적용했습니다.

## API

```text
POST /api/v1/lifelogs/quick-record
Idempotency-Key: required
```

## Idempotency

```text
new request
→ 201 CREATED / replay=false

same key + same payload
→ 200 OK / stored result / replay=true

same key + different payload
→ 409 CONFLICT
```

## Transaction

```text
QuickLifeLogEntry
+ QuickLifeLogRequestReceipt
+ LifeLogRecorded Outbox
→ same commit / same rollback
```

## Migration

- `V9__quick_lifelog_record.sql`
- 기존 V1~V8은 수정하지 않았습니다.

## Test

- [ ] `./gradlew clean test`
- [ ] `./gradlew build`
- [ ] sequential replay/conflict
- [ ] concurrent replay/conflict
- [ ] Entry/Receipt/Outbox atomicity
- [ ] primaryRoleId rejection
- [ ] private payload exclusion
- [ ] V1~V9 checksum / JPA validate

## Out of Scope

- subtype Entity 통합
- Role / Person 구현
- Timeline / Home
- Quest Definition / Seed
- RewardSettlement
- Achievement
- Frontend

Closes #201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a quick life-log recording endpoint supporting collection, exercise, and media entries.
  * Added idempotency-key handling to safely replay requests without creating duplicates.
  * Responses now include the recorded item’s type, ID, timestamp, and replay status.
* **Improvements**
  * Standardized recorded timestamps in collection, exercise, and media results.
  * Authentication failures now return HTTP 401 responses.
* **Bug Fixes**
  * Conflicting payloads using the same idempotency key are rejected with a clear conflict response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->