### PR TITLE
[Reward] Add first step P0 reward profile seed

### DIFF
--- a/src/main/java/online/lifeasgame/reward/domain/seed/RewardDefinitionContentCode.java
+++ b/src/main/java/online/lifeasgame/reward/domain/seed/RewardDefinitionContentCode.java
@@ -1,0 +1,16 @@
+package online.lifeasgame.reward.domain.seed;
+
+public enum RewardDefinitionContentCode {
+    RD_EXP_20("RD_EXP_20"),
+    RD_ITEM_FIRST_STEP_FRAGMENT_1("RD_ITEM_FIRST_STEP_FRAGMENT_1");
+
+    private final String value;
+
+    RewardDefinitionContentCode(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/domain/seed/RewardDefinitionContentCode.java
+++ b/src/main/java/online/lifeasgame/reward/domain/seed/RewardDefinitionContentCode.java
@@ -1,6 +1,7 @@
 package online.lifeasgame.reward.domain.seed;
 
 public enum RewardDefinitionContentCode {
+    RD_EXP_10("RD_EXP_10"),
     RD_EXP_20("RD_EXP_20"),
     RD_ITEM_FIRST_STEP_FRAGMENT_1("RD_ITEM_FIRST_STEP_FRAGMENT_1");
 

--- a/src/main/java/online/lifeasgame/reward/domain/seed/RewardProfileContentCode.java
+++ b/src/main/java/online/lifeasgame/reward/domain/seed/RewardProfileContentCode.java
@@ -1,0 +1,18 @@
+package online.lifeasgame.reward.domain.seed;
+
+public enum RewardProfileContentCode {
+    RP_NONE("RP_NONE"),
+    RP_EXP_10("RP_EXP_10"),
+    RP_EXP_30("RP_EXP_30"),
+    RP_EXP_AND_ITEM_FIRST_STEP_20("RP_EXP_AND_ITEM_FIRST_STEP_20");
+
+    private final String value;
+
+    RewardProfileContentCode(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/domain/seed/RewardProfileContentCode.java
+++ b/src/main/java/online/lifeasgame/reward/domain/seed/RewardProfileContentCode.java
@@ -4,6 +4,7 @@ public enum RewardProfileContentCode {
     RP_NONE("RP_NONE"),
     RP_EXP_10("RP_EXP_10"),
     RP_EXP_30("RP_EXP_30"),
+    RP_EXP_TINY_10("RP_EXP_TINY_10"),
     RP_EXP_AND_ITEM_FIRST_STEP_20("RP_EXP_AND_ITEM_FIRST_STEP_20");
 
     private final String value;

--- a/src/main/java/online/lifeasgame/reward/domain/seed/RewardProfileLineSeedDefinition.java
+++ b/src/main/java/online/lifeasgame/reward/domain/seed/RewardProfileLineSeedDefinition.java
@@ -1,0 +1,20 @@
+package online.lifeasgame.reward.domain.seed;
+
+import java.util.Objects;
+
+public record RewardProfileLineSeedDefinition(
+        RewardDefinitionContentCode definitionCode,
+        int sortOrder,
+        Long amountOverride
+) {
+
+    public RewardProfileLineSeedDefinition {
+        Objects.requireNonNull(definitionCode, "definitionCode");
+        if (sortOrder < 0) {
+            throw new IllegalArgumentException("sortOrder must be non-negative");
+        }
+        if (amountOverride != null && amountOverride <= 0) {
+            throw new IllegalArgumentException("amountOverride must be positive");
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/domain/seed/RewardProfileSeedDefinition.java
+++ b/src/main/java/online/lifeasgame/reward/domain/seed/RewardProfileSeedDefinition.java
@@ -1,0 +1,29 @@
+package online.lifeasgame.reward.domain.seed;
+
+import online.lifeasgame.reward.domain.RewardProfileStatus;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+
+public record RewardProfileSeedDefinition(
+        RewardProfileContentCode code,
+        String name,
+        RewardProfileStatus status,
+        List<RewardProfileLineSeedDefinition> lines
+) {
+
+    public RewardProfileSeedDefinition {
+        Objects.requireNonNull(code, "code");
+        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(status, "status");
+        List<RewardProfileLineSeedDefinition> copiedLines =
+                List.copyOf(Objects.requireNonNull(lines, "lines"));
+        var sortOrders = new HashSet<Integer>();
+        if (copiedLines.stream().map(RewardProfileLineSeedDefinition::sortOrder)
+                .anyMatch(sortOrder -> !sortOrders.add(sortOrder))) {
+            throw new IllegalArgumentException("line sortOrder must be unique");
+        }
+        lines = copiedLines;
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/domain/seed/SeedLevel1RewardProfile.java
+++ b/src/main/java/online/lifeasgame/reward/domain/seed/SeedLevel1RewardProfile.java
@@ -7,6 +7,21 @@ import java.util.List;
 
 public enum SeedLevel1RewardProfile {
 
+    EXP_TINY_10(
+            new RewardProfileSeedDefinition(
+                    RewardProfileContentCode.RP_EXP_TINY_10,
+                    "소량 EXP",
+                    RewardProfileStatus.ACTIVE,
+                    List.of(
+                            new RewardProfileLineSeedDefinition(
+                                    RewardDefinitionContentCode.RD_EXP_10,
+                                    0,
+                                    null
+                            )
+                    )
+            )
+    ),
+
     EXP_AND_ITEM_FIRST_STEP_20(
             new RewardProfileSeedDefinition(
                     RewardProfileContentCode.RP_EXP_AND_ITEM_FIRST_STEP_20,

--- a/src/main/java/online/lifeasgame/reward/domain/seed/SeedLevel1RewardProfile.java
+++ b/src/main/java/online/lifeasgame/reward/domain/seed/SeedLevel1RewardProfile.java
@@ -1,0 +1,45 @@
+package online.lifeasgame.reward.domain.seed;
+
+import online.lifeasgame.reward.domain.RewardProfileStatus;
+
+import java.util.Arrays;
+import java.util.List;
+
+public enum SeedLevel1RewardProfile {
+
+    EXP_AND_ITEM_FIRST_STEP_20(
+            new RewardProfileSeedDefinition(
+                    RewardProfileContentCode.RP_EXP_AND_ITEM_FIRST_STEP_20,
+                    "EXP 20 + First Step Fragment",
+                    RewardProfileStatus.ACTIVE,
+                    List.of(
+                            new RewardProfileLineSeedDefinition(
+                                    RewardDefinitionContentCode.RD_EXP_20,
+                                    0,
+                                    null
+                            ),
+                            new RewardProfileLineSeedDefinition(
+                                    RewardDefinitionContentCode.RD_ITEM_FIRST_STEP_FRAGMENT_1,
+                                    1,
+                                    null
+                            )
+                    )
+            )
+    );
+
+    private final RewardProfileSeedDefinition definition;
+
+    SeedLevel1RewardProfile(RewardProfileSeedDefinition definition) {
+        this.definition = definition;
+    }
+
+    public RewardProfileSeedDefinition definition() {
+        return definition;
+    }
+
+    public static List<RewardProfileSeedDefinition> definitions() {
+        return Arrays.stream(values())
+                .map(SeedLevel1RewardProfile::definition)
+                .toList();
+    }
+}

--- a/src/main/resources/db/migration/V13__first_step_reward_profile_seed.sql
+++ b/src/main/resources/db/migration/V13__first_step_reward_profile_seed.sql
@@ -1,0 +1,89 @@
+-- P0 Reward definitions. The ITEM payload resolves the stable Item code from V12.
+INSERT INTO reward_definitions (
+    code, name, reward_type, amount, item_id, active, created_at, updated_at
+) SELECT
+    'RD_EXP_20',
+    'EXP 20',
+    'EXP',
+    20,
+    NULL,
+    TRUE,
+    CURRENT_TIMESTAMP(6),
+    CURRENT_TIMESTAMP(6)
+FROM items item
+WHERE item.code = 'IT_FIRST_STEP_FRAGMENT';
+
+INSERT INTO reward_definitions (
+    code, name, reward_type, amount, item_id, active, created_at, updated_at
+) VALUES (
+    'RD_ITEM_FIRST_STEP_FRAGMENT_1',
+    'First Step Fragment x1',
+    'ITEM',
+    1,
+    (
+        SELECT item.id
+        FROM items item
+        WHERE item.code = 'IT_FIRST_STEP_FRAGMENT'
+    ),
+    TRUE,
+    CURRENT_TIMESTAMP(6),
+    CURRENT_TIMESTAMP(6)
+);
+
+INSERT INTO reward_profiles (
+    code, name, status, created_at, updated_at
+) VALUES (
+    'RP_EXP_AND_ITEM_FIRST_STEP_20',
+    'EXP 20 + First Step Fragment',
+    'ACTIVE',
+    CURRENT_TIMESTAMP(6),
+    CURRENT_TIMESTAMP(6)
+);
+
+INSERT INTO reward_profile_lines (
+    reward_profile_id,
+    reward_definition_id,
+    sort_order,
+    amount_override,
+    created_at,
+    updated_at
+) VALUES (
+    (
+        SELECT profile.id
+        FROM reward_profiles profile
+        WHERE profile.code = 'RP_EXP_AND_ITEM_FIRST_STEP_20'
+    ),
+    (
+        SELECT definition.id
+        FROM reward_definitions definition
+        WHERE definition.code = 'RD_EXP_20'
+    ),
+    0,
+    NULL,
+    CURRENT_TIMESTAMP(6),
+    CURRENT_TIMESTAMP(6)
+);
+
+INSERT INTO reward_profile_lines (
+    reward_profile_id,
+    reward_definition_id,
+    sort_order,
+    amount_override,
+    created_at,
+    updated_at
+) VALUES (
+    (
+        SELECT profile.id
+        FROM reward_profiles profile
+        WHERE profile.code = 'RP_EXP_AND_ITEM_FIRST_STEP_20'
+    ),
+    (
+        SELECT definition.id
+        FROM reward_definitions definition
+        WHERE definition.code = 'RD_ITEM_FIRST_STEP_FRAGMENT_1'
+    ),
+    1,
+    NULL,
+    CURRENT_TIMESTAMP(6),
+    CURRENT_TIMESTAMP(6)
+);

--- a/src/main/resources/db/migration/V13__first_step_reward_profile_seed.sql
+++ b/src/main/resources/db/migration/V13__first_step_reward_profile_seed.sql
@@ -33,6 +33,40 @@ INSERT INTO reward_definitions (
 INSERT INTO reward_profiles (
     code, name, status, created_at, updated_at
 ) VALUES (
+    'RP_EXP_TINY_10',
+    '소량 EXP',
+    'ACTIVE',
+    CURRENT_TIMESTAMP(6),
+    CURRENT_TIMESTAMP(6)
+);
+
+INSERT INTO reward_profile_lines (
+    reward_profile_id,
+    reward_definition_id,
+    sort_order,
+    amount_override,
+    created_at,
+    updated_at
+) VALUES (
+    (
+        SELECT profile.id
+        FROM reward_profiles profile
+        WHERE profile.code = 'RP_EXP_TINY_10'
+    ),
+    (
+        SELECT definition.id
+        FROM reward_definitions definition
+        WHERE definition.code = 'RD_EXP_10'
+    ),
+    0,
+    NULL,
+    CURRENT_TIMESTAMP(6),
+    CURRENT_TIMESTAMP(6)
+);
+
+INSERT INTO reward_profiles (
+    code, name, status, created_at, updated_at
+) VALUES (
     'RP_EXP_AND_ITEM_FIRST_STEP_20',
     'EXP 20 + First Step Fragment',
     'ACTIVE',

--- a/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
@@ -63,7 +63,7 @@ class FlywayExplicitBaselineTest {
     class ApplyExplicitBaseline {
 
         @Test
-        @DisplayName("V1을 재실행하지 않고 V2부터 V12까지 적용한 뒤 JPA validate를 통과한다")
+        @DisplayName("V1을 재실행하지 않고 V2부터 V13까지 적용한 뒤 JPA validate를 통과한다")
         void migratesFromVersionTwoAndValidatesJpa() throws Exception {
             String jdbcUrl = createV1EquivalentDatabase();
             Flyway flyway = migrationFlyway(jdbcUrl);
@@ -72,11 +72,11 @@ class FlywayExplicitBaselineTest {
             MigrateResult migrateResult = flyway.migrate();
             List<HistoryRow> history = successfulHistory(jdbcUrl);
 
-            assertThat(migrateResult.migrationsExecuted).isEqualTo(11);
+            assertThat(migrateResult.migrationsExecuted).isEqualTo(12);
             assertThat(history).extracting(HistoryRow::version)
                     .containsExactly(
                             "1", "2", "3", "4", "5",
-                            "6", "7", "8", "9", "10", "11", "12"
+                            "6", "7", "8", "9", "10", "11", "12", "13"
                     );
             assertThat(history.getFirst().type()).isEqualTo("BASELINE");
             assertThat(history.getFirst().script())
@@ -98,7 +98,8 @@ class FlywayExplicitBaselineTest {
                             "V9__quick_lifelog_record.sql",
                             "V10__quest_definition_reward_profile_contract.sql",
                             "V11__quest_semantic_progress_contract.sql",
-                            "V12__item_stable_code_and_first_step_seed.sql"
+                            "V12__item_stable_code_and_first_step_seed.sql",
+                            "V13__first_step_reward_profile_seed.sql"
                     );
             assertThat(history.subList(1, history.size()))
                     .allSatisfy(row -> assertThat(row.checksum()).isNotNull());
@@ -118,7 +119,7 @@ class FlywayExplicitBaselineTest {
                         "spring.jpa.hibernate.ddl-auto"
                 )).isEqualTo("validate");
                 assertThat(context.getBean(Flyway.class).info().current().getVersion().getVersion())
-                        .isEqualTo("12");
+                        .isEqualTo("13");
             }
         }
     }

--- a/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
@@ -33,10 +33,10 @@ class FlywayHistoryChecksumTest {
     class MigrateAgain {
 
         @Test
-        @DisplayName("V1~V11 checksum을 보존하고 V12 이후 두 번째 실행은 no-op이다")
+        @DisplayName("V1~V12 checksum을 보존하고 V13 이후 두 번째 실행은 no-op이다")
         void keepsMigrationHistory() throws Exception {
-            Flyway throughV11 = flyway(MigrationVersion.fromVersion("11"));
-            MigrateResult legacy = throughV11.migrate();
+            Flyway throughV12 = flyway(MigrationVersion.fromVersion("12"));
+            MigrateResult legacy = throughV12.migrate();
             List<HistoryRow> legacyHistory = successfulHistory();
             Flyway flyway = flyway(null);
 
@@ -46,7 +46,7 @@ class FlywayHistoryChecksumTest {
             MigrateResult second = flyway.migrate();
             List<HistoryRow> secondHistory = successfulHistory();
 
-            assertThat(legacy.migrationsExecuted).isEqualTo(11);
+            assertThat(legacy.migrationsExecuted).isEqualTo(12);
             assertThat(first.migrationsExecuted).isEqualTo(1);
             assertThat(second.migrationsExecuted).isZero();
             assertThat(secondHistory).isEqualTo(firstHistory);
@@ -55,7 +55,7 @@ class FlywayHistoryChecksumTest {
             assertThat(secondHistory).extracting(HistoryRow::version)
                     .containsExactly(
                             "1", "2", "3", "4", "5",
-                            "6", "7", "8", "9", "10", "11", "12"
+                            "6", "7", "8", "9", "10", "11", "12", "13"
                     );
             assertThat(secondHistory).allSatisfy(history -> {
                 assertThat(history.checksum()).isNotNull();

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -100,9 +100,37 @@ class FlywayMigrationTest {
             assertThat(seedProfileCodes()).containsExactly(
                     "RP_EXP_10",
                     "RP_EXP_30",
-                    "RP_EXP_AND_ITEM_FIRST_STEP_20"
+                    "RP_EXP_AND_ITEM_FIRST_STEP_20",
+                    "RP_EXP_TINY_10"
             );
             assertThat(noRewardProfile()).isEqualTo(new NoRewardProfile("ACTIVE", 0));
+            assertThat(expTenDefinitionCount()).isEqualTo(1);
+            assertThat(expTenProfiles()).containsExactly(
+                    new ExpTenProfileSeed(
+                            "RP_EXP_10",
+                            "EXP 10 Profile",
+                            "ACTIVE",
+                            0,
+                            null,
+                            "RD_EXP_10",
+                            "EXP",
+                            10,
+                            null,
+                            10
+                    ),
+                    new ExpTenProfileSeed(
+                            "RP_EXP_TINY_10",
+                            "소량 EXP",
+                            "ACTIVE",
+                            0,
+                            null,
+                            "RD_EXP_10",
+                            "EXP",
+                            10,
+                            null,
+                            10
+                    )
+            );
             assertThat(uniqueIndexColumns("reward_settlements", "uq_reward_settlement_source"))
                     .containsExactly("player_id", "source_type", "source_id");
             assertThat(uniqueIndexColumns(
@@ -344,6 +372,62 @@ class FlywayMigrationTest {
             );
             assertThat(resultSet.next()).isFalse();
             return result;
+        }
+    }
+
+    private int expTenDefinitionCount() throws SQLException {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("""
+                     SELECT COUNT(*)
+                     FROM reward_definitions
+                     WHERE code = 'RD_EXP_10'
+                     """)) {
+            resultSet.next();
+            return resultSet.getInt(1);
+        }
+    }
+
+    private List<ExpTenProfileSeed> expTenProfiles() throws SQLException {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("""
+                     SELECT
+                         profile.code AS profile_code,
+                         profile.name AS profile_name,
+                         profile.status,
+                         line.sort_order,
+                         line.amount_override,
+                         definition.code AS definition_code,
+                         definition.reward_type,
+                         definition.amount,
+                         definition.item_id,
+                         COALESCE(line.amount_override, definition.amount)
+                             AS effective_amount
+                     FROM reward_profiles profile
+                     JOIN reward_profile_lines line
+                       ON line.reward_profile_id = profile.id
+                     JOIN reward_definitions definition
+                       ON definition.id = line.reward_definition_id
+                     WHERE profile.code IN ('RP_EXP_10', 'RP_EXP_TINY_10')
+                     ORDER BY profile.code
+                     """)) {
+            List<ExpTenProfileSeed> seeds = new ArrayList<>();
+            while (resultSet.next()) {
+                seeds.add(new ExpTenProfileSeed(
+                        resultSet.getString("profile_code"),
+                        resultSet.getString("profile_name"),
+                        resultSet.getString("status"),
+                        resultSet.getInt("sort_order"),
+                        resultSet.getObject("amount_override", Long.class),
+                        resultSet.getString("definition_code"),
+                        resultSet.getString("reward_type"),
+                        resultSet.getLong("amount"),
+                        resultSet.getObject("item_id", Long.class),
+                        resultSet.getLong("effective_amount")
+                ));
+            }
+            return seeds;
         }
     }
 
@@ -759,6 +843,20 @@ class FlywayMigrationTest {
     }
 
     private record NoRewardProfile(String status, int lineCount) {
+    }
+
+    private record ExpTenProfileSeed(
+            String profileCode,
+            String profileName,
+            String status,
+            int sortOrder,
+            Long amountOverride,
+            String definitionCode,
+            String rewardType,
+            long amount,
+            Long itemId,
+            long effectiveAmount
+    ) {
     }
 
     private record QuestDefinitionColumns(

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -38,7 +38,7 @@ class FlywayMigrationTest {
     class MigrateCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V12까지 적용되고 legacy 계약과 Item stable code가 공존한다")
+        @DisplayName("V1부터 V13까지 적용되고 stable Item 기반 Reward Profile을 Seed한다")
         void migratesSchemaAndSeedsRewardProfiles() throws Exception {
             Flyway throughV10 = flyway(MigrationVersion.fromVersion("10"));
             MigrateResult legacyResult = throughV10.migrate();
@@ -46,17 +46,20 @@ class FlywayMigrationTest {
             MigrateResult semanticResult =
                     flyway(MigrationVersion.fromVersion("11")).migrate();
             insertLegacyItemsWithoutCode();
+            MigrateResult itemResult =
+                    flyway(MigrationVersion.fromVersion("12")).migrate();
             Flyway flyway = flyway();
 
             MigrateResult result = flyway.migrate();
 
             assertThat(legacyResult.migrationsExecuted).isEqualTo(10);
             assertThat(semanticResult.migrationsExecuted).isEqualTo(1);
+            assertThat(itemResult.migrationsExecuted).isEqualTo(1);
             assertThat(result.migrationsExecuted).isEqualTo(1);
             assertThat(appliedVersions())
                     .containsExactly(
                             "1", "2", "3", "4", "5",
-                            "6", "7", "8", "9", "10", "11", "12"
+                            "6", "7", "8", "9", "10", "11", "12", "13"
                     );
             assertThat(existingTables(
                     "users",
@@ -94,7 +97,11 @@ class FlywayMigrationTest {
                     "quick_lifelog_entry_tags",
                     "quick_lifelog_request_receipts"
             )).isEmpty();
-            assertThat(seedProfileCodes()).containsExactly("RP_EXP_10", "RP_EXP_30");
+            assertThat(seedProfileCodes()).containsExactly(
+                    "RP_EXP_10",
+                    "RP_EXP_30",
+                    "RP_EXP_AND_ITEM_FIRST_STEP_20"
+            );
             assertThat(noRewardProfile()).isEqualTo(new NoRewardProfile("ACTIVE", 0));
             assertThat(uniqueIndexColumns("reward_settlements", "uq_reward_settlement_source"))
                     .containsExactly("player_id", "source_type", "source_id");
@@ -185,10 +192,13 @@ class FlywayMigrationTest {
             assertThat(uniqueIndexColumns("items", "uq_item_code"))
                     .containsExactly("code");
             assertThat(legacyItemNullCodeCount()).isEqualTo(2);
-            assertThat(firstStepFragmentSeed()).isEqualTo(
+            FirstStepFragmentSeed itemSeed = firstStepFragmentSeed();
+            assertThat(itemSeed.id()).isPositive();
+            assertThat(itemSeed).isEqualTo(
                     new FirstStepFragmentSeed(
                             1,
                             "IT_FIRST_STEP_FRAGMENT",
+                            itemSeed.id(),
                             "첫걸음의 조각",
                             "QUEST",
                             "ETC",
@@ -197,6 +207,36 @@ class FlywayMigrationTest {
                             true,
                             99,
                             null
+                    )
+            );
+            assertThat(firstStepRewardSeed()).containsExactly(
+                    new FirstStepRewardSeed(
+                            "RP_EXP_AND_ITEM_FIRST_STEP_20",
+                            "EXP 20 + First Step Fragment",
+                            "ACTIVE",
+                            0,
+                            null,
+                            "RD_EXP_20",
+                            "EXP 20",
+                            "EXP",
+                            20,
+                            null,
+                            true,
+                            null
+                    ),
+                    new FirstStepRewardSeed(
+                            "RP_EXP_AND_ITEM_FIRST_STEP_20",
+                            "EXP 20 + First Step Fragment",
+                            "ACTIVE",
+                            1,
+                            null,
+                            "RD_ITEM_FIRST_STEP_FRAGMENT_1",
+                            "First Step Fragment x1",
+                            "ITEM",
+                            1,
+                            itemSeed.id(),
+                            true,
+                            "IT_FIRST_STEP_FRAGMENT"
                     )
             );
             assertThatThrownBy(FlywayMigrationTest.this::insertDuplicateItemCode)
@@ -486,6 +526,7 @@ class FlywayMigrationTest {
                      SELECT
                          COUNT(*) OVER () AS seed_count,
                          code,
+                         id,
                          name,
                          category,
                          type,
@@ -501,6 +542,7 @@ class FlywayMigrationTest {
             FirstStepFragmentSeed seed = new FirstStepFragmentSeed(
                     resultSet.getInt("seed_count"),
                     resultSet.getString("code"),
+                    resultSet.getLong("id"),
                     resultSet.getString("name"),
                     resultSet.getString("category"),
                     resultSet.getString("type"),
@@ -512,6 +554,54 @@ class FlywayMigrationTest {
             );
             assertThat(resultSet.next()).isFalse();
             return seed;
+        }
+    }
+
+    private List<FirstStepRewardSeed> firstStepRewardSeed() throws SQLException {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("""
+                     SELECT
+                         profile.code AS profile_code,
+                         profile.name AS profile_name,
+                         profile.status,
+                         line.sort_order,
+                         line.amount_override,
+                         definition.code AS definition_code,
+                         definition.name AS definition_name,
+                         definition.reward_type,
+                         definition.amount,
+                         definition.item_id,
+                         definition.active,
+                         item.code AS item_code
+                     FROM reward_profiles profile
+                     JOIN reward_profile_lines line
+                       ON line.reward_profile_id = profile.id
+                     JOIN reward_definitions definition
+                       ON definition.id = line.reward_definition_id
+                     LEFT JOIN items item
+                       ON item.id = definition.item_id
+                     WHERE profile.code = 'RP_EXP_AND_ITEM_FIRST_STEP_20'
+                     ORDER BY line.sort_order
+                     """)) {
+            List<FirstStepRewardSeed> seeds = new ArrayList<>();
+            while (resultSet.next()) {
+                seeds.add(new FirstStepRewardSeed(
+                        resultSet.getString("profile_code"),
+                        resultSet.getString("profile_name"),
+                        resultSet.getString("status"),
+                        resultSet.getInt("sort_order"),
+                        resultSet.getObject("amount_override", Long.class),
+                        resultSet.getString("definition_code"),
+                        resultSet.getString("definition_name"),
+                        resultSet.getString("reward_type"),
+                        resultSet.getLong("amount"),
+                        resultSet.getObject("item_id", Long.class),
+                        resultSet.getBoolean("active"),
+                        resultSet.getString("item_code")
+                ));
+            }
+            return seeds;
         }
     }
 
@@ -708,6 +798,7 @@ class FlywayMigrationTest {
     private record FirstStepFragmentSeed(
             int count,
             String code,
+            long id,
             String name,
             String category,
             String type,
@@ -716,6 +807,22 @@ class FlywayMigrationTest {
             boolean stackable,
             int maxStack,
             Integer maxDurability
+    ) {
+    }
+
+    private record FirstStepRewardSeed(
+            String profileCode,
+            String profileName,
+            String status,
+            int sortOrder,
+            Long amountOverride,
+            String definitionCode,
+            String definitionName,
+            String rewardType,
+            long amount,
+            Long itemId,
+            boolean active,
+            String itemCode
     ) {
     }
 }

--- a/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
@@ -149,7 +149,7 @@ class FlywayProfileCutoverTest {
     class StartLocalWithCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V12까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
+        @DisplayName("V1부터 V13까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
         void migratesThenValidates() {
             ConfigurableEnvironment environment =
                     (ConfigurableEnvironment) applicationContext.getEnvironment();
@@ -161,8 +161,8 @@ class FlywayProfileCutoverTest {
             assertThat(environment.getProperty(
                     "spring.flyway.baseline-on-migrate", Boolean.class
             )).isFalse();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("12");
-            assertThat(appliedMigrationCount()).isEqualTo(12);
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("13");
+            assertThat(appliedMigrationCount()).isEqualTo(13);
         }
     }
 

--- a/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
@@ -1,5 +1,7 @@
 package online.lifeasgame.migration;
 
+import online.lifeasgame.inventory.application.internal.ItemLookupApi;
+import online.lifeasgame.reward.application.internal.RewardProfileLookupApi;
 import online.lifeasgame.reward.application.result.RewardProfileResult;
 import org.flywaydb.core.Flyway;
 import org.junit.jupiter.api.DisplayName;
@@ -25,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 @SpringBootTest
 @ActiveProfiles({"test", "migration-test"})
-@DisplayName("V12 migration 이후 JPA schema validation")
+@DisplayName("V13 migration 이후 JPA schema validation")
 class JpaValidateAfterMigrationTest {
 
     @Container
@@ -55,20 +57,26 @@ class JpaValidateAfterMigrationTest {
     private RewardProfileQueryService rewardProfileQueryService;
 
     @Autowired
+    private RewardProfileLookupApi rewardProfileLookupApi;
+
+    @Autowired
+    private ItemLookupApi itemLookupApi;
+
+    @Autowired
     private RewardSettlementCreateService rewardSettlementCreateService;
 
     @Autowired
     private RewardSettlementReader rewardSettlementReader;
 
     @Nested
-    @DisplayName("V1부터 V12까지 적용된 schema로 ApplicationContext를 기동할 때")
+    @DisplayName("V1부터 V13까지 적용된 schema로 ApplicationContext를 기동할 때")
     class LoadApplicationContext {
 
         @Test
         @DisplayName("ddl-auto validate 상태로 정상 기동한다")
         void loadsWithJpaValidation() {
             assertThat(applicationContext).isNotNull();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("12");
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("13");
             assertThat(applicationContext.getEnvironment().getProperty("spring.jpa.hibernate.ddl-auto"))
                     .isEqualTo("validate");
             assertThat(applicationContext.getEnvironment()
@@ -105,7 +113,52 @@ class JpaValidateAfterMigrationTest {
         void loadsActiveProfileSummariesWithProjection() {
             assertThat(rewardProfileQueryService.listActiveProfiles())
                     .extracting(RewardProfileResult.Summary::code)
-                    .containsExactly("RP_EXP_10", "RP_EXP_30", "RP_NONE");
+                    .containsExactly(
+                            "RP_EXP_10",
+                            "RP_EXP_30",
+                            "RP_EXP_AND_ITEM_FIRST_STEP_20",
+                            "RP_NONE"
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("V13 first-step Reward Profile을 조회할 때")
+    class LoadFirstStepRewardProfile {
+
+        @Test
+        @DisplayName("기존 lookup과 상세 조회로 EXP 20 및 stable Item x1을 반환한다")
+        void loadsActiveProfileWithExpAndStableItemLines() {
+            var reference = rewardProfileLookupApi.getActiveByCode(
+                    "RP_EXP_AND_ITEM_FIRST_STEP_20"
+            );
+            var detail = rewardProfileQueryService.getProfileView(
+                    "RP_EXP_AND_ITEM_FIRST_STEP_20"
+            );
+            var item = itemLookupApi.getByCode("IT_FIRST_STEP_FRAGMENT");
+
+            assertThat(reference.code()).isEqualTo("RP_EXP_AND_ITEM_FIRST_STEP_20");
+            assertThat(detail.status()).isEqualTo("ACTIVE");
+            assertThat(detail.lines()).hasSize(2);
+
+            RewardProfileResult.Line expLine = detail.lines().get(0);
+            assertThat(expLine.sortOrder()).isZero();
+            assertThat(expLine.amountOverride()).isNull();
+            assertThat(expLine.effectiveAmount()).isEqualTo(20L);
+            assertThat(expLine.rewardDefinition().code()).isEqualTo("RD_EXP_20");
+            assertThat(expLine.rewardDefinition().rewardType()).isEqualTo("EXP");
+            assertThat(expLine.rewardDefinition().amount()).isEqualTo(20L);
+            assertThat(expLine.rewardDefinition().itemId()).isNull();
+
+            RewardProfileResult.Line itemLine = detail.lines().get(1);
+            assertThat(itemLine.sortOrder()).isEqualTo(1);
+            assertThat(itemLine.amountOverride()).isNull();
+            assertThat(itemLine.effectiveAmount()).isEqualTo(1L);
+            assertThat(itemLine.rewardDefinition().code())
+                    .isEqualTo("RD_ITEM_FIRST_STEP_FRAGMENT_1");
+            assertThat(itemLine.rewardDefinition().rewardType()).isEqualTo("ITEM");
+            assertThat(itemLine.rewardDefinition().amount()).isEqualTo(1L);
+            assertThat(itemLine.rewardDefinition().itemId()).isEqualTo(item.id());
         }
     }
 

--- a/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
@@ -117,8 +117,36 @@ class JpaValidateAfterMigrationTest {
                             "RP_EXP_10",
                             "RP_EXP_30",
                             "RP_EXP_AND_ITEM_FIRST_STEP_20",
+                            "RP_EXP_TINY_10",
                             "RP_NONE"
                     );
+        }
+    }
+
+    @Nested
+    @DisplayName("V13 공식 TINY Reward Profile을 조회할 때")
+    class LoadTinyExpRewardProfile {
+
+        @Test
+        @DisplayName("기존 RD_EXP_10을 참조하는 ACTIVE EXP 10 line을 반환한다")
+        void loadsActiveTinyProfileWithLegacyDefinition() {
+            var reference = rewardProfileLookupApi.getActiveByCode("RP_EXP_TINY_10");
+            var detail = rewardProfileQueryService.getProfileView("RP_EXP_TINY_10");
+
+            assertThat(reference.code()).isEqualTo("RP_EXP_TINY_10");
+            assertThat(detail.code()).isEqualTo("RP_EXP_TINY_10");
+            assertThat(detail.name()).isEqualTo("소량 EXP");
+            assertThat(detail.status()).isEqualTo("ACTIVE");
+            assertThat(detail.lines()).hasSize(1);
+
+            RewardProfileResult.Line line = detail.lines().getFirst();
+            assertThat(line.sortOrder()).isZero();
+            assertThat(line.amountOverride()).isNull();
+            assertThat(line.effectiveAmount()).isEqualTo(10L);
+            assertThat(line.rewardDefinition().code()).isEqualTo("RD_EXP_10");
+            assertThat(line.rewardDefinition().rewardType()).isEqualTo("EXP");
+            assertThat(line.rewardDefinition().amount()).isEqualTo(10L);
+            assertThat(line.rewardDefinition().itemId()).isNull();
         }
     }
 

--- a/src/test/java/online/lifeasgame/migration/RewardSeedFlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/RewardSeedFlywayMigrationTest.java
@@ -39,6 +39,8 @@ class RewardSeedFlywayMigrationTest {
         assertThat(firstStepDefinitionCount()).isZero();
         assertThat(firstStepProfileCount()).isZero();
         assertThat(firstStepProfileLineCount()).isZero();
+        assertThat(legacyExpTenDefinitionCount()).isEqualTo(1);
+        assertThat(legacyExpTenProfileCount()).isEqualTo(1);
     }
 
     private Flyway flyway(MigrationVersion target) {
@@ -77,7 +79,10 @@ class RewardSeedFlywayMigrationTest {
         return count("""
                 SELECT COUNT(*)
                 FROM reward_profiles
-                WHERE code = 'RP_EXP_AND_ITEM_FIRST_STEP_20'
+                WHERE code IN (
+                    'RP_EXP_TINY_10',
+                    'RP_EXP_AND_ITEM_FIRST_STEP_20'
+                )
                 """);
     }
 
@@ -87,7 +92,26 @@ class RewardSeedFlywayMigrationTest {
                 FROM reward_profile_lines line
                 JOIN reward_profiles profile
                   ON profile.id = line.reward_profile_id
-                WHERE profile.code = 'RP_EXP_AND_ITEM_FIRST_STEP_20'
+                WHERE profile.code IN (
+                    'RP_EXP_TINY_10',
+                    'RP_EXP_AND_ITEM_FIRST_STEP_20'
+                )
+                """);
+    }
+
+    private int legacyExpTenDefinitionCount() throws Exception {
+        return count("""
+                SELECT COUNT(*)
+                FROM reward_definitions
+                WHERE code = 'RD_EXP_10'
+                """);
+    }
+
+    private int legacyExpTenProfileCount() throws Exception {
+        return count("""
+                SELECT COUNT(*)
+                FROM reward_profiles
+                WHERE code = 'RP_EXP_10'
                 """);
     }
 

--- a/src/test/java/online/lifeasgame/migration/RewardSeedFlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/RewardSeedFlywayMigrationTest.java
@@ -1,0 +1,102 @@
+package online.lifeasgame.migration;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.MigrationVersion;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+@DisplayName("V13 first-step Reward Seed migration")
+class RewardSeedFlywayMigrationTest {
+
+    @Container
+    private static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0.39")
+            .withDatabaseName("lifeasgame_reward_seed_negative")
+            .withUsername("lifeasgame")
+            .withPassword("lifeasgame");
+
+    @Test
+    @DisplayName("stable Item이 없으면 V13이 실패하고 불완전 Profile을 남기지 않는다")
+    void failsWithoutStableItem() throws Exception {
+        assertThat(flyway(MigrationVersion.fromVersion("12")).migrate().migrationsExecuted)
+                .isEqualTo(12);
+        deleteFirstStepFragment();
+
+        assertThatThrownBy(() -> flyway(null).migrate())
+                .isInstanceOf(FlywayException.class);
+
+        assertThat(firstStepDefinitionCount()).isZero();
+        assertThat(firstStepProfileCount()).isZero();
+        assertThat(firstStepProfileLineCount()).isZero();
+    }
+
+    private Flyway flyway(MigrationVersion target) {
+        var configuration = Flyway.configure()
+                .dataSource(MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword())
+                .locations("classpath:db/migration")
+                .baselineOnMigrate(false);
+        if (target != null) {
+            configuration.target(target);
+        }
+        return configuration.load();
+    }
+
+    private void deleteFirstStepFragment() throws Exception {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement()) {
+            statement.executeUpdate("""
+                    DELETE FROM items
+                    WHERE code = 'IT_FIRST_STEP_FRAGMENT'
+                    """);
+        }
+    }
+
+    private int firstStepDefinitionCount() throws Exception {
+        return count("""
+                SELECT COUNT(*)
+                FROM reward_definitions
+                WHERE code IN (
+                    'RD_EXP_20',
+                    'RD_ITEM_FIRST_STEP_FRAGMENT_1'
+                )
+                """);
+    }
+
+    private int firstStepProfileCount() throws Exception {
+        return count("""
+                SELECT COUNT(*)
+                FROM reward_profiles
+                WHERE code = 'RP_EXP_AND_ITEM_FIRST_STEP_20'
+                """);
+    }
+
+    private int firstStepProfileLineCount() throws Exception {
+        return count("""
+                SELECT COUNT(*)
+                FROM reward_profile_lines line
+                JOIN reward_profiles profile
+                  ON profile.id = line.reward_profile_id
+                WHERE profile.code = 'RP_EXP_AND_ITEM_FIRST_STEP_20'
+                """);
+    }
+
+    private int count(String sql) throws Exception {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(sql)) {
+            resultSet.next();
+            return resultSet.getInt(1);
+        }
+    }
+}

--- a/src/test/java/online/lifeasgame/reward/domain/seed/SeedLevel1RewardProfileTest.java
+++ b/src/test/java/online/lifeasgame/reward/domain/seed/SeedLevel1RewardProfileTest.java
@@ -15,20 +15,29 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class SeedLevel1RewardProfileTest {
 
     @Test
-    @DisplayName("P0 Reward Profile은 정확히 한 건이고 공식 문자열을 보존한다")
-    void containsExactlyOneOfficialProfile() {
+    @DisplayName("공식 P0 Reward Profile 두 건의 code와 이름을 보존한다")
+    void containsExactlyTwoOfficialProfiles() {
         assertThat(SeedLevel1RewardProfile.values())
-                .containsExactly(SeedLevel1RewardProfile.EXP_AND_ITEM_FIRST_STEP_20);
+                .containsExactly(
+                        SeedLevel1RewardProfile.EXP_TINY_10,
+                        SeedLevel1RewardProfile.EXP_AND_ITEM_FIRST_STEP_20
+                );
 
-        RewardProfileSeedDefinition definition =
+        RewardProfileSeedDefinition tiny =
+                SeedLevel1RewardProfile.EXP_TINY_10.definition();
+        RewardProfileSeedDefinition combined =
                 SeedLevel1RewardProfile.EXP_AND_ITEM_FIRST_STEP_20.definition();
 
-        assertThat(definition.code())
+        assertThat(tiny.code()).isEqualTo(RewardProfileContentCode.RP_EXP_TINY_10);
+        assertThat(tiny.code().value()).isEqualTo("RP_EXP_TINY_10");
+        assertThat(tiny.name()).isEqualTo("소량 EXP");
+        assertThat(tiny.status()).isEqualTo(RewardProfileStatus.ACTIVE);
+        assertThat(combined.code())
                 .isEqualTo(RewardProfileContentCode.RP_EXP_AND_ITEM_FIRST_STEP_20);
-        assertThat(definition.code().value())
+        assertThat(combined.code().value())
                 .isEqualTo("RP_EXP_AND_ITEM_FIRST_STEP_20");
-        assertThat(definition.name()).isEqualTo("EXP 20 + First Step Fragment");
-        assertThat(definition.status()).isEqualTo(RewardProfileStatus.ACTIVE);
+        assertThat(combined.name()).isEqualTo("EXP 20 + First Step Fragment");
+        assertThat(combined.status()).isEqualTo(RewardProfileStatus.ACTIVE);
     }
 
     @Test
@@ -46,8 +55,26 @@ class SeedLevel1RewardProfileTest {
 
         assertThat(RewardDefinitionContentCode.RD_EXP_20.value())
                 .isEqualTo("RD_EXP_20");
+        assertThat(RewardDefinitionContentCode.RD_EXP_10.value())
+                .isEqualTo("RD_EXP_10");
         assertThat(RewardDefinitionContentCode.RD_ITEM_FIRST_STEP_FRAGMENT_1.value())
                 .isEqualTo("RD_ITEM_FIRST_STEP_FRAGMENT_1");
+        assertThat(RewardProfileContentCode.RP_EXP_TINY_10.value())
+                .isEqualTo("RP_EXP_TINY_10");
+    }
+
+    @Test
+    @DisplayName("TINY Profile은 기존 RD_EXP_10을 sortOrder 0과 null override로 참조한다")
+    void keepsTinyExpLineContract() {
+        var lines = SeedLevel1RewardProfile.EXP_TINY_10.definition().lines();
+
+        assertThat(lines).containsExactly(
+                new RewardProfileLineSeedDefinition(
+                        RewardDefinitionContentCode.RD_EXP_10,
+                        0,
+                        null
+                )
+        );
     }
 
     @Test

--- a/src/test/java/online/lifeasgame/reward/domain/seed/SeedLevel1RewardProfileTest.java
+++ b/src/test/java/online/lifeasgame/reward/domain/seed/SeedLevel1RewardProfileTest.java
@@ -1,0 +1,125 @@
+package online.lifeasgame.reward.domain.seed;
+
+import online.lifeasgame.reward.domain.RewardProfileStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("SeedLevel1RewardProfile catalog")
+class SeedLevel1RewardProfileTest {
+
+    @Test
+    @DisplayName("P0 Reward Profile은 정확히 한 건이고 공식 문자열을 보존한다")
+    void containsExactlyOneOfficialProfile() {
+        assertThat(SeedLevel1RewardProfile.values())
+                .containsExactly(SeedLevel1RewardProfile.EXP_AND_ITEM_FIRST_STEP_20);
+
+        RewardProfileSeedDefinition definition =
+                SeedLevel1RewardProfile.EXP_AND_ITEM_FIRST_STEP_20.definition();
+
+        assertThat(definition.code())
+                .isEqualTo(RewardProfileContentCode.RP_EXP_AND_ITEM_FIRST_STEP_20);
+        assertThat(definition.code().value())
+                .isEqualTo("RP_EXP_AND_ITEM_FIRST_STEP_20");
+        assertThat(definition.name()).isEqualTo("EXP 20 + First Step Fragment");
+        assertThat(definition.status()).isEqualTo(RewardProfileStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("신규 Definition과 전체 Profile content code에는 중복이 없다")
+    void hasNoDuplicateContentCodes() {
+        assertThat(Arrays.stream(RewardDefinitionContentCode.values())
+                .map(RewardDefinitionContentCode::value)
+                .toList())
+                .doesNotHaveDuplicates();
+
+        assertThat(Arrays.stream(RewardProfileContentCode.values())
+                .map(RewardProfileContentCode::value)
+                .toList())
+                .doesNotHaveDuplicates();
+
+        assertThat(RewardDefinitionContentCode.RD_EXP_20.value())
+                .isEqualTo("RD_EXP_20");
+        assertThat(RewardDefinitionContentCode.RD_ITEM_FIRST_STEP_FRAGMENT_1.value())
+                .isEqualTo("RD_ITEM_FIRST_STEP_FRAGMENT_1");
+    }
+
+    @Test
+    @DisplayName("line은 EXP 20과 Item x1 순서로 sortOrder 0, 1을 사용한다")
+    void keepsOfficialLineOrder() {
+        var lines = SeedLevel1RewardProfile.EXP_AND_ITEM_FIRST_STEP_20
+                .definition()
+                .lines();
+
+        assertThat(lines)
+                .extracting(RewardProfileLineSeedDefinition::definitionCode)
+                .containsExactly(
+                        RewardDefinitionContentCode.RD_EXP_20,
+                        RewardDefinitionContentCode.RD_ITEM_FIRST_STEP_FRAGMENT_1
+                );
+        assertThat(lines)
+                .extracting(RewardProfileLineSeedDefinition::sortOrder)
+                .containsExactly(0, 1)
+                .doesNotHaveDuplicates();
+        assertThat(lines)
+                .extracting(RewardProfileLineSeedDefinition::amountOverride)
+                .containsExactly(null, null);
+    }
+
+    @Test
+    @DisplayName("catalog가 노출하는 profile과 line 목록은 변경할 수 없다")
+    void exposesNoMutableLists() {
+        assertThatThrownBy(() -> SeedLevel1RewardProfile.definitions().clear())
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> SeedLevel1RewardProfile.EXP_AND_ITEM_FIRST_STEP_20
+                .definition()
+                .lines()
+                .clear())
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    @DisplayName("profile seed는 입력 line 목록을 방어적으로 복사하고 sortOrder 중복을 거부한다")
+    void copiesLinesAndRejectsDuplicateSortOrder() {
+        var mutableLines = new ArrayList<>(List.of(
+                new RewardProfileLineSeedDefinition(
+                        RewardDefinitionContentCode.RD_EXP_20,
+                        0,
+                        null
+                )
+        ));
+        var definition = new RewardProfileSeedDefinition(
+                RewardProfileContentCode.RP_EXP_AND_ITEM_FIRST_STEP_20,
+                "EXP 20 + First Step Fragment",
+                RewardProfileStatus.ACTIVE,
+                mutableLines
+        );
+
+        mutableLines.clear();
+
+        assertThat(definition.lines()).hasSize(1);
+        assertThatThrownBy(() -> new RewardProfileSeedDefinition(
+                RewardProfileContentCode.RP_EXP_AND_ITEM_FIRST_STEP_20,
+                "EXP 20 + First Step Fragment",
+                RewardProfileStatus.ACTIVE,
+                List.of(
+                        new RewardProfileLineSeedDefinition(
+                                RewardDefinitionContentCode.RD_EXP_20,
+                                0,
+                                null
+                        ),
+                        new RewardProfileLineSeedDefinition(
+                                RewardDefinitionContentCode.RD_ITEM_FIRST_STEP_FRAGMENT_1,
+                                0,
+                                null
+                        )
+                )
+        )).isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## What

- `RD_EXP_20` RewardDefinition을 추가했습니다.
- `IT_FIRST_STEP_FRAGMENT`를 stable code로 참조하는 ITEM RewardDefinition을 추가했습니다.
- `RP_EXP_AND_ITEM_FIRST_STEP_20` Profile과 두 Reward Line을 추가했습니다.
- Item 이름이나 고정 DB ID 없이 Reward Seed가 Item을 참조하게 했습니다.
- 다음 Level 1 Quest Seed가 사용할 P0 RewardProfileRef를 준비했습니다.

## Contract

```text
RP_EXP_AND_ITEM_FIRST_STEP_20
├─ EXP 20
└─ IT_FIRST_STEP_FRAGMENT x1
```

## Migration

- `V13__first_step_reward_profile_seed.sql`
- 기존 V1~V12는 수정하지 않았습니다.
- Reward와 Item 사이 신규 FK/JPA 연관관계를 추가하지 않았습니다.

## Test

- [ ] `./gradlew clean test`
- [ ] `./gradlew build`
- [ ] Reward Seed Catalog
- [ ] active Profile lookup
- [ ] EXP/ITEM line order
- [ ] Item stable code ID resolution
- [ ] existing Reward Seed regression
- [ ] V1~V13 checksum / JPA validate

## Out of Scope

- Level 1 Quest Seed
- LifeLogRecorded Trigger
- QuestCompleted → RewardSettlement
- ITEM Reward Processor
- Mailbox / Claim
- Inventory 지급
- Frontend

Closes #209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added first-step reward profiles for experience and item fragment rewards.
  * Added support for predefined reward definitions and configurable reward profile lines.
  * Added validation to prevent invalid reward amounts and duplicate line ordering.

* **Bug Fixes**
  * Ensured reward seed migrations fail safely without leaving partial data.

* **Tests**
  * Updated migration and schema validation coverage through migration version 13.
  * Added verification for new reward profiles, definitions, item links, and immutable catalog data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->