### PR TITLE
[Inventory] Add stable item code and first step seed

### DIFF
--- a/src/main/java/online/lifeasgame/inventory/api/player/mapper/ItemWebMapper.java
+++ b/src/main/java/online/lifeasgame/inventory/api/player/mapper/ItemWebMapper.java
@@ -11,6 +11,7 @@ public final class ItemWebMapper {
     public static ItemResponse.Detail toDetail(ItemResult.Detail result) {
         return new ItemResponse.Detail(
                 result.id(),
+                result.code(),
                 result.name(),
                 result.category(),
                 result.type(),
@@ -25,6 +26,7 @@ public final class ItemWebMapper {
     public static ItemResponse.Summary toSummary(ItemResult.Summary result) {
         return new ItemResponse.Summary(
                 result.id(),
+                result.code(),
                 result.name(),
                 result.category(),
                 result.type(),

--- a/src/main/java/online/lifeasgame/inventory/api/player/response/ItemResponse.java
+++ b/src/main/java/online/lifeasgame/inventory/api/player/response/ItemResponse.java
@@ -14,6 +14,7 @@ public final class ItemResponse {
 
     public record Summary(
             Long id,
+            String code,
             String name,
             String category,
             String type,
@@ -25,6 +26,7 @@ public final class ItemResponse {
 
     public record Detail(
             Long id,
+            String code,
             String name,
             String category,
             String type,

--- a/src/main/java/online/lifeasgame/inventory/application/ItemLookupService.java
+++ b/src/main/java/online/lifeasgame/inventory/application/ItemLookupService.java
@@ -1,0 +1,23 @@
+package online.lifeasgame.inventory.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.inventory.application.internal.ItemLookupApi;
+import online.lifeasgame.inventory.domain.Item;
+import online.lifeasgame.inventory.domain.ItemCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+public class ItemLookupService implements ItemLookupApi {
+
+    private final ItemReader itemReader;
+
+    @Override
+    public ItemReference getByCode(String code) {
+        Item item = itemReader.getByCodeOrThrow(ItemCode.of(code));
+        return new ItemReference(item.getId(), item.getCode().value());
+    }
+}

--- a/src/main/java/online/lifeasgame/inventory/application/ItemReader.java
+++ b/src/main/java/online/lifeasgame/inventory/application/ItemReader.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.inventory.domain.Item;
 import online.lifeasgame.inventory.domain.ItemCategory;
+import online.lifeasgame.inventory.domain.ItemCode;
 import online.lifeasgame.inventory.domain.ItemType;
 import online.lifeasgame.inventory.domain.Rarity;
 import online.lifeasgame.inventory.domain.error.ItemError;
@@ -24,6 +25,11 @@ class ItemReader {
     public Item getByIdOrThrow(Long id) {
         return repository.findById(id)
                 .orElseThrow(() -> new DomainException(ItemError.ITEM_NOT_FOUND));
+    }
+
+    public Item getByCodeOrThrow(ItemCode code) {
+        return repository.findByCode(code)
+                .orElseThrow(() -> new DomainException(ItemError.ITEM_CODE_NOT_FOUND));
     }
 
     public Page<Item> search(

--- a/src/main/java/online/lifeasgame/inventory/application/internal/ItemLookupApi.java
+++ b/src/main/java/online/lifeasgame/inventory/application/internal/ItemLookupApi.java
@@ -1,0 +1,9 @@
+package online.lifeasgame.inventory.application.internal;
+
+public interface ItemLookupApi {
+
+    ItemReference getByCode(String code);
+
+    record ItemReference(Long id, String code) {
+    }
+}

--- a/src/main/java/online/lifeasgame/inventory/application/result/ItemResult.java
+++ b/src/main/java/online/lifeasgame/inventory/application/result/ItemResult.java
@@ -18,6 +18,7 @@ public final class ItemResult {
 
     public record Detail(
             Long id,
+            String code,
             String name,
             String category,
             String type,
@@ -30,6 +31,7 @@ public final class ItemResult {
         public static Detail from(Item item) {
             return new ItemResult.Detail(
                     item.getId(),
+                    item.getCode() == null ? null : item.getCode().value(),
                     item.getName().value(),
                     item.getCategory().name(),
                     item.getType().name(),
@@ -44,6 +46,7 @@ public final class ItemResult {
 
     public record Summary(
             Long id,
+            String code,
             String name,
             String category,
             String type,
@@ -54,6 +57,7 @@ public final class ItemResult {
         public static Summary from(Item item) {
             return new ItemResult.Summary(
                     item.getId(),
+                    item.getCode() == null ? null : item.getCode().value(),
                     item.getName().value(),
                     item.getCategory().name(),
                     item.getType().name(),

--- a/src/main/java/online/lifeasgame/inventory/domain/Item.java
+++ b/src/main/java/online/lifeasgame/inventory/domain/Item.java
@@ -25,6 +25,9 @@ public class Item extends AbstractTime {
     private Long id;
 
     @Embedded
+    private ItemCode code;
+
+    @Embedded
     private ItemName name;
 
     @Enumerated(EnumType.STRING)
@@ -53,6 +56,7 @@ public class Item extends AbstractTime {
     private DurabilityPolicy durabilityPolicy;
 
     private Item(
+            ItemCode code,
             ItemName name,
             ItemCategory category,
             ItemType type,
@@ -62,6 +66,7 @@ public class Item extends AbstractTime {
             int maxStack,
             DurabilityPolicy durabilityPolicy
     ) {
+        this.code = code;
         this.name = Guard.notNull(name, "name");
         this.category = Guard.notNull(category, "category");
         this.type = Guard.notNull(type, "type");
@@ -84,7 +89,36 @@ public class Item extends AbstractTime {
     ) {
         int ms = (stackable) ? Guard.minValue(Optional.ofNullable(maxStack).orElse(0), 2, "maxStack") : 1;
         DurabilityPolicy durabilityPolicy = (maxDurabilityOrNull == null) ? null : DurabilityPolicy.of(maxDurabilityOrNull);
-        return new Item(name, category, type, rarity, baseAttrs, stackable, ms, durabilityPolicy);
+        return new Item(null, name, category, type, rarity, baseAttrs, stackable, ms, durabilityPolicy);
+    }
+
+    public static Item createContentItem(
+            ItemCode code,
+            ItemName name,
+            ItemCategory category,
+            ItemType type,
+            Rarity rarity,
+            BaseAttrs baseAttrs,
+            boolean stackable,
+            Integer maxStack,
+            Integer maxDurabilityOrNull
+    ) {
+        ItemCode requiredCode = Guard.notNull(code, "code");
+        int ms = (stackable) ? Guard.minValue(Optional.ofNullable(maxStack).orElse(0), 2, "maxStack") : 1;
+        DurabilityPolicy durabilityPolicy = (maxDurabilityOrNull == null)
+                ? null
+                : DurabilityPolicy.of(maxDurabilityOrNull);
+        return new Item(
+                requiredCode,
+                name,
+                category,
+                type,
+                rarity,
+                baseAttrs,
+                stackable,
+                ms,
+                durabilityPolicy
+        );
     }
 
     public void update(
@@ -116,6 +150,6 @@ public class Item extends AbstractTime {
     }
 
     public Integer maxDurability() {
-        return this.durabilityPolicy.max();
+        return (this.durabilityPolicy == null) ? null : this.durabilityPolicy.max();
     }
 }

--- a/src/main/java/online/lifeasgame/inventory/domain/ItemCode.java
+++ b/src/main/java/online/lifeasgame/inventory/domain/ItemCode.java
@@ -1,0 +1,32 @@
+package online.lifeasgame.inventory.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import online.lifeasgame.core.guard.Guard;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemCode {
+
+    public static final int MAX_LENGTH = 80;
+
+    @Column(name = "code", length = MAX_LENGTH, unique = true)
+    private String value;
+
+    private ItemCode(String raw) {
+        String normalized = Guard.notBlank(raw, "item code");
+        this.value = Guard.maxLength(normalized, MAX_LENGTH, "item code");
+    }
+
+    public static ItemCode of(String raw) {
+        return new ItemCode(raw);
+    }
+
+    public String value() {
+        return value;
+    }
+}

--- a/src/main/java/online/lifeasgame/inventory/domain/error/ItemError.java
+++ b/src/main/java/online/lifeasgame/inventory/domain/error/ItemError.java
@@ -5,6 +5,7 @@ import online.lifeasgame.core.error.ErrorCode;
 public enum ItemError implements ErrorCode {
 
     ITEM_NOT_FOUND("ITM-404-NOT-FOUND", "Item not found", 404),
+    ITEM_CODE_NOT_FOUND("ITM-404-CODE-NOT-FOUND", "Item code not found", 404),
     ITEM_NAME_DUP("ITM-409-NAME-DUP", "Duplicate item name", 409),
     INVALID_ITEM_CATEGORY("ITM-400-INVALID-ITEM-CATEGORY", "Invalid item category", 400),
     INVALID_ITEM_TYPE("ITM-400-INVALID-ITEM-TYPE", "Invalid item type", 400),

--- a/src/main/java/online/lifeasgame/inventory/domain/repository/ItemRepository.java
+++ b/src/main/java/online/lifeasgame/inventory/domain/repository/ItemRepository.java
@@ -2,6 +2,7 @@ package online.lifeasgame.inventory.domain.repository;
 
 import online.lifeasgame.inventory.domain.Item;
 import online.lifeasgame.inventory.domain.ItemCategory;
+import online.lifeasgame.inventory.domain.ItemCode;
 import online.lifeasgame.inventory.domain.ItemType;
 import online.lifeasgame.inventory.domain.Rarity;
 import org.springframework.data.domain.Page;
@@ -11,6 +12,8 @@ import java.util.Optional;
 
 public interface ItemRepository {
     Optional<Item> findById(Long id);
+
+    Optional<Item> findByCode(ItemCode code);
 
     boolean existsById(Long id);
 

--- a/src/main/java/online/lifeasgame/inventory/domain/seed/ItemContentCode.java
+++ b/src/main/java/online/lifeasgame/inventory/domain/seed/ItemContentCode.java
@@ -1,0 +1,15 @@
+package online.lifeasgame.inventory.domain.seed;
+
+public enum ItemContentCode {
+    IT_FIRST_STEP_FRAGMENT("IT_FIRST_STEP_FRAGMENT");
+
+    private final String value;
+
+    ItemContentCode(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+}

--- a/src/main/java/online/lifeasgame/inventory/domain/seed/ItemSeedDefinition.java
+++ b/src/main/java/online/lifeasgame/inventory/domain/seed/ItemSeedDefinition.java
@@ -1,0 +1,30 @@
+package online.lifeasgame.inventory.domain.seed;
+
+import online.lifeasgame.inventory.domain.BaseAttrs;
+import online.lifeasgame.inventory.domain.ItemCategory;
+import online.lifeasgame.inventory.domain.ItemType;
+import online.lifeasgame.inventory.domain.Rarity;
+
+import java.util.Objects;
+
+public record ItemSeedDefinition(
+        ItemContentCode code,
+        String name,
+        ItemCategory category,
+        ItemType type,
+        Rarity rarity,
+        BaseAttrs baseAttrs,
+        boolean stackable,
+        int maxStack,
+        Integer maxDurability
+) {
+
+    public ItemSeedDefinition {
+        Objects.requireNonNull(code, "code");
+        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(category, "category");
+        Objects.requireNonNull(type, "type");
+        Objects.requireNonNull(rarity, "rarity");
+        Objects.requireNonNull(baseAttrs, "baseAttrs");
+    }
+}

--- a/src/main/java/online/lifeasgame/inventory/domain/seed/SeedLevel1Item.java
+++ b/src/main/java/online/lifeasgame/inventory/domain/seed/SeedLevel1Item.java
@@ -1,0 +1,42 @@
+package online.lifeasgame.inventory.domain.seed;
+
+import online.lifeasgame.inventory.domain.BaseAttrs;
+import online.lifeasgame.inventory.domain.ItemCategory;
+import online.lifeasgame.inventory.domain.ItemType;
+import online.lifeasgame.inventory.domain.Rarity;
+
+import java.util.Arrays;
+import java.util.List;
+
+public enum SeedLevel1Item {
+
+    FIRST_STEP_FRAGMENT(
+            new ItemSeedDefinition(
+                    ItemContentCode.IT_FIRST_STEP_FRAGMENT,
+                    "첫걸음의 조각",
+                    ItemCategory.QUEST,
+                    ItemType.ETC,
+                    Rarity.COMMON,
+                    BaseAttrs.empty(),
+                    true,
+                    99,
+                    null
+            )
+    );
+
+    private final ItemSeedDefinition definition;
+
+    SeedLevel1Item(ItemSeedDefinition definition) {
+        this.definition = definition;
+    }
+
+    public ItemSeedDefinition definition() {
+        return definition;
+    }
+
+    public static List<ItemSeedDefinition> definitions() {
+        return Arrays.stream(values())
+                .map(SeedLevel1Item::definition)
+                .toList();
+    }
+}

--- a/src/main/java/online/lifeasgame/inventory/infra/ItemRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/inventory/infra/ItemRepositoryAdapter.java
@@ -3,6 +3,7 @@ package online.lifeasgame.inventory.infra;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.inventory.domain.Item;
 import online.lifeasgame.inventory.domain.ItemCategory;
+import online.lifeasgame.inventory.domain.ItemCode;
 import online.lifeasgame.inventory.domain.ItemType;
 import online.lifeasgame.inventory.domain.Rarity;
 import online.lifeasgame.inventory.domain.repository.ItemRepository;
@@ -21,6 +22,11 @@ public class ItemRepositoryAdapter implements ItemRepository {
     @Override
     public Optional<Item> findById(Long id) {
         return jpaRepository.findById(id);
+    }
+
+    @Override
+    public Optional<Item> findByCode(ItemCode code) {
+        return jpaRepository.findByCode(code);
     }
 
     @Override

--- a/src/main/java/online/lifeasgame/inventory/infra/JpaItemRepository.java
+++ b/src/main/java/online/lifeasgame/inventory/infra/JpaItemRepository.java
@@ -1,12 +1,17 @@
 package online.lifeasgame.inventory.infra;
 
 import online.lifeasgame.inventory.domain.Item;
+import online.lifeasgame.inventory.domain.ItemCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface JpaItemRepository extends JpaRepository<Item, Long>, JpaSpecificationExecutor<Item> {
+
+    Optional<Item> findByCode(ItemCode code);
 
     @Query(
             """

--- a/src/main/resources/db/migration/V12__item_stable_code_and_first_step_seed.sql
+++ b/src/main/resources/db/migration/V12__item_stable_code_and_first_step_seed.sql
@@ -1,0 +1,31 @@
+-- Stable content code remains nullable so existing Item rows and the legacy create API keep working.
+ALTER TABLE items
+    ADD COLUMN code VARCHAR(80) NULL AFTER id,
+    ADD CONSTRAINT uq_item_code UNIQUE (code);
+
+-- Runtime mapping only. Description and MEMORY_FRAGMENT content metadata are not modeled yet.
+INSERT INTO items (
+    code,
+    name,
+    category,
+    type,
+    rarity,
+    base_attrs,
+    stackable,
+    max_stack,
+    max_durability,
+    created_at,
+    updated_at
+) VALUES (
+    'IT_FIRST_STEP_FRAGMENT',
+    '첫걸음의 조각',
+    'QUEST',
+    'ETC',
+    'COMMON',
+    JSON_OBJECT(),
+    TRUE,
+    99,
+    NULL,
+    CURRENT_TIMESTAMP(6),
+    CURRENT_TIMESTAMP(6)
+);

--- a/src/test/java/online/lifeasgame/inventory/api/ItemApiContractTest.java
+++ b/src/test/java/online/lifeasgame/inventory/api/ItemApiContractTest.java
@@ -1,0 +1,69 @@
+package online.lifeasgame.inventory.api;
+
+import online.lifeasgame.inventory.api.admin.mapper.AdminItemWebMapper;
+import online.lifeasgame.inventory.api.admin.request.AdminItemRequest;
+import online.lifeasgame.inventory.api.player.mapper.ItemWebMapper;
+import online.lifeasgame.inventory.api.player.response.ItemResponse;
+import online.lifeasgame.inventory.application.command.ItemCommand;
+import online.lifeasgame.inventory.application.result.ItemResult;
+import online.lifeasgame.inventory.domain.BaseAttrs;
+import online.lifeasgame.inventory.domain.Item;
+import online.lifeasgame.inventory.domain.ItemCategory;
+import online.lifeasgame.inventory.domain.ItemCode;
+import online.lifeasgame.inventory.domain.ItemName;
+import online.lifeasgame.inventory.domain.ItemType;
+import online.lifeasgame.inventory.domain.Rarity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Item API contract")
+class ItemApiContractTest {
+
+    @Test
+    @DisplayName("Admin legacy create request는 code 입력 없이 기존 command로 변환된다")
+    void keepsAdminLegacyCreateContract() {
+        AdminItemRequest.Create request = new AdminItemRequest.Create(
+                "Legacy Item",
+                "MISC",
+                "ETC",
+                "COMMON",
+                Map.of(),
+                false,
+                null,
+                null
+        );
+
+        ItemCommand.Create command = AdminItemWebMapper.toCreateCommand(request);
+
+        assertThat(command.name()).isEqualTo("Legacy Item");
+        assertThat(command.category()).isEqualTo("MISC");
+        assertThat(command.type()).isEqualTo("ETC");
+        assertThat(command.stackable()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Player content Item 응답은 stable code를 유실하지 않는다")
+    void exposesContentCodeInPlayerResponse() {
+        Item item = Item.createContentItem(
+                ItemCode.of("IT_FIRST_STEP_FRAGMENT"),
+                ItemName.of("첫걸음의 조각"),
+                ItemCategory.QUEST,
+                ItemType.ETC,
+                Rarity.COMMON,
+                BaseAttrs.empty(),
+                true,
+                99,
+                null
+        );
+
+        ItemResponse.Detail response =
+                ItemWebMapper.toDetail(ItemResult.Detail.from(item));
+
+        assertThat(response.code()).isEqualTo("IT_FIRST_STEP_FRAGMENT");
+        assertThat(response.maxDurability()).isNull();
+    }
+}

--- a/src/test/java/online/lifeasgame/inventory/application/ItemLookupIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/inventory/application/ItemLookupIntegrationTest.java
@@ -1,0 +1,62 @@
+package online.lifeasgame.inventory.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.inventory.application.internal.ItemLookupApi;
+import online.lifeasgame.inventory.domain.error.ItemError;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles({"test", "migration-test"})
+@DisplayName("ItemLookupApi integration")
+class ItemLookupIntegrationTest {
+
+    @Container
+    private static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0.39")
+            .withDatabaseName("lifeasgame_item_lookup")
+            .withUsername("lifeasgame")
+            .withPassword("lifeasgame");
+
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", MYSQL::getDriverClassName);
+    }
+
+    @Autowired
+    private ItemLookupApi itemLookupApi;
+
+    @Test
+    @DisplayName("V12 Seed를 stable code로 조회해 양수 ID와 정확한 code를 반환한다")
+    void getsSeedByStableCode() {
+        ItemLookupApi.ItemReference reference =
+                itemLookupApi.getByCode("  IT_FIRST_STEP_FRAGMENT  ");
+
+        assertThat(reference.id()).isPositive();
+        assertThat(reference.code()).isEqualTo("IT_FIRST_STEP_FRAGMENT");
+    }
+
+    @Test
+    @DisplayName("알 수 없는 stable code는 ItemError로 실패한다")
+    void rejectsUnknownStableCode() {
+        assertThatThrownBy(() -> itemLookupApi.getByCode("IT_UNKNOWN"))
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode())
+                                .isEqualTo(ItemError.ITEM_CODE_NOT_FOUND)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/inventory/domain/ItemCodeTest.java
+++ b/src/test/java/online/lifeasgame/inventory/domain/ItemCodeTest.java
@@ -1,0 +1,43 @@
+package online.lifeasgame.inventory.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("ItemCode")
+class ItemCodeTest {
+
+    @Test
+    @DisplayName("앞뒤 공백만 제거하고 원래 대소문자를 보존한다")
+    void trimsAndPreservesCase() {
+        ItemCode code = ItemCode.of("  IT_First_Step_Fragment  ");
+
+        assertThat(code.value()).isEqualTo("IT_First_Step_Fragment");
+    }
+
+    @Test
+    @DisplayName("같은 문자열 값은 동등하다")
+    void hasValueEquality() {
+        assertThat(ItemCode.of("IT_FIRST_STEP_FRAGMENT"))
+                .isEqualTo(ItemCode.of("IT_FIRST_STEP_FRAGMENT"))
+                .hasSameHashCodeAs(ItemCode.of("IT_FIRST_STEP_FRAGMENT"));
+    }
+
+    @Test
+    @DisplayName("null과 blank code를 거부한다")
+    void rejectsNullAndBlank() {
+        assertThatThrownBy(() -> ItemCode.of(null))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> ItemCode.of(" \t "))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("80자를 초과하는 code를 거부한다")
+    void rejectsTooLongCode() {
+        assertThatThrownBy(() -> ItemCode.of("I".repeat(ItemCode.MAX_LENGTH + 1)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/online/lifeasgame/inventory/domain/ItemContentFactoryTest.java
+++ b/src/test/java/online/lifeasgame/inventory/domain/ItemContentFactoryTest.java
@@ -1,0 +1,95 @@
+package online.lifeasgame.inventory.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Item content factory")
+class ItemContentFactoryTest {
+
+    @Test
+    @DisplayName("legacy factory는 code가 없는 Item 생성을 유지한다")
+    void createsLegacyItemWithoutCode() {
+        Item item = Item.create(
+                ItemName.of("Legacy Item"),
+                ItemCategory.MISC,
+                ItemType.ETC,
+                Rarity.COMMON,
+                BaseAttrs.empty(),
+                false,
+                null,
+                null
+        );
+
+        assertThat(item.getCode()).isNull();
+        assertThat(item.maxStack()).isEqualTo(1);
+        assertThat(item.maxDurability()).isNull();
+    }
+
+    @Test
+    @DisplayName("content factory는 stable code와 요청된 최소 Runtime 매핑으로 생성한다")
+    void createsContentItemWithRuntimeMapping() {
+        Item item = firstStepFragment();
+
+        assertThat(item.getCode().value()).isEqualTo("IT_FIRST_STEP_FRAGMENT");
+        assertThat(item.getName().value()).isEqualTo("첫걸음의 조각");
+        assertThat(item.getCategory()).isEqualTo(ItemCategory.QUEST);
+        assertThat(item.getType()).isEqualTo(ItemType.ETC);
+        assertThat(item.getRarity()).isEqualTo(Rarity.COMMON);
+        assertThat(item.getBaseAttrs()).isEqualTo(BaseAttrs.empty());
+        assertThat(item.isStackable()).isTrue();
+        assertThat(item.maxStack()).isEqualTo(99);
+        assertThat(item.maxDurability()).isNull();
+    }
+
+    @Test
+    @DisplayName("content factory는 null code를 거부한다")
+    void rejectsContentItemWithoutCode() {
+        assertThatThrownBy(() -> Item.createContentItem(
+                null,
+                ItemName.of("첫걸음의 조각"),
+                ItemCategory.QUEST,
+                ItemType.ETC,
+                Rarity.COMMON,
+                BaseAttrs.empty(),
+                true,
+                99,
+                null
+        )).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("일반 속성을 수정해도 content code는 바뀌지 않는다")
+    void keepsContentCodeImmutableOnUpdate() {
+        Item item = firstStepFragment();
+
+        item.update(
+                ItemName.of("첫걸음의 조각 수정"),
+                ItemCategory.MISC,
+                ItemType.ETC,
+                Rarity.UNCOMMON,
+                BaseAttrs.empty(),
+                true,
+                50,
+                null
+        );
+
+        assertThat(item.getCode().value()).isEqualTo("IT_FIRST_STEP_FRAGMENT");
+    }
+
+    private Item firstStepFragment() {
+        return Item.createContentItem(
+                ItemCode.of("IT_FIRST_STEP_FRAGMENT"),
+                ItemName.of("첫걸음의 조각"),
+                ItemCategory.QUEST,
+                ItemType.ETC,
+                Rarity.COMMON,
+                BaseAttrs.empty(),
+                true,
+                99,
+                null
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/inventory/domain/seed/SeedLevel1ItemTest.java
+++ b/src/test/java/online/lifeasgame/inventory/domain/seed/SeedLevel1ItemTest.java
@@ -1,0 +1,67 @@
+package online.lifeasgame.inventory.domain.seed;
+
+import online.lifeasgame.inventory.domain.BaseAttrs;
+import online.lifeasgame.inventory.domain.ItemCategory;
+import online.lifeasgame.inventory.domain.ItemType;
+import online.lifeasgame.inventory.domain.Rarity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("SeedLevel1Item catalog")
+class SeedLevel1ItemTest {
+
+    @Test
+    @DisplayName("P0 Seed는 정확히 FIRST_STEP_FRAGMENT 한 건이다")
+    void containsExactlyOneP0Seed() {
+        assertThat(SeedLevel1Item.values())
+                .containsExactly(SeedLevel1Item.FIRST_STEP_FRAGMENT);
+        assertThat(SeedLevel1Item.definitions()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("stable code는 중복 없이 공식 문자열을 보존한다")
+    void hasUniqueStableCode() {
+        var definitions = SeedLevel1Item.definitions();
+        var uniqueCodes = new HashSet<>(
+                definitions.stream().map(ItemSeedDefinition::code).toList()
+        );
+
+        assertThat(uniqueCodes).hasSameSizeAs(definitions);
+        assertThat(ItemContentCode.IT_FIRST_STEP_FRAGMENT.value())
+                .isEqualTo("IT_FIRST_STEP_FRAGMENT");
+    }
+
+    @Test
+    @DisplayName("MEMORY_FRAGMENT metadata 대신 요청된 최소 Runtime 매핑만 정의한다")
+    void mapsOfficialContentToCurrentRuntimeTaxonomy() {
+        ItemSeedDefinition definition = SeedLevel1Item.FIRST_STEP_FRAGMENT.definition();
+
+        assertThat(definition.code()).isEqualTo(ItemContentCode.IT_FIRST_STEP_FRAGMENT);
+        assertThat(definition.name()).isEqualTo("첫걸음의 조각");
+        assertThat(definition.category()).isEqualTo(ItemCategory.QUEST);
+        assertThat(definition.type()).isEqualTo(ItemType.ETC);
+        assertThat(definition.rarity()).isEqualTo(Rarity.COMMON);
+        assertThat(definition.baseAttrs()).isEqualTo(BaseAttrs.empty());
+        assertThat(definition.stackable()).isTrue();
+        assertThat(definition.maxStack()).isEqualTo(99);
+        assertThat(definition.maxDurability()).isNull();
+    }
+
+    @Test
+    @DisplayName("catalog가 노출하는 collection과 baseAttrs는 변경할 수 없다")
+    void exposesNoMutableState() {
+        assertThatThrownBy(() -> SeedLevel1Item.definitions().clear())
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> SeedLevel1Item.FIRST_STEP_FRAGMENT
+                .definition()
+                .baseAttrs()
+                .attrs()
+                .put("strength", 1))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+}

--- a/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
@@ -63,7 +63,7 @@ class FlywayExplicitBaselineTest {
     class ApplyExplicitBaseline {
 
         @Test
-        @DisplayName("V1을 재실행하지 않고 V2부터 V11까지 적용한 뒤 JPA validate를 통과한다")
+        @DisplayName("V1을 재실행하지 않고 V2부터 V12까지 적용한 뒤 JPA validate를 통과한다")
         void migratesFromVersionTwoAndValidatesJpa() throws Exception {
             String jdbcUrl = createV1EquivalentDatabase();
             Flyway flyway = migrationFlyway(jdbcUrl);
@@ -72,11 +72,11 @@ class FlywayExplicitBaselineTest {
             MigrateResult migrateResult = flyway.migrate();
             List<HistoryRow> history = successfulHistory(jdbcUrl);
 
-            assertThat(migrateResult.migrationsExecuted).isEqualTo(10);
+            assertThat(migrateResult.migrationsExecuted).isEqualTo(11);
             assertThat(history).extracting(HistoryRow::version)
                     .containsExactly(
                             "1", "2", "3", "4", "5",
-                            "6", "7", "8", "9", "10", "11"
+                            "6", "7", "8", "9", "10", "11", "12"
                     );
             assertThat(history.getFirst().type()).isEqualTo("BASELINE");
             assertThat(history.getFirst().script())
@@ -97,7 +97,8 @@ class FlywayExplicitBaselineTest {
                             "V8__transactional_outbox.sql",
                             "V9__quick_lifelog_record.sql",
                             "V10__quest_definition_reward_profile_contract.sql",
-                            "V11__quest_semantic_progress_contract.sql"
+                            "V11__quest_semantic_progress_contract.sql",
+                            "V12__item_stable_code_and_first_step_seed.sql"
                     );
             assertThat(history.subList(1, history.size()))
                     .allSatisfy(row -> assertThat(row.checksum()).isNotNull());
@@ -117,7 +118,7 @@ class FlywayExplicitBaselineTest {
                         "spring.jpa.hibernate.ddl-auto"
                 )).isEqualTo("validate");
                 assertThat(context.getBean(Flyway.class).info().current().getVersion().getVersion())
-                        .isEqualTo("11");
+                        .isEqualTo("12");
             }
         }
     }

--- a/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
@@ -1,6 +1,7 @@
 package online.lifeasgame.migration;
 
 import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.output.MigrateResult;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -32,9 +33,12 @@ class FlywayHistoryChecksumTest {
     class MigrateAgain {
 
         @Test
-        @DisplayName("두 번째 실행은 no-op이고 V1부터 V11까지 checksum history를 유지한다")
+        @DisplayName("V1~V11 checksum을 보존하고 V12 이후 두 번째 실행은 no-op이다")
         void keepsMigrationHistory() throws Exception {
-            Flyway flyway = flyway();
+            Flyway throughV11 = flyway(MigrationVersion.fromVersion("11"));
+            MigrateResult legacy = throughV11.migrate();
+            List<HistoryRow> legacyHistory = successfulHistory();
+            Flyway flyway = flyway(null);
 
             MigrateResult first = flyway.migrate();
             List<HistoryRow> firstHistory = successfulHistory();
@@ -42,13 +46,16 @@ class FlywayHistoryChecksumTest {
             MigrateResult second = flyway.migrate();
             List<HistoryRow> secondHistory = successfulHistory();
 
-            assertThat(first.migrationsExecuted).isEqualTo(11);
+            assertThat(legacy.migrationsExecuted).isEqualTo(11);
+            assertThat(first.migrationsExecuted).isEqualTo(1);
             assertThat(second.migrationsExecuted).isZero();
             assertThat(secondHistory).isEqualTo(firstHistory);
+            assertThat(firstHistory.subList(0, legacyHistory.size()))
+                    .isEqualTo(legacyHistory);
             assertThat(secondHistory).extracting(HistoryRow::version)
                     .containsExactly(
                             "1", "2", "3", "4", "5",
-                            "6", "7", "8", "9", "10", "11"
+                            "6", "7", "8", "9", "10", "11", "12"
                     );
             assertThat(secondHistory).allSatisfy(history -> {
                 assertThat(history.checksum()).isNotNull();
@@ -57,12 +64,15 @@ class FlywayHistoryChecksumTest {
         }
     }
 
-    private Flyway flyway() {
-        return Flyway.configure()
+    private Flyway flyway(MigrationVersion target) {
+        var configuration = Flyway.configure()
                 .dataSource(MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword())
                 .locations("classpath:db/migration")
-                .baselineOnMigrate(false)
-                .load();
+                .baselineOnMigrate(false);
+        if (target != null) {
+            configuration.target(target);
+        }
+        return configuration.load();
     }
 
     private List<HistoryRow> successfulHistory() throws Exception {

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -38,21 +38,25 @@ class FlywayMigrationTest {
     class MigrateCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V11까지 적용되고 legacy Quest에 semantic 계약이 안전하게 추가된다")
+        @DisplayName("V1부터 V12까지 적용되고 legacy 계약과 Item stable code가 공존한다")
         void migratesSchemaAndSeedsRewardProfiles() throws Exception {
             Flyway throughV10 = flyway(MigrationVersion.fromVersion("10"));
             MigrateResult legacyResult = throughV10.migrate();
             insertLegacyQuest();
+            MigrateResult semanticResult =
+                    flyway(MigrationVersion.fromVersion("11")).migrate();
+            insertLegacyItemsWithoutCode();
             Flyway flyway = flyway();
 
             MigrateResult result = flyway.migrate();
 
             assertThat(legacyResult.migrationsExecuted).isEqualTo(10);
+            assertThat(semanticResult.migrationsExecuted).isEqualTo(1);
             assertThat(result.migrationsExecuted).isEqualTo(1);
             assertThat(appliedVersions())
                     .containsExactly(
                             "1", "2", "3", "4", "5",
-                            "6", "7", "8", "9", "10", "11"
+                            "6", "7", "8", "9", "10", "11", "12"
                     );
             assertThat(existingTables(
                     "users",
@@ -177,6 +181,28 @@ class FlywayMigrationTest {
                     "quick_record_request_receipts",
                     "uq_quick_record_request_receipt_identity"
             )).containsExactly("player_id", "idempotency_key");
+            assertThat(itemCodeColumn()).isEqualTo(new ItemCodeColumn("YES", 80));
+            assertThat(uniqueIndexColumns("items", "uq_item_code"))
+                    .containsExactly("code");
+            assertThat(legacyItemNullCodeCount()).isEqualTo(2);
+            assertThat(firstStepFragmentSeed()).isEqualTo(
+                    new FirstStepFragmentSeed(
+                            1,
+                            "IT_FIRST_STEP_FRAGMENT",
+                            "첫걸음의 조각",
+                            "QUEST",
+                            "ETC",
+                            "COMMON",
+                            0,
+                            true,
+                            99,
+                            null
+                    )
+            );
+            assertThatThrownBy(FlywayMigrationTest.this::insertDuplicateItemCode)
+                    .isInstanceOfSatisfying(SQLException.class, exception ->
+                            assertThat(exception.getSQLState()).startsWith("23")
+                    );
             insertSettlementIdentity();
             assertThatThrownBy(FlywayMigrationTest.this::insertSettlementIdentity)
                     .isInstanceOfSatisfying(SQLException.class, exception ->
@@ -393,6 +419,135 @@ class FlywayMigrationTest {
         }
     }
 
+    private void insertLegacyItemsWithoutCode() throws SQLException {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement()) {
+            statement.executeUpdate("""
+                    INSERT INTO items (
+                        max_durability,
+                        max_stack,
+                        stackable,
+                        created_at,
+                        updated_at,
+                        name,
+                        base_attrs,
+                        category,
+                        rarity,
+                        type
+                    ) VALUES
+                        (
+                            NULL, 1, FALSE, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6),
+                            'Legacy Item One', JSON_OBJECT(), 'MISC', 'COMMON', 'ETC'
+                        ),
+                        (
+                            NULL, 1, FALSE, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6),
+                            'Legacy Item Two', JSON_OBJECT(), 'MISC', 'COMMON', 'ETC'
+                        )
+                    """);
+        }
+    }
+
+    private ItemCodeColumn itemCodeColumn() throws SQLException {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("""
+                     SELECT is_nullable, character_maximum_length
+                     FROM information_schema.columns
+                     WHERE table_schema = DATABASE()
+                       AND table_name = 'items'
+                       AND column_name = 'code'
+                     """)) {
+            assertThat(resultSet.next()).isTrue();
+            return new ItemCodeColumn(
+                    resultSet.getString("is_nullable"),
+                    resultSet.getInt("character_maximum_length")
+            );
+        }
+    }
+
+    private int legacyItemNullCodeCount() throws SQLException {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("""
+                     SELECT COUNT(*)
+                     FROM items
+                     WHERE name LIKE 'Legacy Item %'
+                       AND code IS NULL
+                     """)) {
+            resultSet.next();
+            return resultSet.getInt(1);
+        }
+    }
+
+    private FirstStepFragmentSeed firstStepFragmentSeed() throws SQLException {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("""
+                     SELECT
+                         COUNT(*) OVER () AS seed_count,
+                         code,
+                         name,
+                         category,
+                         type,
+                         rarity,
+                         JSON_LENGTH(base_attrs) AS base_attr_count,
+                         stackable,
+                         max_stack,
+                         max_durability
+                     FROM items
+                     WHERE code = 'IT_FIRST_STEP_FRAGMENT'
+                     """)) {
+            assertThat(resultSet.next()).isTrue();
+            FirstStepFragmentSeed seed = new FirstStepFragmentSeed(
+                    resultSet.getInt("seed_count"),
+                    resultSet.getString("code"),
+                    resultSet.getString("name"),
+                    resultSet.getString("category"),
+                    resultSet.getString("type"),
+                    resultSet.getString("rarity"),
+                    resultSet.getInt("base_attr_count"),
+                    resultSet.getBoolean("stackable"),
+                    resultSet.getInt("max_stack"),
+                    resultSet.getObject("max_durability", Integer.class)
+            );
+            assertThat(resultSet.next()).isFalse();
+            return seed;
+        }
+    }
+
+    private void insertDuplicateItemCode() throws SQLException {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement()) {
+            statement.executeUpdate("""
+                    INSERT INTO items (
+                        code,
+                        name,
+                        category,
+                        type,
+                        rarity,
+                        base_attrs,
+                        stackable,
+                        max_stack,
+                        max_durability,
+                        created_at,
+                        updated_at
+                    ) VALUES (
+                        'IT_FIRST_STEP_FRAGMENT',
+                        'Duplicate Stable Item',
+                        'QUEST',
+                        'ETC',
+                        'COMMON',
+                        JSON_OBJECT(),
+                        TRUE,
+                        99,
+                        NULL,
+                        CURRENT_TIMESTAMP(6),
+                        CURRENT_TIMESTAMP(6)
+                    )
+                    """);
+        }
+    }
+
     private QuestDefinitionColumns questDefinitionColumns() throws SQLException {
         try (Connection connection = MYSQL.createConnection("");
              var statement = connection.prepareStatement("""
@@ -544,6 +699,23 @@ class FlywayMigrationTest {
             int repeatPolicyColumnCount,
             String repeatRuleNullable,
             String repeatRuleColumnType
+    ) {
+    }
+
+    private record ItemCodeColumn(String nullable, int maximumLength) {
+    }
+
+    private record FirstStepFragmentSeed(
+            int count,
+            String code,
+            String name,
+            String category,
+            String type,
+            String rarity,
+            int baseAttrCount,
+            boolean stackable,
+            int maxStack,
+            Integer maxDurability
     ) {
     }
 }

--- a/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
@@ -149,7 +149,7 @@ class FlywayProfileCutoverTest {
     class StartLocalWithCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V11까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
+        @DisplayName("V1부터 V12까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
         void migratesThenValidates() {
             ConfigurableEnvironment environment =
                     (ConfigurableEnvironment) applicationContext.getEnvironment();
@@ -161,8 +161,8 @@ class FlywayProfileCutoverTest {
             assertThat(environment.getProperty(
                     "spring.flyway.baseline-on-migrate", Boolean.class
             )).isFalse();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("11");
-            assertThat(appliedMigrationCount()).isEqualTo(11);
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("12");
+            assertThat(appliedMigrationCount()).isEqualTo(12);
         }
     }
 

--- a/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 @SpringBootTest
 @ActiveProfiles({"test", "migration-test"})
-@DisplayName("V11 migration 이후 JPA schema validation")
+@DisplayName("V12 migration 이후 JPA schema validation")
 class JpaValidateAfterMigrationTest {
 
     @Container
@@ -61,14 +61,14 @@ class JpaValidateAfterMigrationTest {
     private RewardSettlementReader rewardSettlementReader;
 
     @Nested
-    @DisplayName("V1부터 V11까지 적용된 schema로 ApplicationContext를 기동할 때")
+    @DisplayName("V1부터 V12까지 적용된 schema로 ApplicationContext를 기동할 때")
     class LoadApplicationContext {
 
         @Test
         @DisplayName("ddl-auto validate 상태로 정상 기동한다")
         void loadsWithJpaValidation() {
             assertThat(applicationContext).isNotNull();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("11");
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("12");
             assertThat(applicationContext.getEnvironment().getProperty("spring.jpa.hibernate.ddl-auto"))
                     .isEqualTo("validate");
             assertThat(applicationContext.getEnvironment()


### PR DESCRIPTION
## What

- Item에 nullable stable content code 계약을 추가했습니다.
- 기존 legacy Item row와 create 경로의 호환을 유지했습니다.
- `IT_FIRST_STEP_FRAGMENT` P0 Item을 Flyway Seed로 추가했습니다.
- code 기반 Item 조회용 provider-owned InternalApi를 추가했습니다.
- 다음 Reward Profile Seed가 이름이나 고정 DB ID 없이 Item을 참조할 수 있게 했습니다.

## Content

```text
IT_FIRST_STEP_FRAGMENT
- name: 첫걸음의 조각
- category: QUEST
- type: ETC
- rarity: COMMON
- stackable: true
- maxStack: 99
```

`MEMORY_FRAGMENT`는 콘텐츠 분류이며 이번 PR에서 기존 ItemType 전체를 개편하지 않았습니다.

## Migration

- `V12__item_stable_code_and_first_step_seed.sql`
- 기존 V1~V11은 수정하지 않았습니다.
- legacy row를 이름 기반으로 backfill하지 않았습니다.

## Test

- [ ] `./gradlew clean test`
- [ ] `./gradlew build`
- [ ] ItemCode validation
- [ ] legacy null-code compatibility
- [ ] code unique constraint
- [ ] Seed catalog/DB consistency
- [ ] ItemLookupApi
- [ ] V1~V12 checksum / JPA validate

## Out of Scope

- Reward Profile Seed
- Quest Seed
- Mailbox / Claim
- Item Reward Processor
- Item taxonomy 전체 개편
- IT_FOCUS_SHARD / IT_CALM_FRAGMENT
- Frontend

Closes #207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stable codes for content items, including the first-step fragment.
  * Added item lookup by code, with normalized input and clear not-found errors.
  * Item details and summaries now include the item code.
  * Added database seeding for the first-step fragment.

* **Bug Fixes**
  * Items without durability policies no longer cause errors when durability is requested.

* **Tests**
  * Expanded coverage for item codes, lookups, content creation, and database migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->