### PR TITLE
[Quest] Add versioned reward profile reference contract

### DIFF
--- a/src/main/java/online/lifeasgame/quest/api/admin/AdminQuestController.java
+++ b/src/main/java/online/lifeasgame/quest/api/admin/AdminQuestController.java
@@ -56,7 +56,7 @@ public class AdminQuestController implements AdminQuestSpecV1 {
     @PatchMapping("/definitions/{questCode}")
     public ResponseEntity<AdminQuestResponse.Definition> update(
             @PathVariable String questCode,
-            @RequestBody AdminQuestRequest.Update request
+            @Valid @RequestBody AdminQuestRequest.Update request
     ) {
         QuestResult.Definition result = questService.updateDefinition(
                 AdminQuestWebMapper.toUpdateCommand(questCode, request)

--- a/src/main/java/online/lifeasgame/quest/api/admin/mapper/AdminQuestWebMapper.java
+++ b/src/main/java/online/lifeasgame/quest/api/admin/mapper/AdminQuestWebMapper.java
@@ -29,6 +29,8 @@ public final class AdminQuestWebMapper {
                 result.target().value(),
                 result.repeatRule(),
                 result.completionPolicy(),
+                result.definitionVersion(),
+                result.rewardProfileCode(),
                 result.rewardExp(),
                 result.rewardStats(),
                 result.dueAt()
@@ -53,8 +55,10 @@ public final class AdminQuestWebMapper {
     public static QuestCommand.UpdateDefinition toUpdateCommand(String questCode, AdminQuestRequest.Update request) {
         return new QuestCommand.UpdateDefinition(
                 questCode,
+                request.definitionVersion(),
                 request.targetType(),
                 request.targetValue(),
+                request.rewardProfileCode(),
                 request.rewardExp(),
                 request.rewardStats(),
                 request.repeatRule(),
@@ -73,6 +77,8 @@ public final class AdminQuestWebMapper {
                 result.targetValue(),
                 result.repeatRule(),
                 result.completionPolicy(),
+                result.definitionVersion(),
+                result.rewardProfileCode(),
                 result.rewardExp(),
                 result.rewardStats(),
                 result.dueAt()

--- a/src/main/java/online/lifeasgame/quest/api/admin/request/AdminQuestRequest.java
+++ b/src/main/java/online/lifeasgame/quest/api/admin/request/AdminQuestRequest.java
@@ -1,6 +1,7 @@
 package online.lifeasgame.quest.api.admin.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
 import java.time.Instant;
@@ -13,9 +14,11 @@ public final class AdminQuestRequest {
     public record Ensure(@NotBlank String code) {}
 
     public record Update(
+            @Positive Integer definitionVersion,
             String targetType,
             Integer targetValue,
             String repeatRule,
+            @Size(max = 80) String rewardProfileCode,
             Integer rewardExp,
             Map<String, Integer> rewardStats,
             Instant dueAt

--- a/src/main/java/online/lifeasgame/quest/api/admin/response/AdminQuestResponse.java
+++ b/src/main/java/online/lifeasgame/quest/api/admin/response/AdminQuestResponse.java
@@ -18,7 +18,9 @@ public final class AdminQuestResponse {
             int targetValue,
             String repeatRule,
             String completionPolicy,
-            int rewardExp,
+            int definitionVersion,
+            String rewardProfileCode,
+            Integer rewardExp,
             Map<String, Integer> rewardStats,
             Instant dueAt
     ) {
@@ -37,7 +39,9 @@ public final class AdminQuestResponse {
             int targetValue,
             String repeatRule,
             String completionPolicy,
-            int rewardExp,
+            int definitionVersion,
+            String rewardProfileCode,
+            Integer rewardExp,
             Map<String, Integer> rewardStats,
             Instant dueAt
     ) {

--- a/src/main/java/online/lifeasgame/quest/api/admin/spec/AdminQuestSpecV1.java
+++ b/src/main/java/online/lifeasgame/quest/api/admin/spec/AdminQuestSpecV1.java
@@ -13,10 +13,16 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "Admin Quest API V1")
 public interface AdminQuestSpecV1 {
 
-    @Operation(summary = "Quest Blueprint 목록", description = "서버에 정의된 Blueprint(카탈로그 소스) 목록을 조회합니다.")
+    @Operation(
+            summary = "Quest Blueprint 목록",
+            description = "서버에 정의된 Blueprint 목록입니다. rewardProfileCode가 있으면 신규 Profile 계약, null이면 legacy inline reward 계약입니다."
+    )
     ResponseEntity<AdminQuestResponse.Blueprints> catalog();
 
-    @Operation(summary = "Quest Definition 목록", description = "DB에 저장된 Quest Definition 목록을 조회합니다.")
+    @Operation(
+            summary = "Quest Definition 목록",
+            description = "DB Definition 목록입니다. rewardProfileCode가 있으면 신규 Profile 계약, null이면 legacy inline reward 계약입니다."
+    )
     ResponseEntity<AdminQuestResponse.Definitions> definitions();
 
     @Operation(summary = "Quest Definition 생성/보장", description = "Blueprint code 기준으로 Quest Definition을 생성(또는 존재 보장)합니다.")
@@ -25,8 +31,14 @@ public interface AdminQuestSpecV1 {
     @Operation(summary = "Quest Definition 단건 조회", description = "questCode로 Quest Definition을 조회합니다.")
     ResponseEntity<AdminQuestResponse.Definition> definition(String questCode);
 
-    @Operation(summary = "Quest Definition 수정", description = "타겟/보상/반복/마감일을 수정합니다.")
-    ResponseEntity<AdminQuestResponse.Definition> update(String questCode, AdminQuestRequest.Update request);
+    @Operation(
+            summary = "Quest Definition 수정",
+            description = "타겟/버전/Profile 참조/legacy 보상/반복/마감일을 부분 수정합니다. Profile 참조와 legacy 보상은 동시에 변경할 수 없습니다."
+    )
+    ResponseEntity<AdminQuestResponse.Definition> update(
+            String questCode,
+            @Valid @RequestBody AdminQuestRequest.Update request
+    );
 
     @Operation(summary = "Quest Acceptance 목록(quest 기준)", description = "특정 questCode에 대한 Acceptance 목록을 조회합니다. (status 필터 가능)")
     ResponseEntity<AdminQuestResponse.Acceptances> acceptances(String questCode, String status);

--- a/src/main/java/online/lifeasgame/quest/api/player/mapper/QuestWebMapper.java
+++ b/src/main/java/online/lifeasgame/quest/api/player/mapper/QuestWebMapper.java
@@ -37,6 +37,8 @@ public final class QuestWebMapper {
                 result.targetValue(),
                 result.repeatRule(),
                 result.completionPolicy(),
+                result.definitionVersion(),
+                result.rewardProfileCode(),
                 result.rewardExp(),
                 result.rewardStats(),
                 result.dueAt(),
@@ -76,6 +78,8 @@ public final class QuestWebMapper {
                 result.target().value(),
                 result.repeatRule(),
                 result.completionPolicy(),
+                result.definitionVersion(),
+                result.rewardProfileCode(),
                 result.rewardExp(),
                 result.rewardStats(),
                 result.dueAt()

--- a/src/main/java/online/lifeasgame/quest/api/player/response/QuestResponse.java
+++ b/src/main/java/online/lifeasgame/quest/api/player/response/QuestResponse.java
@@ -19,7 +19,9 @@ public final class QuestResponse {
             int targetValue,
             String repeatRule,
             String completionPolicy,
-            int rewardExp,
+            int definitionVersion,
+            String rewardProfileCode,
+            Integer rewardExp,
             Map<String, Integer> rewardStats,
             Instant dueAt
     ) {
@@ -61,7 +63,9 @@ public final class QuestResponse {
             int targetValue,
             String repeatRule,
             String completionPolicy,
-            int rewardExp,
+            int definitionVersion,
+            String rewardProfileCode,
+            Integer rewardExp,
             Map<String, Integer> rewardStats,
             Instant dueAt,
             Acceptance acceptance

--- a/src/main/java/online/lifeasgame/quest/api/player/spec/QuestCatalogSpecV1.java
+++ b/src/main/java/online/lifeasgame/quest/api/player/spec/QuestCatalogSpecV1.java
@@ -8,7 +8,10 @@ import org.springframework.http.ResponseEntity;
 @Tag(name = "Quest API V1")
 public interface QuestCatalogSpecV1 {
 
-    @Operation(summary = "Quest 카탈로그 조회", description = "Quest Blueprint(게시판) 목록을 조회합니다. (필터 선택)")
+    @Operation(
+            summary = "Quest 카탈로그 조회",
+            description = "Quest Blueprint 목록입니다. rewardProfileCode가 있으면 신규 Profile 계약, null이면 legacy inline reward 계약입니다."
+    )
     ResponseEntity<QuestResponse.Blueprints> catalog(
 //            @RequestParam(name = "category", required = false) List<String> categories,
 //            @RequestParam(name = "repeatRule", required = false) List<String> repeatRules

--- a/src/main/java/online/lifeasgame/quest/api/player/spec/QuestSpecV1.java
+++ b/src/main/java/online/lifeasgame/quest/api/player/spec/QuestSpecV1.java
@@ -22,7 +22,10 @@ public interface QuestSpecV1 {
 
     );
 
-    @Operation(summary = "내 퀘스트 상세", description = "Quest 정의 + 플레이어의 최신 Acceptance(있으면)까지 함께 조회합니다.")
+    @Operation(
+            summary = "내 퀘스트 상세",
+            description = "Quest 정의와 최신 Acceptance를 조회합니다. rewardProfileCode가 있으면 신규 Profile 계약, null이면 legacy inline reward 계약입니다."
+    )
     ResponseEntity<QuestResponse.PlayerQuest> detail(
             @PathVariable String questCode
     );

--- a/src/main/java/online/lifeasgame/quest/application/QuestAcceptanceCompletionService.java
+++ b/src/main/java/online/lifeasgame/quest/application/QuestAcceptanceCompletionService.java
@@ -50,6 +50,14 @@ public class QuestAcceptanceCompletionService {
                         .attribute("goalReachedAt", acceptance.getGoalReachedAt())
                         .attribute("completedAt", acceptance.getCompletedAt())
                         .attribute("completionPolicy", quest.getCompletionPolicy().name())
+                        .attribute(
+                                "questDefinitionVersion",
+                                quest.getDefinitionVersion()
+                        )
+                        .attribute(
+                                "rewardProfileCode",
+                                quest.rewardProfileCodeOrNull()
+                        )
                         .occurredAt(acceptance.getCompletedAt())
                         .correlationId(
                                 "quest:%d:acceptance:%d:completed".formatted(

--- a/src/main/java/online/lifeasgame/quest/application/QuestAcceptanceCompletionService.java
+++ b/src/main/java/online/lifeasgame/quest/application/QuestAcceptanceCompletionService.java
@@ -50,14 +50,7 @@ public class QuestAcceptanceCompletionService {
                         .attribute("goalReachedAt", acceptance.getGoalReachedAt())
                         .attribute("completedAt", acceptance.getCompletedAt())
                         .attribute("completionPolicy", quest.getCompletionPolicy().name())
-                        .attribute(
-                                "questDefinitionVersion",
-                                quest.getDefinitionVersion()
-                        )
-                        .attribute(
-                                "rewardProfileCode",
-                                quest.rewardProfileCodeOrNull()
-                        )
+                        .definitionSnapshot(quest)
                         .occurredAt(acceptance.getCompletedAt())
                         .correlationId(
                                 "quest:%d:acceptance:%d:completed".formatted(

--- a/src/main/java/online/lifeasgame/quest/application/QuestService.java
+++ b/src/main/java/online/lifeasgame/quest/application/QuestService.java
@@ -9,6 +9,7 @@ import online.lifeasgame.quest.domain.*;
 import online.lifeasgame.quest.domain.error.QuestError;
 import online.lifeasgame.quest.domain.event.QuestEvent;
 import online.lifeasgame.quest.domain.event.QuestEventType;
+import online.lifeasgame.reward.application.internal.RewardProfileLookupApi;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +29,7 @@ public class QuestService {
     private final QuestBlueprintCatalog questBlueprintCatalog;
     private final QuestReader questReader;
     private final QuestWriter questWriter;
+    private final RewardProfileLookupApi rewardProfileLookupApi;
     private final DomainEventPublisher domainEventPublisher;
 
     @Transactional
@@ -59,15 +61,23 @@ public class QuestService {
     @Transactional
     public QuestResult.Definition updateDefinition(QuestCommand.UpdateDefinition command) {
         Quest quest = ensureQuest(QuestCode.parse(command.questCode()));
+        assertRewardContract(command, quest);
+        RewardProfileRef rewardProfileRef =
+                rewardProfileRefOrNull(command.rewardProfileCode(), quest);
 
         quest.updateDefinition(
                 targetOrNull(command),
                 rewardOrNull(command, quest),
                 QuestRepeatRule.parseNullable(command.repeatRule()),
-                command.dueAt()
+                command.dueAt(),
+                command.definitionVersion(),
+                rewardProfileRef
         );
 
-        domainEventPublisher.publishAll(quest.pullEvents());
+        var events = quest.pullEvents();
+        if (!events.isEmpty()) {
+            domainEventPublisher.publishAll(events);
+        }
 
         return QuestResult.Definition.from(quest);
     }
@@ -86,6 +96,35 @@ public class QuestService {
         int exp = (c.rewardExp() != null) ? c.rewardExp() : quest.getReward().exp();
         RewardStats stats = (c.rewardStats() != null) ? new RewardStats(c.rewardStats()) : quest.getReward().stats();
         return QuestReward.of(exp, stats);
+    }
+
+    private void assertRewardContract(
+            QuestCommand.UpdateDefinition command,
+            Quest quest
+    ) {
+        boolean changesInlineReward =
+                command.rewardExp() != null || command.rewardStats() != null;
+        if (changesInlineReward
+                && (command.rewardProfileCode() != null
+                || quest.usesRewardProfile())) {
+            throw new DomainException(QuestError.QUEST_REWARD_CONTRACT_CONFLICT);
+        }
+    }
+
+    private RewardProfileRef rewardProfileRefOrNull(
+            String rewardProfileCode,
+            Quest quest
+    ) {
+        if (rewardProfileCode == null) {
+            return null;
+        }
+        RewardProfileRef requested = RewardProfileRef.of(rewardProfileCode);
+        if (requested.code().equals(quest.rewardProfileCodeOrNull())) {
+            return null;
+        }
+        RewardProfileLookupApi.RewardProfileReference reference =
+                rewardProfileLookupApi.getActiveByCode(requested.code());
+        return RewardProfileRef.of(reference.code());
     }
 
     @Transactional(readOnly = true)
@@ -141,7 +180,16 @@ public class QuestService {
     @Transactional
     public Quest ensureQuest(QuestCode code) {
         return questReader.findByCode(code)
-                .orElseGet(() -> questWriter.create(questBlueprintCatalog.require(code).instantiate()));
+                .orElseGet(() -> materialize(questBlueprintCatalog.require(code)));
+    }
+
+    private Quest materialize(QuestBlueprint blueprint) {
+        if (blueprint.usesRewardProfile()) {
+            rewardProfileLookupApi.getActiveByCode(
+                    blueprint.rewardProfileCodeOrNull()
+            );
+        }
+        return questWriter.create(blueprint.instantiate());
     }
 
     @Transactional
@@ -271,6 +319,14 @@ public class QuestService {
                         .attribute("goalReachedAt", acceptance.getGoalReachedAt())
                         .attribute("completedAt", acceptance.getCompletedAt())
                         .attribute("completionPolicy", quest.getCompletionPolicy().name())
+                        .attribute(
+                                "questDefinitionVersion",
+                                quest.getDefinitionVersion()
+                        )
+                        .attribute(
+                                "rewardProfileCode",
+                                quest.rewardProfileCodeOrNull()
+                        )
                         .occurredAt(acceptance.getCompletedAt())
                         .correlationId(correlation(acceptance, suffix))
                         .build()

--- a/src/main/java/online/lifeasgame/quest/application/QuestService.java
+++ b/src/main/java/online/lifeasgame/quest/application/QuestService.java
@@ -319,14 +319,7 @@ public class QuestService {
                         .attribute("goalReachedAt", acceptance.getGoalReachedAt())
                         .attribute("completedAt", acceptance.getCompletedAt())
                         .attribute("completionPolicy", quest.getCompletionPolicy().name())
-                        .attribute(
-                                "questDefinitionVersion",
-                                quest.getDefinitionVersion()
-                        )
-                        .attribute(
-                                "rewardProfileCode",
-                                quest.rewardProfileCodeOrNull()
-                        )
+                        .definitionSnapshot(quest)
                         .occurredAt(acceptance.getCompletedAt())
                         .correlationId(correlation(acceptance, suffix))
                         .build()

--- a/src/main/java/online/lifeasgame/quest/application/QuestWriter.java
+++ b/src/main/java/online/lifeasgame/quest/application/QuestWriter.java
@@ -12,8 +12,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Instant;
-
 @Component
 @RequiredArgsConstructor
 @Transactional(propagation = Propagation.MANDATORY)
@@ -27,21 +25,11 @@ class QuestWriter {
         Quest saved = questRepository.save(quest);
 
         domainEventPublisher.publish(
-                QuestEvent.builder(QuestEventType.QUEST_CREATED)
-                        .questCode(saved.getCode())
-                        .questId(saved.getId())
-                        .attribute("title", saved.getTitle().value())
-                        .attribute("category", saved.getCategory().name())
-                        .attribute("targetType", saved.target().type().name())
-                        .attribute("targetValue", saved.target().value())
-                        .attribute("repeatRule", saved.getRepeatRule().name())
-                        .attribute("completionPolicy", saved.getCompletionPolicy().name())
-                        .attribute("rewardExp", saved.getReward().exp())
-                        .attribute("rewardStats", saved.getReward().stats().stats())
-                        .attribute("dueAt", saved.getDueAt())
-                        .occurredAt(Instant.now())
-                        .correlationId("quest:" + saved.getCode())
-                        .build()
+                QuestEvent.snapshot(
+                        QuestEventType.QUEST_CREATED,
+                        saved,
+                        "quest:" + saved.getCode()
+                )
         );
 
         return saved;

--- a/src/main/java/online/lifeasgame/quest/application/automation/QuestSignalProcessingAttempt.java
+++ b/src/main/java/online/lifeasgame/quest/application/automation/QuestSignalProcessingAttempt.java
@@ -326,14 +326,7 @@ public class QuestSignalProcessingAttempt {
                                 acceptance.getGoalReachedAt()
                         )
                         .attribute("completedAt", acceptance.getCompletedAt())
-                        .attribute(
-                                "questDefinitionVersion",
-                                quest.getDefinitionVersion()
-                        )
-                        .attribute(
-                                "rewardProfileCode",
-                                quest.rewardProfileCodeOrNull()
-                        )
+                        .definitionSnapshot(quest)
                         .occurredAt(acceptance.getCompletedAt())
                         .correlationId(correlation(signal, "completed"))
                         .build()

--- a/src/main/java/online/lifeasgame/quest/application/automation/QuestSignalProcessingAttempt.java
+++ b/src/main/java/online/lifeasgame/quest/application/automation/QuestSignalProcessingAttempt.java
@@ -326,6 +326,14 @@ public class QuestSignalProcessingAttempt {
                                 acceptance.getGoalReachedAt()
                         )
                         .attribute("completedAt", acceptance.getCompletedAt())
+                        .attribute(
+                                "questDefinitionVersion",
+                                quest.getDefinitionVersion()
+                        )
+                        .attribute(
+                                "rewardProfileCode",
+                                quest.rewardProfileCodeOrNull()
+                        )
                         .occurredAt(acceptance.getCompletedAt())
                         .correlationId(correlation(signal, "completed"))
                         .build()

--- a/src/main/java/online/lifeasgame/quest/application/command/QuestCommand.java
+++ b/src/main/java/online/lifeasgame/quest/application/command/QuestCommand.java
@@ -16,8 +16,10 @@ public final class QuestCommand {
 
     public record UpdateDefinition(
             String questCode,
+            Integer definitionVersion,
             String targetType,
             Integer targetValue,
+            String rewardProfileCode,
             Integer rewardExp,
             Map<String, Integer> rewardStats,
             String repeatRule,

--- a/src/main/java/online/lifeasgame/quest/application/result/QuestResult.java
+++ b/src/main/java/online/lifeasgame/quest/application/result/QuestResult.java
@@ -18,7 +18,9 @@ public final class QuestResult {
             QuestTarget target,
             String repeatRule,
             String completionPolicy,
-            int rewardExp,
+            int definitionVersion,
+            String rewardProfileCode,
+            Integer rewardExp,
             Map<String, Integer> rewardStats,
             Instant dueAt
     ) {
@@ -31,8 +33,14 @@ public final class QuestResult {
                     blueprint.target(),
                     blueprint.repeatRule().name(),
                     blueprint.completionPolicy().name(),
-                    blueprint.reward().exp(),
-                    blueprint.reward().stats().stats(),
+                    blueprint.definitionVersion(),
+                    blueprint.rewardProfileCodeOrNull(),
+                    blueprint.usesRewardProfile()
+                            ? null
+                            : blueprint.reward().exp(),
+                    blueprint.usesRewardProfile()
+                            ? null
+                            : blueprint.reward().stats().stats(),
                     blueprint.dueAt()
             );
         }
@@ -92,7 +100,9 @@ public final class QuestResult {
             int targetValue,
             String repeatRule,
             String completionPolicy,
-            int rewardExp,
+            int definitionVersion,
+            String rewardProfileCode,
+            Integer rewardExp,
             Map<String, Integer> rewardStats,
             Instant dueAt
     ) {
@@ -107,8 +117,10 @@ public final class QuestResult {
                     quest.target().value(),
                     quest.getRepeatRule().name(),
                     quest.getCompletionPolicy().name(),
-                    quest.getReward().exp(),
-                    quest.getReward().stats().stats(),
+                    quest.getDefinitionVersion(),
+                    quest.rewardProfileCodeOrNull(),
+                    legacyRewardExp(quest),
+                    legacyRewardStats(quest),
                     quest.getDueAt()
             );
         }
@@ -123,7 +135,9 @@ public final class QuestResult {
             int targetValue,
             String repeatRule,
             String completionPolicy,
-            int rewardExp,
+            int definitionVersion,
+            String rewardProfileCode,
+            Integer rewardExp,
             Map<String, Integer> rewardStats,
             Instant dueAt,
             Acceptance acceptance
@@ -138,8 +152,10 @@ public final class QuestResult {
                     quest.target().value(),
                     quest.getRepeatRule().name(),
                     quest.getCompletionPolicy().name(),
-                    quest.getReward().exp(),
-                    quest.getReward().stats().stats(),
+                    quest.getDefinitionVersion(),
+                    quest.rewardProfileCodeOrNull(),
+                    legacyRewardExp(quest),
+                    legacyRewardStats(quest),
                     quest.getDueAt(),
                     acceptance == null ? null : Acceptance.from(acceptance, quest)
             );
@@ -151,5 +167,15 @@ public final class QuestResult {
             Long questId,
             String questCode
     ) {
+    }
+
+    private static Integer legacyRewardExp(Quest quest) {
+        return quest.isLegacyInlineReward() ? quest.getReward().exp() : null;
+    }
+
+    private static Map<String, Integer> legacyRewardStats(Quest quest) {
+        return quest.isLegacyInlineReward()
+                ? quest.getReward().stats().stats()
+                : null;
     }
 }

--- a/src/main/java/online/lifeasgame/quest/domain/Quest.java
+++ b/src/main/java/online/lifeasgame/quest/domain/Quest.java
@@ -5,15 +5,18 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import online.lifeasgame.core.annotation.AggregateRoot;
+import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.core.event.DomainEvent;
 import online.lifeasgame.core.guard.Guard;
 import online.lifeasgame.platform.persistence.jpa.AbstractTime;
+import online.lifeasgame.quest.domain.error.QuestError;
 import online.lifeasgame.quest.domain.event.QuestEvent;
 import online.lifeasgame.quest.domain.event.QuestEventType;
 
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 @Entity
@@ -25,6 +28,9 @@ public class Quest extends AbstractTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name = "definition_version", nullable = false)
+    private int definitionVersion = 1;
 
     @Column(name = "code", length = 80, nullable = false, unique = true)
     private String code;
@@ -45,6 +51,9 @@ public class Quest extends AbstractTime {
 
     @Embedded
     private QuestReward reward;
+
+    @Embedded
+    private RewardProfileRef rewardProfileRef;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "repeat_rule", length = 20)
@@ -67,16 +76,29 @@ public class Quest extends AbstractTime {
             String descriptionMd,
             QuestTarget target,
             QuestReward reward,
+            int definitionVersion,
+            RewardProfileRef rewardProfileRef,
             QuestRepeatRule repeatRule,
             QuestCompletionPolicy completionPolicy,
             Instant dueAt
     ) {
+        validateDefinitionVersion(definitionVersion);
+        if (rewardProfileRef == null && reward == null) {
+            throw new DomainException(QuestError.QUEST_REWARD_PROFILE_CODE_REQUIRED);
+        }
+        if (rewardProfileRef != null && reward != null) {
+            throw new DomainException(QuestError.QUEST_REWARD_CONTRACT_CONFLICT);
+        }
+        this.definitionVersion = definitionVersion;
         this.code = Guard.notBlank(code, "code").trim();
         this.category = Guard.notNull(category, "category");
         this.title = Guard.notNull(title, "title");
         this.descriptionMd = descriptionMd == null ? null : descriptionMd.trim();
         this.target = Guard.notNull(target, "target");
-        this.reward = Guard.notNull(reward, "reward");
+        this.reward = rewardProfileRef == null
+                ? Guard.notNull(reward, "reward")
+                : QuestReward.of(0, RewardStats.empty());
+        this.rewardProfileRef = rewardProfileRef;
         this.repeatRule = repeatRule == null ? QuestRepeatRule.NONE : repeatRule;
         this.completionPolicy = QuestCompletionPolicy.defaultIfNull(completionPolicy);
         this.dueAt = dueAt;
@@ -123,6 +145,35 @@ public class Quest extends AbstractTime {
                 descriptionMd,
                 target,
                 reward,
+                1,
+                null,
+                repeatRule,
+                completionPolicy,
+                dueAt
+        );
+    }
+
+    public static Quest createDefinition(
+            String code,
+            int definitionVersion,
+            QuestCategory category,
+            QuestTitle title,
+            String descriptionMd,
+            QuestTarget target,
+            RewardProfileRef rewardProfileRef,
+            QuestRepeatRule repeatRule,
+            QuestCompletionPolicy completionPolicy,
+            Instant dueAt
+    ) {
+        return new Quest(
+                code,
+                category,
+                title,
+                descriptionMd,
+                target,
+                null,
+                definitionVersion,
+                rewardProfileRef,
                 repeatRule,
                 completionPolicy,
                 dueAt
@@ -133,28 +184,82 @@ public class Quest extends AbstractTime {
             QuestTarget questTarget,
             QuestReward questReward,
             QuestRepeatRule questRepeatRule,
-            Instant dueAt
+            Instant dueAt,
+            Integer nextDefinitionVersion,
+            RewardProfileRef nextRewardProfileRef
     ) {
+        validateUpdate(nextDefinitionVersion, questReward, nextRewardProfileRef);
         boolean changed = false;
 
-        if (questTarget != null) {
+        if (questTarget != null && !questTarget.equals(target)) {
             changeTarget(questTarget);
             changed = true;
         }
-        if (questReward != null) {
+        if (questReward != null && !questReward.equals(reward)) {
             changeReward(questReward);
             changed = true;
         }
-        if (questRepeatRule != null) {
+        if (questRepeatRule != null && questRepeatRule != repeatRule) {
             changeRepeatRule(questRepeatRule);
             changed = true;
         }
-        if (dueAt != null) {
+        if (dueAt != null && !Objects.equals(dueAt, this.dueAt)) {
             reschedule(dueAt);
+            changed = true;
+        }
+        if (nextDefinitionVersion != null
+                && nextDefinitionVersion != definitionVersion) {
+            definitionVersion = nextDefinitionVersion;
+            changed = true;
+        }
+        if (nextRewardProfileRef != null
+                && !nextRewardProfileRef.equals(rewardProfileRef)) {
+            rewardProfileRef = nextRewardProfileRef;
             changed = true;
         }
 
         if (changed) recordUpdatedEvent();
+    }
+
+    public void updateDefinition(
+            QuestTarget questTarget,
+            QuestReward questReward,
+            QuestRepeatRule questRepeatRule,
+            Instant dueAt
+    ) {
+        updateDefinition(
+                questTarget,
+                questReward,
+                questRepeatRule,
+                dueAt,
+                null,
+                null
+        );
+    }
+
+    private void validateUpdate(
+            Integer nextDefinitionVersion,
+            QuestReward questReward,
+            RewardProfileRef nextRewardProfileRef
+    ) {
+        if (nextDefinitionVersion != null) {
+            validateDefinitionVersion(nextDefinitionVersion);
+            if (nextDefinitionVersion < definitionVersion) {
+                throw new DomainException(
+                        QuestError.QUEST_DEFINITION_VERSION_DECREASE_NOT_ALLOWED
+                );
+            }
+        }
+        if (questReward != null
+                && (nextRewardProfileRef != null || usesRewardProfile())) {
+            throw new DomainException(QuestError.QUEST_REWARD_CONTRACT_CONFLICT);
+        }
+    }
+
+    private static void validateDefinitionVersion(int definitionVersion) {
+        if (definitionVersion < 1) {
+            throw new DomainException(QuestError.QUEST_DEFINITION_VERSION_INVALID);
+        }
     }
 
     private void recordUpdatedEvent() {
@@ -176,6 +281,9 @@ public class Quest extends AbstractTime {
     }
 
     public void changeReward(QuestReward reward) {
+        if (usesRewardProfile()) {
+            throw new DomainException(QuestError.QUEST_REWARD_CONTRACT_CONFLICT);
+        }
         this.reward = Guard.notNull(reward, "reward");
     }
 
@@ -197,6 +305,18 @@ public class Quest extends AbstractTime {
 
     public boolean requiresUserConfirmation() {
         return completionPolicy == QuestCompletionPolicy.USER_CONFIRM;
+    }
+
+    public boolean usesRewardProfile() {
+        return rewardProfileRef != null;
+    }
+
+    public boolean isLegacyInlineReward() {
+        return !usesRewardProfile();
+    }
+
+    public String rewardProfileCodeOrNull() {
+        return rewardProfileRef == null ? null : rewardProfileRef.code();
     }
 
     public String getCode() {

--- a/src/main/java/online/lifeasgame/quest/domain/Quest.java
+++ b/src/main/java/online/lifeasgame/quest/domain/Quest.java
@@ -97,7 +97,7 @@ public class Quest extends AbstractTime {
         this.target = Guard.notNull(target, "target");
         this.reward = rewardProfileRef == null
                 ? Guard.notNull(reward, "reward")
-                : QuestReward.of(0, RewardStats.empty());
+                : QuestReward.empty();
         this.rewardProfileRef = rewardProfileRef;
         this.repeatRule = repeatRule == null ? QuestRepeatRule.NONE : repeatRule;
         this.completionPolicy = QuestCompletionPolicy.defaultIfNull(completionPolicy);
@@ -215,6 +215,7 @@ public class Quest extends AbstractTime {
         if (nextRewardProfileRef != null
                 && !nextRewardProfileRef.equals(rewardProfileRef)) {
             rewardProfileRef = nextRewardProfileRef;
+            reward = QuestReward.empty();
             changed = true;
         }
 

--- a/src/main/java/online/lifeasgame/quest/domain/QuestBlueprint.java
+++ b/src/main/java/online/lifeasgame/quest/domain/QuestBlueprint.java
@@ -1,5 +1,8 @@
 package online.lifeasgame.quest.domain;
 
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.quest.domain.error.QuestError;
+
 import java.time.Instant;
 
 public record QuestBlueprint(
@@ -11,10 +14,47 @@ public record QuestBlueprint(
         QuestReward reward,
         QuestRepeatRule repeatRule,
         Instant dueAt,
-        QuestCompletionPolicy completionPolicy
+        QuestCompletionPolicy completionPolicy,
+        int definitionVersion,
+        RewardProfileRef rewardProfileRef
 ) {
     public QuestBlueprint {
         completionPolicy = QuestCompletionPolicy.defaultIfNull(completionPolicy);
+        if (definitionVersion < 1) {
+            throw new DomainException(QuestError.QUEST_DEFINITION_VERSION_INVALID);
+        }
+        if (reward == null && rewardProfileRef == null) {
+            throw new DomainException(QuestError.QUEST_REWARD_PROFILE_CODE_REQUIRED);
+        }
+        if (reward != null && rewardProfileRef != null) {
+            throw new DomainException(QuestError.QUEST_REWARD_CONTRACT_CONFLICT);
+        }
+    }
+
+    public QuestBlueprint(
+            QuestCode code,
+            QuestCategory category,
+            QuestTitle title,
+            String descriptionMd,
+            QuestTarget target,
+            QuestReward reward,
+            QuestRepeatRule repeatRule,
+            Instant dueAt,
+            QuestCompletionPolicy completionPolicy
+    ) {
+        this(
+                code,
+                category,
+                title,
+                descriptionMd,
+                target,
+                reward,
+                repeatRule,
+                dueAt,
+                completionPolicy,
+                1,
+                null
+        );
     }
 
     public QuestBlueprint(
@@ -36,11 +76,54 @@ public record QuestBlueprint(
                 reward,
                 repeatRule,
                 dueAt,
-                QuestCompletionPolicy.AUTO
+                QuestCompletionPolicy.AUTO,
+                1,
+                null
+        );
+    }
+
+    public static QuestBlueprint profileBased(
+            QuestCode code,
+            int definitionVersion,
+            QuestCategory category,
+            QuestTitle title,
+            String descriptionMd,
+            QuestTarget target,
+            RewardProfileRef rewardProfileRef,
+            QuestRepeatRule repeatRule,
+            Instant dueAt,
+            QuestCompletionPolicy completionPolicy
+    ) {
+        return new QuestBlueprint(
+                code,
+                category,
+                title,
+                descriptionMd,
+                target,
+                null,
+                repeatRule,
+                dueAt,
+                completionPolicy,
+                definitionVersion,
+                rewardProfileRef
         );
     }
 
     public Quest instantiate() {
+        if (rewardProfileRef != null) {
+            return Quest.createDefinition(
+                    code.value(),
+                    definitionVersion,
+                    category,
+                    title,
+                    descriptionMd,
+                    target,
+                    rewardProfileRef,
+                    repeatRule,
+                    completionPolicy,
+                    dueAt
+            );
+        }
         return Quest.create(
                 code.value(),
                 category,
@@ -52,5 +135,13 @@ public record QuestBlueprint(
                 completionPolicy,
                 dueAt
         );
+    }
+
+    public boolean usesRewardProfile() {
+        return rewardProfileRef != null;
+    }
+
+    public String rewardProfileCodeOrNull() {
+        return rewardProfileRef == null ? null : rewardProfileRef.code();
     }
 }

--- a/src/main/java/online/lifeasgame/quest/domain/QuestReward.java
+++ b/src/main/java/online/lifeasgame/quest/domain/QuestReward.java
@@ -4,10 +4,12 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import online.lifeasgame.core.guard.Guard;
 
 @Embeddable
+@EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class QuestReward {
 

--- a/src/main/java/online/lifeasgame/quest/domain/QuestReward.java
+++ b/src/main/java/online/lifeasgame/quest/domain/QuestReward.java
@@ -30,6 +30,10 @@ public class QuestReward {
         return new QuestReward(exp, stats);
     }
 
+    public static QuestReward empty() {
+        return new QuestReward(0, RewardStats.empty());
+    }
+
     public int exp() {
         return exp;
     }

--- a/src/main/java/online/lifeasgame/quest/domain/QuestTarget.java
+++ b/src/main/java/online/lifeasgame/quest/domain/QuestTarget.java
@@ -5,10 +5,12 @@ import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import online.lifeasgame.core.guard.Guard;
 
 @Embeddable
+@EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class QuestTarget {
 

--- a/src/main/java/online/lifeasgame/quest/domain/RewardProfileRef.java
+++ b/src/main/java/online/lifeasgame/quest/domain/RewardProfileRef.java
@@ -1,0 +1,39 @@
+package online.lifeasgame.quest.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.quest.domain.error.QuestError;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RewardProfileRef {
+
+    public static final int MAX_CODE_LENGTH = 80;
+
+    @Column(name = "reward_profile_code", length = MAX_CODE_LENGTH)
+    private String code;
+
+    private RewardProfileRef(String code) {
+        if (code == null || code.isBlank()) {
+            throw new DomainException(QuestError.QUEST_REWARD_PROFILE_CODE_REQUIRED);
+        }
+        String normalized = code.trim();
+        if (normalized.length() > MAX_CODE_LENGTH) {
+            throw new DomainException(QuestError.QUEST_REWARD_PROFILE_CODE_TOO_LONG);
+        }
+        this.code = normalized;
+    }
+
+    public static RewardProfileRef of(String code) {
+        return new RewardProfileRef(code);
+    }
+
+    public String code() {
+        return code;
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/domain/error/QuestError.java
+++ b/src/main/java/online/lifeasgame/quest/domain/error/QuestError.java
@@ -61,6 +61,31 @@ public enum QuestError implements ErrorCode {
             "QUE-409-QUEST-SIGNAL-RECEIPT-PAYLOAD-CONFLICT",
             "Quest signal identity was already used with a different payload",
             409
+    ),
+    QUEST_DEFINITION_VERSION_INVALID(
+            "QUE-400-DEFINITION-VERSION-INVALID",
+            "Quest definition version must be at least 1",
+            400
+    ),
+    QUEST_DEFINITION_VERSION_DECREASE_NOT_ALLOWED(
+            "QUE-400-DEFINITION-VERSION-DECREASE-NOT-ALLOWED",
+            "Quest definition version cannot decrease",
+            400
+    ),
+    QUEST_REWARD_PROFILE_CODE_REQUIRED(
+            "QUE-400-REWARD-PROFILE-CODE-REQUIRED",
+            "Quest reward profile code is required",
+            400
+    ),
+    QUEST_REWARD_PROFILE_CODE_TOO_LONG(
+            "QUE-400-REWARD-PROFILE-CODE-TOO-LONG",
+            "Quest reward profile code is too long",
+            400
+    ),
+    QUEST_REWARD_CONTRACT_CONFLICT(
+            "QUE-400-REWARD-CONTRACT-CONFLICT",
+            "Reward profile and legacy inline reward cannot be changed together",
+            400
     )
     ;
 

--- a/src/main/java/online/lifeasgame/quest/domain/event/QuestEvent.java
+++ b/src/main/java/online/lifeasgame/quest/domain/event/QuestEvent.java
@@ -47,7 +47,7 @@ public record QuestEvent(
     }
 
     public static QuestEvent snapshot(QuestEventType type, Quest quest, String correlationId) {
-        return QuestEvent.builder(type)
+        Builder builder = QuestEvent.builder(type)
                 .questId(quest.getId())
                 .questCode(quest.getCode())
                 .attribute("title", quest.getTitle().value())
@@ -56,12 +56,16 @@ public record QuestEvent(
                 .attribute("targetValue", quest.target().value())
                 .attribute("repeatRule", quest.getRepeatRule().name())
                 .attribute("completionPolicy", quest.getCompletionPolicy().name())
-                .attribute("rewardExp", quest.getReward().exp())
-                .attribute("rewardStats", quest.getReward().stats().stats())
+                .attribute("questDefinitionVersion", quest.getDefinitionVersion())
+                .attribute("rewardProfileCode", quest.rewardProfileCodeOrNull())
                 .attribute("dueAt", quest.getDueAt())
                 .occurredAt(Instant.now())
-                .correlationId(correlationId)
-                .build();
+                .correlationId(correlationId);
+        if (quest.isLegacyInlineReward()) {
+            builder.attribute("rewardExp", quest.getReward().exp())
+                    .attribute("rewardStats", quest.getReward().stats().stats());
+        }
+        return builder.build();
     }
 
     public static final class Builder {

--- a/src/main/java/online/lifeasgame/quest/domain/event/QuestEvent.java
+++ b/src/main/java/online/lifeasgame/quest/domain/event/QuestEvent.java
@@ -56,15 +56,10 @@ public record QuestEvent(
                 .attribute("targetValue", quest.target().value())
                 .attribute("repeatRule", quest.getRepeatRule().name())
                 .attribute("completionPolicy", quest.getCompletionPolicy().name())
-                .attribute("questDefinitionVersion", quest.getDefinitionVersion())
-                .attribute("rewardProfileCode", quest.rewardProfileCodeOrNull())
+                .definitionSnapshot(quest)
                 .attribute("dueAt", quest.getDueAt())
                 .occurredAt(Instant.now())
                 .correlationId(correlationId);
-        if (quest.isLegacyInlineReward()) {
-            builder.attribute("rewardExp", quest.getReward().exp())
-                    .attribute("rewardStats", quest.getReward().stats().stats());
-        }
         return builder.build();
     }
 
@@ -114,6 +109,27 @@ public record QuestEvent(
                 this.attributes.put(key, value);
             }
             return this;
+        }
+
+        public Builder definitionSnapshot(Quest quest) {
+            Guard.notNull(quest, "quest");
+            attribute("questDefinitionVersion", quest.getDefinitionVersion())
+                    .attribute("rewardLines", null)
+                    .attribute("rewardProfileId", null);
+            if (quest.usesRewardProfile()) {
+                return attribute(
+                        "rewardProfileCode",
+                        quest.rewardProfileCodeOrNull()
+                )
+                        .attribute("rewardExp", null)
+                        .attribute("rewardStats", null);
+            }
+            return attribute("rewardProfileCode", null)
+                    .attribute("rewardExp", quest.getReward().exp())
+                    .attribute(
+                            "rewardStats",
+                            quest.getReward().stats().stats()
+                    );
         }
 
         public Builder occurredAt(Instant occurredAt) {

--- a/src/main/java/online/lifeasgame/reward/application/RewardProfileLookupService.java
+++ b/src/main/java/online/lifeasgame/reward/application/RewardProfileLookupService.java
@@ -1,0 +1,22 @@
+package online.lifeasgame.reward.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.reward.application.internal.RewardProfileLookupApi;
+import online.lifeasgame.reward.domain.RewardProfile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+public class RewardProfileLookupService implements RewardProfileLookupApi {
+
+    private final RewardProfileReader rewardProfileReader;
+
+    @Override
+    public RewardProfileReference getActiveByCode(String code) {
+        RewardProfile profile = rewardProfileReader.getActiveByCodeOrThrow(code);
+        return new RewardProfileReference(profile.getCode());
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/application/internal/RewardProfileLookupApi.java
+++ b/src/main/java/online/lifeasgame/reward/application/internal/RewardProfileLookupApi.java
@@ -1,0 +1,9 @@
+package online.lifeasgame.reward.application.internal;
+
+public interface RewardProfileLookupApi {
+
+    RewardProfileReference getActiveByCode(String code);
+
+    record RewardProfileReference(String code) {
+    }
+}

--- a/src/main/resources/db/migration/V10__quest_definition_reward_profile_contract.sql
+++ b/src/main/resources/db/migration/V10__quest_definition_reward_profile_contract.sql
@@ -1,0 +1,10 @@
+ALTER TABLE quests
+    ADD COLUMN definition_version INT NOT NULL DEFAULT 1
+        AFTER reward_exp,
+    ADD COLUMN reward_profile_code VARCHAR(80) NULL
+        AFTER reward_stats,
+    ADD CONSTRAINT ck_quest_definition_version
+        CHECK (definition_version >= 1);
+
+CREATE INDEX idx_quest_reward_profile_code
+    ON quests (reward_profile_code);

--- a/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
@@ -63,7 +63,7 @@ class FlywayExplicitBaselineTest {
     class ApplyExplicitBaseline {
 
         @Test
-        @DisplayName("V1을 재실행하지 않고 V2부터 V9까지 적용한 뒤 JPA validate를 통과한다")
+        @DisplayName("V1을 재실행하지 않고 V2부터 V10까지 적용한 뒤 JPA validate를 통과한다")
         void migratesFromVersionTwoAndValidatesJpa() throws Exception {
             String jdbcUrl = createV1EquivalentDatabase();
             Flyway flyway = migrationFlyway(jdbcUrl);
@@ -72,11 +72,11 @@ class FlywayExplicitBaselineTest {
             MigrateResult migrateResult = flyway.migrate();
             List<HistoryRow> history = successfulHistory(jdbcUrl);
 
-            assertThat(migrateResult.migrationsExecuted).isEqualTo(8);
+            assertThat(migrateResult.migrationsExecuted).isEqualTo(9);
             assertThat(history).extracting(HistoryRow::version)
                     .containsExactly(
                             "1", "2", "3", "4", "5",
-                            "6", "7", "8", "9"
+                            "6", "7", "8", "9", "10"
                     );
             assertThat(history.getFirst().type()).isEqualTo("BASELINE");
             assertThat(history.getFirst().script())
@@ -95,7 +95,8 @@ class FlywayExplicitBaselineTest {
                             "V6__quest_state_contract.sql",
                             "V7__quest_signal_receipt.sql",
                             "V8__transactional_outbox.sql",
-                            "V9__quick_lifelog_record.sql"
+                            "V9__quick_lifelog_record.sql",
+                            "V10__quest_definition_reward_profile_contract.sql"
                     );
             assertThat(history.subList(1, history.size()))
                     .allSatisfy(row -> assertThat(row.checksum()).isNotNull());
@@ -115,7 +116,7 @@ class FlywayExplicitBaselineTest {
                         "spring.jpa.hibernate.ddl-auto"
                 )).isEqualTo("validate");
                 assertThat(context.getBean(Flyway.class).info().current().getVersion().getVersion())
-                        .isEqualTo("9");
+                        .isEqualTo("10");
             }
         }
     }

--- a/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
@@ -32,7 +32,7 @@ class FlywayHistoryChecksumTest {
     class MigrateAgain {
 
         @Test
-        @DisplayName("두 번째 실행은 no-op이고 V1부터 V9까지 checksum history를 유지한다")
+        @DisplayName("두 번째 실행은 no-op이고 V1부터 V10까지 checksum history를 유지한다")
         void keepsMigrationHistory() throws Exception {
             Flyway flyway = flyway();
 
@@ -42,13 +42,13 @@ class FlywayHistoryChecksumTest {
             MigrateResult second = flyway.migrate();
             List<HistoryRow> secondHistory = successfulHistory();
 
-            assertThat(first.migrationsExecuted).isEqualTo(9);
+            assertThat(first.migrationsExecuted).isEqualTo(10);
             assertThat(second.migrationsExecuted).isZero();
             assertThat(secondHistory).isEqualTo(firstHistory);
             assertThat(secondHistory).extracting(HistoryRow::version)
                     .containsExactly(
                             "1", "2", "3", "4", "5",
-                            "6", "7", "8", "9"
+                            "6", "7", "8", "9", "10"
                     );
             assertThat(secondHistory).allSatisfy(history -> {
                 assertThat(history.checksum()).isNotNull();

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -1,6 +1,7 @@
 package online.lifeasgame.migration;
 
 import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.output.MigrateResult;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -37,17 +38,21 @@ class FlywayMigrationTest {
     class MigrateCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V9까지 적용되고 Quick Record Receipt unique가 생성된다")
+        @DisplayName("V1부터 V10까지 적용되고 legacy Quest에 Definition 계약이 안전하게 추가된다")
         void migratesSchemaAndSeedsRewardProfiles() throws Exception {
+            Flyway throughV9 = flyway(MigrationVersion.fromVersion("9"));
+            MigrateResult legacyResult = throughV9.migrate();
+            insertLegacyQuest();
             Flyway flyway = flyway();
 
             MigrateResult result = flyway.migrate();
 
-            assertThat(result.migrationsExecuted).isEqualTo(9);
+            assertThat(legacyResult.migrationsExecuted).isEqualTo(9);
+            assertThat(result.migrationsExecuted).isEqualTo(1);
             assertThat(appliedVersions())
                     .containsExactly(
                             "1", "2", "3", "4", "5",
-                            "6", "7", "8", "9"
+                            "6", "7", "8", "9", "10"
                     );
             assertThat(existingTables(
                     "users",
@@ -121,6 +126,27 @@ class FlywayMigrationTest {
                     "outbox_events",
                     "idx_outbox_event_lease"
             )).containsExactly("status", "locked_at");
+            assertThat(indexColumns(
+                    "quests",
+                    "idx_quest_reward_profile_code"
+            )).containsExactly("reward_profile_code");
+            assertThat(questDefinitionColumns()).isEqualTo(
+                    new QuestDefinitionColumns(
+                            "NO",
+                            "1",
+                            "YES",
+                            "reward_exp",
+                            "reward_stats"
+                    )
+            );
+            assertThat(legacyQuestContract()).isEqualTo(
+                    new LegacyQuestContract(1, null, 7, 2)
+            );
+            assertThat(rewardProfileForeignKeyCount()).isZero();
+            assertThatThrownBy(FlywayMigrationTest.this::violateDefinitionVersionCheck)
+                    .isInstanceOfSatisfying(SQLException.class, exception ->
+                            assertThat(exception.getErrorCode()).isEqualTo(3819)
+                    );
             assertThat(uniqueIndexColumns(
                     "quick_record_request_receipts",
                     "uq_quick_record_request_receipt_identity"
@@ -134,11 +160,18 @@ class FlywayMigrationTest {
     }
 
     private Flyway flyway() {
-        return Flyway.configure()
+        return flyway(null);
+    }
+
+    private Flyway flyway(MigrationVersion target) {
+        var configuration = Flyway.configure()
                 .dataSource(MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword())
                 .locations("classpath:db/migration")
-                .baselineOnMigrate(false)
-                .load();
+                .baselineOnMigrate(false);
+        if (target != null) {
+            configuration.target(target);
+        }
+        return configuration.load();
     }
 
     private Set<String> appliedVersions() throws Exception {
@@ -297,6 +330,139 @@ class FlywayMigrationTest {
         }
     }
 
+    private void insertLegacyQuest() throws SQLException {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement()) {
+            statement.executeUpdate("""
+                    INSERT INTO quests (
+                        reward_exp,
+                        target_value,
+                        created_at,
+                        due_at,
+                        updated_at,
+                        code,
+                        title_id,
+                        reward_stats,
+                        category,
+                        description_md,
+                        repeat_rule,
+                        completion_policy,
+                        target_type
+                    ) VALUES (
+                        7,
+                        1,
+                        CURRENT_TIMESTAMP(6),
+                        NULL,
+                        CURRENT_TIMESTAMP(6),
+                        'quest:test:v9-legacy',
+                        'V9 Legacy Quest',
+                        JSON_OBJECT('strength', 2),
+                        'MAIN',
+                        'V9 legacy row',
+                        'NONE',
+                        'AUTO',
+                        'COUNT'
+                    )
+                    """);
+        }
+    }
+
+    private QuestDefinitionColumns questDefinitionColumns() throws SQLException {
+        try (Connection connection = MYSQL.createConnection("");
+             var statement = connection.prepareStatement("""
+                     SELECT
+                         MAX(CASE WHEN column_name = 'definition_version'
+                             THEN is_nullable END) AS version_nullable,
+                         MAX(CASE WHEN column_name = 'definition_version'
+                             THEN column_default END) AS version_default,
+                         MAX(CASE WHEN column_name = 'reward_profile_code'
+                             THEN is_nullable END) AS profile_nullable,
+                         MAX(CASE WHEN column_name = 'reward_exp'
+                             THEN column_name END) AS reward_exp_column,
+                         MAX(CASE WHEN column_name = 'reward_stats'
+                             THEN column_name END) AS reward_stats_column
+                     FROM information_schema.columns
+                     WHERE table_schema = DATABASE()
+                       AND table_name = 'quests'
+                     """);
+             ResultSet resultSet = statement.executeQuery()) {
+            assertThat(resultSet.next()).isTrue();
+            return new QuestDefinitionColumns(
+                    resultSet.getString("version_nullable"),
+                    resultSet.getString("version_default"),
+                    resultSet.getString("profile_nullable"),
+                    resultSet.getString("reward_exp_column"),
+                    resultSet.getString("reward_stats_column")
+            );
+        }
+    }
+
+    private LegacyQuestContract legacyQuestContract() throws SQLException {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("""
+                     SELECT
+                         definition_version,
+                         reward_profile_code,
+                         reward_exp,
+                         JSON_EXTRACT(reward_stats, '$.strength') AS strength
+                     FROM quests
+                     WHERE code = 'quest:test:v9-legacy'
+                     """)) {
+            assertThat(resultSet.next()).isTrue();
+            return new LegacyQuestContract(
+                    resultSet.getInt("definition_version"),
+                    resultSet.getString("reward_profile_code"),
+                    resultSet.getInt("reward_exp"),
+                    resultSet.getInt("strength")
+            );
+        }
+    }
+
+    private int rewardProfileForeignKeyCount() throws SQLException {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("""
+                     SELECT COUNT(*)
+                     FROM information_schema.key_column_usage
+                     WHERE table_schema = DATABASE()
+                       AND table_name = 'quests'
+                       AND column_name = 'reward_profile_code'
+                       AND referenced_table_name IS NOT NULL
+                     """)) {
+            resultSet.next();
+            return resultSet.getInt(1);
+        }
+    }
+
+    private void violateDefinitionVersionCheck() throws SQLException {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement()) {
+            statement.executeUpdate("""
+                    UPDATE quests
+                    SET definition_version = 0
+                    WHERE code = 'quest:test:v9-legacy'
+                    """);
+        }
+    }
+
     private record NoRewardProfile(String status, int lineCount) {
+    }
+
+    private record QuestDefinitionColumns(
+            String versionNullable,
+            String versionDefault,
+            String profileNullable,
+            String rewardExpColumn,
+            String rewardStatsColumn
+    ) {
+    }
+
+    private record LegacyQuestContract(
+            int definitionVersion,
+            String rewardProfileCode,
+            int rewardExp,
+            int strength
+    ) {
     }
 }

--- a/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
@@ -149,7 +149,7 @@ class FlywayProfileCutoverTest {
     class StartLocalWithCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V9까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
+        @DisplayName("V1부터 V10까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
         void migratesThenValidates() {
             ConfigurableEnvironment environment =
                     (ConfigurableEnvironment) applicationContext.getEnvironment();
@@ -161,8 +161,8 @@ class FlywayProfileCutoverTest {
             assertThat(environment.getProperty(
                     "spring.flyway.baseline-on-migrate", Boolean.class
             )).isFalse();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("9");
-            assertThat(appliedMigrationCount()).isEqualTo(9);
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("10");
+            assertThat(appliedMigrationCount()).isEqualTo(10);
         }
     }
 

--- a/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 @SpringBootTest
 @ActiveProfiles({"test", "migration-test"})
-@DisplayName("V9 migration 이후 JPA schema validation")
+@DisplayName("V10 migration 이후 JPA schema validation")
 class JpaValidateAfterMigrationTest {
 
     @Container
@@ -61,14 +61,14 @@ class JpaValidateAfterMigrationTest {
     private RewardSettlementReader rewardSettlementReader;
 
     @Nested
-    @DisplayName("V1부터 V9까지 적용된 schema로 ApplicationContext를 기동할 때")
+    @DisplayName("V1부터 V10까지 적용된 schema로 ApplicationContext를 기동할 때")
     class LoadApplicationContext {
 
         @Test
         @DisplayName("ddl-auto validate 상태로 정상 기동한다")
         void loadsWithJpaValidation() {
             assertThat(applicationContext).isNotNull();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("9");
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("10");
             assertThat(applicationContext.getEnvironment().getProperty("spring.jpa.hibernate.ddl-auto"))
                     .isEqualTo("validate");
             assertThat(applicationContext.getEnvironment()

--- a/src/test/java/online/lifeasgame/platform/outbox/application/TransactionalOutboxIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/platform/outbox/application/TransactionalOutboxIntegrationTest.java
@@ -4,7 +4,10 @@ import online.lifeasgame.core.event.DomainEvent;
 import online.lifeasgame.core.event.DomainEventPublisher;
 import online.lifeasgame.lifelog.domain.event.CollectionLogged;
 import online.lifeasgame.platform.outbox.OutboxProperties;
+import online.lifeasgame.platform.outbox.application.codec.OutboxEventCodecRegistry;
 import online.lifeasgame.platform.outbox.domain.OutboxStatus;
+import online.lifeasgame.quest.domain.event.QuestEvent;
+import online.lifeasgame.quest.domain.event.QuestEventType;
 import online.lifeasgame.social.domain.ChatChannelType;
 import online.lifeasgame.social.domain.event.ChatChannelDeactivated;
 import org.junit.jupiter.api.*;
@@ -28,6 +31,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -85,6 +89,9 @@ class TransactionalOutboxIntegrationTest {
 
     @Autowired
     private OutboxProperties properties;
+
+    @Autowired
+    private OutboxEventCodecRegistry codecRegistry;
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
@@ -188,6 +195,52 @@ class TransactionalOutboxIntegrationTest {
                     .IllegalTransactionStateException.class);
 
             assertThat(outboxCount()).isZero();
+        }
+
+        @Test
+        @DisplayName("QuestCompleted Definition Snapshot을 JSON payload에 보존한다")
+        void persistsQuestCompletedSnapshot() {
+            QuestEvent source = new QuestEvent(
+                    QuestEventType.QUEST_COMPLETED,
+                    QUEST_PLAYER_ID,
+                    203L,
+                    "quest:test:profile",
+                    Map.of(
+                            "acceptanceId", 20301L,
+                            "questDefinitionVersion", 3,
+                            "rewardProfileCode", "RP_EXP_30",
+                            "completedAt", OCCURRED_AT
+                    ),
+                    OCCURRED_AT,
+                    "quest:203:acceptance:20301:completed"
+            );
+
+            append(source);
+
+            String eventType = jdbcTemplate.queryForObject(
+                    "SELECT event_type FROM outbox_events",
+                    String.class
+            );
+            String payload = jdbcTemplate.queryForObject(
+                    "SELECT payload FROM outbox_events",
+                    String.class
+            );
+            QuestEvent decoded = (QuestEvent) codecRegistry.decode(
+                    eventType,
+                    payload
+            );
+
+            assertThat(eventType).isEqualTo("quest.event.v1");
+            assertThat(decoded).isEqualTo(source);
+            assertThat(decoded.attributes())
+                    .containsEntry("questDefinitionVersion", 3)
+                    .containsEntry("rewardProfileCode", "RP_EXP_30")
+                    .doesNotContainKeys(
+                            "rewardExp",
+                            "rewardStats",
+                            "rewardLines",
+                            "rewardProfileId"
+                    );
         }
     }
 

--- a/src/test/java/online/lifeasgame/platform/outbox/application/codec/OutboxEventCodecRegistryTest.java
+++ b/src/test/java/online/lifeasgame/platform/outbox/application/codec/OutboxEventCodecRegistryTest.java
@@ -220,6 +220,55 @@ class OutboxEventCodecRegistryTest {
 
             assertThat(decoded.attributes()).isEqualTo(attributes);
         }
+
+        @Test
+        @DisplayName("신규 QuestCompleted Definition Snapshot을 그대로 왕복한다")
+        void roundTripsProfileQuestCompletedSnapshot() {
+            QuestEvent source = completedQuestEvent(Map.of(
+                    "acceptanceId", 19701L,
+                    "questDefinitionVersion", 4,
+                    "rewardProfileCode", "RP_EXP_30",
+                    "completedAt", OCCURRED_AT
+            ));
+
+            OutboxEventEnvelope envelope = registry.encode(source);
+            QuestEvent decoded = (QuestEvent) registry.decode(
+                    envelope.eventType(),
+                    envelope.payload()
+            );
+
+            assertThat(decoded).isEqualTo(source);
+            assertThat(decoded.attributes())
+                    .containsEntry("questDefinitionVersion", 4)
+                    .containsEntry("rewardProfileCode", "RP_EXP_30")
+                    .doesNotContainKeys(
+                            "rewardExp",
+                            "rewardStats",
+                            "rewardLines",
+                            "rewardProfileId"
+                    );
+        }
+
+        @Test
+        @DisplayName("legacy QuestCompleted는 rewardProfileCode 없이도 왕복한다")
+        void roundTripsLegacyQuestCompletedWithoutProfileCode() {
+            QuestEvent source = completedQuestEvent(Map.of(
+                    "acceptanceId", 19702L,
+                    "questDefinitionVersion", 1,
+                    "completedAt", OCCURRED_AT
+            ));
+
+            OutboxEventEnvelope envelope = registry.encode(source);
+            QuestEvent decoded = (QuestEvent) registry.decode(
+                    envelope.eventType(),
+                    envelope.payload()
+            );
+
+            assertThat(decoded).isEqualTo(source);
+            assertThat(decoded.attributes())
+                    .containsEntry("questDefinitionVersion", 1)
+                    .doesNotContainKey("rewardProfileCode");
+        }
     }
 
     @Nested
@@ -285,6 +334,18 @@ class OutboxEventCodecRegistryTest {
                 ),
                 OCCURRED_AT,
                 "quest:197:progress"
+        );
+    }
+
+    private QuestEvent completedQuestEvent(Map<String, Object> attributes) {
+        return new QuestEvent(
+                QuestEventType.QUEST_COMPLETED,
+                197L,
+                91L,
+                "Q_OUTBOX",
+                attributes,
+                OCCURRED_AT,
+                "quest:91:acceptance:197:completed"
         );
     }
 

--- a/src/test/java/online/lifeasgame/quest/api/QuestResponseContractTest.java
+++ b/src/test/java/online/lifeasgame/quest/api/QuestResponseContractTest.java
@@ -1,6 +1,8 @@
 package online.lifeasgame.quest.api;
 
+import jakarta.validation.Validation;
 import online.lifeasgame.quest.api.admin.mapper.AdminQuestWebMapper;
+import online.lifeasgame.quest.api.admin.request.AdminQuestRequest;
 import online.lifeasgame.quest.api.admin.response.AdminQuestResponse;
 import online.lifeasgame.quest.api.player.mapper.QuestWebMapper;
 import online.lifeasgame.quest.api.player.response.QuestResponse;
@@ -12,6 +14,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Instant;
+import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -61,6 +65,116 @@ class QuestResponseContractTest {
         }
     }
 
+    @Nested
+    @DisplayName("RewardProfile 기반 Definition을 응답으로 변환할 때")
+    class MapProfileDefinition {
+
+        @Test
+        @DisplayName("Admin과 Player 응답은 version/code를 노출하고 inline reward를 null로 둔다")
+        void exposesProfileReferenceWithoutFakeInlineReward() {
+            Quest quest = profileQuest();
+
+            AdminQuestResponse.Definition admin =
+                    AdminQuestWebMapper.toDefinition(
+                            QuestResult.Definition.from(quest)
+                    );
+            QuestResponse.PlayerQuest player =
+                    QuestWebMapper.toPlayerQuest(
+                            QuestResult.PlayerQuest.from(quest, null)
+                    );
+
+            assertThat(admin.definitionVersion()).isEqualTo(4);
+            assertThat(admin.rewardProfileCode()).isEqualTo("RP_EXP_30");
+            assertThat(admin.rewardExp()).isNull();
+            assertThat(admin.rewardStats()).isNull();
+
+            assertThat(player.definitionVersion()).isEqualTo(4);
+            assertThat(player.rewardProfileCode()).isEqualTo("RP_EXP_30");
+            assertThat(player.rewardExp()).isNull();
+            assertThat(player.rewardStats()).isNull();
+        }
+
+        @Test
+        @DisplayName("legacy 응답은 version 1과 기존 inline reward 값을 유지한다")
+        void keepsLegacyInlineRewardResponse() {
+            Quest quest = quest();
+
+            AdminQuestResponse.Definition admin =
+                    AdminQuestWebMapper.toDefinition(
+                            QuestResult.Definition.from(quest)
+                    );
+            QuestResponse.PlayerQuest player =
+                    QuestWebMapper.toPlayerQuest(
+                            QuestResult.PlayerQuest.from(quest, null)
+                    );
+
+            assertThat(admin.definitionVersion()).isEqualTo(1);
+            assertThat(admin.rewardProfileCode()).isNull();
+            assertThat(admin.rewardExp()).isZero();
+            assertThat(admin.rewardStats()).isEqualTo(Map.of());
+            assertThat(player.definitionVersion()).isEqualTo(1);
+            assertThat(player.rewardProfileCode()).isNull();
+            assertThat(player.rewardExp()).isZero();
+            assertThat(player.rewardStats()).isEqualTo(Map.of());
+        }
+
+        @Test
+        @DisplayName("Admin Update의 0 version은 Bean Validation 400 대상이다")
+        void rejectsNonPositiveRequestVersion() {
+            AdminQuestRequest.Update request = new AdminQuestRequest.Update(
+                    0,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+
+            var validator = Validation.buildDefaultValidatorFactory()
+                    .getValidator();
+
+            assertThat(validator.validate(request))
+                    .extracting(violation ->
+                            violation.getPropertyPath().toString())
+                    .containsExactly("definitionVersion");
+        }
+
+        @Test
+        @DisplayName("Admin과 Player Blueprint 응답에도 version/code 계약을 노출한다")
+        void exposesBlueprintContract() {
+            QuestBlueprint blueprint = QuestBlueprint.profileBased(
+                    QuestCode.PLAYER_WELCOME,
+                    5,
+                    QuestCategory.MAIN,
+                    QuestTitle.of("Profile Blueprint"),
+                    "profile blueprint",
+                    QuestTarget.of(QuestTargetType.COUNT, 1),
+                    RewardProfileRef.of("RP_EXP_10"),
+                    QuestRepeatRule.NONE,
+                    null,
+                    QuestCompletionPolicy.AUTO
+            );
+            QuestResult.Blueprint result = QuestResult.Blueprint.from(blueprint);
+
+            AdminQuestResponse.Blueprint admin =
+                    AdminQuestWebMapper.toBlueprints(List.of(result))
+                            .blueprints()
+                            .getFirst();
+            QuestResponse.Blueprint player = QuestWebMapper.toBlueprint(result);
+
+            assertThat(admin.definitionVersion()).isEqualTo(5);
+            assertThat(admin.rewardProfileCode()).isEqualTo("RP_EXP_10");
+            assertThat(admin.rewardExp()).isNull();
+            assertThat(admin.rewardStats()).isNull();
+            assertThat(player.definitionVersion()).isEqualTo(5);
+            assertThat(player.rewardProfileCode()).isEqualTo("RP_EXP_10");
+            assertThat(player.rewardExp()).isNull();
+            assertThat(player.rewardStats()).isNull();
+        }
+    }
+
     private Quest quest() {
         Quest quest = Quest.create(
                 "quest:test:response-contract",
@@ -74,6 +188,23 @@ class QuestResponseContractTest {
                 null
         );
         ReflectionTestUtils.setField(quest, "id", 193L);
+        return quest;
+    }
+
+    private Quest profileQuest() {
+        Quest quest = Quest.createDefinition(
+                "quest:test:profile-response-contract",
+                4,
+                QuestCategory.MAIN,
+                QuestTitle.of("Profile 응답 계약 테스트"),
+                "Quest Profile 응답 계약 테스트",
+                QuestTarget.of(QuestTargetType.COUNT, 1),
+                RewardProfileRef.of("RP_EXP_30"),
+                QuestRepeatRule.NONE,
+                QuestCompletionPolicy.USER_CONFIRM,
+                null
+        );
+        ReflectionTestUtils.setField(quest, "id", 204L);
         return quest;
     }
 }

--- a/src/test/java/online/lifeasgame/quest/application/QuestAcceptanceCompletionServiceTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/QuestAcceptanceCompletionServiceTest.java
@@ -60,7 +60,7 @@ class QuestAcceptanceCompletionServiceTest {
         @Test
         @DisplayName("COMPLETED로 저장하고 Completed Event와 결과를 반환한다")
         void completesAndPublishesEvent() {
-            Quest quest = quest(QuestCompletionPolicy.USER_CONFIRM);
+            Quest quest = profileQuest(QuestCompletionPolicy.USER_CONFIRM);
             QuestAcceptance acceptance = goalReachedAcceptance(quest);
             given(questReader.getAcceptance(ACCEPTANCE_ID)).willReturn(acceptance);
             given(questReader.getById(QUEST_ID)).willReturn(quest);
@@ -85,7 +85,18 @@ class QuestAcceptanceCompletionServiceTest {
                     .containsEntry(
                             "completionPolicy",
                             QuestCompletionPolicy.USER_CONFIRM.name()
+                    )
+                    .containsEntry("questDefinitionVersion", 7)
+                    .containsEntry("rewardProfileCode", "RP_EXP_30")
+                    .doesNotContainKeys(
+                            "rewardExp",
+                            "rewardStats",
+                            "rewardLines",
+                            "rewardProfileId"
                     );
+            assertThat(event.correlationId())
+                    .isEqualTo("quest:193:acceptance:1930:completed");
+            assertThat(event.occurredAt()).isEqualTo(result.completedAt());
         }
 
         @Test
@@ -165,6 +176,23 @@ class QuestAcceptanceCompletionServiceTest {
                 "Quest 명시적 완료 테스트",
                 QuestTarget.of(QuestTargetType.COUNT, 1),
                 QuestReward.of(0, RewardStats.empty()),
+                QuestRepeatRule.NONE,
+                completionPolicy,
+                null
+        );
+        ReflectionTestUtils.setField(quest, "id", QUEST_ID);
+        return quest;
+    }
+
+    private Quest profileQuest(QuestCompletionPolicy completionPolicy) {
+        Quest quest = Quest.createDefinition(
+                "quest:test:explicit-completion-profile",
+                7,
+                QuestCategory.MAIN,
+                QuestTitle.of("Profile 명시적 완료 테스트"),
+                "RewardProfile Quest 명시적 완료 테스트",
+                QuestTarget.of(QuestTargetType.COUNT, 1),
+                RewardProfileRef.of("RP_EXP_30"),
                 QuestRepeatRule.NONE,
                 completionPolicy,
                 null

--- a/src/test/java/online/lifeasgame/quest/application/QuestAcceptanceCompletionServiceTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/QuestAcceptanceCompletionServiceTest.java
@@ -113,7 +113,25 @@ class QuestAcceptanceCompletionServiceTest {
             assertThat(replay.status()).isEqualTo(QuestStatus.COMPLETED.name());
             assertThat(replay.completedAt()).isEqualTo(first.completedAt());
             verify(questWriter, times(1)).saveAcceptance(acceptance);
-            verify(domainEventPublisher, times(1)).publish(any());
+            ArgumentCaptor<DomainEvent> eventCaptor =
+                    ArgumentCaptor.forClass(DomainEvent.class);
+            verify(domainEventPublisher, times(1))
+                    .publish(eventCaptor.capture());
+            QuestEvent event = (QuestEvent) eventCaptor.getValue();
+            assertThat(event.attributes())
+                    .containsEntry("questDefinitionVersion", 1)
+                    .containsEntry("rewardExp", 25)
+                    .containsEntry(
+                            "rewardStats",
+                            java.util.Map.of("vitality", 1)
+                    )
+                    .doesNotContainKeys(
+                            "rewardProfileCode",
+                            "rewardLines",
+                            "rewardProfileId"
+                    );
+            assertThat(event.correlationId())
+                    .isEqualTo("quest:193:acceptance:1930:completed");
         }
     }
 
@@ -175,7 +193,10 @@ class QuestAcceptanceCompletionServiceTest {
                 QuestTitle.of("명시적 완료 테스트"),
                 "Quest 명시적 완료 테스트",
                 QuestTarget.of(QuestTargetType.COUNT, 1),
-                QuestReward.of(0, RewardStats.empty()),
+                QuestReward.of(
+                        25,
+                        new RewardStats(java.util.Map.of("vitality", 1))
+                ),
                 QuestRepeatRule.NONE,
                 completionPolicy,
                 null

--- a/src/test/java/online/lifeasgame/quest/application/QuestDefinitionServiceTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/QuestDefinitionServiceTest.java
@@ -1,0 +1,287 @@
+package online.lifeasgame.quest.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.event.DomainEventPublisher;
+import online.lifeasgame.quest.application.command.QuestCommand;
+import online.lifeasgame.quest.application.result.QuestResult;
+import online.lifeasgame.quest.domain.*;
+import online.lifeasgame.quest.domain.error.QuestError;
+import online.lifeasgame.reward.application.internal.RewardProfileLookupApi;
+import online.lifeasgame.reward.domain.error.RewardError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Quest Definition Application 계약")
+class QuestDefinitionServiceTest {
+
+    @Mock
+    private QuestBlueprintCatalog blueprintCatalog;
+
+    @Mock
+    private QuestReader questReader;
+
+    @Mock
+    private QuestWriter questWriter;
+
+    @Mock
+    private RewardProfileLookupApi rewardProfileLookupApi;
+
+    @Mock
+    private DomainEventPublisher domainEventPublisher;
+
+    private QuestService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new QuestService(
+                blueprintCatalog,
+                questReader,
+                questWriter,
+                rewardProfileLookupApi,
+                domainEventPublisher
+        );
+    }
+
+    @Nested
+    @DisplayName("Admin이 RewardProfile 참조를 수정할 때")
+    class UpdateRewardProfile {
+
+        @Test
+        @DisplayName("active profile code만 저장하고 신규 응답의 inline reward는 null이다")
+        void updatesWithActiveProfile() {
+            Quest quest = legacyQuest();
+            stubExisting(quest);
+            given(rewardProfileLookupApi.getActiveByCode("RP_EXP_30"))
+                    .willReturn(reference("RP_EXP_30"));
+
+            QuestResult.Definition result = service.updateDefinition(
+                    update(2, "  RP_EXP_30  ", null, null)
+            );
+
+            assertThat(result.definitionVersion()).isEqualTo(2);
+            assertThat(result.rewardProfileCode()).isEqualTo("RP_EXP_30");
+            assertThat(result.rewardExp()).isNull();
+            assertThat(result.rewardStats()).isNull();
+            verify(rewardProfileLookupApi).getActiveByCode("RP_EXP_30");
+            verify(domainEventPublisher).publishAll(any());
+        }
+
+        @Test
+        @DisplayName("missing profile 오류를 번역하지 않고 Quest mutation을 남기지 않는다")
+        void keepsMissingProfileError() {
+            Quest quest = legacyQuest();
+            stubExisting(quest);
+            given(rewardProfileLookupApi.getActiveByCode("UNKNOWN"))
+                    .willThrow(new DomainException(RewardError.REWARD_PROFILE_NOT_FOUND));
+
+            assertRewardError(
+                    () -> service.updateDefinition(
+                            update(2, "UNKNOWN", null, null)
+                    ),
+                    RewardError.REWARD_PROFILE_NOT_FOUND
+            );
+
+            assertUnchangedLegacy(quest);
+            verifyNoInteractions(domainEventPublisher);
+        }
+
+        @Test
+        @DisplayName("inactive profile 오류를 번역하지 않고 Quest mutation을 남기지 않는다")
+        void keepsInactiveProfileError() {
+            Quest quest = legacyQuest();
+            stubExisting(quest);
+            given(rewardProfileLookupApi.getActiveByCode("RP_INACTIVE"))
+                    .willThrow(new DomainException(RewardError.REWARD_PROFILE_INACTIVE));
+
+            assertRewardError(
+                    () -> service.updateDefinition(
+                            update(2, "RP_INACTIVE", null, null)
+                    ),
+                    RewardError.REWARD_PROFILE_INACTIVE
+            );
+
+            assertUnchangedLegacy(quest);
+            verifyNoInteractions(domainEventPublisher);
+        }
+
+        @Test
+        @DisplayName("profile code와 inline reward를 한 요청에서 변경하면 400 계약으로 거부한다")
+        void rejectsMixedRewardContract() {
+            Quest quest = legacyQuest();
+            stubExisting(quest);
+
+            assertQuestError(
+                    () -> service.updateDefinition(
+                            update(2, "RP_EXP_10", 10, Map.of())
+                    ),
+                    QuestError.QUEST_REWARD_CONTRACT_CONFLICT
+            );
+
+            assertUnchangedLegacy(quest);
+            verifyNoInteractions(rewardProfileLookupApi, domainEventPublisher);
+        }
+
+        @Test
+        @DisplayName("동일 version과 profile code는 lookup과 Event가 없는 no-op이다")
+        void doesNotPublishNoOp() {
+            Quest quest = profileQuest(2, "RP_EXP_10");
+            stubExisting(quest);
+
+            QuestResult.Definition result = service.updateDefinition(
+                    update(2, " RP_EXP_10 ", null, null)
+            );
+
+            assertThat(result.definitionVersion()).isEqualTo(2);
+            assertThat(result.rewardProfileCode()).isEqualTo("RP_EXP_10");
+            verifyNoInteractions(rewardProfileLookupApi, domainEventPublisher);
+        }
+    }
+
+    @Test
+    @DisplayName("legacy inline reward partial update는 기존 동작을 유지한다")
+    void updatesLegacyInlineReward() {
+        Quest quest = legacyQuest();
+        stubExisting(quest);
+
+        QuestResult.Definition result = service.updateDefinition(
+                update(null, null, 50, Map.of("strength", 1))
+        );
+
+        assertThat(result.definitionVersion()).isEqualTo(1);
+        assertThat(result.rewardProfileCode()).isNull();
+        assertThat(result.rewardExp()).isEqualTo(50);
+        assertThat(result.rewardStats()).containsEntry("strength", 1);
+        verifyNoInteractions(rewardProfileLookupApi);
+        verify(domainEventPublisher).publishAll(any());
+    }
+
+    @Test
+    @DisplayName("신규 계약 Blueprint materialization 전에 active profile을 조회한다")
+    void validatesProfileBlueprintBeforeMaterialization() {
+        QuestBlueprint blueprint = QuestBlueprint.profileBased(
+                QuestCode.PLAYER_WELCOME,
+                4,
+                QuestCategory.MAIN,
+                QuestTitle.of("Profile Blueprint"),
+                "profile blueprint",
+                QuestTarget.of(QuestTargetType.COUNT, 1),
+                RewardProfileRef.of("RP_EXP_30"),
+                QuestRepeatRule.NONE,
+                null,
+                QuestCompletionPolicy.AUTO
+        );
+        given(questReader.findByCode(QuestCode.PLAYER_WELCOME))
+                .willReturn(Optional.empty());
+        given(blueprintCatalog.require(QuestCode.PLAYER_WELCOME))
+                .willReturn(blueprint);
+        given(rewardProfileLookupApi.getActiveByCode("RP_EXP_30"))
+                .willReturn(reference("RP_EXP_30"));
+        given(questWriter.create(any())).willAnswer(
+                invocation -> invocation.getArgument(0)
+        );
+
+        Quest result = service.ensureQuest(QuestCode.PLAYER_WELCOME);
+
+        assertThat(result.getDefinitionVersion()).isEqualTo(4);
+        assertThat(result.rewardProfileCodeOrNull()).isEqualTo("RP_EXP_30");
+        verify(rewardProfileLookupApi).getActiveByCode("RP_EXP_30");
+        verify(questWriter).create(any());
+    }
+
+    private void stubExisting(Quest quest) {
+        given(questReader.findByCode(QuestCode.PLAYER_WELCOME))
+                .willReturn(Optional.of(quest));
+    }
+
+    private QuestCommand.UpdateDefinition update(
+            Integer definitionVersion,
+            String rewardProfileCode,
+            Integer rewardExp,
+            Map<String, Integer> rewardStats
+    ) {
+        return new QuestCommand.UpdateDefinition(
+                QuestCode.PLAYER_WELCOME.name(),
+                definitionVersion,
+                null,
+                null,
+                rewardProfileCode,
+                rewardExp,
+                rewardStats,
+                null,
+                null
+        );
+    }
+
+    private RewardProfileLookupApi.RewardProfileReference reference(String code) {
+        return new RewardProfileLookupApi.RewardProfileReference(code);
+    }
+
+    private Quest legacyQuest() {
+        return Quest.create(
+                QuestCode.PLAYER_WELCOME.value(),
+                QuestCategory.MAIN,
+                QuestTitle.of("Legacy Definition"),
+                "legacy",
+                QuestTarget.of(QuestTargetType.COUNT, 1),
+                QuestReward.of(0, RewardStats.empty()),
+                QuestRepeatRule.NONE,
+                QuestCompletionPolicy.AUTO,
+                null
+        );
+    }
+
+    private Quest profileQuest(int version, String profileCode) {
+        return Quest.createDefinition(
+                QuestCode.PLAYER_WELCOME.value(),
+                version,
+                QuestCategory.MAIN,
+                QuestTitle.of("Profile Definition"),
+                "profile",
+                QuestTarget.of(QuestTargetType.COUNT, 1),
+                RewardProfileRef.of(profileCode),
+                QuestRepeatRule.NONE,
+                QuestCompletionPolicy.AUTO,
+                null
+        );
+    }
+
+    private void assertUnchangedLegacy(Quest quest) {
+        assertThat(quest.getDefinitionVersion()).isEqualTo(1);
+        assertThat(quest.rewardProfileCodeOrNull()).isNull();
+        assertThat(quest.getReward().exp()).isZero();
+        assertThat(quest.pullEvents()).isEmpty();
+    }
+
+    private void assertQuestError(Runnable action, QuestError error) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(
+                        DomainException.class,
+                        exception -> assertThat(exception.getErrorCode())
+                                .isEqualTo(error)
+                );
+    }
+
+    private void assertRewardError(Runnable action, RewardError error) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(
+                        DomainException.class,
+                        exception -> assertThat(exception.getErrorCode())
+                                .isEqualTo(error)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/quest/application/QuestServiceStateContractTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/QuestServiceStateContractTest.java
@@ -7,6 +7,7 @@ import online.lifeasgame.quest.application.result.QuestResult;
 import online.lifeasgame.quest.domain.*;
 import online.lifeasgame.quest.domain.event.QuestEvent;
 import online.lifeasgame.quest.domain.event.QuestEventType;
+import online.lifeasgame.reward.application.internal.RewardProfileLookupApi;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -42,6 +43,9 @@ class QuestServiceStateContractTest {
     private QuestWriter questWriter;
 
     @Mock
+    private RewardProfileLookupApi rewardProfileLookupApi;
+
+    @Mock
     private DomainEventPublisher domainEventPublisher;
 
     private QuestService service;
@@ -52,6 +56,7 @@ class QuestServiceStateContractTest {
                 questBlueprintCatalog,
                 questReader,
                 questWriter,
+                rewardProfileLookupApi,
                 domainEventPublisher
         );
     }
@@ -78,8 +83,19 @@ class QuestServiceStateContractTest {
 
             ArgumentCaptor<DomainEvent> eventCaptor = ArgumentCaptor.forClass(DomainEvent.class);
             verify(domainEventPublisher).publish(eventCaptor.capture());
-            assertThat(((QuestEvent) eventCaptor.getValue()).type())
-                    .isEqualTo(QuestEventType.QUEST_COMPLETED);
+            QuestEvent event = (QuestEvent) eventCaptor.getValue();
+            assertThat(event.type()).isEqualTo(QuestEventType.QUEST_COMPLETED);
+            assertThat(event.attributes())
+                    .containsEntry("questDefinitionVersion", 6)
+                    .containsEntry("rewardProfileCode", "RP_EXP_30")
+                    .doesNotContainKeys(
+                            "rewardExp",
+                            "rewardStats",
+                            "rewardLines",
+                            "rewardProfileId"
+                    );
+            assertThat(event.correlationId())
+                    .isEqualTo("quest:193:acceptance:1930:admin-completed");
         }
     }
 
@@ -126,13 +142,14 @@ class QuestServiceStateContractTest {
     }
 
     private Quest quest() {
-        Quest quest = Quest.create(
+        Quest quest = Quest.createDefinition(
                 QuestCode.PLAYER_WELCOME.value(),
+                6,
                 QuestCategory.MAIN,
                 QuestTitle.of("서비스 상태 계약"),
                 "QuestService 상태 계약 테스트",
                 QuestTarget.of(QuestTargetType.COUNT, 1),
-                QuestReward.of(0, RewardStats.empty()),
+                RewardProfileRef.of("RP_EXP_30"),
                 QuestRepeatRule.NONE,
                 QuestCompletionPolicy.USER_CONFIRM,
                 null

--- a/src/test/java/online/lifeasgame/quest/application/QuestServiceStateContractTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/QuestServiceStateContractTest.java
@@ -86,11 +86,14 @@ class QuestServiceStateContractTest {
             QuestEvent event = (QuestEvent) eventCaptor.getValue();
             assertThat(event.type()).isEqualTo(QuestEventType.QUEST_COMPLETED);
             assertThat(event.attributes())
-                    .containsEntry("questDefinitionVersion", 6)
-                    .containsEntry("rewardProfileCode", "RP_EXP_30")
-                    .doesNotContainKeys(
-                            "rewardExp",
+                    .containsEntry("questDefinitionVersion", 1)
+                    .containsEntry("rewardExp", 45)
+                    .containsEntry(
                             "rewardStats",
+                            java.util.Map.of("wisdom", 3)
+                    )
+                    .doesNotContainKeys(
+                            "rewardProfileCode",
                             "rewardLines",
                             "rewardProfileId"
                     );
@@ -142,14 +145,16 @@ class QuestServiceStateContractTest {
     }
 
     private Quest quest() {
-        Quest quest = Quest.createDefinition(
+        Quest quest = Quest.create(
                 QuestCode.PLAYER_WELCOME.value(),
-                6,
                 QuestCategory.MAIN,
                 QuestTitle.of("서비스 상태 계약"),
                 "QuestService 상태 계약 테스트",
                 QuestTarget.of(QuestTargetType.COUNT, 1),
-                RewardProfileRef.of("RP_EXP_30"),
+                QuestReward.of(
+                        45,
+                        new RewardStats(java.util.Map.of("wisdom", 3))
+                ),
                 QuestRepeatRule.NONE,
                 QuestCompletionPolicy.USER_CONFIRM,
                 null

--- a/src/test/java/online/lifeasgame/quest/application/automation/QuestSignalProcessingAttemptTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/automation/QuestSignalProcessingAttemptTest.java
@@ -78,7 +78,7 @@ class QuestSignalProcessingAttemptTest {
         @Test
         @DisplayName("Receipt를 먼저 flush하고 Goal과 Completed Event를 순서대로 발행한다")
         void savesReceiptBeforeApplyingQuest() {
-            Quest quest = quest(QuestCompletionPolicy.AUTO, QuestRepeatRule.NONE);
+            Quest quest = profileQuest();
             QuestSignal signal = signal(OCCURRED_AT);
             stubReceipt(signal);
             stubNewAcceptance(quest, signal);
@@ -101,6 +101,18 @@ class QuestSignalProcessingAttemptTest {
                             QuestEventType.QUEST_GOAL_REACHED,
                             QuestEventType.QUEST_COMPLETED
                     );
+            QuestEvent completed = events.getLast();
+            assertThat(completed.attributes())
+                    .containsEntry("questDefinitionVersion", 5)
+                    .containsEntry("rewardProfileCode", "RP_EXP_10")
+                    .doesNotContainKeys(
+                            "rewardExp",
+                            "rewardStats",
+                            "rewardLines",
+                            "rewardProfileId"
+                    );
+            assertThat(completed.correlationId())
+                    .isEqualTo("source:signal-195:completed");
             QuestAcceptance saved = lastSavedAcceptance();
             assertThat(saved.getStatus()).isEqualTo(QuestStatus.COMPLETED);
             assertThat(saved.getGoalReachedAt()).isEqualTo(OCCURRED_AT);
@@ -380,6 +392,23 @@ class QuestSignalProcessingAttemptTest {
                 QuestReward.of(0, RewardStats.empty()),
                 repeatRule,
                 completionPolicy,
+                null
+        );
+        ReflectionTestUtils.setField(quest, "id", QUEST_ID);
+        return quest;
+    }
+
+    private Quest profileQuest() {
+        Quest quest = Quest.createDefinition(
+                QuestCode.PLAYER_WELCOME.value(),
+                5,
+                QuestCategory.MAIN,
+                QuestTitle.of("Profile Signal 계약"),
+                "RewardProfile Quest Signal 계약 테스트",
+                QuestTarget.of(QuestTargetType.COUNT, 1),
+                RewardProfileRef.of("RP_EXP_10"),
+                QuestRepeatRule.NONE,
+                QuestCompletionPolicy.AUTO,
                 null
         );
         ReflectionTestUtils.setField(quest, "id", QUEST_ID);

--- a/src/test/java/online/lifeasgame/quest/application/automation/QuestSignalProcessingAttemptTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/automation/QuestSignalProcessingAttemptTest.java
@@ -284,13 +284,29 @@ class QuestSignalProcessingAttemptTest {
             assertThat(current.getPeriod().start()).isEqualTo(eventDate);
             assertThat(current.getStatus())
                     .isEqualTo(QuestStatus.COMPLETED);
-            assertThat(publishedEvents(4)).extracting(QuestEvent::type)
+            List<QuestEvent> events = publishedEvents(4);
+            assertThat(events).extracting(QuestEvent::type)
                     .containsExactly(
                             QuestEventType.QUEST_ACCEPTED,
                             QuestEventType.QUEST_PROGRESS,
                             QuestEventType.QUEST_GOAL_REACHED,
                             QuestEventType.QUEST_COMPLETED
                     );
+            QuestEvent completed = events.getLast();
+            assertThat(completed.attributes())
+                    .containsEntry("questDefinitionVersion", 1)
+                    .containsEntry("rewardExp", 15)
+                    .containsEntry(
+                            "rewardStats",
+                            java.util.Map.of("focus", 1)
+                    )
+                    .doesNotContainKeys(
+                            "rewardProfileCode",
+                            "rewardLines",
+                            "rewardProfileId"
+                    );
+            assertThat(completed.correlationId())
+                    .isEqualTo("source:signal-195:completed");
             verify(questProgressStore).reset(
                     QuestCode.PLAYER_WELCOME,
                     PLAYER_ID
@@ -389,7 +405,10 @@ class QuestSignalProcessingAttemptTest {
                 QuestTitle.of("Receipt 상태 계약"),
                 "Quest Signal Receipt 상태 계약 테스트",
                 QuestTarget.of(QuestTargetType.COUNT, target),
-                QuestReward.of(0, RewardStats.empty()),
+                QuestReward.of(
+                        15,
+                        new RewardStats(java.util.Map.of("focus", 1))
+                ),
                 repeatRule,
                 completionPolicy,
                 null

--- a/src/test/java/online/lifeasgame/quest/domain/QuestDefinitionContractTest.java
+++ b/src/test/java/online/lifeasgame/quest/domain/QuestDefinitionContractTest.java
@@ -1,0 +1,192 @@
+package online.lifeasgame.quest.domain;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.quest.domain.error.QuestError;
+import online.lifeasgame.quest.domain.event.QuestEvent;
+import online.lifeasgame.quest.domain.event.QuestEventType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Quest Definition version과 RewardProfile 참조 계약")
+class QuestDefinitionContractTest {
+
+    @Nested
+    @DisplayName("RewardProfile 기반 Definition을 생성할 때")
+    class CreateProfileDefinition {
+
+        @Test
+        @DisplayName("명시한 version과 trim된 profile code를 보존한다")
+        void createsDefinition() {
+            Quest quest = profileQuest(3, "  RP_EXP_30  ");
+
+            assertThat(quest.getDefinitionVersion()).isEqualTo(3);
+            assertThat(quest.rewardProfileCodeOrNull()).isEqualTo("RP_EXP_30");
+            assertThat(quest.usesRewardProfile()).isTrue();
+            assertThat(quest.isLegacyInlineReward()).isFalse();
+        }
+
+        @Test
+        @DisplayName("version 1 미만은 안정된 QuestError로 거부한다")
+        void rejectsInvalidVersion() {
+            assertQuestError(
+                    () -> profileQuest(0, "RP_EXP_10"),
+                    QuestError.QUEST_DEFINITION_VERSION_INVALID
+            );
+        }
+
+        @Test
+        @DisplayName("blank 또는 80자를 넘는 profile code를 거부한다")
+        void rejectsInvalidProfileCode() {
+            assertQuestError(
+                    () -> RewardProfileRef.of("   "),
+                    QuestError.QUEST_REWARD_PROFILE_CODE_REQUIRED
+            );
+            assertQuestError(
+                    () -> RewardProfileRef.of("R".repeat(81)),
+                    QuestError.QUEST_REWARD_PROFILE_CODE_TOO_LONG
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("Definition을 수정할 때")
+    class UpdateDefinition {
+
+        @Test
+        @DisplayName("저장된 version보다 낮은 version은 mutation 전에 거부한다")
+        void rejectsVersionDecrease() {
+            Quest quest = profileQuest(3, "RP_EXP_30");
+
+            assertQuestError(
+                    () -> quest.updateDefinition(
+                            QuestTarget.of(QuestTargetType.COUNT, 2),
+                            null,
+                            null,
+                            null,
+                            2,
+                            null
+                    ),
+                    QuestError.QUEST_DEFINITION_VERSION_DECREASE_NOT_ALLOWED
+            );
+
+            assertThat(quest.getDefinitionVersion()).isEqualTo(3);
+            assertThat(quest.target().value()).isEqualTo(1);
+            assertThat(quest.pullEvents()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("profile ref와 inline reward 동시 변경을 거부한다")
+        void rejectsMixedRewardContracts() {
+            Quest quest = legacyQuest();
+
+            assertQuestError(
+                    () -> quest.updateDefinition(
+                            null,
+                            QuestReward.of(10, RewardStats.empty()),
+                            null,
+                            null,
+                            2,
+                            RewardProfileRef.of("RP_EXP_10")
+                    ),
+                    QuestError.QUEST_REWARD_CONTRACT_CONFLICT
+            );
+
+            assertThat(quest.getDefinitionVersion()).isEqualTo(1);
+            assertThat(quest.rewardProfileCodeOrNull()).isNull();
+            assertThat(quest.getReward().exp()).isZero();
+            assertThat(quest.pullEvents()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("동일한 명시 값은 no-op이며 Event를 만들지 않는다")
+        void doesNotRecordNoOpEvent() {
+            Quest quest = profileQuest(2, "RP_EXP_10");
+
+            quest.updateDefinition(
+                    quest.target(),
+                    null,
+                    quest.getRepeatRule(),
+                    null,
+                    2,
+                    RewardProfileRef.of("RP_EXP_10")
+            );
+
+            assertThat(quest.pullEvents()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("변경 Event에는 version과 profile code만 보상 Snapshot으로 담는다")
+        void snapshotsDefinitionReference() {
+            Quest quest = profileQuest(1, "RP_EXP_10");
+
+            quest.updateDefinition(
+                    null,
+                    null,
+                    null,
+                    null,
+                    2,
+                    RewardProfileRef.of("RP_EXP_30")
+            );
+
+            QuestEvent event = (QuestEvent) quest.pullEvents().getFirst();
+            assertThat(event.type()).isEqualTo(QuestEventType.QUEST_UPDATED);
+            assertThat(event.attributes())
+                    .containsEntry("questDefinitionVersion", 2)
+                    .containsEntry("rewardProfileCode", "RP_EXP_30")
+                    .doesNotContainKeys("rewardExp", "rewardStats", "rewardLines");
+        }
+    }
+
+    @Test
+    @DisplayName("legacy 생성 overload는 version 1과 inline reward를 유지한다")
+    void keepsLegacyCreation() {
+        Quest quest = legacyQuest();
+
+        assertThat(quest.getDefinitionVersion()).isEqualTo(1);
+        assertThat(quest.rewardProfileCodeOrNull()).isNull();
+        assertThat(quest.isLegacyInlineReward()).isTrue();
+        assertThat(quest.getReward().exp()).isZero();
+    }
+
+    private Quest profileQuest(int version, String profileCode) {
+        return Quest.createDefinition(
+                "quest:test:profile",
+                version,
+                QuestCategory.MAIN,
+                QuestTitle.of("Profile Quest"),
+                "RewardProfile 기반 Quest",
+                QuestTarget.of(QuestTargetType.COUNT, 1),
+                RewardProfileRef.of(profileCode),
+                QuestRepeatRule.NONE,
+                QuestCompletionPolicy.AUTO,
+                null
+        );
+    }
+
+    private Quest legacyQuest() {
+        return Quest.create(
+                "quest:test:legacy",
+                QuestCategory.MAIN,
+                QuestTitle.of("Legacy Quest"),
+                "inline reward 기반 Quest",
+                QuestTarget.of(QuestTargetType.COUNT, 1),
+                QuestReward.of(0, RewardStats.empty()),
+                QuestRepeatRule.NONE,
+                QuestCompletionPolicy.AUTO,
+                null
+        );
+    }
+
+    private void assertQuestError(Runnable action, QuestError error) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(
+                        DomainException.class,
+                        exception -> assertThat(exception.getErrorCode())
+                                .isEqualTo(error)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/quest/domain/QuestDefinitionContractTest.java
+++ b/src/test/java/online/lifeasgame/quest/domain/QuestDefinitionContractTest.java
@@ -81,7 +81,7 @@ class QuestDefinitionContractTest {
         @Test
         @DisplayName("profile ref와 inline reward 동시 변경을 거부한다")
         void rejectsMixedRewardContracts() {
-            Quest quest = legacyQuest();
+            Quest quest = nonZeroLegacyQuest();
 
             assertQuestError(
                     () -> quest.updateDefinition(
@@ -97,7 +97,64 @@ class QuestDefinitionContractTest {
 
             assertThat(quest.getDefinitionVersion()).isEqualTo(1);
             assertThat(quest.rewardProfileCodeOrNull()).isNull();
+            assertThat(quest.getReward().exp()).isEqualTo(70);
+            assertThat(quest.getReward().stats().stats())
+                    .containsEntry("strength", 2);
+            assertThat(quest.pullEvents()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("non-zero legacy reward를 profile 계약 전환 시 empty로 정리한다")
+        void clearsLegacyRewardWhenApplyingProfileReference() {
+            Quest quest = nonZeroLegacyQuest();
+
+            quest.updateDefinition(
+                    null,
+                    null,
+                    null,
+                    null,
+                    2,
+                    RewardProfileRef.of("RP_EXP_30")
+            );
+
+            assertThat(quest.usesRewardProfile()).isTrue();
+            assertThat(quest.rewardProfileCodeOrNull()).isEqualTo("RP_EXP_30");
             assertThat(quest.getReward().exp()).isZero();
+            assertThat(quest.getReward().stats().stats()).isEmpty();
+            QuestEvent event = (QuestEvent) quest.pullEvents().getFirst();
+            assertThat(event.attributes())
+                    .containsEntry("questDefinitionVersion", 2)
+                    .containsEntry("rewardProfileCode", "RP_EXP_30")
+                    .doesNotContainKeys(
+                            "rewardExp",
+                            "rewardStats",
+                            "rewardLines",
+                            "rewardProfileId"
+                    );
+        }
+
+        @Test
+        @DisplayName("version validation 실패 시 legacy reward와 profile ref를 모두 보존한다")
+        void preservesRewardWhenValidationFails() {
+            Quest quest = nonZeroLegacyQuest();
+
+            assertQuestError(
+                    () -> quest.updateDefinition(
+                            QuestTarget.of(QuestTargetType.COUNT, 2),
+                            null,
+                            null,
+                            null,
+                            0,
+                            RewardProfileRef.of("RP_EXP_30")
+                    ),
+                    QuestError.QUEST_DEFINITION_VERSION_INVALID
+            );
+
+            assertThat(quest.target().value()).isEqualTo(1);
+            assertThat(quest.rewardProfileCodeOrNull()).isNull();
+            assertThat(quest.getReward().exp()).isEqualTo(70);
+            assertThat(quest.getReward().stats().stats())
+                    .containsEntry("strength", 2);
             assertThat(quest.pullEvents()).isEmpty();
         }
 
@@ -175,6 +232,23 @@ class QuestDefinitionContractTest {
                 "inline reward 기반 Quest",
                 QuestTarget.of(QuestTargetType.COUNT, 1),
                 QuestReward.of(0, RewardStats.empty()),
+                QuestRepeatRule.NONE,
+                QuestCompletionPolicy.AUTO,
+                null
+        );
+    }
+
+    private Quest nonZeroLegacyQuest() {
+        return Quest.create(
+                "quest:test:legacy-non-zero",
+                QuestCategory.MAIN,
+                QuestTitle.of("Non-zero Legacy Quest"),
+                "non-zero inline reward 기반 Quest",
+                QuestTarget.of(QuestTargetType.COUNT, 1),
+                QuestReward.of(
+                        70,
+                        new RewardStats(java.util.Map.of("strength", 2))
+                ),
                 QuestRepeatRule.NONE,
                 QuestCompletionPolicy.AUTO,
                 null

--- a/src/test/java/online/lifeasgame/quest/domain/event/QuestEventDefinitionSnapshotTest.java
+++ b/src/test/java/online/lifeasgame/quest/domain/event/QuestEventDefinitionSnapshotTest.java
@@ -10,14 +10,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 class QuestEventDefinitionSnapshotTest {
 
     @Test
-    @DisplayName("RewardProfile Definition은 version과 code만 보상 계약으로 기록한다")
+    @DisplayName("RewardProfile QuestCompleted는 version과 code만 보상 계약으로 기록한다")
     void snapshotsProfileDefinitionReference() {
         QuestEvent event = QuestEvent.snapshot(
-                QuestEventType.QUEST_UPDATED,
+                QuestEventType.QUEST_COMPLETED,
                 profileQuest(),
-                "quest:test:profile:updated"
+                "quest:test:profile:completed"
         );
 
+        assertThat(event.type()).isEqualTo(QuestEventType.QUEST_COMPLETED);
         assertThat(event.attributes())
                 .containsEntry("questDefinitionVersion", 3)
                 .containsEntry("rewardProfileCode", "RP_EXP_30")
@@ -30,19 +31,24 @@ class QuestEventDefinitionSnapshotTest {
     }
 
     @Test
-    @DisplayName("legacy Definition은 version 1과 기존 inline reward Snapshot을 유지한다")
+    @DisplayName("legacy QuestCompleted는 version 1과 inline reward Snapshot을 유지한다")
     void snapshotsLegacyDefinition() {
         QuestEvent event = QuestEvent.snapshot(
-                QuestEventType.QUEST_UPDATED,
+                QuestEventType.QUEST_COMPLETED,
                 legacyQuest(),
-                "quest:test:legacy:updated"
+                "quest:test:legacy:completed"
         );
 
+        assertThat(event.type()).isEqualTo(QuestEventType.QUEST_COMPLETED);
         assertThat(event.attributes())
                 .containsEntry("questDefinitionVersion", 1)
                 .containsEntry("rewardExp", 7)
                 .containsEntry("rewardStats", java.util.Map.of("strength", 2))
-                .doesNotContainKey("rewardProfileCode");
+                .doesNotContainKeys(
+                        "rewardProfileCode",
+                        "rewardLines",
+                        "rewardProfileId"
+                );
     }
 
     private Quest profileQuest() {

--- a/src/test/java/online/lifeasgame/quest/domain/event/QuestEventDefinitionSnapshotTest.java
+++ b/src/test/java/online/lifeasgame/quest/domain/event/QuestEventDefinitionSnapshotTest.java
@@ -1,0 +1,79 @@
+package online.lifeasgame.quest.domain.event;
+
+import online.lifeasgame.quest.domain.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("QuestEvent Definition Snapshot")
+class QuestEventDefinitionSnapshotTest {
+
+    @Test
+    @DisplayName("RewardProfile Definition은 version과 code만 보상 계약으로 기록한다")
+    void snapshotsProfileDefinitionReference() {
+        QuestEvent event = QuestEvent.snapshot(
+                QuestEventType.QUEST_UPDATED,
+                profileQuest(),
+                "quest:test:profile:updated"
+        );
+
+        assertThat(event.attributes())
+                .containsEntry("questDefinitionVersion", 3)
+                .containsEntry("rewardProfileCode", "RP_EXP_30")
+                .doesNotContainKeys(
+                        "rewardExp",
+                        "rewardStats",
+                        "rewardLines",
+                        "rewardProfileId"
+                );
+    }
+
+    @Test
+    @DisplayName("legacy Definition은 version 1과 기존 inline reward Snapshot을 유지한다")
+    void snapshotsLegacyDefinition() {
+        QuestEvent event = QuestEvent.snapshot(
+                QuestEventType.QUEST_UPDATED,
+                legacyQuest(),
+                "quest:test:legacy:updated"
+        );
+
+        assertThat(event.attributes())
+                .containsEntry("questDefinitionVersion", 1)
+                .containsEntry("rewardExp", 7)
+                .containsEntry("rewardStats", java.util.Map.of("strength", 2))
+                .doesNotContainKey("rewardProfileCode");
+    }
+
+    private Quest profileQuest() {
+        return Quest.createDefinition(
+                "quest:test:profile",
+                3,
+                QuestCategory.MAIN,
+                QuestTitle.of("Profile Quest"),
+                "profile",
+                QuestTarget.of(QuestTargetType.COUNT, 1),
+                RewardProfileRef.of("RP_EXP_30"),
+                QuestRepeatRule.NONE,
+                QuestCompletionPolicy.AUTO,
+                null
+        );
+    }
+
+    private Quest legacyQuest() {
+        return Quest.create(
+                "quest:test:legacy",
+                QuestCategory.MAIN,
+                QuestTitle.of("Legacy Quest"),
+                "legacy",
+                QuestTarget.of(QuestTargetType.COUNT, 1),
+                QuestReward.of(
+                        7,
+                        new RewardStats(java.util.Map.of("strength", 2))
+                ),
+                QuestRepeatRule.NONE,
+                QuestCompletionPolicy.AUTO,
+                null
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/reward/application/RewardProfileLookupServiceTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardProfileLookupServiceTest.java
@@ -1,0 +1,92 @@
+package online.lifeasgame.reward.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.reward.application.internal.RewardProfileLookupApi;
+import online.lifeasgame.reward.domain.RewardProfile;
+import online.lifeasgame.reward.domain.RewardProfileStatus;
+import online.lifeasgame.reward.domain.error.RewardError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RewardProfile provider-owned lookup API")
+class RewardProfileLookupServiceTest {
+
+    @Mock
+    private RewardProfileReader rewardProfileReader;
+
+    private RewardProfileLookupService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new RewardProfileLookupService(rewardProfileReader);
+    }
+
+    @Nested
+    @DisplayName("활성 Profile을 code로 조회할 때")
+    class LookupActiveProfile {
+
+        @Test
+        @DisplayName("Entity 대신 code-only Reference DTO를 반환한다")
+        void returnsCodeOnlyReference() {
+            RewardProfile profile = RewardProfile.create(
+                    "RP_EXP_10",
+                    "EXP 10 Profile",
+                    RewardProfileStatus.ACTIVE
+            );
+            given(rewardProfileReader.getActiveByCodeOrThrow("RP_EXP_10"))
+                    .willReturn(profile);
+
+            RewardProfileLookupApi.RewardProfileReference result =
+                    service.getActiveByCode("RP_EXP_10");
+
+            assertThat(result.code()).isEqualTo("RP_EXP_10");
+            assertThat(result).isNotInstanceOf(RewardProfile.class);
+            assertThat(result.getClass().getRecordComponents())
+                    .extracting(component -> component.getName())
+                    .containsExactly("code");
+        }
+    }
+
+    @Test
+    @DisplayName("missing Profile의 RewardError를 그대로 전달한다")
+    void keepsMissingProfileError() {
+        given(rewardProfileReader.getActiveByCodeOrThrow("UNKNOWN"))
+                .willThrow(new DomainException(RewardError.REWARD_PROFILE_NOT_FOUND));
+
+        assertRewardError(
+                () -> service.getActiveByCode("UNKNOWN"),
+                RewardError.REWARD_PROFILE_NOT_FOUND
+        );
+    }
+
+    @Test
+    @DisplayName("inactive Profile의 RewardError를 그대로 전달한다")
+    void keepsInactiveProfileError() {
+        given(rewardProfileReader.getActiveByCodeOrThrow("RP_INACTIVE"))
+                .willThrow(new DomainException(RewardError.REWARD_PROFILE_INACTIVE));
+
+        assertRewardError(
+                () -> service.getActiveByCode("RP_INACTIVE"),
+                RewardError.REWARD_PROFILE_INACTIVE
+        );
+    }
+
+    private void assertRewardError(Runnable action, RewardError error) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(
+                        DomainException.class,
+                        exception -> assertThat(exception.getErrorCode())
+                                .isEqualTo(error)
+                );
+    }
+}


### PR DESCRIPTION
## What

- Quest Definition에 `definitionVersion`을 추가했습니다.
- Quest Definition에 `rewardProfileCode` 참조 계약을 추가했습니다.
- Quest와 Reward 사이를 Entity/FK가 아닌 InternalApi와 stable code로 연결했습니다.
- QuestCompleted Event에 Definition version과 Reward Profile code Snapshot을 추가했습니다.
- 기존 inline `QuestReward`는 Seed 전환 전까지 transitional compatibility로 유지했습니다.

## Contract

```text
QuestDefinition
- definitionVersion
- rewardProfileCode
```

```text
QuestCompleted
- questDefinitionVersion
- rewardProfileCode
```

## Migration

- `V10__quest_definition_reward_profile_contract.sql`
- 기존 V1~V9은 수정하지 않았습니다.
- legacy `reward_exp`, `reward_stats`는 이번 PR에서 유지합니다.

## Test

- [ ] `./gradlew clean test`
- [ ] `./gradlew build`
- [ ] active RewardProfile validation
- [ ] Definition version invariant
- [ ] new/legacy contract exclusivity
- [ ] QuestCompleted Snapshot
- [ ] legacy Quest regression
- [ ] V1~V10 checksum / JPA validate

## Out of Scope

- Core Quest Seed
- Reward Profile 최종 Seed
- QuestCompleted → RewardSettlement
- legacy reward column 삭제
- Reward Line / Mailbox / Item
- QuestRoute
- Frontend

Closes #203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quest definitions now include definition versioning and optional reward-profile references.
  * Quest catalog/blueprints/player and admin responses expose `definitionVersion` and `rewardProfileCode`.
  * Quest completion events now carry definition and reward-profile metadata.
* **Bug Fixes**
  * Added request validation for definition version (positive) and reward profile code length.
  * Enforced reward contract consistency to prevent conflicting legacy vs profile updates.
  * Made reward experience fields nullable to match profile-based vs legacy responses.
* **Documentation**
  * Expanded OpenAPI descriptions to clarify reward contract behavior and partial update rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->