### PR TITLE
[Quest] Add semantic category and progress source contract

### DIFF
--- a/src/main/java/online/lifeasgame/quest/api/admin/mapper/AdminQuestWebMapper.java
+++ b/src/main/java/online/lifeasgame/quest/api/admin/mapper/AdminQuestWebMapper.java
@@ -33,7 +33,11 @@ public final class AdminQuestWebMapper {
                 result.rewardProfileCode(),
                 result.rewardExp(),
                 result.rewardStats(),
-                result.dueAt()
+                result.dueAt(),
+                result.semanticCategory(),
+                result.progressSource(),
+                result.repeatPolicy(),
+                result.roleTemplateCode()
         );
     }
 
@@ -62,7 +66,11 @@ public final class AdminQuestWebMapper {
                 request.rewardExp(),
                 request.rewardStats(),
                 request.repeatRule(),
-                request.dueAt()
+                request.dueAt(),
+                request.semanticCategory(),
+                request.progressSource(),
+                request.repeatPolicy(),
+                request.roleTemplateCode()
         );
     }
 
@@ -81,7 +89,11 @@ public final class AdminQuestWebMapper {
                 result.rewardProfileCode(),
                 result.rewardExp(),
                 result.rewardStats(),
-                result.dueAt()
+                result.dueAt(),
+                result.semanticCategory(),
+                result.progressSource(),
+                result.repeatPolicy(),
+                result.roleTemplateCode()
         );
     }
 
@@ -118,7 +130,11 @@ public final class AdminQuestWebMapper {
                 result.periodEnd(),
                 result.goalReachedAt(),
                 result.completedAt(),
-                result.dueAt()
+                result.dueAt(),
+                result.semanticCategory(),
+                result.progressSource(),
+                result.repeatPolicy(),
+                result.roleTemplateCode()
         );
     }
 

--- a/src/main/java/online/lifeasgame/quest/api/admin/request/AdminQuestRequest.java
+++ b/src/main/java/online/lifeasgame/quest/api/admin/request/AdminQuestRequest.java
@@ -1,6 +1,7 @@
 package online.lifeasgame.quest.api.admin.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
@@ -21,8 +22,40 @@ public final class AdminQuestRequest {
             @Size(max = 80) String rewardProfileCode,
             Integer rewardExp,
             Map<String, Integer> rewardStats,
-            Instant dueAt
-    ) {}
+            Instant dueAt,
+            String semanticCategory,
+            String progressSource,
+            String repeatPolicy,
+            @Size(max = 80)
+            @Pattern(regexp = ".*\\S.*")
+            String roleTemplateCode
+    ) {
+        public Update(
+                Integer definitionVersion,
+                String targetType,
+                Integer targetValue,
+                String repeatRule,
+                String rewardProfileCode,
+                Integer rewardExp,
+                Map<String, Integer> rewardStats,
+                Instant dueAt
+        ) {
+            this(
+                    definitionVersion,
+                    targetType,
+                    targetValue,
+                    repeatRule,
+                    rewardProfileCode,
+                    rewardExp,
+                    rewardStats,
+                    dueAt,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+        }
+    }
 
     public record AdjustProgress(
             @NotBlank String type,

--- a/src/main/java/online/lifeasgame/quest/api/admin/response/AdminQuestResponse.java
+++ b/src/main/java/online/lifeasgame/quest/api/admin/response/AdminQuestResponse.java
@@ -22,7 +22,11 @@ public final class AdminQuestResponse {
             String rewardProfileCode,
             Integer rewardExp,
             Map<String, Integer> rewardStats,
-            Instant dueAt
+            Instant dueAt,
+            String semanticCategory,
+            String progressSource,
+            String repeatPolicy,
+            String roleTemplateCode
     ) {
     }
 
@@ -43,7 +47,11 @@ public final class AdminQuestResponse {
             String rewardProfileCode,
             Integer rewardExp,
             Map<String, Integer> rewardStats,
-            Instant dueAt
+            Instant dueAt,
+            String semanticCategory,
+            String progressSource,
+            String repeatPolicy,
+            String roleTemplateCode
     ) {
     }
 
@@ -67,7 +75,11 @@ public final class AdminQuestResponse {
             java.time.LocalDate periodEnd,
             Instant goalReachedAt,
             Instant completedAt,
-            Instant dueAt
+            Instant dueAt,
+            String semanticCategory,
+            String progressSource,
+            String repeatPolicy,
+            String roleTemplateCode
     ) {
     }
 
@@ -88,7 +100,26 @@ public final class AdminQuestResponse {
             List<String> categories,
             List<String> targetTypes,
             List<String> repeatRules,
-            List<String> statuses
+            List<String> statuses,
+            List<String> semanticCategories,
+            List<String> progressSources,
+            List<String> repeatPolicies
     ) {
+        public Meta(
+                List<String> categories,
+                List<String> targetTypes,
+                List<String> repeatRules,
+                List<String> statuses
+        ) {
+            this(
+                    categories,
+                    targetTypes,
+                    repeatRules,
+                    statuses,
+                    List.of(),
+                    List.of(),
+                    List.of()
+            );
+        }
     }
 }

--- a/src/main/java/online/lifeasgame/quest/api/admin/spec/AdminQuestSpecV1.java
+++ b/src/main/java/online/lifeasgame/quest/api/admin/spec/AdminQuestSpecV1.java
@@ -15,13 +15,13 @@ public interface AdminQuestSpecV1 {
 
     @Operation(
             summary = "Quest Blueprint 목록",
-            description = "서버에 정의된 Blueprint 목록입니다. rewardProfileCode가 있으면 신규 Profile 계약, null이면 legacy inline reward 계약입니다."
+            description = "서버에 정의된 Blueprint 목록입니다. semanticCategory/progressSource/repeatPolicy는 final 계약에만 존재하며, legacy repeatRule은 호환을 위해 유지됩니다."
     )
     ResponseEntity<AdminQuestResponse.Blueprints> catalog();
 
     @Operation(
             summary = "Quest Definition 목록",
-            description = "DB Definition 목록입니다. rewardProfileCode가 있으면 신규 Profile 계약, null이면 legacy inline reward 계약입니다."
+            description = "DB Definition 목록입니다. repeatPolicy는 ONCE/DAILY/WEEKLY final 계약이고 repeatRule은 NONE/MONTHLY를 포함한 legacy 호환 필드입니다."
     )
     ResponseEntity<AdminQuestResponse.Definitions> definitions();
 
@@ -33,7 +33,7 @@ public interface AdminQuestSpecV1 {
 
     @Operation(
             summary = "Quest Definition 수정",
-            description = "타겟/버전/Profile 참조/legacy 보상/반복/마감일을 부분 수정합니다. Profile 참조와 legacy 보상은 동시에 변경할 수 없습니다."
+            description = "타겟/버전/Profile 참조/semantic category/progress source/repeat policy/선택적 Role 맥락을 부분 수정합니다. null은 no-change이며 repeatRule은 legacy 호환 필드입니다."
     )
     ResponseEntity<AdminQuestResponse.Definition> update(
             String questCode,

--- a/src/main/java/online/lifeasgame/quest/api/player/mapper/QuestWebMapper.java
+++ b/src/main/java/online/lifeasgame/quest/api/player/mapper/QuestWebMapper.java
@@ -42,7 +42,13 @@ public final class QuestWebMapper {
                 result.rewardExp(),
                 result.rewardStats(),
                 result.dueAt(),
-                result.acceptance() == null ? null : toAcceptance(result.acceptance())
+                result.acceptance() == null
+                        ? null
+                        : toAcceptance(result.acceptance()),
+                result.semanticCategory(),
+                result.progressSource(),
+                result.repeatPolicy(),
+                result.roleTemplateCode()
         );
     }
 
@@ -64,7 +70,11 @@ public final class QuestWebMapper {
                 result.periodEnd(),
                 result.goalReachedAt(),
                 result.completedAt(),
-                result.dueAt()
+                result.dueAt(),
+                result.semanticCategory(),
+                result.progressSource(),
+                result.repeatPolicy(),
+                result.roleTemplateCode()
         );
     }
 
@@ -82,7 +92,11 @@ public final class QuestWebMapper {
                 result.rewardProfileCode(),
                 result.rewardExp(),
                 result.rewardStats(),
-                result.dueAt()
+                result.dueAt(),
+                result.semanticCategory(),
+                result.progressSource(),
+                result.repeatPolicy(),
+                result.roleTemplateCode()
         );
     }
 

--- a/src/main/java/online/lifeasgame/quest/api/player/response/QuestResponse.java
+++ b/src/main/java/online/lifeasgame/quest/api/player/response/QuestResponse.java
@@ -23,7 +23,11 @@ public final class QuestResponse {
             String rewardProfileCode,
             Integer rewardExp,
             Map<String, Integer> rewardStats,
-            Instant dueAt
+            Instant dueAt,
+            String semanticCategory,
+            String progressSource,
+            String repeatPolicy,
+            String roleTemplateCode
     ) {
     }
 
@@ -47,7 +51,11 @@ public final class QuestResponse {
             LocalDate periodEnd,
             Instant goalReachedAt,
             Instant completedAt,
-            Instant dueAt
+            Instant dueAt,
+            String semanticCategory,
+            String progressSource,
+            String repeatPolicy,
+            String roleTemplateCode
     ) {
     }
 
@@ -68,7 +76,11 @@ public final class QuestResponse {
             Integer rewardExp,
             Map<String, Integer> rewardStats,
             Instant dueAt,
-            Acceptance acceptance
+            Acceptance acceptance,
+            String semanticCategory,
+            String progressSource,
+            String repeatPolicy,
+            String roleTemplateCode
     ) {
     }
 
@@ -92,8 +104,27 @@ public final class QuestResponse {
             List<String> categories,
             List<String> targetTypes,
             List<String> repeatRules,
-            List<String> statuses
+            List<String> statuses,
+            List<String> semanticCategories,
+            List<String> progressSources,
+            List<String> repeatPolicies
     ) {
+        public Meta(
+                List<String> categories,
+                List<String> targetTypes,
+                List<String> repeatRules,
+                List<String> statuses
+        ) {
+            this(
+                    categories,
+                    targetTypes,
+                    repeatRules,
+                    statuses,
+                    List.of(),
+                    List.of(),
+                    List.of()
+            );
+        }
     }
 
     public record Canceled(

--- a/src/main/java/online/lifeasgame/quest/api/player/spec/QuestCatalogSpecV1.java
+++ b/src/main/java/online/lifeasgame/quest/api/player/spec/QuestCatalogSpecV1.java
@@ -10,7 +10,7 @@ public interface QuestCatalogSpecV1 {
 
     @Operation(
             summary = "Quest 카탈로그 조회",
-            description = "Quest Blueprint 목록입니다. rewardProfileCode가 있으면 신규 Profile 계약, null이면 legacy inline reward 계약입니다."
+            description = "Quest Blueprint 목록입니다. final 계약은 semanticCategory/progressSource와 ONCE/DAILY/WEEKLY repeatPolicy를 노출하며 repeatRule은 legacy 호환을 위해 유지됩니다."
     )
     ResponseEntity<QuestResponse.Blueprints> catalog(
 //            @RequestParam(name = "category", required = false) List<String> categories,

--- a/src/main/java/online/lifeasgame/quest/api/player/spec/QuestSpecV1.java
+++ b/src/main/java/online/lifeasgame/quest/api/player/spec/QuestSpecV1.java
@@ -24,7 +24,7 @@ public interface QuestSpecV1 {
 
     @Operation(
             summary = "내 퀘스트 상세",
-            description = "Quest 정의와 최신 Acceptance를 조회합니다. rewardProfileCode가 있으면 신규 Profile 계약, null이면 legacy inline reward 계약입니다."
+            description = "Quest 정의와 최신 Acceptance를 조회합니다. repeatPolicy는 final 계약, repeatRule은 NONE/MONTHLY를 포함한 legacy 호환 필드입니다."
     )
     ResponseEntity<QuestResponse.PlayerQuest> detail(
             @PathVariable String questCode

--- a/src/main/java/online/lifeasgame/quest/application/QuestService.java
+++ b/src/main/java/online/lifeasgame/quest/application/QuestService.java
@@ -71,7 +71,13 @@ public class QuestService {
                 QuestRepeatRule.parseNullable(command.repeatRule()),
                 command.dueAt(),
                 command.definitionVersion(),
-                rewardProfileRef
+                rewardProfileRef,
+                QuestSemanticCategory.parseNullable(
+                        command.semanticCategory()
+                ),
+                QuestProgressSource.parseNullable(command.progressSource()),
+                QuestRepeatRule.parsePolicyNullable(command.repeatPolicy()),
+                roleTemplateRefOrNull(command.roleTemplateCode())
         );
 
         var events = quest.pullEvents();
@@ -125,6 +131,10 @@ public class QuestService {
         RewardProfileLookupApi.RewardProfileReference reference =
                 rewardProfileLookupApi.getActiveByCode(requested.code());
         return RewardProfileRef.of(reference.code());
+    }
+
+    private QuestRoleTemplateRef roleTemplateRefOrNull(String code) {
+        return code == null ? null : QuestRoleTemplateRef.of(code);
     }
 
     @Transactional(readOnly = true)
@@ -196,8 +206,17 @@ public class QuestService {
     public QuestResult.Acceptance accept(Long playerId, QuestCommand.Accept command) {
         QuestCode questCode = QuestCode.parse(command.questCode());
         Quest quest = questReader.getByCode(questCode);
-
-        questReader.assertAcceptanceIsExists(playerId, quest.getId());
+        LocalDate acceptedDate = LocalDate.now();
+        TimePeriod period = quest.getRepeatRule().periodFor(acceptedDate);
+        QuestAcceptance latest = questReader.findLatest(
+                quest.getId(),
+                playerId
+        );
+        if (latest != null && latest.getPeriod().contains(acceptedDate)) {
+            throw new DomainException(
+                    QuestError.QUEST_ACCEPTANCE_ALREADY_EXISTS
+            );
+        }
 
         QuestAcceptance questAcceptance = questWriter.accept(
                 QuestAcceptance.start(
@@ -205,7 +224,7 @@ public class QuestService {
                         playerId,
                         command.partyId(),
                         command.guildId(),
-                        TimePeriod.daily(LocalDate.now())
+                        period
                 )
         );
 

--- a/src/main/java/online/lifeasgame/quest/application/automation/QuestSignalProcessingAttempt.java
+++ b/src/main/java/online/lifeasgame/quest/application/automation/QuestSignalProcessingAttempt.java
@@ -127,13 +127,13 @@ public class QuestSignalProcessingAttempt {
                 return Optional.empty();
             }
             if (current.isCompleted()) {
-                if (quest.getRepeatRule() == QuestRepeatRule.NONE
+                if (quest.getRepeatRule().isOneTime()
                         || current.getPeriod().contains(eventDate)) {
                     return Optional.empty();
                 }
             }
             if (current.isCanceled()
-                    && (quest.getRepeatRule() == QuestRepeatRule.NONE
+                    && (quest.getRepeatRule().isOneTime()
                     || current.getPeriod().contains(eventDate))) {
                 return Optional.empty();
             }
@@ -150,16 +150,11 @@ public class QuestSignalProcessingAttempt {
     }
 
     private TimePeriod periodFor(Quest quest, LocalDate eventDate) {
-        return switch (quest.getRepeatRule()) {
-            case NONE -> TimePeriod.forever();
-            case DAILY -> TimePeriod.daily(eventDate);
-            case WEEKLY -> TimePeriod.weekly(eventDate);
-            case MONTHLY -> TimePeriod.monthly(eventDate);
-        };
+        return quest.getRepeatRule().periodFor(eventDate);
     }
 
     private Duration ttlFor(Quest quest, LocalDate eventDate) {
-        if (quest.getRepeatRule() == QuestRepeatRule.NONE) {
+        if (quest.getRepeatRule().isOneTime()) {
             return null;
         }
         TimePeriod period = periodFor(quest, eventDate);

--- a/src/main/java/online/lifeasgame/quest/application/command/QuestCommand.java
+++ b/src/main/java/online/lifeasgame/quest/application/command/QuestCommand.java
@@ -23,8 +23,39 @@ public final class QuestCommand {
             Integer rewardExp,
             Map<String, Integer> rewardStats,
             String repeatRule,
-            Instant dueAt
+            Instant dueAt,
+            String semanticCategory,
+            String progressSource,
+            String repeatPolicy,
+            String roleTemplateCode
     ) {
+        public UpdateDefinition(
+                String questCode,
+                Integer definitionVersion,
+                String targetType,
+                Integer targetValue,
+                String rewardProfileCode,
+                Integer rewardExp,
+                Map<String, Integer> rewardStats,
+                String repeatRule,
+                Instant dueAt
+        ) {
+            this(
+                    questCode,
+                    definitionVersion,
+                    targetType,
+                    targetValue,
+                    rewardProfileCode,
+                    rewardExp,
+                    rewardStats,
+                    repeatRule,
+                    dueAt,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+        }
     }
 
     public record Acceptances(String questCode, String status) {

--- a/src/main/java/online/lifeasgame/quest/application/result/QuestResult.java
+++ b/src/main/java/online/lifeasgame/quest/application/result/QuestResult.java
@@ -22,7 +22,11 @@ public final class QuestResult {
             String rewardProfileCode,
             Integer rewardExp,
             Map<String, Integer> rewardStats,
-            Instant dueAt
+            Instant dueAt,
+            String semanticCategory,
+            String progressSource,
+            String repeatPolicy,
+            String roleTemplateCode
     ) {
         public static Blueprint from(QuestBlueprint blueprint) {
             return new Blueprint(
@@ -41,7 +45,17 @@ public final class QuestResult {
                     blueprint.usesRewardProfile()
                             ? null
                             : blueprint.reward().stats().stats(),
-                    blueprint.dueAt()
+                    blueprint.dueAt(),
+                    blueprint.semanticCategory() == null
+                            ? null
+                            : blueprint.semanticCategory().name(),
+                    blueprint.progressSource() == null
+                            ? null
+                            : blueprint.progressSource().name(),
+                    blueprint.repeatPolicy() == null
+                            ? null
+                            : blueprint.repeatPolicy().name(),
+                    blueprint.roleTemplateCodeOrNull()
             );
         }
     }
@@ -64,7 +78,11 @@ public final class QuestResult {
             LocalDate periodEnd,
             Instant goalReachedAt,
             Instant completedAt,
-            Instant dueAt
+            Instant dueAt,
+            String semanticCategory,
+            String progressSource,
+            String repeatPolicy,
+            String roleTemplateCode
     ) {
         public static Acceptance from(QuestAcceptance acceptance, Quest quest) {
             return new Acceptance(
@@ -85,7 +103,11 @@ public final class QuestResult {
                     acceptance.getPeriod().end(),
                     acceptance.getGoalReachedAt(),
                     acceptance.getCompletedAt(),
-                    quest.getDueAt()
+                    quest.getDueAt(),
+                    QuestResult.semanticCategory(quest),
+                    QuestResult.progressSource(quest),
+                    QuestResult.repeatPolicy(quest),
+                    quest.roleTemplateCodeOrNull()
             );
         }
     }
@@ -104,7 +126,11 @@ public final class QuestResult {
             String rewardProfileCode,
             Integer rewardExp,
             Map<String, Integer> rewardStats,
-            Instant dueAt
+            Instant dueAt,
+            String semanticCategory,
+            String progressSource,
+            String repeatPolicy,
+            String roleTemplateCode
     ) {
         public static Definition from(Quest quest) {
             return new Definition(
@@ -121,7 +147,11 @@ public final class QuestResult {
                     quest.rewardProfileCodeOrNull(),
                     legacyRewardExp(quest),
                     legacyRewardStats(quest),
-                    quest.getDueAt()
+                    quest.getDueAt(),
+                    QuestResult.semanticCategory(quest),
+                    QuestResult.progressSource(quest),
+                    QuestResult.repeatPolicy(quest),
+                    quest.roleTemplateCodeOrNull()
             );
         }
     }
@@ -140,7 +170,11 @@ public final class QuestResult {
             Integer rewardExp,
             Map<String, Integer> rewardStats,
             Instant dueAt,
-            Acceptance acceptance
+            Acceptance acceptance,
+            String semanticCategory,
+            String progressSource,
+            String repeatPolicy,
+            String roleTemplateCode
     ) {
         public static PlayerQuest from(Quest quest, QuestAcceptance acceptance) {
             return new PlayerQuest(
@@ -157,7 +191,13 @@ public final class QuestResult {
                     legacyRewardExp(quest),
                     legacyRewardStats(quest),
                     quest.getDueAt(),
-                    acceptance == null ? null : Acceptance.from(acceptance, quest)
+                    acceptance == null
+                            ? null
+                            : Acceptance.from(acceptance, quest),
+                    QuestResult.semanticCategory(quest),
+                    QuestResult.progressSource(quest),
+                    QuestResult.repeatPolicy(quest),
+                    quest.roleTemplateCodeOrNull()
             );
         }
     }
@@ -177,5 +217,23 @@ public final class QuestResult {
         return quest.isLegacyInlineReward()
                 ? quest.getReward().stats().stats()
                 : null;
+    }
+
+    private static String semanticCategory(Quest quest) {
+        return quest.getSemanticCategory() == null
+                ? null
+                : quest.getSemanticCategory().name();
+    }
+
+    private static String progressSource(Quest quest) {
+        return quest.getProgressSource() == null
+                ? null
+                : quest.getProgressSource().name();
+    }
+
+    private static String repeatPolicy(Quest quest) {
+        return quest.repeatPolicyOrNull() == null
+                ? null
+                : quest.repeatPolicyOrNull().name();
     }
 }

--- a/src/main/java/online/lifeasgame/quest/domain/Quest.java
+++ b/src/main/java/online/lifeasgame/quest/domain/Quest.java
@@ -39,6 +39,17 @@ public class Quest extends AbstractTime {
     @Column(length = 20, nullable = false)
     private QuestCategory category;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "semantic_category", length = 20)
+    private QuestSemanticCategory semanticCategory;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "progress_source", length = 30)
+    private QuestProgressSource progressSource;
+
+    @Embedded
+    private QuestRoleTemplateRef roleTemplateRef;
+
     @Embedded
     private QuestTitle title;
 
@@ -56,7 +67,7 @@ public class Quest extends AbstractTime {
     private RewardProfileRef rewardProfileRef;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "repeat_rule", length = 20)
+    @Column(name = "repeat_rule", length = 20, nullable = false)
     private QuestRepeatRule repeatRule = QuestRepeatRule.NONE;
 
     @Enumerated(EnumType.STRING)
@@ -72,13 +83,16 @@ public class Quest extends AbstractTime {
     private Quest(
             String code,
             QuestCategory category,
+            QuestSemanticCategory semanticCategory,
             QuestTitle title,
             String descriptionMd,
             QuestTarget target,
+            QuestProgressSource progressSource,
             QuestReward reward,
             int definitionVersion,
             RewardProfileRef rewardProfileRef,
             QuestRepeatRule repeatRule,
+            QuestRoleTemplateRef roleTemplateRef,
             QuestCompletionPolicy completionPolicy,
             Instant dueAt
     ) {
@@ -89,17 +103,28 @@ public class Quest extends AbstractTime {
         if (rewardProfileRef != null && reward != null) {
             throw new DomainException(QuestError.QUEST_REWARD_CONTRACT_CONFLICT);
         }
+        QuestRepeatRule normalizedRepeatRule =
+                repeatRule == null ? QuestRepeatRule.NONE : repeatRule;
+        validateCreationContract(
+                semanticCategory,
+                progressSource,
+                normalizedRepeatRule,
+                roleTemplateRef
+        );
         this.definitionVersion = definitionVersion;
         this.code = Guard.notBlank(code, "code").trim();
         this.category = Guard.notNull(category, "category");
+        this.semanticCategory = semanticCategory;
         this.title = Guard.notNull(title, "title");
         this.descriptionMd = descriptionMd == null ? null : descriptionMd.trim();
         this.target = Guard.notNull(target, "target");
+        this.progressSource = progressSource;
         this.reward = rewardProfileRef == null
                 ? Guard.notNull(reward, "reward")
                 : QuestReward.empty();
         this.rewardProfileRef = rewardProfileRef;
-        this.repeatRule = repeatRule == null ? QuestRepeatRule.NONE : repeatRule;
+        this.repeatRule = normalizedRepeatRule;
+        this.roleTemplateRef = roleTemplateRef;
         this.completionPolicy = QuestCompletionPolicy.defaultIfNull(completionPolicy);
         this.dueAt = dueAt;
     }
@@ -141,13 +166,16 @@ public class Quest extends AbstractTime {
         return new Quest(
                 code,
                 category,
+                null,
                 title,
                 descriptionMd,
                 target,
+                null,
                 reward,
                 1,
                 null,
                 repeatRule,
+                null,
                 completionPolicy,
                 dueAt
         );
@@ -168,13 +196,54 @@ public class Quest extends AbstractTime {
         return new Quest(
                 code,
                 category,
+                null,
                 title,
                 descriptionMd,
                 target,
                 null,
+                null,
                 definitionVersion,
                 rewardProfileRef,
                 repeatRule,
+                null,
+                completionPolicy,
+                dueAt
+        );
+    }
+
+    public static Quest createDefinition(
+            String code,
+            int definitionVersion,
+            QuestCategory category,
+            QuestSemanticCategory semanticCategory,
+            QuestTitle title,
+            String descriptionMd,
+            QuestTarget target,
+            QuestProgressSource progressSource,
+            RewardProfileRef rewardProfileRef,
+            QuestRepeatRule repeatPolicy,
+            QuestRoleTemplateRef roleTemplateRef,
+            QuestCompletionPolicy completionPolicy,
+            Instant dueAt
+    ) {
+        validateFinalContract(
+                semanticCategory,
+                progressSource,
+                repeatPolicy
+        );
+        return new Quest(
+                code,
+                category,
+                semanticCategory,
+                title,
+                descriptionMd,
+                target,
+                progressSource,
+                null,
+                definitionVersion,
+                rewardProfileRef,
+                repeatPolicy,
+                roleTemplateRef,
                 completionPolicy,
                 dueAt
         );
@@ -188,7 +257,46 @@ public class Quest extends AbstractTime {
             Integer nextDefinitionVersion,
             RewardProfileRef nextRewardProfileRef
     ) {
-        validateUpdate(nextDefinitionVersion, questReward, nextRewardProfileRef);
+        updateDefinition(
+                questTarget,
+                questReward,
+                questRepeatRule,
+                dueAt,
+                nextDefinitionVersion,
+                nextRewardProfileRef,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    public void updateDefinition(
+            QuestTarget questTarget,
+            QuestReward questReward,
+            QuestRepeatRule questRepeatRule,
+            Instant dueAt,
+            Integer nextDefinitionVersion,
+            RewardProfileRef nextRewardProfileRef,
+            QuestSemanticCategory nextSemanticCategory,
+            QuestProgressSource nextProgressSource,
+            QuestRepeatRule nextRepeatPolicy,
+            QuestRoleTemplateRef nextRoleTemplateRef
+    ) {
+        QuestRepeatRule requestedRepeatRule = resolveRequestedRepeatRule(
+                questRepeatRule,
+                nextRepeatPolicy
+        );
+        validateUpdate(
+                nextDefinitionVersion,
+                questReward,
+                nextRewardProfileRef,
+                requestedRepeatRule,
+                nextSemanticCategory,
+                nextProgressSource,
+                nextRepeatPolicy,
+                nextRoleTemplateRef
+        );
         boolean changed = false;
 
         if (questTarget != null && !questTarget.equals(target)) {
@@ -199,8 +307,9 @@ public class Quest extends AbstractTime {
             changeReward(questReward);
             changed = true;
         }
-        if (questRepeatRule != null && questRepeatRule != repeatRule) {
-            changeRepeatRule(questRepeatRule);
+        if (requestedRepeatRule != null
+                && requestedRepeatRule != repeatRule) {
+            repeatRule = requestedRepeatRule;
             changed = true;
         }
         if (dueAt != null && !Objects.equals(dueAt, this.dueAt)) {
@@ -216,6 +325,21 @@ public class Quest extends AbstractTime {
                 && !nextRewardProfileRef.equals(rewardProfileRef)) {
             rewardProfileRef = nextRewardProfileRef;
             reward = QuestReward.empty();
+            changed = true;
+        }
+        if (nextSemanticCategory != null
+                && nextSemanticCategory != semanticCategory) {
+            semanticCategory = nextSemanticCategory;
+            changed = true;
+        }
+        if (nextProgressSource != null
+                && nextProgressSource != progressSource) {
+            progressSource = nextProgressSource;
+            changed = true;
+        }
+        if (nextRoleTemplateRef != null
+                && !nextRoleTemplateRef.equals(roleTemplateRef)) {
+            roleTemplateRef = nextRoleTemplateRef;
             changed = true;
         }
 
@@ -241,7 +365,12 @@ public class Quest extends AbstractTime {
     private void validateUpdate(
             Integer nextDefinitionVersion,
             QuestReward questReward,
-            RewardProfileRef nextRewardProfileRef
+            RewardProfileRef nextRewardProfileRef,
+            QuestRepeatRule requestedRepeatRule,
+            QuestSemanticCategory nextSemanticCategory,
+            QuestProgressSource nextProgressSource,
+            QuestRepeatRule nextRepeatPolicy,
+            QuestRoleTemplateRef nextRoleTemplateRef
     ) {
         if (nextDefinitionVersion != null) {
             validateDefinitionVersion(nextDefinitionVersion);
@@ -254,6 +383,106 @@ public class Quest extends AbstractTime {
         if (questReward != null
                 && (nextRewardProfileRef != null || usesRewardProfile())) {
             throw new DomainException(QuestError.QUEST_REWARD_CONTRACT_CONFLICT);
+        }
+        QuestSemanticCategory candidateSemanticCategory =
+                nextSemanticCategory == null
+                        ? semanticCategory
+                        : nextSemanticCategory;
+        QuestProgressSource candidateProgressSource =
+                nextProgressSource == null
+                        ? progressSource
+                        : nextProgressSource;
+        QuestRepeatRule candidateRepeatRule =
+                requestedRepeatRule == null
+                        ? repeatRule
+                        : requestedRepeatRule;
+        QuestRoleTemplateRef candidateRoleTemplateRef =
+                nextRoleTemplateRef == null
+                        ? roleTemplateRef
+                        : nextRoleTemplateRef;
+        boolean requestsFinalContract = isFinalContract()
+                || nextSemanticCategory != null
+                || nextProgressSource != null
+                || nextRepeatPolicy != null
+                || nextRoleTemplateRef != null;
+        if (requestsFinalContract) {
+            if (nextRewardProfileRef == null && !usesRewardProfile()) {
+                throw new DomainException(
+                        QuestError.QUEST_REWARD_PROFILE_CODE_REQUIRED
+                );
+            }
+            validateFinalContract(
+                    candidateSemanticCategory,
+                    candidateProgressSource,
+                    candidateRepeatRule
+            );
+        } else if (candidateRepeatRule == QuestRepeatRule.ONCE) {
+            validateFinalContract(
+                    candidateSemanticCategory,
+                    candidateProgressSource,
+                    candidateRepeatRule
+            );
+        }
+        if (candidateRoleTemplateRef != null && !requestsFinalContract) {
+            throw new DomainException(
+                    QuestError.QUEST_SEMANTIC_CATEGORY_REQUIRED
+            );
+        }
+    }
+
+    private QuestRepeatRule resolveRequestedRepeatRule(
+            QuestRepeatRule questRepeatRule,
+            QuestRepeatRule nextRepeatPolicy
+    ) {
+        if (questRepeatRule != null
+                && nextRepeatPolicy != null
+                && questRepeatRule != nextRepeatPolicy) {
+            throw new DomainException(
+                    QuestError.QUEST_REPEAT_CONTRACT_CONFLICT
+            );
+        }
+        return nextRepeatPolicy == null ? questRepeatRule : nextRepeatPolicy;
+    }
+
+    private static void validateCreationContract(
+            QuestSemanticCategory semanticCategory,
+            QuestProgressSource progressSource,
+            QuestRepeatRule repeatRule,
+            QuestRoleTemplateRef roleTemplateRef
+    ) {
+        boolean finalContractRequested = semanticCategory != null
+                || progressSource != null
+                || roleTemplateRef != null
+                || repeatRule == QuestRepeatRule.ONCE;
+        if (finalContractRequested) {
+            validateFinalContract(
+                    semanticCategory,
+                    progressSource,
+                    repeatRule
+            );
+        }
+    }
+
+    private static void validateFinalContract(
+            QuestSemanticCategory semanticCategory,
+            QuestProgressSource progressSource,
+            QuestRepeatRule repeatPolicy
+    ) {
+        if (semanticCategory == null) {
+            throw new DomainException(
+                    QuestError.QUEST_SEMANTIC_CATEGORY_REQUIRED
+            );
+        }
+        if (progressSource == null) {
+            throw new DomainException(
+                    QuestError.QUEST_PROGRESS_SOURCE_REQUIRED
+            );
+        }
+        if (repeatPolicy == null) {
+            throw new DomainException(QuestError.QUEST_REPEAT_POLICY_REQUIRED);
+        }
+        if (!repeatPolicy.isFinalPolicy()) {
+            throw new DomainException(QuestError.INVALID_QUEST_REPEAT_POLICY);
         }
     }
 
@@ -289,7 +518,17 @@ public class Quest extends AbstractTime {
     }
 
     public void changeRepeatRule(QuestRepeatRule repeatRule) {
-        this.repeatRule = repeatRule == null ? QuestRepeatRule.NONE : repeatRule;
+        QuestRepeatRule normalized =
+                repeatRule == null ? QuestRepeatRule.NONE : repeatRule;
+        if (isFinalContract() && !normalized.isFinalPolicy()) {
+            throw new DomainException(QuestError.INVALID_QUEST_REPEAT_POLICY);
+        }
+        if (!isFinalContract() && normalized == QuestRepeatRule.ONCE) {
+            throw new DomainException(
+                    QuestError.QUEST_SEMANTIC_CATEGORY_REQUIRED
+            );
+        }
+        this.repeatRule = normalized;
     }
 
     public void reschedule(Instant dueAt) {
@@ -314,6 +553,21 @@ public class Quest extends AbstractTime {
 
     public boolean isLegacyInlineReward() {
         return !usesRewardProfile();
+    }
+
+    public boolean isFinalContract() {
+        return semanticCategory != null
+                && progressSource != null
+                && repeatRule != null
+                && repeatRule.isFinalPolicy();
+    }
+
+    public QuestRepeatRule repeatPolicyOrNull() {
+        return isFinalContract() ? repeatRule : null;
+    }
+
+    public String roleTemplateCodeOrNull() {
+        return roleTemplateRef == null ? null : roleTemplateRef.code();
     }
 
     public String rewardProfileCodeOrNull() {

--- a/src/main/java/online/lifeasgame/quest/domain/QuestBlueprint.java
+++ b/src/main/java/online/lifeasgame/quest/domain/QuestBlueprint.java
@@ -16,7 +16,11 @@ public record QuestBlueprint(
         Instant dueAt,
         QuestCompletionPolicy completionPolicy,
         int definitionVersion,
-        RewardProfileRef rewardProfileRef
+        RewardProfileRef rewardProfileRef,
+        QuestSemanticCategory semanticCategory,
+        QuestProgressSource progressSource,
+        QuestRepeatRule repeatPolicy,
+        QuestRoleTemplateRef roleTemplateRef
 ) {
     public QuestBlueprint {
         completionPolicy = QuestCompletionPolicy.defaultIfNull(completionPolicy);
@@ -28,6 +32,27 @@ public record QuestBlueprint(
         }
         if (reward != null && rewardProfileRef != null) {
             throw new DomainException(QuestError.QUEST_REWARD_CONTRACT_CONFLICT);
+        }
+        boolean finalContractRequested = semanticCategory != null
+                || progressSource != null
+                || repeatPolicy != null
+                || roleTemplateRef != null;
+        if (finalContractRequested) {
+            validateFinalContract(
+                    semanticCategory,
+                    progressSource,
+                    repeatPolicy
+            );
+            if (rewardProfileRef == null) {
+                throw new DomainException(
+                        QuestError.QUEST_REWARD_PROFILE_CODE_REQUIRED
+                );
+            }
+            if (repeatRule != repeatPolicy) {
+                throw new DomainException(
+                        QuestError.QUEST_REPEAT_CONTRACT_CONFLICT
+                );
+            }
         }
     }
 
@@ -53,6 +78,10 @@ public record QuestBlueprint(
                 dueAt,
                 completionPolicy,
                 1,
+                null,
+                null,
+                null,
+                null,
                 null
         );
     }
@@ -78,6 +107,10 @@ public record QuestBlueprint(
                 dueAt,
                 QuestCompletionPolicy.AUTO,
                 1,
+                null,
+                null,
+                null,
+                null,
                 null
         );
     }
@@ -105,11 +138,66 @@ public record QuestBlueprint(
                 dueAt,
                 completionPolicy,
                 definitionVersion,
-                rewardProfileRef
+                rewardProfileRef,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    public static QuestBlueprint finalContract(
+            QuestCode code,
+            int definitionVersion,
+            QuestCategory category,
+            QuestSemanticCategory semanticCategory,
+            QuestTitle title,
+            String descriptionMd,
+            QuestTarget target,
+            QuestProgressSource progressSource,
+            RewardProfileRef rewardProfileRef,
+            QuestRepeatRule repeatPolicy,
+            QuestRoleTemplateRef roleTemplateRef,
+            Instant dueAt,
+            QuestCompletionPolicy completionPolicy
+    ) {
+        return new QuestBlueprint(
+                code,
+                category,
+                title,
+                descriptionMd,
+                target,
+                null,
+                repeatPolicy,
+                dueAt,
+                completionPolicy,
+                definitionVersion,
+                rewardProfileRef,
+                semanticCategory,
+                progressSource,
+                repeatPolicy,
+                roleTemplateRef
         );
     }
 
     public Quest instantiate() {
+        if (isFinalContract()) {
+            return Quest.createDefinition(
+                    code.value(),
+                    definitionVersion,
+                    category,
+                    semanticCategory,
+                    title,
+                    descriptionMd,
+                    target,
+                    progressSource,
+                    rewardProfileRef,
+                    repeatPolicy,
+                    roleTemplateRef,
+                    completionPolicy,
+                    dueAt
+            );
+        }
         if (rewardProfileRef != null) {
             return Quest.createDefinition(
                     code.value(),
@@ -143,5 +231,38 @@ public record QuestBlueprint(
 
     public String rewardProfileCodeOrNull() {
         return rewardProfileRef == null ? null : rewardProfileRef.code();
+    }
+
+    public boolean isFinalContract() {
+        return semanticCategory != null
+                && progressSource != null
+                && repeatPolicy != null;
+    }
+
+    public String roleTemplateCodeOrNull() {
+        return roleTemplateRef == null ? null : roleTemplateRef.code();
+    }
+
+    private static void validateFinalContract(
+            QuestSemanticCategory semanticCategory,
+            QuestProgressSource progressSource,
+            QuestRepeatRule repeatPolicy
+    ) {
+        if (semanticCategory == null) {
+            throw new DomainException(
+                    QuestError.QUEST_SEMANTIC_CATEGORY_REQUIRED
+            );
+        }
+        if (progressSource == null) {
+            throw new DomainException(
+                    QuestError.QUEST_PROGRESS_SOURCE_REQUIRED
+            );
+        }
+        if (repeatPolicy == null) {
+            throw new DomainException(QuestError.QUEST_REPEAT_POLICY_REQUIRED);
+        }
+        if (!repeatPolicy.isFinalPolicy()) {
+            throw new DomainException(QuestError.INVALID_QUEST_REPEAT_POLICY);
+        }
     }
 }

--- a/src/main/java/online/lifeasgame/quest/domain/QuestProgressSource.java
+++ b/src/main/java/online/lifeasgame/quest/domain/QuestProgressSource.java
@@ -1,0 +1,23 @@
+package online.lifeasgame.quest.domain;
+
+import online.lifeasgame.core.lang.EnumParsers;
+import online.lifeasgame.quest.domain.error.QuestError;
+
+public enum QuestProgressSource {
+    RECORD_CREATED,
+    COUNT,
+    MANUAL_CHECK;
+
+    public static QuestProgressSource parse(String raw) {
+        return EnumParsers.parseStrict(
+                QuestProgressSource.class,
+                raw,
+                QuestError.INVALID_QUEST_PROGRESS_SOURCE,
+                "Quest progress source"
+        );
+    }
+
+    public static QuestProgressSource parseNullable(String raw) {
+        return raw == null ? null : parse(raw);
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/domain/QuestRepeatRule.java
+++ b/src/main/java/online/lifeasgame/quest/domain/QuestRepeatRule.java
@@ -4,9 +4,11 @@ import online.lifeasgame.core.lang.EnumParsers;
 import online.lifeasgame.quest.domain.error.QuestError;
 
 import java.time.Duration;
+import java.time.LocalDate;
 import java.util.List;
 
 public enum QuestRepeatRule {
+    ONCE,
     NONE,
     DAILY,
     WEEKLY,
@@ -38,9 +40,45 @@ public enum QuestRepeatRule {
         );
     }
 
+    public static QuestRepeatRule parsePolicy(String raw) {
+        QuestRepeatRule parsed = EnumParsers.parseStrict(
+                QuestRepeatRule.class,
+                raw,
+                QuestError.INVALID_QUEST_REPEAT_POLICY,
+                "Quest repeat policy"
+        );
+        if (!parsed.isFinalPolicy()) {
+            throw new online.lifeasgame.core.error.DomainException(
+                    QuestError.INVALID_QUEST_REPEAT_POLICY
+            );
+        }
+        return parsed;
+    }
+
+    public static QuestRepeatRule parsePolicyNullable(String raw) {
+        return raw == null ? null : parsePolicy(raw);
+    }
+
+    public boolean isFinalPolicy() {
+        return this == ONCE || this == DAILY || this == WEEKLY;
+    }
+
+    public boolean isOneTime() {
+        return this == ONCE || this == NONE;
+    }
+
+    public TimePeriod periodFor(LocalDate eventDate) {
+        return switch (this) {
+            case ONCE, NONE -> TimePeriod.forever();
+            case DAILY -> TimePeriod.daily(eventDate);
+            case WEEKLY -> TimePeriod.weekly(eventDate);
+            case MONTHLY -> TimePeriod.monthly(eventDate);
+        };
+    }
+
     public Duration idempotencyTtl() {
         return switch (this) {
-            case NONE -> Duration.ofDays(90);
+            case ONCE, NONE -> Duration.ofDays(90);
             case DAILY -> Duration.ofDays(7);
             case WEEKLY -> Duration.ofDays(30);
             case MONTHLY -> Duration.ofDays(120);

--- a/src/main/java/online/lifeasgame/quest/domain/QuestRoleTemplateRef.java
+++ b/src/main/java/online/lifeasgame/quest/domain/QuestRoleTemplateRef.java
@@ -1,0 +1,43 @@
+package online.lifeasgame.quest.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.quest.domain.error.QuestError;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestRoleTemplateRef {
+
+    public static final int MAX_CODE_LENGTH = 80;
+
+    @Column(name = "role_template_code", length = MAX_CODE_LENGTH)
+    private String code;
+
+    private QuestRoleTemplateRef(String code) {
+        if (code == null || code.isBlank()) {
+            throw new DomainException(
+                    QuestError.QUEST_ROLE_TEMPLATE_CODE_REQUIRED
+            );
+        }
+        String normalized = code.trim();
+        if (normalized.length() > MAX_CODE_LENGTH) {
+            throw new DomainException(
+                    QuestError.QUEST_ROLE_TEMPLATE_CODE_TOO_LONG
+            );
+        }
+        this.code = normalized;
+    }
+
+    public static QuestRoleTemplateRef of(String code) {
+        return new QuestRoleTemplateRef(code);
+    }
+
+    public String code() {
+        return code;
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/domain/QuestSemanticCategory.java
+++ b/src/main/java/online/lifeasgame/quest/domain/QuestSemanticCategory.java
@@ -1,0 +1,25 @@
+package online.lifeasgame.quest.domain;
+
+import online.lifeasgame.core.lang.EnumParsers;
+import online.lifeasgame.quest.domain.error.QuestError;
+
+public enum QuestSemanticCategory {
+    GROWTH,
+    RECORD,
+    RECOVERY,
+    RELATION,
+    ROLE;
+
+    public static QuestSemanticCategory parse(String raw) {
+        return EnumParsers.parseStrict(
+                QuestSemanticCategory.class,
+                raw,
+                QuestError.INVALID_QUEST_SEMANTIC_CATEGORY,
+                "Quest semantic category"
+        );
+    }
+
+    public static QuestSemanticCategory parseNullable(String raw) {
+        return raw == null ? null : parse(raw);
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/domain/error/QuestError.java
+++ b/src/main/java/online/lifeasgame/quest/domain/error/QuestError.java
@@ -6,8 +6,23 @@ public enum QuestError implements ErrorCode {
 
     INVALID_QUEST_STATUS("QUE-400-INVALID-QUEST-STATUS", "Invalid Quest status", 400),
     INVALID_QUEST_CATEGORY("QUE-400-INVALID-QUEST-CATEGORY", "Invalid Quest category", 400),
+    INVALID_QUEST_SEMANTIC_CATEGORY(
+            "QUE-400-INVALID-QUEST-SEMANTIC-CATEGORY",
+            "Invalid Quest semantic category",
+            400
+    ),
+    INVALID_QUEST_PROGRESS_SOURCE(
+            "QUE-400-INVALID-QUEST-PROGRESS-SOURCE",
+            "Invalid Quest progress source",
+            400
+    ),
     INVALID_QUEST_CODE("QUE-400-INVALID-QUEST-CODE", "Invalid Quest code", 400),
     INVALID_QUEST_REPEATABLE_RULE("QUE-400-INVALID-QUEST-REPEATABLE-RULE", "Invalid Quest repeatable rule", 400),
+    INVALID_QUEST_REPEAT_POLICY(
+            "QUE-400-INVALID-QUEST-REPEAT-POLICY",
+            "Invalid Quest repeat policy",
+            400
+    ),
     INVALID_QUEST_TARGET_TYPE("QUE-400-INVALID-QUEST-TARGET-TYPE", "Invalid Quest target type", 400),
     QUEST_NOT_FOUND("QUE-404-QUEST-NOT-FOUND", "Quest not found", 404),
     QUEST_ACCEPTANCE_NOT_FOUND("QUE-404-QUEST-ACCEPTANCE-NOT-FOUND", "Quest acceptance not found", 404),
@@ -70,6 +85,36 @@ public enum QuestError implements ErrorCode {
     QUEST_DEFINITION_VERSION_DECREASE_NOT_ALLOWED(
             "QUE-400-DEFINITION-VERSION-DECREASE-NOT-ALLOWED",
             "Quest definition version cannot decrease",
+            400
+    ),
+    QUEST_SEMANTIC_CATEGORY_REQUIRED(
+            "QUE-400-SEMANTIC-CATEGORY-REQUIRED",
+            "Quest semantic category is required for the final definition contract",
+            400
+    ),
+    QUEST_PROGRESS_SOURCE_REQUIRED(
+            "QUE-400-PROGRESS-SOURCE-REQUIRED",
+            "Quest progress source is required for the final definition contract",
+            400
+    ),
+    QUEST_REPEAT_POLICY_REQUIRED(
+            "QUE-400-REPEAT-POLICY-REQUIRED",
+            "Quest repeat policy is required for the final definition contract",
+            400
+    ),
+    QUEST_REPEAT_CONTRACT_CONFLICT(
+            "QUE-400-REPEAT-CONTRACT-CONFLICT",
+            "repeatRule and repeatPolicy cannot specify different values",
+            400
+    ),
+    QUEST_ROLE_TEMPLATE_CODE_REQUIRED(
+            "QUE-400-ROLE-TEMPLATE-CODE-REQUIRED",
+            "Quest role template code is required when provided",
+            400
+    ),
+    QUEST_ROLE_TEMPLATE_CODE_TOO_LONG(
+            "QUE-400-ROLE-TEMPLATE-CODE-TOO-LONG",
+            "Quest role template code is too long",
             400
     ),
     QUEST_REWARD_PROFILE_CODE_REQUIRED(

--- a/src/main/java/online/lifeasgame/quest/domain/event/QuestEvent.java
+++ b/src/main/java/online/lifeasgame/quest/domain/event/QuestEvent.java
@@ -114,6 +114,28 @@ public record QuestEvent(
         public Builder definitionSnapshot(Quest quest) {
             Guard.notNull(quest, "quest");
             attribute("questDefinitionVersion", quest.getDefinitionVersion())
+                    .attribute(
+                            "questSemanticCategory",
+                            quest.getSemanticCategory() == null
+                                    ? null
+                                    : quest.getSemanticCategory().name()
+                    )
+                    .attribute(
+                            "progressSource",
+                            quest.getProgressSource() == null
+                                    ? null
+                                    : quest.getProgressSource().name()
+                    )
+                    .attribute(
+                            "repeatPolicy",
+                            quest.repeatPolicyOrNull() == null
+                                    ? null
+                                    : quest.repeatPolicyOrNull().name()
+                    )
+                    .attribute(
+                            "roleTemplateCode",
+                            quest.roleTemplateCodeOrNull()
+                    )
                     .attribute("rewardLines", null)
                     .attribute("rewardProfileId", null);
             if (quest.usesRewardProfile()) {

--- a/src/main/resources/db/migration/V11__quest_semantic_progress_contract.sql
+++ b/src/main/resources/db/migration/V11__quest_semantic_progress_contract.sql
@@ -1,0 +1,22 @@
+ALTER TABLE quests
+    ADD COLUMN semantic_category VARCHAR(20) NULL
+        AFTER category,
+    ADD COLUMN progress_source VARCHAR(30) NULL
+        AFTER target_type,
+    ADD COLUMN role_template_code VARCHAR(80) NULL
+        AFTER repeat_rule;
+
+UPDATE quests
+SET repeat_rule = 'NONE'
+WHERE repeat_rule IS NULL;
+
+-- repeat_rule remains the single persisted source of truth.
+-- ONCE is the final-contract value; NONE and MONTHLY remain legacy-compatible.
+ALTER TABLE quests
+    MODIFY COLUMN repeat_rule ENUM (
+        'ONCE',
+        'DAILY',
+        'WEEKLY',
+        'NONE',
+        'MONTHLY'
+    ) NOT NULL DEFAULT 'NONE';

--- a/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
@@ -63,7 +63,7 @@ class FlywayExplicitBaselineTest {
     class ApplyExplicitBaseline {
 
         @Test
-        @DisplayName("V1을 재실행하지 않고 V2부터 V10까지 적용한 뒤 JPA validate를 통과한다")
+        @DisplayName("V1을 재실행하지 않고 V2부터 V11까지 적용한 뒤 JPA validate를 통과한다")
         void migratesFromVersionTwoAndValidatesJpa() throws Exception {
             String jdbcUrl = createV1EquivalentDatabase();
             Flyway flyway = migrationFlyway(jdbcUrl);
@@ -72,11 +72,11 @@ class FlywayExplicitBaselineTest {
             MigrateResult migrateResult = flyway.migrate();
             List<HistoryRow> history = successfulHistory(jdbcUrl);
 
-            assertThat(migrateResult.migrationsExecuted).isEqualTo(9);
+            assertThat(migrateResult.migrationsExecuted).isEqualTo(10);
             assertThat(history).extracting(HistoryRow::version)
                     .containsExactly(
                             "1", "2", "3", "4", "5",
-                            "6", "7", "8", "9", "10"
+                            "6", "7", "8", "9", "10", "11"
                     );
             assertThat(history.getFirst().type()).isEqualTo("BASELINE");
             assertThat(history.getFirst().script())
@@ -96,7 +96,8 @@ class FlywayExplicitBaselineTest {
                             "V7__quest_signal_receipt.sql",
                             "V8__transactional_outbox.sql",
                             "V9__quick_lifelog_record.sql",
-                            "V10__quest_definition_reward_profile_contract.sql"
+                            "V10__quest_definition_reward_profile_contract.sql",
+                            "V11__quest_semantic_progress_contract.sql"
                     );
             assertThat(history.subList(1, history.size()))
                     .allSatisfy(row -> assertThat(row.checksum()).isNotNull());
@@ -116,7 +117,7 @@ class FlywayExplicitBaselineTest {
                         "spring.jpa.hibernate.ddl-auto"
                 )).isEqualTo("validate");
                 assertThat(context.getBean(Flyway.class).info().current().getVersion().getVersion())
-                        .isEqualTo("10");
+                        .isEqualTo("11");
             }
         }
     }

--- a/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
@@ -32,7 +32,7 @@ class FlywayHistoryChecksumTest {
     class MigrateAgain {
 
         @Test
-        @DisplayName("두 번째 실행은 no-op이고 V1부터 V10까지 checksum history를 유지한다")
+        @DisplayName("두 번째 실행은 no-op이고 V1부터 V11까지 checksum history를 유지한다")
         void keepsMigrationHistory() throws Exception {
             Flyway flyway = flyway();
 
@@ -42,13 +42,13 @@ class FlywayHistoryChecksumTest {
             MigrateResult second = flyway.migrate();
             List<HistoryRow> secondHistory = successfulHistory();
 
-            assertThat(first.migrationsExecuted).isEqualTo(10);
+            assertThat(first.migrationsExecuted).isEqualTo(11);
             assertThat(second.migrationsExecuted).isZero();
             assertThat(secondHistory).isEqualTo(firstHistory);
             assertThat(secondHistory).extracting(HistoryRow::version)
                     .containsExactly(
                             "1", "2", "3", "4", "5",
-                            "6", "7", "8", "9", "10"
+                            "6", "7", "8", "9", "10", "11"
                     );
             assertThat(secondHistory).allSatisfy(history -> {
                 assertThat(history.checksum()).isNotNull();

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -38,21 +38,21 @@ class FlywayMigrationTest {
     class MigrateCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V10까지 적용되고 legacy Quest에 Definition 계약이 안전하게 추가된다")
+        @DisplayName("V1부터 V11까지 적용되고 legacy Quest에 semantic 계약이 안전하게 추가된다")
         void migratesSchemaAndSeedsRewardProfiles() throws Exception {
-            Flyway throughV9 = flyway(MigrationVersion.fromVersion("9"));
-            MigrateResult legacyResult = throughV9.migrate();
+            Flyway throughV10 = flyway(MigrationVersion.fromVersion("10"));
+            MigrateResult legacyResult = throughV10.migrate();
             insertLegacyQuest();
             Flyway flyway = flyway();
 
             MigrateResult result = flyway.migrate();
 
-            assertThat(legacyResult.migrationsExecuted).isEqualTo(9);
+            assertThat(legacyResult.migrationsExecuted).isEqualTo(10);
             assertThat(result.migrationsExecuted).isEqualTo(1);
             assertThat(appliedVersions())
                     .containsExactly(
                             "1", "2", "3", "4", "5",
-                            "6", "7", "8", "9", "10"
+                            "6", "7", "8", "9", "10", "11"
                     );
             assertThat(existingTables(
                     "users",
@@ -140,8 +140,34 @@ class FlywayMigrationTest {
                     )
             );
             assertThat(legacyQuestContract()).isEqualTo(
-                    new LegacyQuestContract(1, null, 7, 2)
+                    new LegacyQuestContract(
+                            1,
+                            null,
+                            7,
+                            2,
+                            null,
+                            null,
+                            "NONE",
+                            null
+                    )
             );
+            QuestSemanticColumns semanticColumns = questSemanticColumns();
+            assertThat(semanticColumns.semanticCategoryNullable())
+                    .isEqualTo("YES");
+            assertThat(semanticColumns.progressSourceNullable())
+                    .isEqualTo("YES");
+            assertThat(semanticColumns.roleTemplateCodeNullable())
+                    .isEqualTo("YES");
+            assertThat(semanticColumns.repeatPolicyColumnCount()).isZero();
+            assertThat(semanticColumns.repeatRuleNullable()).isEqualTo("NO");
+            assertThat(semanticColumns.repeatRuleColumnType())
+                    .contains(
+                            "'ONCE'",
+                            "'DAILY'",
+                            "'WEEKLY'",
+                            "'NONE'",
+                            "'MONTHLY'"
+                    );
             assertThat(rewardProfileForeignKeyCount()).isZero();
             assertThatThrownBy(FlywayMigrationTest.this::violateDefinitionVersionCheck)
                     .isInstanceOfSatisfying(SQLException.class, exception ->
@@ -405,7 +431,11 @@ class FlywayMigrationTest {
                          definition_version,
                          reward_profile_code,
                          reward_exp,
-                         JSON_EXTRACT(reward_stats, '$.strength') AS strength
+                         JSON_EXTRACT(reward_stats, '$.strength') AS strength,
+                         semantic_category,
+                         progress_source,
+                         repeat_rule,
+                         role_template_code
                      FROM quests
                      WHERE code = 'quest:test:v9-legacy'
                      """)) {
@@ -414,7 +444,44 @@ class FlywayMigrationTest {
                     resultSet.getInt("definition_version"),
                     resultSet.getString("reward_profile_code"),
                     resultSet.getInt("reward_exp"),
-                    resultSet.getInt("strength")
+                    resultSet.getInt("strength"),
+                    resultSet.getString("semantic_category"),
+                    resultSet.getString("progress_source"),
+                    resultSet.getString("repeat_rule"),
+                    resultSet.getString("role_template_code")
+            );
+        }
+    }
+
+    private QuestSemanticColumns questSemanticColumns() throws SQLException {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("""
+                     SELECT
+                         MAX(CASE WHEN column_name = 'semantic_category'
+                             THEN is_nullable END) AS semantic_nullable,
+                         MAX(CASE WHEN column_name = 'progress_source'
+                             THEN is_nullable END) AS progress_nullable,
+                         MAX(CASE WHEN column_name = 'role_template_code'
+                             THEN is_nullable END) AS role_nullable,
+                         SUM(column_name = 'repeat_policy')
+                             AS repeat_policy_count,
+                         MAX(CASE WHEN column_name = 'repeat_rule'
+                             THEN is_nullable END) AS repeat_rule_nullable,
+                         MAX(CASE WHEN column_name = 'repeat_rule'
+                             THEN column_type END) AS repeat_rule_type
+                     FROM information_schema.columns
+                     WHERE table_schema = DATABASE()
+                       AND table_name = 'quests'
+                     """)) {
+            assertThat(resultSet.next()).isTrue();
+            return new QuestSemanticColumns(
+                    resultSet.getString("semantic_nullable"),
+                    resultSet.getString("progress_nullable"),
+                    resultSet.getString("role_nullable"),
+                    resultSet.getInt("repeat_policy_count"),
+                    resultSet.getString("repeat_rule_nullable"),
+                    resultSet.getString("repeat_rule_type")
             );
         }
     }
@@ -462,7 +529,21 @@ class FlywayMigrationTest {
             int definitionVersion,
             String rewardProfileCode,
             int rewardExp,
-            int strength
+            int strength,
+            String semanticCategory,
+            String progressSource,
+            String repeatRule,
+            String roleTemplateCode
+    ) {
+    }
+
+    private record QuestSemanticColumns(
+            String semanticCategoryNullable,
+            String progressSourceNullable,
+            String roleTemplateCodeNullable,
+            int repeatPolicyColumnCount,
+            String repeatRuleNullable,
+            String repeatRuleColumnType
     ) {
     }
 }

--- a/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
@@ -149,7 +149,7 @@ class FlywayProfileCutoverTest {
     class StartLocalWithCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V10까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
+        @DisplayName("V1부터 V11까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
         void migratesThenValidates() {
             ConfigurableEnvironment environment =
                     (ConfigurableEnvironment) applicationContext.getEnvironment();
@@ -161,8 +161,8 @@ class FlywayProfileCutoverTest {
             assertThat(environment.getProperty(
                     "spring.flyway.baseline-on-migrate", Boolean.class
             )).isFalse();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("10");
-            assertThat(appliedMigrationCount()).isEqualTo(10);
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("11");
+            assertThat(appliedMigrationCount()).isEqualTo(11);
         }
     }
 

--- a/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 @SpringBootTest
 @ActiveProfiles({"test", "migration-test"})
-@DisplayName("V10 migration 이후 JPA schema validation")
+@DisplayName("V11 migration 이후 JPA schema validation")
 class JpaValidateAfterMigrationTest {
 
     @Container
@@ -61,14 +61,14 @@ class JpaValidateAfterMigrationTest {
     private RewardSettlementReader rewardSettlementReader;
 
     @Nested
-    @DisplayName("V1부터 V10까지 적용된 schema로 ApplicationContext를 기동할 때")
+    @DisplayName("V1부터 V11까지 적용된 schema로 ApplicationContext를 기동할 때")
     class LoadApplicationContext {
 
         @Test
         @DisplayName("ddl-auto validate 상태로 정상 기동한다")
         void loadsWithJpaValidation() {
             assertThat(applicationContext).isNotNull();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("10");
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("11");
             assertThat(applicationContext.getEnvironment().getProperty("spring.jpa.hibernate.ddl-auto"))
                     .isEqualTo("validate");
             assertThat(applicationContext.getEnvironment()

--- a/src/test/java/online/lifeasgame/quest/api/QuestResponseContractTest.java
+++ b/src/test/java/online/lifeasgame/quest/api/QuestResponseContractTest.java
@@ -87,11 +87,21 @@ class QuestResponseContractTest {
             assertThat(admin.rewardProfileCode()).isEqualTo("RP_EXP_30");
             assertThat(admin.rewardExp()).isNull();
             assertThat(admin.rewardStats()).isNull();
+            assertThat(admin.semanticCategory()).isEqualTo("GROWTH");
+            assertThat(admin.progressSource()).isEqualTo("COUNT");
+            assertThat(admin.repeatPolicy()).isEqualTo("ONCE");
+            assertThat(admin.repeatRule()).isEqualTo("ONCE");
+            assertThat(admin.roleTemplateCode()).isEqualTo("ROLE_WARRIOR");
 
             assertThat(player.definitionVersion()).isEqualTo(4);
             assertThat(player.rewardProfileCode()).isEqualTo("RP_EXP_30");
             assertThat(player.rewardExp()).isNull();
             assertThat(player.rewardStats()).isNull();
+            assertThat(player.semanticCategory()).isEqualTo("GROWTH");
+            assertThat(player.progressSource()).isEqualTo("COUNT");
+            assertThat(player.repeatPolicy()).isEqualTo("ONCE");
+            assertThat(player.repeatRule()).isEqualTo("ONCE");
+            assertThat(player.roleTemplateCode()).isEqualTo("ROLE_WARRIOR");
         }
 
         @Test
@@ -112,10 +122,45 @@ class QuestResponseContractTest {
             assertThat(admin.rewardProfileCode()).isNull();
             assertThat(admin.rewardExp()).isZero();
             assertThat(admin.rewardStats()).isEqualTo(Map.of());
+            assertThat(admin.semanticCategory()).isNull();
+            assertThat(admin.progressSource()).isNull();
+            assertThat(admin.repeatPolicy()).isNull();
+            assertThat(admin.roleTemplateCode()).isNull();
             assertThat(player.definitionVersion()).isEqualTo(1);
             assertThat(player.rewardProfileCode()).isNull();
             assertThat(player.rewardExp()).isZero();
             assertThat(player.rewardStats()).isEqualTo(Map.of());
+            assertThat(player.semanticCategory()).isNull();
+            assertThat(player.progressSource()).isNull();
+            assertThat(player.repeatPolicy()).isNull();
+            assertThat(player.roleTemplateCode()).isNull();
+        }
+
+        @Test
+        @DisplayName("Admin Update의 blank Role code는 Bean Validation 400 대상이다")
+        void rejectsBlankRoleTemplateCode() {
+            AdminQuestRequest.Update request = new AdminQuestRequest.Update(
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    "GROWTH",
+                    "COUNT",
+                    "ONCE",
+                    "   "
+            );
+
+            var validator = Validation.buildDefaultValidatorFactory()
+                    .getValidator();
+
+            assertThat(validator.validate(request))
+                    .extracting(violation ->
+                            violation.getPropertyPath().toString())
+                    .containsExactly("roleTemplateCode");
         }
 
         @Test
@@ -144,15 +189,18 @@ class QuestResponseContractTest {
         @Test
         @DisplayName("Admin과 Player Blueprint 응답에도 version/code 계약을 노출한다")
         void exposesBlueprintContract() {
-            QuestBlueprint blueprint = QuestBlueprint.profileBased(
+            QuestBlueprint blueprint = QuestBlueprint.finalContract(
                     QuestCode.PLAYER_WELCOME,
                     5,
                     QuestCategory.MAIN,
+                    QuestSemanticCategory.RECORD,
                     QuestTitle.of("Profile Blueprint"),
                     "profile blueprint",
                     QuestTarget.of(QuestTargetType.COUNT, 1),
+                    QuestProgressSource.RECORD_CREATED,
                     RewardProfileRef.of("RP_EXP_10"),
-                    QuestRepeatRule.NONE,
+                    QuestRepeatRule.DAILY,
+                    null,
                     null,
                     QuestCompletionPolicy.AUTO
             );
@@ -168,10 +216,18 @@ class QuestResponseContractTest {
             assertThat(admin.rewardProfileCode()).isEqualTo("RP_EXP_10");
             assertThat(admin.rewardExp()).isNull();
             assertThat(admin.rewardStats()).isNull();
+            assertThat(admin.semanticCategory()).isEqualTo("RECORD");
+            assertThat(admin.progressSource()).isEqualTo("RECORD_CREATED");
+            assertThat(admin.repeatPolicy()).isEqualTo("DAILY");
+            assertThat(admin.roleTemplateCode()).isNull();
             assertThat(player.definitionVersion()).isEqualTo(5);
             assertThat(player.rewardProfileCode()).isEqualTo("RP_EXP_10");
             assertThat(player.rewardExp()).isNull();
             assertThat(player.rewardStats()).isNull();
+            assertThat(player.semanticCategory()).isEqualTo("RECORD");
+            assertThat(player.progressSource()).isEqualTo("RECORD_CREATED");
+            assertThat(player.repeatPolicy()).isEqualTo("DAILY");
+            assertThat(player.roleTemplateCode()).isNull();
         }
     }
 
@@ -196,11 +252,14 @@ class QuestResponseContractTest {
                 "quest:test:profile-response-contract",
                 4,
                 QuestCategory.MAIN,
+                QuestSemanticCategory.GROWTH,
                 QuestTitle.of("Profile 응답 계약 테스트"),
                 "Quest Profile 응답 계약 테스트",
                 QuestTarget.of(QuestTargetType.COUNT, 1),
+                QuestProgressSource.COUNT,
                 RewardProfileRef.of("RP_EXP_30"),
-                QuestRepeatRule.NONE,
+                QuestRepeatRule.ONCE,
+                QuestRoleTemplateRef.of("ROLE_WARRIOR"),
                 QuestCompletionPolicy.USER_CONFIRM,
                 null
         );

--- a/src/test/java/online/lifeasgame/quest/application/QuestDefinitionServiceTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/QuestDefinitionServiceTest.java
@@ -170,18 +170,97 @@ class QuestDefinitionServiceTest {
         verify(domainEventPublisher).publishAll(any());
     }
 
+    @Nested
+    @DisplayName("Admin이 final Definition 계약을 수정할 때")
+    class UpdateSemanticContract {
+
+        @Test
+        @DisplayName("semantic/progress/repeat/Role partial update를 적용한다")
+        void updatesFinalContractFields() {
+            Quest quest = profileQuest(2, "RP_EXP_10");
+            stubExisting(quest);
+
+            QuestResult.Definition result = service.updateDefinition(
+                    semanticUpdate(
+                            3,
+                            "RECORD",
+                            "RECORD_CREATED",
+                            "ONCE",
+                            "  ROLE_READER  "
+                    )
+            );
+
+            assertThat(result.definitionVersion()).isEqualTo(3);
+            assertThat(result.semanticCategory()).isEqualTo("RECORD");
+            assertThat(result.progressSource()).isEqualTo("RECORD_CREATED");
+            assertThat(result.repeatPolicy()).isEqualTo("ONCE");
+            assertThat(result.repeatRule()).isEqualTo("ONCE");
+            assertThat(result.roleTemplateCode()).isEqualTo("ROLE_READER");
+            verify(domainEventPublisher).publishAll(any());
+        }
+
+        @Test
+        @DisplayName("invalid semantic enum은 mutation과 Event 없이 400 계약으로 거부한다")
+        void rejectsInvalidSemanticCategory() {
+            Quest quest = profileQuest(2, "RP_EXP_10");
+            stubExisting(quest);
+
+            assertQuestError(
+                    () -> service.updateDefinition(
+                            semanticUpdate(
+                                    3,
+                                    "DAILY",
+                                    "COUNT",
+                                    "ONCE",
+                                    null
+                            )
+                    ),
+                    QuestError.INVALID_QUEST_SEMANTIC_CATEGORY
+            );
+
+            assertThat(quest.getDefinitionVersion()).isEqualTo(2);
+            assertThat(quest.getSemanticCategory()).isNull();
+            verifyNoInteractions(domainEventPublisher);
+        }
+
+        @Test
+        @DisplayName("동일 final-contract 값은 Event 없는 no-op이다")
+        void keepsFinalContractNoOp() {
+            Quest quest = finalQuest();
+            stubExisting(quest);
+
+            QuestResult.Definition result = service.updateDefinition(
+                    semanticUpdate(
+                            2,
+                            "RECORD",
+                            "COUNT",
+                            "ONCE",
+                            " ROLE_READER "
+                    )
+            );
+
+            assertThat(result.semanticCategory()).isEqualTo("RECORD");
+            assertThat(result.progressSource()).isEqualTo("COUNT");
+            assertThat(result.repeatPolicy()).isEqualTo("ONCE");
+            verifyNoInteractions(domainEventPublisher);
+        }
+    }
+
     @Test
     @DisplayName("신규 계약 Blueprint materialization 전에 active profile을 조회한다")
     void validatesProfileBlueprintBeforeMaterialization() {
-        QuestBlueprint blueprint = QuestBlueprint.profileBased(
+        QuestBlueprint blueprint = QuestBlueprint.finalContract(
                 QuestCode.PLAYER_WELCOME,
                 4,
                 QuestCategory.MAIN,
+                QuestSemanticCategory.RECORD,
                 QuestTitle.of("Profile Blueprint"),
                 "profile blueprint",
                 QuestTarget.of(QuestTargetType.COUNT, 1),
+                QuestProgressSource.RECORD_CREATED,
                 RewardProfileRef.of("RP_EXP_30"),
-                QuestRepeatRule.NONE,
+                QuestRepeatRule.ONCE,
+                QuestRoleTemplateRef.of("ROLE_READER"),
                 null,
                 QuestCompletionPolicy.AUTO
         );
@@ -199,6 +278,13 @@ class QuestDefinitionServiceTest {
 
         assertThat(result.getDefinitionVersion()).isEqualTo(4);
         assertThat(result.rewardProfileCodeOrNull()).isEqualTo("RP_EXP_30");
+        assertThat(result.getSemanticCategory())
+                .isEqualTo(QuestSemanticCategory.RECORD);
+        assertThat(result.getProgressSource())
+                .isEqualTo(QuestProgressSource.RECORD_CREATED);
+        assertThat(result.repeatPolicyOrNull())
+                .isEqualTo(QuestRepeatRule.ONCE);
+        assertThat(result.roleTemplateCodeOrNull()).isEqualTo("ROLE_READER");
         verify(rewardProfileLookupApi).getActiveByCode("RP_EXP_30");
         verify(questWriter).create(any());
     }
@@ -231,6 +317,30 @@ class QuestDefinitionServiceTest {
         return new RewardProfileLookupApi.RewardProfileReference(code);
     }
 
+    private QuestCommand.UpdateDefinition semanticUpdate(
+            Integer definitionVersion,
+            String semanticCategory,
+            String progressSource,
+            String repeatPolicy,
+            String roleTemplateCode
+    ) {
+        return new QuestCommand.UpdateDefinition(
+                QuestCode.PLAYER_WELCOME.name(),
+                definitionVersion,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                semanticCategory,
+                progressSource,
+                repeatPolicy,
+                roleTemplateCode
+        );
+    }
+
     private Quest legacyQuest() {
         return Quest.create(
                 QuestCode.PLAYER_WELCOME.value(),
@@ -255,6 +365,24 @@ class QuestDefinitionServiceTest {
                 QuestTarget.of(QuestTargetType.COUNT, 1),
                 RewardProfileRef.of(profileCode),
                 QuestRepeatRule.NONE,
+                QuestCompletionPolicy.AUTO,
+                null
+        );
+    }
+
+    private Quest finalQuest() {
+        return Quest.createDefinition(
+                QuestCode.PLAYER_WELCOME.value(),
+                2,
+                QuestCategory.MAIN,
+                QuestSemanticCategory.RECORD,
+                QuestTitle.of("Final Definition"),
+                "final",
+                QuestTarget.of(QuestTargetType.COUNT, 1),
+                QuestProgressSource.COUNT,
+                RewardProfileRef.of("RP_EXP_10"),
+                QuestRepeatRule.ONCE,
+                QuestRoleTemplateRef.of("ROLE_READER"),
                 QuestCompletionPolicy.AUTO,
                 null
         );

--- a/src/test/java/online/lifeasgame/quest/application/QuestServiceStateContractTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/QuestServiceStateContractTest.java
@@ -2,9 +2,11 @@ package online.lifeasgame.quest.application;
 
 import online.lifeasgame.core.event.DomainEvent;
 import online.lifeasgame.core.event.DomainEventPublisher;
+import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.quest.application.command.QuestCommand;
 import online.lifeasgame.quest.application.result.QuestResult;
 import online.lifeasgame.quest.domain.*;
+import online.lifeasgame.quest.domain.error.QuestError;
 import online.lifeasgame.quest.domain.event.QuestEvent;
 import online.lifeasgame.quest.domain.event.QuestEventType;
 import online.lifeasgame.reward.application.internal.RewardProfileLookupApi;
@@ -19,9 +21,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -133,6 +138,104 @@ class QuestServiceStateContractTest {
         }
     }
 
+    @Nested
+    @DisplayName("Player가 repeat 정책에 따라 Quest를 수락할 때")
+    class AcceptByRepeatPolicy {
+
+        @Test
+        @DisplayName("ONCE는 영구 Acceptance 기간을 생성한다")
+        void acceptsOnceWithForeverPeriod() {
+            Quest quest = finalQuest(QuestRepeatRule.ONCE);
+            given(questReader.getByCode(QuestCode.PLAYER_WELCOME))
+                    .willReturn(quest);
+            given(questReader.findLatest(QUEST_ID, PLAYER_ID))
+                    .willReturn(null);
+            given(questWriter.accept(any())).willAnswer(
+                    invocation -> invocation.getArgument(0)
+            );
+
+            QuestResult.Acceptance result = service.accept(
+                    PLAYER_ID,
+                    new QuestCommand.Accept(
+                            QuestCode.PLAYER_WELCOME.name(),
+                            null,
+                            null
+                    )
+            );
+
+            assertThat(result.periodStart())
+                    .isEqualTo(LocalDate.of(1970, 1, 1));
+            assertThat(result.periodEnd())
+                    .isEqualTo(LocalDate.of(9999, 12, 31));
+            assertThat(result.repeatPolicy()).isEqualTo("ONCE");
+        }
+
+        @Test
+        @DisplayName("DAILY는 이전 기간 완료 후 현재 기간 재수락을 허용한다")
+        void acceptsNextDailyPeriod() {
+            Quest quest = finalQuest(QuestRepeatRule.DAILY);
+            LocalDate today = LocalDate.now();
+            QuestAcceptance previous = QuestAcceptance.start(
+                    QUEST_ID,
+                    PLAYER_ID,
+                    TimePeriod.daily(today.minusDays(1))
+            );
+            previous.reachGoal(Instant.now().minusSeconds(60));
+            previous.complete(Instant.now().minusSeconds(30));
+            given(questReader.getByCode(QuestCode.PLAYER_WELCOME))
+                    .willReturn(quest);
+            given(questReader.findLatest(QUEST_ID, PLAYER_ID))
+                    .willReturn(previous);
+            given(questWriter.accept(any())).willAnswer(
+                    invocation -> invocation.getArgument(0)
+            );
+
+            QuestResult.Acceptance result = service.accept(
+                    PLAYER_ID,
+                    new QuestCommand.Accept(
+                            QuestCode.PLAYER_WELCOME.name(),
+                            null,
+                            null
+                    )
+            );
+
+            assertThat(result.periodStart()).isEqualTo(today);
+            assertThat(result.periodEnd()).isEqualTo(today);
+        }
+
+        @Test
+        @DisplayName("ONCE의 기존 Acceptance가 있으면 재수락을 거부한다")
+        void rejectsRepeatedOnceAcceptance() {
+            Quest quest = finalQuest(QuestRepeatRule.ONCE);
+            QuestAcceptance previous = QuestAcceptance.start(
+                    QUEST_ID,
+                    PLAYER_ID,
+                    TimePeriod.forever()
+            );
+            given(questReader.getByCode(QuestCode.PLAYER_WELCOME))
+                    .willReturn(quest);
+            given(questReader.findLatest(QUEST_ID, PLAYER_ID))
+                    .willReturn(previous);
+
+            assertThatThrownBy(() -> service.accept(
+                    PLAYER_ID,
+                    new QuestCommand.Accept(
+                            QuestCode.PLAYER_WELCOME.name(),
+                            null,
+                            null
+                    )
+            ))
+                    .isInstanceOfSatisfying(
+                            DomainException.class,
+                            exception -> assertThat(exception.getErrorCode())
+                                    .isEqualTo(
+                                            QuestError
+                                                    .QUEST_ACCEPTANCE_ALREADY_EXISTS
+                                    )
+                    );
+        }
+    }
+
     private QuestAcceptance goalReachedAcceptance(Quest quest) {
         QuestAcceptance acceptance = QuestAcceptance.start(
                 QUEST_ID,
@@ -156,6 +259,26 @@ class QuestServiceStateContractTest {
                         new RewardStats(java.util.Map.of("wisdom", 3))
                 ),
                 QuestRepeatRule.NONE,
+                QuestCompletionPolicy.USER_CONFIRM,
+                null
+        );
+        ReflectionTestUtils.setField(quest, "id", QUEST_ID);
+        return quest;
+    }
+
+    private Quest finalQuest(QuestRepeatRule repeatPolicy) {
+        Quest quest = Quest.createDefinition(
+                QuestCode.PLAYER_WELCOME.value(),
+                2,
+                QuestCategory.MAIN,
+                QuestSemanticCategory.GROWTH,
+                QuestTitle.of("Repeat 수락 계약"),
+                "Repeat 수락 계약 테스트",
+                QuestTarget.of(QuestTargetType.COUNT, 1),
+                QuestProgressSource.COUNT,
+                RewardProfileRef.of("RP_EXP_10"),
+                repeatPolicy,
+                null,
                 QuestCompletionPolicy.USER_CONFIRM,
                 null
         );

--- a/src/test/java/online/lifeasgame/quest/application/automation/QuestSignalProcessingAttemptTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/automation/QuestSignalProcessingAttemptTest.java
@@ -104,6 +104,10 @@ class QuestSignalProcessingAttemptTest {
             QuestEvent completed = events.getLast();
             assertThat(completed.attributes())
                     .containsEntry("questDefinitionVersion", 5)
+                    .containsEntry("questSemanticCategory", "GROWTH")
+                    .containsEntry("progressSource", "COUNT")
+                    .containsEntry("repeatPolicy", "ONCE")
+                    .containsEntry("roleTemplateCode", "ROLE_WARRIOR")
                     .containsEntry("rewardProfileCode", "RP_EXP_10")
                     .doesNotContainKeys(
                             "rewardExp",
@@ -314,6 +318,94 @@ class QuestSignalProcessingAttemptTest {
         }
     }
 
+    @Nested
+    @DisplayName("repeat policy 기간과 TTL을 계산할 때")
+    class RepeatPolicyBoundary {
+
+        @Test
+        @DisplayName("ONCE와 legacy NONE은 TTL 없는 one-time 의미를 공유한다")
+        void keepsOneTimeTtlCompatibility() {
+            LocalDate today = LocalDate.now();
+
+            Duration onceTtl = ReflectionTestUtils.invokeMethod(
+                    attempt,
+                    "ttlFor",
+                    finalRepeatQuest(QuestRepeatRule.ONCE),
+                    today
+            );
+            Duration noneTtl = ReflectionTestUtils.invokeMethod(
+                    attempt,
+                    "ttlFor",
+                    quest(
+                            QuestCompletionPolicy.AUTO,
+                            QuestRepeatRule.NONE
+                    ),
+                    today
+            );
+
+            assertThat(onceTtl).isNull();
+            assertThat(noneTtl).isNull();
+        }
+
+        @Test
+        @DisplayName("DAILY/WEEKLY와 legacy MONTHLY는 기간 종료 기반 TTL을 유지한다")
+        void keepsRepeatingTtl() {
+            LocalDate today = LocalDate.now();
+
+            Duration dailyTtl = ReflectionTestUtils.invokeMethod(
+                    attempt,
+                    "ttlFor",
+                    finalRepeatQuest(QuestRepeatRule.DAILY),
+                    today
+            );
+            Duration weeklyTtl = ReflectionTestUtils.invokeMethod(
+                    attempt,
+                    "ttlFor",
+                    finalRepeatQuest(QuestRepeatRule.WEEKLY),
+                    today
+            );
+            Duration monthlyTtl = ReflectionTestUtils.invokeMethod(
+                    attempt,
+                    "ttlFor",
+                    quest(
+                            QuestCompletionPolicy.AUTO,
+                            QuestRepeatRule.MONTHLY
+                    ),
+                    today
+            );
+
+            assertThat(dailyTtl).isPositive();
+            assertThat(weeklyTtl).isPositive();
+            assertThat(monthlyTtl).isPositive();
+        }
+
+        @Test
+        @DisplayName("완료된 ONCE Acceptance에는 새 Acceptance를 만들지 않는다")
+        void doesNotRepeatOnceAcceptance() {
+            Quest quest = finalRepeatQuest(QuestRepeatRule.ONCE);
+            QuestAcceptance completed = acceptance(
+                    quest,
+                    TimePeriod.forever(),
+                    903L
+            );
+            completed.reachGoal(OCCURRED_AT.minusSeconds(60));
+            completed.complete(OCCURRED_AT.minusSeconds(30));
+            QuestSignal signal = signal(OCCURRED_AT);
+            stubReceipt(signal);
+            given(questService.ensureQuest(signal.questCode()))
+                    .willReturn(quest);
+            given(questAcceptanceRepository.findLatestByQuestAndPlayer(
+                    QUEST_ID,
+                    PLAYER_ID
+            )).willReturn(Optional.of(completed));
+
+            attempt.process(signal, FINGERPRINT);
+
+            verify(questAcceptanceRepository, never()).save(any());
+            verifyNoInteractions(questProgressStore, domainEventPublisher);
+        }
+    }
+
     private void stubReceipt(QuestSignal signal) {
         given(receiptRepository.saveAndFlush(any())).willAnswer(invocation -> {
             QuestSignalReceipt receipt = invocation.getArgument(0);
@@ -422,11 +514,34 @@ class QuestSignalProcessingAttemptTest {
                 QuestCode.PLAYER_WELCOME.value(),
                 5,
                 QuestCategory.MAIN,
+                QuestSemanticCategory.GROWTH,
                 QuestTitle.of("Profile Signal 계약"),
                 "RewardProfile Quest Signal 계약 테스트",
                 QuestTarget.of(QuestTargetType.COUNT, 1),
+                QuestProgressSource.COUNT,
                 RewardProfileRef.of("RP_EXP_10"),
-                QuestRepeatRule.NONE,
+                QuestRepeatRule.ONCE,
+                QuestRoleTemplateRef.of("ROLE_WARRIOR"),
+                QuestCompletionPolicy.AUTO,
+                null
+        );
+        ReflectionTestUtils.setField(quest, "id", QUEST_ID);
+        return quest;
+    }
+
+    private Quest finalRepeatQuest(QuestRepeatRule repeatPolicy) {
+        Quest quest = Quest.createDefinition(
+                QuestCode.PLAYER_WELCOME.value(),
+                5,
+                QuestCategory.MAIN,
+                QuestSemanticCategory.GROWTH,
+                QuestTitle.of("Repeat policy 계약"),
+                "Quest repeat policy 계약 테스트",
+                QuestTarget.of(QuestTargetType.COUNT, 1),
+                QuestProgressSource.COUNT,
+                RewardProfileRef.of("RP_EXP_10"),
+                repeatPolicy,
+                null,
                 QuestCompletionPolicy.AUTO,
                 null
         );

--- a/src/test/java/online/lifeasgame/quest/domain/QuestBlueprintContractTest.java
+++ b/src/test/java/online/lifeasgame/quest/domain/QuestBlueprintContractTest.java
@@ -1,0 +1,85 @@
+package online.lifeasgame.quest.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("QuestBlueprint semantic 계약")
+class QuestBlueprintContractTest {
+
+    @Test
+    @DisplayName("final-contract Blueprint는 신규 Quest 생성 계약을 materialize한다")
+    void instantiatesFinalContract() {
+        QuestBlueprint blueprint = finalBlueprint(
+                QuestRoleTemplateRef.of(" ROLE_READER ")
+        );
+
+        Quest quest = blueprint.instantiate();
+
+        assertThat(blueprint.isFinalContract()).isTrue();
+        assertThat(quest.isFinalContract()).isTrue();
+        assertThat(quest.getSemanticCategory())
+                .isEqualTo(QuestSemanticCategory.RECORD);
+        assertThat(quest.getProgressSource())
+                .isEqualTo(QuestProgressSource.RECORD_CREATED);
+        assertThat(quest.getRepeatRule()).isEqualTo(QuestRepeatRule.DAILY);
+        assertThat(quest.roleTemplateCodeOrNull()).isEqualTo("ROLE_READER");
+        assertThat(quest.rewardProfileCodeOrNull()).isEqualTo("RP_EXP_10");
+    }
+
+    @Test
+    @DisplayName("null Role code를 허용하고 Quest에도 null을 유지한다")
+    void allowsNullRoleContext() {
+        Quest quest = finalBlueprint(null).instantiate();
+
+        assertThat(quest.isFinalContract()).isTrue();
+        assertThat(quest.roleTemplateCodeOrNull()).isNull();
+    }
+
+    @Test
+    @DisplayName("legacy Blueprint는 기존 category와 MONTHLY를 재해석하지 않는다")
+    void instantiatesLegacyBlueprint() {
+        QuestBlueprint blueprint = new QuestBlueprint(
+                QuestCode.COLLECTION_HUNTER_10,
+                QuestCategory.RECOMMENDED,
+                QuestTitle.of("Legacy Blueprint"),
+                "legacy blueprint",
+                QuestTarget.of(QuestTargetType.COUNT, 10),
+                QuestReward.of(3, RewardStats.empty()),
+                QuestRepeatRule.MONTHLY,
+                null
+        );
+
+        Quest quest = blueprint.instantiate();
+
+        assertThat(blueprint.isFinalContract()).isFalse();
+        assertThat(blueprint.semanticCategory()).isNull();
+        assertThat(blueprint.progressSource()).isNull();
+        assertThat(blueprint.repeatPolicy()).isNull();
+        assertThat(quest.getCategory()).isEqualTo(QuestCategory.RECOMMENDED);
+        assertThat(quest.getRepeatRule()).isEqualTo(QuestRepeatRule.MONTHLY);
+        assertThat(quest.getSemanticCategory()).isNull();
+        assertThat(quest.getProgressSource()).isNull();
+    }
+
+    private QuestBlueprint finalBlueprint(
+            QuestRoleTemplateRef roleTemplateRef
+    ) {
+        return QuestBlueprint.finalContract(
+                QuestCode.PLAYER_WELCOME,
+                2,
+                QuestCategory.MAIN,
+                QuestSemanticCategory.RECORD,
+                QuestTitle.of("Final Blueprint"),
+                "final blueprint",
+                QuestTarget.of(QuestTargetType.COUNT, 1),
+                QuestProgressSource.RECORD_CREATED,
+                RewardProfileRef.of("RP_EXP_10"),
+                QuestRepeatRule.DAILY,
+                roleTemplateRef,
+                null,
+                QuestCompletionPolicy.AUTO
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/quest/domain/QuestRepeatPolicyTest.java
+++ b/src/test/java/online/lifeasgame/quest/domain/QuestRepeatPolicyTest.java
@@ -1,0 +1,81 @@
+package online.lifeasgame.quest.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Quest repeat policy")
+class QuestRepeatPolicyTest {
+
+    private static final LocalDate MONDAY = LocalDate.of(2026, 7, 27);
+
+    @Test
+    @DisplayName("ONCE와 legacy NONE은 영구 기간을 사용한다")
+    void usesForeverForOneTimePolicies() {
+        assertPeriod(
+                QuestRepeatRule.ONCE.periodFor(MONDAY),
+                LocalDate.of(1970, 1, 1),
+                LocalDate.of(9999, 12, 31)
+        );
+        assertPeriod(
+                QuestRepeatRule.NONE.periodFor(MONDAY),
+                LocalDate.of(1970, 1, 1),
+                LocalDate.of(9999, 12, 31)
+        );
+        assertThat(QuestRepeatRule.ONCE.isOneTime()).isTrue();
+        assertThat(QuestRepeatRule.NONE.isOneTime()).isTrue();
+    }
+
+    @Test
+    @DisplayName("DAILY와 WEEKLY는 공식 기간 경계를 유지한다")
+    void calculatesFinalRepeatPeriods() {
+        assertPeriod(
+                QuestRepeatRule.DAILY.periodFor(MONDAY),
+                MONDAY,
+                MONDAY
+        );
+        assertPeriod(
+                QuestRepeatRule.WEEKLY.periodFor(MONDAY.plusDays(3)),
+                MONDAY,
+                MONDAY.plusDays(6)
+        );
+    }
+
+    @Test
+    @DisplayName("legacy MONTHLY는 월 기간 계산을 유지한다")
+    void keepsLegacyMonthlyPeriod() {
+        assertPeriod(
+                QuestRepeatRule.MONTHLY.periodFor(MONDAY),
+                LocalDate.of(2026, 7, 1),
+                LocalDate.of(2026, 7, 31)
+        );
+    }
+
+    @Test
+    @DisplayName("ONCE는 NONE의 idempotency TTL 의미를 유지한다")
+    void keepsIdempotencyTtlCompatibility() {
+        assertThat(QuestRepeatRule.ONCE.idempotencyTtl())
+                .isEqualTo(Duration.ofDays(90));
+        assertThat(QuestRepeatRule.NONE.idempotencyTtl())
+                .isEqualTo(Duration.ofDays(90));
+        assertThat(QuestRepeatRule.DAILY.idempotencyTtl())
+                .isEqualTo(Duration.ofDays(7));
+        assertThat(QuestRepeatRule.WEEKLY.idempotencyTtl())
+                .isEqualTo(Duration.ofDays(30));
+        assertThat(QuestRepeatRule.MONTHLY.idempotencyTtl())
+                .isEqualTo(Duration.ofDays(120));
+    }
+
+    private void assertPeriod(
+            TimePeriod period,
+            LocalDate expectedStart,
+            LocalDate expectedEnd
+    ) {
+        assertThat(period.start()).isEqualTo(expectedStart);
+        assertThat(period.end()).isEqualTo(expectedEnd);
+    }
+}

--- a/src/test/java/online/lifeasgame/quest/domain/QuestSemanticDefinitionContractTest.java
+++ b/src/test/java/online/lifeasgame/quest/domain/QuestSemanticDefinitionContractTest.java
@@ -1,0 +1,268 @@
+package online.lifeasgame.quest.domain;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.quest.domain.error.QuestError;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Quest semantic Definition 계약")
+class QuestSemanticDefinitionContractTest {
+
+    @Nested
+    @DisplayName("final-contract Definition을 생성할 때")
+    class CreateFinalContract {
+
+        @Test
+        @DisplayName("semantic/progress/repeat과 선택적 Role code를 보존한다")
+        void createsFinalDefinition() {
+            Quest quest = finalQuest(QuestRoleTemplateRef.of("  ROLE_WARRIOR  "));
+
+            assertThat(quest.isFinalContract()).isTrue();
+            assertThat(quest.getSemanticCategory())
+                    .isEqualTo(QuestSemanticCategory.GROWTH);
+            assertThat(quest.getProgressSource())
+                    .isEqualTo(QuestProgressSource.COUNT);
+            assertThat(quest.getRepeatRule()).isEqualTo(QuestRepeatRule.ONCE);
+            assertThat(quest.repeatPolicyOrNull())
+                    .isEqualTo(QuestRepeatRule.ONCE);
+            assertThat(quest.roleTemplateCodeOrNull())
+                    .isEqualTo("ROLE_WARRIOR");
+        }
+
+        @Test
+        @DisplayName("semantic category는 필수다")
+        void requiresSemanticCategory() {
+            assertQuestError(
+                    () -> createFinal(
+                            null,
+                            QuestProgressSource.COUNT,
+                            QuestRepeatRule.ONCE
+                    ),
+                    QuestError.QUEST_SEMANTIC_CATEGORY_REQUIRED
+            );
+        }
+
+        @Test
+        @DisplayName("progress source는 필수다")
+        void requiresProgressSource() {
+            assertQuestError(
+                    () -> createFinal(
+                            QuestSemanticCategory.GROWTH,
+                            null,
+                            QuestRepeatRule.ONCE
+                    ),
+                    QuestError.QUEST_PROGRESS_SOURCE_REQUIRED
+            );
+        }
+
+        @Test
+        @DisplayName("repeat policy는 필수이며 legacy MONTHLY를 허용하지 않는다")
+        void requiresFinalRepeatPolicy() {
+            assertQuestError(
+                    () -> createFinal(
+                            QuestSemanticCategory.GROWTH,
+                            QuestProgressSource.COUNT,
+                            null
+                    ),
+                    QuestError.QUEST_REPEAT_POLICY_REQUIRED
+            );
+            assertQuestError(
+                    () -> createFinal(
+                            QuestSemanticCategory.GROWTH,
+                            QuestProgressSource.COUNT,
+                            QuestRepeatRule.MONTHLY
+                    ),
+                    QuestError.INVALID_QUEST_REPEAT_POLICY
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("enum과 Role code를 입력할 때")
+    class ParseContract {
+
+        @Test
+        @DisplayName("semantic category와 progress source를 strict parse한다")
+        void parsesStrictEnums() {
+            assertThat(QuestSemanticCategory.parse(" growth "))
+                    .isEqualTo(QuestSemanticCategory.GROWTH);
+            assertThat(QuestProgressSource.parse("record-created"))
+                    .isEqualTo(QuestProgressSource.RECORD_CREATED);
+
+            assertQuestError(
+                    () -> QuestSemanticCategory.parse("DAILY"),
+                    QuestError.INVALID_QUEST_SEMANTIC_CATEGORY
+            );
+            assertQuestError(
+                    () -> QuestProgressSource.parse("QuestEvent"),
+                    QuestError.INVALID_QUEST_PROGRESS_SOURCE
+            );
+        }
+
+        @Test
+        @DisplayName("repeatPolicy는 ONCE/DAILY/WEEKLY만 parse한다")
+        void parsesFinalRepeatPolicy() {
+            assertThat(QuestRepeatRule.parsePolicy("once"))
+                    .isEqualTo(QuestRepeatRule.ONCE);
+            assertThat(QuestRepeatRule.parsePolicy("WEEKLY"))
+                    .isEqualTo(QuestRepeatRule.WEEKLY);
+            assertQuestError(
+                    () -> QuestRepeatRule.parsePolicy("NONE"),
+                    QuestError.INVALID_QUEST_REPEAT_POLICY
+            );
+            assertQuestError(
+                    () -> QuestRepeatRule.parsePolicy("MONTHLY"),
+                    QuestError.INVALID_QUEST_REPEAT_POLICY
+            );
+        }
+
+        @Test
+        @DisplayName("Role code는 trim하고 blank와 80자 초과를 거부한다")
+        void validatesRoleTemplateCode() {
+            assertThat(QuestRoleTemplateRef.of("  ROLE_READER  ").code())
+                    .isEqualTo("ROLE_READER");
+            assertQuestError(
+                    () -> QuestRoleTemplateRef.of("   "),
+                    QuestError.QUEST_ROLE_TEMPLATE_CODE_REQUIRED
+            );
+            assertQuestError(
+                    () -> QuestRoleTemplateRef.of("R".repeat(81)),
+                    QuestError.QUEST_ROLE_TEMPLATE_CODE_TOO_LONG
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("final-contract Definition을 수정할 때")
+    class UpdateFinalContract {
+
+        @Test
+        @DisplayName("동일 값 partial update는 Event 없는 no-op이다")
+        void keepsSameValueNoOp() {
+            Quest quest = finalQuest(QuestRoleTemplateRef.of("ROLE_WARRIOR"));
+
+            quest.updateDefinition(
+                    quest.target(),
+                    null,
+                    QuestRepeatRule.ONCE,
+                    null,
+                    2,
+                    RewardProfileRef.of("RP_EXP_30"),
+                    QuestSemanticCategory.GROWTH,
+                    QuestProgressSource.COUNT,
+                    QuestRepeatRule.ONCE,
+                    QuestRoleTemplateRef.of(" ROLE_WARRIOR ")
+            );
+
+            assertThat(quest.pullEvents()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("version validation 실패는 다른 Definition mutation보다 먼저 끝난다")
+        void validatesBeforeMutation() {
+            Quest quest = finalQuest(null);
+
+            assertQuestError(
+                    () -> quest.updateDefinition(
+                            QuestTarget.of(QuestTargetType.COUNT, 9),
+                            null,
+                            null,
+                            null,
+                            1,
+                            null,
+                            QuestSemanticCategory.RECOVERY,
+                            QuestProgressSource.MANUAL_CHECK,
+                            QuestRepeatRule.DAILY,
+                            QuestRoleTemplateRef.of("ROLE_RECOVERY")
+                    ),
+                    QuestError.QUEST_DEFINITION_VERSION_DECREASE_NOT_ALLOWED
+            );
+
+            assertThat(quest.target().value()).isEqualTo(1);
+            assertThat(quest.getSemanticCategory())
+                    .isEqualTo(QuestSemanticCategory.GROWTH);
+            assertThat(quest.getProgressSource())
+                    .isEqualTo(QuestProgressSource.COUNT);
+            assertThat(quest.getRepeatRule()).isEqualTo(QuestRepeatRule.ONCE);
+            assertThat(quest.roleTemplateCodeOrNull()).isNull();
+            assertThat(quest.pullEvents()).isEmpty();
+        }
+    }
+
+    @Test
+    @DisplayName("legacy 생성은 semantic/progress/repeatPolicy/Role을 추론하지 않는다")
+    void keepsLegacyCreationUninterpreted() {
+        Quest quest = Quest.create(
+                "quest:test:legacy-semantic",
+                QuestCategory.REPEAT,
+                QuestTitle.of("Legacy Repeat"),
+                "legacy category를 의미 분류로 해석하지 않는다",
+                QuestTarget.of(QuestTargetType.COUNT, 1),
+                QuestReward.of(0, RewardStats.empty()),
+                QuestRepeatRule.MONTHLY,
+                QuestCompletionPolicy.AUTO,
+                null
+        );
+
+        assertThat(quest.isFinalContract()).isFalse();
+        assertThat(quest.getSemanticCategory()).isNull();
+        assertThat(quest.getProgressSource()).isNull();
+        assertThat(quest.repeatPolicyOrNull()).isNull();
+        assertThat(quest.roleTemplateCodeOrNull()).isNull();
+        assertThat(quest.getCategory()).isEqualTo(QuestCategory.REPEAT);
+        assertThat(quest.getRepeatRule()).isEqualTo(QuestRepeatRule.MONTHLY);
+    }
+
+    private Quest finalQuest(QuestRoleTemplateRef roleTemplateRef) {
+        return Quest.createDefinition(
+                "quest:test:semantic-final",
+                2,
+                QuestCategory.MAIN,
+                QuestSemanticCategory.GROWTH,
+                QuestTitle.of("Semantic Final Quest"),
+                "final contract",
+                QuestTarget.of(QuestTargetType.COUNT, 1),
+                QuestProgressSource.COUNT,
+                RewardProfileRef.of("RP_EXP_30"),
+                QuestRepeatRule.ONCE,
+                roleTemplateRef,
+                QuestCompletionPolicy.AUTO,
+                null
+        );
+    }
+
+    private Quest createFinal(
+            QuestSemanticCategory semanticCategory,
+            QuestProgressSource progressSource,
+            QuestRepeatRule repeatPolicy
+    ) {
+        return Quest.createDefinition(
+                "quest:test:required-final",
+                2,
+                QuestCategory.MAIN,
+                semanticCategory,
+                QuestTitle.of("Required Final Quest"),
+                "required final contract",
+                QuestTarget.of(QuestTargetType.COUNT, 1),
+                progressSource,
+                RewardProfileRef.of("RP_EXP_10"),
+                repeatPolicy,
+                null,
+                QuestCompletionPolicy.AUTO,
+                null
+        );
+    }
+
+    private void assertQuestError(Runnable action, QuestError error) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(
+                        DomainException.class,
+                        exception -> assertThat(exception.getErrorCode())
+                                .isEqualTo(error)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/quest/domain/event/QuestEventDefinitionSnapshotTest.java
+++ b/src/test/java/online/lifeasgame/quest/domain/event/QuestEventDefinitionSnapshotTest.java
@@ -21,8 +21,36 @@ class QuestEventDefinitionSnapshotTest {
         assertThat(event.type()).isEqualTo(QuestEventType.QUEST_COMPLETED);
         assertThat(event.attributes())
                 .containsEntry("questDefinitionVersion", 3)
+                .containsEntry("questSemanticCategory", "GROWTH")
+                .containsEntry("progressSource", "COUNT")
+                .containsEntry("repeatPolicy", "ONCE")
+                .containsEntry("roleTemplateCode", "ROLE_WARRIOR")
                 .containsEntry("rewardProfileCode", "RP_EXP_30")
                 .doesNotContainKeys(
+                        "rewardExp",
+                        "rewardStats",
+                        "rewardLines",
+                        "rewardProfileId"
+                );
+    }
+
+    @Test
+    @DisplayName("QUEST_UPDATED final Snapshot은 null Role code를 제외한다")
+    void snapshotsUpdatedFinalDefinitionWithoutRole() {
+        QuestEvent event = QuestEvent.snapshot(
+                QuestEventType.QUEST_UPDATED,
+                profileQuest(null),
+                "quest:test:profile:updated"
+        );
+
+        assertThat(event.attributes())
+                .containsEntry("questDefinitionVersion", 3)
+                .containsEntry("questSemanticCategory", "GROWTH")
+                .containsEntry("progressSource", "COUNT")
+                .containsEntry("repeatPolicy", "ONCE")
+                .containsEntry("rewardProfileCode", "RP_EXP_30")
+                .doesNotContainKeys(
+                        "roleTemplateCode",
                         "rewardExp",
                         "rewardStats",
                         "rewardLines",
@@ -45,6 +73,10 @@ class QuestEventDefinitionSnapshotTest {
                 .containsEntry("rewardExp", 7)
                 .containsEntry("rewardStats", java.util.Map.of("strength", 2))
                 .doesNotContainKeys(
+                        "questSemanticCategory",
+                        "progressSource",
+                        "repeatPolicy",
+                        "roleTemplateCode",
                         "rewardProfileCode",
                         "rewardLines",
                         "rewardProfileId"
@@ -52,15 +84,22 @@ class QuestEventDefinitionSnapshotTest {
     }
 
     private Quest profileQuest() {
+        return profileQuest(QuestRoleTemplateRef.of("ROLE_WARRIOR"));
+    }
+
+    private Quest profileQuest(QuestRoleTemplateRef roleTemplateRef) {
         return Quest.createDefinition(
                 "quest:test:profile",
                 3,
                 QuestCategory.MAIN,
+                QuestSemanticCategory.GROWTH,
                 QuestTitle.of("Profile Quest"),
                 "profile",
                 QuestTarget.of(QuestTargetType.COUNT, 1),
+                QuestProgressSource.COUNT,
                 RewardProfileRef.of("RP_EXP_30"),
-                QuestRepeatRule.NONE,
+                QuestRepeatRule.ONCE,
+                roleTemplateRef,
                 QuestCompletionPolicy.AUTO,
                 null
         );


### PR DESCRIPTION
## What

- Quest Definition에 semantic category 계약을 추가했습니다.
- 진행 근거를 표현하는 progress source 계약을 추가했습니다.
- ONCE 기반 repeat policy와 기존 repeat rule 호환을 정렬했습니다.
- optional `roleTemplateCode` 참조를 stable code로 추가했습니다.
- Definition/Blueprint/Player API와 Quest Event Snapshot을 확장했습니다.

## Contract

```text
semanticCategory
- GROWTH
- RECORD
- RECOVERY
- RELATION
- ROLE
```

```text
progressSource
- RECORD_CREATED
- COUNT
- MANUAL_CHECK
```

```text
repeatPolicy
- ONCE
- DAILY
- WEEKLY
```

## Migration

- `V11__quest_semantic_progress_contract.sql`
- 기존 V1~V10은 수정하지 않았습니다.
- Role Context FK/JPA 연관관계를 추가하지 않았습니다.

## Compatibility

- 기존 legacy category를 유지합니다.
- 기존 QuestTargetType을 유지합니다.
- 기존 NONE/MONTHLY Quest 동작을 보존합니다.
- legacy Blueprint와 DB row를 임의 semantic category로 변환하지 않습니다.

## Test

- [ ] `./gradlew clean test`
- [ ] `./gradlew build`
- [ ] semantic/progress validation
- [ ] ONCE/DAILY/WEEKLY
- [ ] legacy NONE/MONTHLY
- [ ] optional roleTemplateCode
- [ ] API/Event Snapshot
- [ ] V1~V11 checksum / JPA validate

## Out of Scope

- Seed Level 1 Quest
- Reward/Item/Achievement Seed
- LifeLogRecorded Trigger
- Manual Check API
- QuestCompleted → RewardSettlement
- QuestRoute
- Role Domain
- Frontend

Closes #205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quest definitions now support semantic categories, progress sources, repeat policies, and optional role templates.
  * Quest details, blueprints, and acceptance responses expose the new contract information.
  * Added support for one-time, daily, and weekly repeat policies with appropriate acceptance periods.
* **Bug Fixes**
  * Prevented duplicate acceptance of one-time quests and improved repeat-period handling.
* **Validation**
  * Added validation for required contract fields and role template codes.
* **Documentation**
  * Updated API descriptions to clarify the new contract and legacy compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->