### PR TITLE
[Quest] Add Content 1B Seed Level 1 definitions

### DIFF
--- a/src/main/java/online/lifeasgame/quest/application/blueprint/SeedLevel1QuestBlueprintAdapter.java
+++ b/src/main/java/online/lifeasgame/quest/application/blueprint/SeedLevel1QuestBlueprintAdapter.java
@@ -1,0 +1,69 @@
+package online.lifeasgame.quest.application.blueprint;
+
+import online.lifeasgame.quest.domain.QuestBlueprint;
+import online.lifeasgame.quest.domain.QuestCompletionPolicy;
+import online.lifeasgame.quest.domain.QuestProgressSource;
+import online.lifeasgame.quest.domain.QuestTarget;
+import online.lifeasgame.quest.domain.QuestTargetType;
+import online.lifeasgame.quest.domain.QuestTitle;
+import online.lifeasgame.quest.domain.RewardProfileRef;
+import online.lifeasgame.quest.domain.seed.QuestContentTargetUnit;
+import online.lifeasgame.quest.domain.seed.QuestProgressSourceType;
+import online.lifeasgame.quest.domain.seed.SeedLevel1QuestDefinition;
+
+public final class SeedLevel1QuestBlueprintAdapter {
+
+    private SeedLevel1QuestBlueprintAdapter() {
+    }
+
+    public static QuestBlueprint toBlueprint(
+            SeedLevel1QuestDefinition definition
+    ) {
+        return QuestBlueprint.finalContract(
+                definition.questCode(),
+                definition.definitionVersion(),
+                definition.semanticCategory(),
+                QuestTitle.of(definition.displayNameKo()),
+                definition.longDescriptionKo(),
+                QuestTarget.of(
+                        targetType(definition.targetUnit()),
+                        definition.targetValue()
+                ),
+                progressSource(definition.progressSourceType()),
+                RewardProfileRef.of(definition.rewardProfileCode()),
+                definition.repeatPolicy(),
+                null,
+                null,
+                completionPolicy(definition.autoComplete())
+        );
+    }
+
+    private static QuestTargetType targetType(
+            QuestContentTargetUnit targetUnit
+    ) {
+        return switch (targetUnit) {
+            case DISTINCT_LIFELOG, WEEKLY_REFLECTION ->
+                    QuestTargetType.COUNT;
+            case MINUTE_INTENT -> QuestTargetType.MINUTES;
+        };
+    }
+
+    private static QuestProgressSource progressSource(
+            QuestProgressSourceType sourceType
+    ) {
+        return switch (sourceType) {
+            case DURABLE_OUTBOX_FACT ->
+                    QuestProgressSource.RECORD_CREATED;
+            case USER_CONFIRMATION ->
+                    QuestProgressSource.MANUAL_CHECK;
+        };
+    }
+
+    private static QuestCompletionPolicy completionPolicy(
+            boolean autoComplete
+    ) {
+        return autoComplete
+                ? QuestCompletionPolicy.AUTO
+                : QuestCompletionPolicy.USER_CONFIRM;
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/application/blueprint/StaticQuestBlueprintCatalog.java
+++ b/src/main/java/online/lifeasgame/quest/application/blueprint/StaticQuestBlueprintCatalog.java
@@ -3,11 +3,13 @@ package online.lifeasgame.quest.application.blueprint;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.quest.domain.*;
+import online.lifeasgame.quest.domain.seed.SeedLevel1Quest;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.Optional;
@@ -17,7 +19,8 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class StaticQuestBlueprintCatalog implements QuestBlueprintCatalog {
 
-    private final Map<QuestCode, QuestBlueprint> blueprints = Map.copyOf(initialize());
+    private final Map<QuestCode, QuestBlueprint> blueprints =
+            Collections.unmodifiableMap(initialize());
 
     private static Map<QuestCode, QuestBlueprint> initialize() {
         EnumMap<QuestCode, QuestBlueprint> map = new EnumMap<>(QuestCode.class);
@@ -243,6 +246,13 @@ public class StaticQuestBlueprintCatalog implements QuestBlueprintCatalog {
                         QuestReward.of(500, new RewardStats(Map.of("dexterity", 2, "luck", 2))),
                         QuestRepeatRule.NONE,
                         Instant.now().plus(365, ChronoUnit.DAYS)
+                )
+        );
+
+        SeedLevel1Quest.definitions().forEach(definition ->
+                map.put(
+                        definition.questCode(),
+                        SeedLevel1QuestBlueprintAdapter.toBlueprint(definition)
                 )
         );
 

--- a/src/main/java/online/lifeasgame/quest/application/bootstrap/QuestDefinitionBootstrapper.java
+++ b/src/main/java/online/lifeasgame/quest/application/bootstrap/QuestDefinitionBootstrapper.java
@@ -7,11 +7,18 @@ import online.lifeasgame.quest.domain.QuestBlueprint;
 import online.lifeasgame.quest.domain.QuestBlueprintCatalog;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
+@ConditionalOnProperty(
+        prefix = "app.quest.definition-bootstrap",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true
+)
 @RequiredArgsConstructor
 public class QuestDefinitionBootstrapper implements ApplicationRunner {
 

--- a/src/main/java/online/lifeasgame/quest/application/result/QuestResult.java
+++ b/src/main/java/online/lifeasgame/quest/application/result/QuestResult.java
@@ -32,7 +32,7 @@ public final class QuestResult {
             return new Blueprint(
                     blueprint.code().value(),
                     blueprint.title().value(),
-                    blueprint.category().name(),
+                    QuestResult.category(blueprint.category()),
                     blueprint.descriptionMd(),
                     blueprint.target(),
                     blueprint.repeatRule().name(),
@@ -91,7 +91,7 @@ public final class QuestResult {
                     acceptance.getPlayerId(),
                     quest.getCode(),
                     quest.getTitle().value(),
-                    quest.getCategory().name(),
+                    QuestResult.category(quest.getCategory()),
                     quest.getDescriptionMd(),
                     quest.target().type(),
                     quest.target().value(),
@@ -137,7 +137,7 @@ public final class QuestResult {
                     quest.getId(),
                     quest.getCode(),
                     quest.getTitle().value(),
-                    quest.getCategory().name(),
+                    QuestResult.category(quest.getCategory()),
                     quest.getDescriptionMd(),
                     quest.target().type(),
                     quest.target().value(),
@@ -180,7 +180,7 @@ public final class QuestResult {
             return new PlayerQuest(
                     quest.getCode(),
                     quest.getTitle().value(),
-                    quest.getCategory().name(),
+                    QuestResult.category(quest.getCategory()),
                     quest.getDescriptionMd(),
                     quest.target().type(),
                     quest.target().value(),
@@ -235,5 +235,9 @@ public final class QuestResult {
         return quest.repeatPolicyOrNull() == null
                 ? null
                 : quest.repeatPolicyOrNull().name();
+    }
+
+    private static String category(QuestCategory category) {
+        return category == null ? null : category.name();
     }
 }

--- a/src/main/java/online/lifeasgame/quest/domain/Quest.java
+++ b/src/main/java/online/lifeasgame/quest/domain/Quest.java
@@ -36,7 +36,7 @@ public class Quest extends AbstractTime {
     private String code;
 
     @Enumerated(EnumType.STRING)
-    @Column(length = 20, nullable = false)
+    @Column(length = 20)
     private QuestCategory category;
 
     @Enumerated(EnumType.STRING)
@@ -113,7 +113,9 @@ public class Quest extends AbstractTime {
         );
         this.definitionVersion = definitionVersion;
         this.code = Guard.notBlank(code, "code").trim();
-        this.category = Guard.notNull(category, "category");
+        this.category = semanticCategory == null
+                ? Guard.notNull(category, "category")
+                : category;
         this.semanticCategory = semanticCategory;
         this.title = Guard.notNull(title, "title");
         this.descriptionMd = descriptionMd == null ? null : descriptionMd.trim();
@@ -206,6 +208,37 @@ public class Quest extends AbstractTime {
                 rewardProfileRef,
                 repeatRule,
                 null,
+                completionPolicy,
+                dueAt
+        );
+    }
+
+    public static Quest createDefinition(
+            String code,
+            int definitionVersion,
+            QuestSemanticCategory semanticCategory,
+            QuestTitle title,
+            String descriptionMd,
+            QuestTarget target,
+            QuestProgressSource progressSource,
+            RewardProfileRef rewardProfileRef,
+            QuestRepeatRule repeatPolicy,
+            QuestRoleTemplateRef roleTemplateRef,
+            QuestCompletionPolicy completionPolicy,
+            Instant dueAt
+    ) {
+        return createDefinition(
+                code,
+                definitionVersion,
+                null,
+                semanticCategory,
+                title,
+                descriptionMd,
+                target,
+                progressSource,
+                rewardProfileRef,
+                repeatPolicy,
+                roleTemplateRef,
                 completionPolicy,
                 dueAt
         );

--- a/src/main/java/online/lifeasgame/quest/domain/QuestBlueprint.java
+++ b/src/main/java/online/lifeasgame/quest/domain/QuestBlueprint.java
@@ -149,6 +149,37 @@ public record QuestBlueprint(
     public static QuestBlueprint finalContract(
             QuestCode code,
             int definitionVersion,
+            QuestSemanticCategory semanticCategory,
+            QuestTitle title,
+            String descriptionMd,
+            QuestTarget target,
+            QuestProgressSource progressSource,
+            RewardProfileRef rewardProfileRef,
+            QuestRepeatRule repeatPolicy,
+            QuestRoleTemplateRef roleTemplateRef,
+            Instant dueAt,
+            QuestCompletionPolicy completionPolicy
+    ) {
+        return finalContract(
+                code,
+                definitionVersion,
+                null,
+                semanticCategory,
+                title,
+                descriptionMd,
+                target,
+                progressSource,
+                rewardProfileRef,
+                repeatPolicy,
+                roleTemplateRef,
+                dueAt,
+                completionPolicy
+        );
+    }
+
+    public static QuestBlueprint finalContract(
+            QuestCode code,
+            int definitionVersion,
             QuestCategory category,
             QuestSemanticCategory semanticCategory,
             QuestTitle title,

--- a/src/main/java/online/lifeasgame/quest/domain/QuestCode.java
+++ b/src/main/java/online/lifeasgame/quest/domain/QuestCode.java
@@ -22,7 +22,12 @@ public enum QuestCode {
     EXERCISE_MINUTES_300("quest:exercise:minutes-300"),
     COLLECTION_HUNTER_10("quest:collection:hunter-10"),
     MEDIA_BINGE_5("quest:media:binge-5"),
-    INVENTORY_COLLECTOR_100("quest:inventory:collector-100");
+    INVENTORY_COLLECTOR_100("quest:inventory:collector-100"),
+    Q_RECORD_FIRST_TRACE("Q_RECORD_FIRST_TRACE"),
+    Q_RECORD_THREE_TRACES("Q_RECORD_THREE_TRACES"),
+    Q_RECORD_WEEKLY_LOOKBACK("Q_RECORD_WEEKLY_LOOKBACK"),
+    Q_GROWTH_ONE_FOCUS("Q_GROWTH_ONE_FOCUS"),
+    Q_RECOVERY_REST_TEN("Q_RECOVERY_REST_TEN");
 
     private final String value;
 

--- a/src/main/java/online/lifeasgame/quest/domain/event/QuestEvent.java
+++ b/src/main/java/online/lifeasgame/quest/domain/event/QuestEvent.java
@@ -51,7 +51,12 @@ public record QuestEvent(
                 .questId(quest.getId())
                 .questCode(quest.getCode())
                 .attribute("title", quest.getTitle().value())
-                .attribute("category", quest.getCategory().name())
+                .attribute(
+                        "category",
+                        quest.getCategory() == null
+                                ? null
+                                : quest.getCategory().name()
+                )
                 .attribute("targetType", quest.target().type().name())
                 .attribute("targetValue", quest.target().value())
                 .attribute("repeatRule", quest.getRepeatRule().name())

--- a/src/main/java/online/lifeasgame/quest/domain/seed/QuestContentPeriodBoundary.java
+++ b/src/main/java/online/lifeasgame/quest/domain/seed/QuestContentPeriodBoundary.java
@@ -1,0 +1,24 @@
+package online.lifeasgame.quest.domain.seed;
+
+public enum QuestContentPeriodBoundary {
+    PLAYER_LIFETIME("PLAYER_LIFETIME"),
+    FROM_ACCEPTANCE_UNTIL_COMPLETION(
+            "FROM_ACCEPTANCE_UNTIL_COMPLETION"
+    ),
+    MONDAY_00_00_INCLUSIVE_TO_NEXT_MONDAY_00_00_EXCLUSIVE(
+            "MONDAY_00:00_INCLUSIVE_TO_NEXT_MONDAY_00:00_EXCLUSIVE"
+    ),
+    LOCAL_DAY_00_00_TO_NEXT_DAY_00_00(
+            "LOCAL_DAY_00:00_TO_NEXT_DAY_00:00"
+    );
+
+    private final String value;
+
+    QuestContentPeriodBoundary(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/domain/seed/QuestContentPriority.java
+++ b/src/main/java/online/lifeasgame/quest/domain/seed/QuestContentPriority.java
@@ -1,0 +1,5 @@
+package online.lifeasgame.quest.domain.seed;
+
+public enum QuestContentPriority {
+    P0
+}

--- a/src/main/java/online/lifeasgame/quest/domain/seed/QuestContentTargetUnit.java
+++ b/src/main/java/online/lifeasgame/quest/domain/seed/QuestContentTargetUnit.java
@@ -1,0 +1,7 @@
+package online.lifeasgame.quest.domain.seed;
+
+public enum QuestContentTargetUnit {
+    DISTINCT_LIFELOG,
+    WEEKLY_REFLECTION,
+    MINUTE_INTENT
+}

--- a/src/main/java/online/lifeasgame/quest/domain/seed/QuestContentTimezonePolicy.java
+++ b/src/main/java/online/lifeasgame/quest/domain/seed/QuestContentTimezonePolicy.java
@@ -1,0 +1,6 @@
+package online.lifeasgame.quest.domain.seed;
+
+public enum QuestContentTimezonePolicy {
+    NOT_APPLICABLE,
+    PLAYER_PROFILE_TIMEZONE
+}

--- a/src/main/java/online/lifeasgame/quest/domain/seed/QuestDefinitionStatus.java
+++ b/src/main/java/online/lifeasgame/quest/domain/seed/QuestDefinitionStatus.java
@@ -1,0 +1,5 @@
+package online.lifeasgame.quest.domain.seed;
+
+public enum QuestDefinitionStatus {
+    ACTIVE
+}

--- a/src/main/java/online/lifeasgame/quest/domain/seed/QuestProgressMode.java
+++ b/src/main/java/online/lifeasgame/quest/domain/seed/QuestProgressMode.java
@@ -1,0 +1,6 @@
+package online.lifeasgame.quest.domain.seed;
+
+public enum QuestProgressMode {
+    EVENT_COUNT,
+    MANUAL_CHECK
+}

--- a/src/main/java/online/lifeasgame/quest/domain/seed/QuestProgressSourceType.java
+++ b/src/main/java/online/lifeasgame/quest/domain/seed/QuestProgressSourceType.java
@@ -1,0 +1,6 @@
+package online.lifeasgame.quest.domain.seed;
+
+public enum QuestProgressSourceType {
+    DURABLE_OUTBOX_FACT,
+    USER_CONFIRMATION
+}

--- a/src/main/java/online/lifeasgame/quest/domain/seed/QuestRoleContextPolicy.java
+++ b/src/main/java/online/lifeasgame/quest/domain/seed/QuestRoleContextPolicy.java
@@ -1,0 +1,6 @@
+package online.lifeasgame.quest.domain.seed;
+
+public enum QuestRoleContextPolicy {
+    OPTIONAL_SOURCE_ROLE_CONTEXT,
+    OPTIONAL_RECOMMENDED_ROLE_CONTEXT
+}

--- a/src/main/java/online/lifeasgame/quest/domain/seed/SeedLevel1Quest.java
+++ b/src/main/java/online/lifeasgame/quest/domain/seed/SeedLevel1Quest.java
@@ -1,0 +1,282 @@
+package online.lifeasgame.quest.domain.seed;
+
+import online.lifeasgame.quest.domain.QuestCode;
+import online.lifeasgame.quest.domain.QuestRepeatRule;
+import online.lifeasgame.quest.domain.QuestSemanticCategory;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public enum SeedLevel1Quest {
+
+    RECORD_FIRST_TRACE(
+            new SeedLevel1QuestDefinition(
+                    QuestCode.Q_RECORD_FIRST_TRACE,
+                    1,
+                    QuestContentPriority.P0,
+                    1,
+                    QuestDefinitionStatus.ACTIVE,
+                    "첫 흔적 남기기",
+                    "오늘의 생각·행동·기억 중 하나를 짧게 남겨보세요.",
+                    "사용자가 직접 작성한 LifeLog 한 건을 남기면 완료됩니다. "
+                            + "Quick LifeLog도 실제 LifeLog로 저장되고 사용자 작성 "
+                            + "기록이라는 조건을 충족하면 인정합니다.",
+                    QuestSemanticCategory.RECORD,
+                    QuestProgressMode.EVENT_COUNT,
+                    QuestProgressSourceType.DURABLE_OUTBOX_FACT,
+                    "LifeLogRecorded",
+                    "LIFE_LOG",
+                    "event.playerId == questAcceptance.playerId; "
+                            + "event.occurredAt >= acceptance.acceptedAt",
+                    1,
+                    QuestContentTargetUnit.DISTINCT_LIFELOG,
+                    true,
+                    QuestRepeatRule.ONCE,
+                    QuestContentPeriodBoundary.PLAYER_LIFETIME,
+                    QuestContentTimezonePolicy.NOT_APPLICABLE,
+                    null,
+                    QuestRoleContextPolicy.OPTIONAL_SOURCE_ROLE_CONTEXT,
+                    Set.of("ANY"),
+                    "RP_EXP_TINY_10",
+                    false,
+                    false,
+                    "완료 전 취소와 새 attempt 허용; 한 번 완료되면 재수락 불가",
+                    "미완료/취소 페널티 없음",
+                    null,
+                    10,
+                    "icon.quest.record.first_trace",
+                    "quest.record.primary",
+                    "quest.q_record_first_trace.completed",
+                    "quest.q_record_first_trace.empty",
+                    List.of(
+                            "허용 subtype의 사용자 작성 LifeLogRecorded 1건에서 자동 완료",
+                            "동일 eventId 또는 lifeLogId 재전달 무시"
+                    )
+            )
+    ),
+
+    RECORD_THREE_TRACES(
+            new SeedLevel1QuestDefinition(
+                    QuestCode.Q_RECORD_THREE_TRACES,
+                    1,
+                    QuestContentPriority.P0,
+                    1,
+                    QuestDefinitionStatus.ACTIVE,
+                    "흔적 세 개 이어보기",
+                    "서로 다른 순간의 기록을 세 개 남겨 작은 흐름을 만들어보세요.",
+                    "수락 이후 사용자가 직접 남긴 서로 다른 LifeLog 세 건을 연결합니다. "
+                            + "수정은 새 기록으로 보지 않으며 중복 전달은 진행도를 올리지 "
+                            + "않습니다.",
+                    QuestSemanticCategory.RECORD,
+                    QuestProgressMode.EVENT_COUNT,
+                    QuestProgressSourceType.DURABLE_OUTBOX_FACT,
+                    "LifeLogRecorded",
+                    "LIFE_LOG",
+                    "event.playerId == questAcceptance.playerId; "
+                            + "event.occurredAt >= acceptance.acceptedAt",
+                    3,
+                    QuestContentTargetUnit.DISTINCT_LIFELOG,
+                    true,
+                    QuestRepeatRule.ONCE,
+                    QuestContentPeriodBoundary
+                            .FROM_ACCEPTANCE_UNTIL_COMPLETION,
+                    QuestContentTimezonePolicy.NOT_APPLICABLE,
+                    null,
+                    QuestRoleContextPolicy.OPTIONAL_SOURCE_ROLE_CONTEXT,
+                    Set.of("ANY"),
+                    "RP_EXP_AND_ITEM_FIRST_STEP_20",
+                    false,
+                    false,
+                    null,
+                    null,
+                    null,
+                    20,
+                    "icon.quest.record.three_traces",
+                    "quest.record.secondary",
+                    "quest.q_record_three_traces.completed",
+                    "quest.q_record_three_traces.empty",
+                    List.of()
+            )
+    ),
+
+    RECORD_WEEKLY_LOOKBACK(
+            new SeedLevel1QuestDefinition(
+                    QuestCode.Q_RECORD_WEEKLY_LOOKBACK,
+                    1,
+                    QuestContentPriority.P0,
+                    1,
+                    QuestDefinitionStatus.ACTIVE,
+                    "이번 주 흔적 돌아보기",
+                    "이번 주 기록 중 하나를 골라 지금의 나에게 남길 한 줄을 적어보세요.",
+                    "별도 회고 전용 Entity를 만들지 않고 LifeLog subtype REFLECTION과 "
+                            + "reflectionScope WEEKLY_LOOKBACK 메타데이터로 주간 회고를 "
+                            + "식별합니다.",
+                    QuestSemanticCategory.RECORD,
+                    QuestProgressMode.EVENT_COUNT,
+                    QuestProgressSourceType.DURABLE_OUTBOX_FACT,
+                    "LifeLogRecorded",
+                    "LIFE_LOG",
+                    "event.playerId == questAcceptance.playerId; "
+                            + "event.subtype == REFLECTION; "
+                            + "event.reflectionScope == WEEKLY_LOOKBACK; "
+                            + "event.periodKey == acceptance.periodKey",
+                    1,
+                    QuestContentTargetUnit.WEEKLY_REFLECTION,
+                    true,
+                    QuestRepeatRule.WEEKLY,
+                    QuestContentPeriodBoundary
+                            .MONDAY_00_00_INCLUSIVE_TO_NEXT_MONDAY_00_00_EXCLUSIVE,
+                    QuestContentTimezonePolicy.PLAYER_PROFILE_TIMEZONE,
+                    "Asia/Seoul",
+                    QuestRoleContextPolicy.OPTIONAL_SOURCE_ROLE_CONTEXT,
+                    Set.of("ANY"),
+                    "RP_NONE",
+                    false,
+                    false,
+                    null,
+                    null,
+                    null,
+                    30,
+                    "icon.quest.record.weekly_lookback",
+                    "quest.record.reflection",
+                    "quest.q_record_weekly_lookback.completed",
+                    "quest.q_record_weekly_lookback.empty",
+                    List.of()
+            )
+    ),
+
+    GROWTH_ONE_FOCUS(
+            new SeedLevel1QuestDefinition(
+                    QuestCode.Q_GROWTH_ONE_FOCUS,
+                    1,
+                    QuestContentPriority.P0,
+                    1,
+                    QuestDefinitionStatus.ACTIVE,
+                    "한 가지에 25분 집중하기",
+                    "지금 가장 작은 한 가지를 골라 25분만 집중해보세요.",
+                    "사용자는 시작 전에 집중할 한 가지를 1~80자 자유 텍스트로 입력하고, "
+                            + "집중을 마친 뒤 직접 완료를 확인합니다. 서버는 집중 내용이나 "
+                            + "성과를 평가하지 않습니다.",
+                    QuestSemanticCategory.GROWTH,
+                    QuestProgressMode.MANUAL_CHECK,
+                    QuestProgressSourceType.USER_CONFIRMATION,
+                    "NONE_DIRECT_COMMAND",
+                    "QUEST_ACCEPTANCE",
+                    "command.playerId == questAcceptance.playerId",
+                    25,
+                    QuestContentTargetUnit.MINUTE_INTENT,
+                    false,
+                    QuestRepeatRule.DAILY,
+                    QuestContentPeriodBoundary
+                            .LOCAL_DAY_00_00_TO_NEXT_DAY_00_00,
+                    QuestContentTimezonePolicy.PLAYER_PROFILE_TIMEZONE,
+                    "Asia/Seoul",
+                    QuestRoleContextPolicy
+                            .OPTIONAL_RECOMMENDED_ROLE_CONTEXT,
+                    Set.of("ANY"),
+                    "RP_NONE",
+                    true,
+                    false,
+                    null,
+                    null,
+                    null,
+                    40,
+                    "icon.quest.growth.one_focus",
+                    "quest.growth.primary",
+                    "quest.q_growth_one_focus.completed",
+                    "quest.q_growth_one_focus.empty",
+                    List.of(
+                            "Focus enum 신설 금지",
+                            "focusLabel은 후속 Manual API에서 1~80자 필수",
+                            "추천 Role은 optional이며 현재 single roleTemplateCode로 축약 금지"
+                    )
+            )
+    ),
+
+    RECOVERY_REST_TEN(
+            new SeedLevel1QuestDefinition(
+                    QuestCode.Q_RECOVERY_REST_TEN,
+                    1,
+                    QuestContentPriority.P0,
+                    1,
+                    QuestDefinitionStatus.ACTIVE,
+                    "10분 쉬어가기",
+                    "아무것도 증명하지 않아도 되는 10분을 가져보세요.",
+                    "사용자가 10분 정도 쉬었다고 직접 확인하면 완료합니다. P0에서는 "
+                            + "Timer, Exercise, LifeLog를 필수 원본으로 요구하지 않습니다.",
+                    QuestSemanticCategory.RECOVERY,
+                    QuestProgressMode.MANUAL_CHECK,
+                    QuestProgressSourceType.USER_CONFIRMATION,
+                    "NONE_DIRECT_COMMAND",
+                    "QUEST_ACCEPTANCE",
+                    "command.playerId == questAcceptance.playerId",
+                    10,
+                    QuestContentTargetUnit.MINUTE_INTENT,
+                    false,
+                    QuestRepeatRule.DAILY,
+                    QuestContentPeriodBoundary
+                            .LOCAL_DAY_00_00_TO_NEXT_DAY_00_00,
+                    QuestContentTimezonePolicy.PLAYER_PROFILE_TIMEZONE,
+                    "Asia/Seoul",
+                    QuestRoleContextPolicy
+                            .OPTIONAL_RECOMMENDED_ROLE_CONTEXT,
+                    Set.of("ANY"),
+                    "RP_NONE",
+                    true,
+                    false,
+                    null,
+                    "미완료 불이익/연속 수행 압박 금지",
+                    null,
+                    50,
+                    "icon.quest.recovery.rest_ten",
+                    "quest.recovery.calm",
+                    "quest.q_recovery_rest_ten.completed",
+                    "quest.q_recovery_rest_ten.empty",
+                    List.of(
+                            "Timer 증빙 강제 금지",
+                            "부분 시간 누적 금지",
+                            "미완료 불이익/연속 수행 압박 금지"
+                    )
+            )
+    );
+
+    private final SeedLevel1QuestDefinition definition;
+
+    static {
+        var codes = new HashSet<QuestCode>();
+        var sortOrders = new HashSet<Integer>();
+        for (SeedLevel1QuestDefinition definition : definitions()) {
+            if (!codes.add(definition.questCode())) {
+                throw new IllegalStateException(
+                        "Seed Level 1 quest code must be unique"
+                );
+            }
+            if (!sortOrders.add(definition.sortOrder())) {
+                throw new IllegalStateException(
+                        "Seed Level 1 quest sortOrder must be unique"
+                );
+            }
+        }
+    }
+
+    SeedLevel1Quest(SeedLevel1QuestDefinition definition) {
+        this.definition = definition;
+    }
+
+    public SeedLevel1QuestDefinition definition() {
+        return definition;
+    }
+
+    public static List<SeedLevel1QuestDefinition> definitions() {
+        return Arrays.stream(values())
+                .map(SeedLevel1Quest::definition)
+                .sorted(
+                        java.util.Comparator.comparingInt(
+                                SeedLevel1QuestDefinition::sortOrder
+                        )
+                )
+                .toList();
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/domain/seed/SeedLevel1Quest.java
+++ b/src/main/java/online/lifeasgame/quest/domain/seed/SeedLevel1Quest.java
@@ -32,28 +32,34 @@ public enum SeedLevel1Quest {
                             + "event.occurredAt >= acceptance.acceptedAt",
                     1,
                     QuestContentTargetUnit.DISTINCT_LIFELOG,
+                    "허용 subtype의 사용자 작성 LifeLogRecorded 1건을 수신하면 goal reached와 "
+                            + "QuestCompleted를 한 번만 확정한다. 동일 eventId 또는 "
+                            + "lifeLogId 재전달은 무시한다.",
                     true,
                     QuestRepeatRule.ONCE,
                     QuestContentPeriodBoundary.PLAYER_LIFETIME,
                     QuestContentTimezonePolicy.NOT_APPLICABLE,
+                    null,
+                    null,
                     null,
                     QuestRoleContextPolicy.OPTIONAL_SOURCE_ROLE_CONTEXT,
                     Set.of("ANY"),
                     "RP_EXP_TINY_10",
                     false,
                     false,
-                    "완료 전 취소와 새 attempt 허용; 한 번 완료되면 재수락 불가",
-                    "미완료/취소 페널티 없음",
-                    null,
+                    "완료 전 취소 가능; 재수락 시 새 attempt로 시작하며 새 acceptedAt 이후 "
+                            + "이벤트만 인정; 한 번 완료되면 재수락 불가",
+                    "미완료·취소에 페널티, 연속 수행 손실, 죄책감 문구 없음",
+                    "Q_RECORD_THREE_TRACES 또는 방금 남긴 LifeLog 보기",
                     10,
                     "icon.quest.record.first_trace",
                     "quest.record.primary",
                     "quest.q_record_first_trace.completed",
                     "quest.q_record_first_trace.empty",
-                    List.of(
-                            "허용 subtype의 사용자 작성 LifeLogRecorded 1건에서 자동 완료",
-                            "동일 eventId 또는 lifeLogId 재전달 무시"
-                    )
+                    "허용 subtype: QUICK_NOTE|ACTIVITY|STUDY|PROJECT|MEMORY|REFLECTION|"
+                            + "MOOD|HEALTH_NOTE. SYSTEM_GENERATED는 제외. 기록 생성 후 "
+                            + "삭제되어도 이미 확정된 완료 사실과 보상은 되돌리지 않는다. "
+                            + "삭제 사실은 별도 정책이며 Quest 진행도 감소 원인이 아니다."
             )
     ),
 
@@ -78,26 +84,34 @@ public enum SeedLevel1Quest {
                             + "event.occurredAt >= acceptance.acceptedAt",
                     3,
                     QuestContentTargetUnit.DISTINCT_LIFELOG,
+                    "서로 다른 eventId이면서 서로 다른 lifeLogId인 LifeLogRecorded 세 건만 "
+                            + "누적한다. 세 번째 고유 기록에서 goal reached와 "
+                            + "QuestCompleted를 한 번만 확정한다.",
                     true,
                     QuestRepeatRule.ONCE,
                     QuestContentPeriodBoundary
                             .FROM_ACCEPTANCE_UNTIL_COMPLETION,
                     QuestContentTimezonePolicy.NOT_APPLICABLE,
                     null,
+                    null,
+                    null,
                     QuestRoleContextPolicy.OPTIONAL_SOURCE_ROLE_CONTEXT,
                     Set.of("ANY"),
                     "RP_EXP_AND_ITEM_FIRST_STEP_20",
                     false,
                     false,
-                    null,
-                    null,
-                    null,
+                    "완료 전 취소 가능; 재수락 시 진행도 0으로 새 attempt 시작; 이전 "
+                            + "attempt의 기록 이벤트는 새 attempt에 이월하지 않음",
+                    "기간 만료와 연속 수행 압박 없음; 중단해도 실패 낙인 없음",
+                    "Mailbox에서 첫걸음의 조각 확인 또는 ROUTE_RECORD_START 다음 단계 확인",
                     20,
                     "icon.quest.record.three_traces",
                     "quest.record.secondary",
                     "quest.q_record_three_traces.completed",
                     "quest.q_record_three_traces.empty",
-                    List.of()
+                    "수행 기간 제한 없음. 동일 LifeLog 수정 이벤트는 진행도 증가 없음. "
+                            + "동일 이벤트 재전달은 eventId 멱등 처리. 기록 삭제 후에도 "
+                            + "이미 누적·완료된 사실은 유지한다."
             )
     ),
 
@@ -124,26 +138,36 @@ public enum SeedLevel1Quest {
                             + "event.periodKey == acceptance.periodKey",
                     1,
                     QuestContentTargetUnit.WEEKLY_REFLECTION,
+                    "해당 주기 안에 생성된 REFLECTION LifeLog 중 "
+                            + "reflectionScope=WEEKLY_LOOKBACK인 고유 기록 1건을 수신하면 "
+                            + "자동 완료한다. 본문 내용은 판정하지 않는다.",
                     true,
                     QuestRepeatRule.WEEKLY,
                     QuestContentPeriodBoundary
                             .MONDAY_00_00_INCLUSIVE_TO_NEXT_MONDAY_00_00_EXCLUSIVE,
                     QuestContentTimezonePolicy.PLAYER_PROFILE_TIMEZONE,
                     "Asia/Seoul",
+                    null,
+                    null,
                     QuestRoleContextPolicy.OPTIONAL_SOURCE_ROLE_CONTEXT,
                     Set.of("ANY"),
                     "RP_NONE",
                     false,
                     false,
-                    null,
-                    null,
-                    null,
+                    "해당 주기 내 완료 전 취소 가능; 다음 주기에 새 acceptance 생성 가능; "
+                            + "이전 주기 미완료는 EXPIRED가 아니라 CLOSED_INCOMPLETE로 "
+                            + "기록하되 사용자에게 실패로 표현하지 않음",
+                    "미완료 페널티·연속 주차 손실·재촉 알림 없음",
+                    "ROUTE_RECORD_START의 준비된 마지막 Step을 직접 advance하거나 "
+                            + "회고 LifeLog 보기",
                     30,
                     "icon.quest.record.weekly_lookback",
                     "quest.record.reflection",
                     "quest.q_record_weekly_lookback.completed",
                     "quest.q_record_weekly_lookback.empty",
-                    List.of()
+                    "회고 전용 subtype 신설 불필요. REFLECTION + reflectionScope로 구분. "
+                            + "Quick LifeLog는 인정하지 않음. 다음 주기 재수행 가능. "
+                            + "주기당 Player별 완료 1회."
             )
     ),
 
@@ -167,31 +191,35 @@ public enum SeedLevel1Quest {
                     "command.playerId == questAcceptance.playerId",
                     25,
                     QuestContentTargetUnit.MINUTE_INTENT,
+                    "focusLabel 필수, memo 선택. 사용자가 약 25분의 집중을 마쳤다고 확인하면 "
+                            + "완료한다. 타이머 증빙·성과 검증·텍스트 분석은 하지 않는다.",
                     false,
                     QuestRepeatRule.DAILY,
                     QuestContentPeriodBoundary
                             .LOCAL_DAY_00_00_TO_NEXT_DAY_00_00,
                     QuestContentTimezonePolicy.PLAYER_PROFILE_TIMEZONE,
                     "Asia/Seoul",
+                    null,
+                    null,
                     QuestRoleContextPolicy
                             .OPTIONAL_RECOMMENDED_ROLE_CONTEXT,
                     Set.of("ANY"),
                     "RP_NONE",
                     true,
                     false,
-                    null,
-                    null,
-                    null,
+                    "당일 완료 전 취소 가능; 같은 일자 재수락 시 새 attempt로 시작; "
+                            + "완료 후 같은 periodKey 재완료 불가",
+                    "미완료·짧게 끝냄·성과 없음에 페널티나 평가 문구 없음",
+                    "집중 중 알게 된 점을 짧은 LifeLog로 남기거나 오늘은 여기서 마치기",
                     40,
                     "icon.quest.growth.one_focus",
                     "quest.growth.primary",
                     "quest.q_growth_one_focus.completed",
                     "quest.q_growth_one_focus.empty",
-                    List.of(
-                            "Focus enum 신설 금지",
-                            "focusLabel은 후속 Manual API에서 1~80자 필수",
-                            "추천 Role은 optional이며 현재 single roleTemplateCode로 축약 금지"
-                    )
+                    "Focus 유형 domain enum은 P0에 만들지 않는다. 선택형 preset은 FE "
+                            + "제안값일 뿐 저장·판정 필수값이 아니다. 필수 입력은 "
+                            + "focusLabel 하나. 추천 Role Template: "
+                            + "ROLE_JOB_SEEKER|ROLE_BACKEND_DEVELOPER."
             )
     ),
 
@@ -214,31 +242,36 @@ public enum SeedLevel1Quest {
                     "command.playerId == questAcceptance.playerId",
                     10,
                     QuestContentTargetUnit.MINUTE_INTENT,
+                    "한 번의 휴식 세션을 사용자가 직접 확인하면 완료한다. 부분 수행 시간은 "
+                            + "누적하지 않으며 메모와 휴식 이유는 요구하지 않는다.",
                     false,
                     QuestRepeatRule.DAILY,
                     QuestContentPeriodBoundary
                             .LOCAL_DAY_00_00_TO_NEXT_DAY_00_00,
                     QuestContentTimezonePolicy.PLAYER_PROFILE_TIMEZONE,
                     "Asia/Seoul",
+                    null,
+                    null,
                     QuestRoleContextPolicy
                             .OPTIONAL_RECOMMENDED_ROLE_CONTEXT,
                     Set.of("ANY"),
                     "RP_NONE",
                     true,
                     false,
-                    null,
-                    "미완료 불이익/연속 수행 압박 금지",
-                    null,
+                    "언제든 완료 전 취소 가능; 같은 일자 재수락 가능; 미완료 attempt는 "
+                            + "일자 경계에서 CLOSED_INCOMPLETE 처리",
+                    "실패·연속 수행·손실·마감 압박 없음. 미완료 상태에서도 휴식을 권리처럼 "
+                            + "표현하며 재촉하지 않음",
+                    "조금 더 쉬거나, 상태가 괜찮다면 짧은 LifeLog를 남기기",
                     50,
                     "icon.quest.recovery.rest_ten",
                     "quest.recovery.calm",
                     "quest.q_recovery_rest_ten.completed",
                     "quest.q_recovery_rest_ten.empty",
-                    List.of(
-                            "Timer 증빙 강제 금지",
-                            "부분 시간 누적 금지",
-                            "미완료 불이익/연속 수행 압박 금지"
-                    )
+                    "10의 단위는 minute. P0 인정 원본은 수동 확인. Rest Timer는 P1 "
+                            + "보조 입력 후보이며 완료 증빙으로 강제하지 않는다. "
+                            + "Exercise와 일반 LifeLog는 이 Quest의 완료 원본으로 "
+                            + "사용하지 않는다."
             )
     );
 

--- a/src/main/java/online/lifeasgame/quest/domain/seed/SeedLevel1QuestDefinition.java
+++ b/src/main/java/online/lifeasgame/quest/domain/seed/SeedLevel1QuestDefinition.java
@@ -4,7 +4,7 @@ import online.lifeasgame.quest.domain.QuestCode;
 import online.lifeasgame.quest.domain.QuestRepeatRule;
 import online.lifeasgame.quest.domain.QuestSemanticCategory;
 
-import java.util.List;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Set;
 
@@ -25,11 +25,14 @@ public record SeedLevel1QuestDefinition(
         String sourceOwnerRule,
         int targetValue,
         QuestContentTargetUnit targetUnit,
+        String completionPolicy,
         boolean autoComplete,
         QuestRepeatRule repeatPolicy,
         QuestContentPeriodBoundary periodBoundary,
         QuestContentTimezonePolicy timezonePolicy,
         String timezoneFallback,
+        Instant availabilityStartAt,
+        Instant availabilityEndAt,
         QuestRoleContextPolicy roleContextPolicy,
         Set<String> allowedRoleTypes,
         String rewardProfileCode,
@@ -43,7 +46,7 @@ public record SeedLevel1QuestDefinition(
         String colorToken,
         String resultCopyKey,
         String emptyStateCopyKey,
-        List<String> notes
+        String notes
 ) {
 
     public SeedLevel1QuestDefinition {
@@ -75,6 +78,7 @@ public record SeedLevel1QuestDefinition(
             throw new IllegalArgumentException("targetValue must be positive");
         }
         Objects.requireNonNull(targetUnit, "targetUnit");
+        requireText(completionPolicy, "completionPolicy");
         Objects.requireNonNull(repeatPolicy, "repeatPolicy");
         if (!repeatPolicy.isFinalPolicy()) {
             throw new IllegalArgumentException(
@@ -110,6 +114,9 @@ public record SeedLevel1QuestDefinition(
                     "autoComplete and manualCheckAllowed must be opposite"
             );
         }
+        requireText(cancellationPolicy, "cancellationPolicy");
+        requireText(failurePressurePolicy, "failurePressurePolicy");
+        requireText(recommendedNextAction, "recommendedNextAction");
         if (sortOrder <= 0) {
             throw new IllegalArgumentException("sortOrder must be positive");
         }
@@ -117,7 +124,7 @@ public record SeedLevel1QuestDefinition(
         requireText(colorToken, "colorToken");
         requireText(resultCopyKey, "resultCopyKey");
         requireText(emptyStateCopyKey, "emptyStateCopyKey");
-        notes = List.copyOf(Objects.requireNonNull(notes, "notes"));
+        requireText(notes, "notes");
     }
 
     private static void requireText(String value, String field) {

--- a/src/main/java/online/lifeasgame/quest/domain/seed/SeedLevel1QuestDefinition.java
+++ b/src/main/java/online/lifeasgame/quest/domain/seed/SeedLevel1QuestDefinition.java
@@ -1,0 +1,128 @@
+package online.lifeasgame.quest.domain.seed;
+
+import online.lifeasgame.quest.domain.QuestCode;
+import online.lifeasgame.quest.domain.QuestRepeatRule;
+import online.lifeasgame.quest.domain.QuestSemanticCategory;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+public record SeedLevel1QuestDefinition(
+        QuestCode questCode,
+        int seedLevel,
+        QuestContentPriority priority,
+        int definitionVersion,
+        QuestDefinitionStatus status,
+        String displayNameKo,
+        String shortDescriptionKo,
+        String longDescriptionKo,
+        QuestSemanticCategory semanticCategory,
+        QuestProgressMode progressMode,
+        QuestProgressSourceType progressSourceType,
+        String sourceEventType,
+        String sourceEntityType,
+        String sourceOwnerRule,
+        int targetValue,
+        QuestContentTargetUnit targetUnit,
+        boolean autoComplete,
+        QuestRepeatRule repeatPolicy,
+        QuestContentPeriodBoundary periodBoundary,
+        QuestContentTimezonePolicy timezonePolicy,
+        String timezoneFallback,
+        QuestRoleContextPolicy roleContextPolicy,
+        Set<String> allowedRoleTypes,
+        String rewardProfileCode,
+        boolean manualCheckAllowed,
+        boolean manualCheckRequiresMemo,
+        String cancellationPolicy,
+        String failurePressurePolicy,
+        String recommendedNextAction,
+        int sortOrder,
+        String iconKey,
+        String colorToken,
+        String resultCopyKey,
+        String emptyStateCopyKey,
+        List<String> notes
+) {
+
+    public SeedLevel1QuestDefinition {
+        Objects.requireNonNull(questCode, "questCode");
+        if (seedLevel != 1) {
+            throw new IllegalArgumentException("seedLevel must be 1");
+        }
+        if (priority != QuestContentPriority.P0) {
+            throw new IllegalArgumentException("priority must be P0");
+        }
+        if (definitionVersion < 1) {
+            throw new IllegalArgumentException(
+                    "definitionVersion must be at least 1"
+            );
+        }
+        if (status != QuestDefinitionStatus.ACTIVE) {
+            throw new IllegalArgumentException("status must be ACTIVE");
+        }
+        requireText(displayNameKo, "displayNameKo");
+        requireText(shortDescriptionKo, "shortDescriptionKo");
+        requireText(longDescriptionKo, "longDescriptionKo");
+        Objects.requireNonNull(semanticCategory, "semanticCategory");
+        Objects.requireNonNull(progressMode, "progressMode");
+        Objects.requireNonNull(progressSourceType, "progressSourceType");
+        requireText(sourceEventType, "sourceEventType");
+        requireText(sourceEntityType, "sourceEntityType");
+        requireText(sourceOwnerRule, "sourceOwnerRule");
+        if (targetValue <= 0) {
+            throw new IllegalArgumentException("targetValue must be positive");
+        }
+        Objects.requireNonNull(targetUnit, "targetUnit");
+        Objects.requireNonNull(repeatPolicy, "repeatPolicy");
+        if (!repeatPolicy.isFinalPolicy()) {
+            throw new IllegalArgumentException(
+                    "repeatPolicy must be a final policy"
+            );
+        }
+        Objects.requireNonNull(periodBoundary, "periodBoundary");
+        Objects.requireNonNull(timezonePolicy, "timezonePolicy");
+        if (timezonePolicy == QuestContentTimezonePolicy.PLAYER_PROFILE_TIMEZONE) {
+            requireText(timezoneFallback, "timezoneFallback");
+        } else if (timezoneFallback != null) {
+            throw new IllegalArgumentException(
+                    "timezoneFallback must be null when timezone is not applicable"
+            );
+        }
+        Objects.requireNonNull(roleContextPolicy, "roleContextPolicy");
+        allowedRoleTypes = Set.copyOf(
+                Objects.requireNonNull(allowedRoleTypes, "allowedRoleTypes")
+        );
+        if (allowedRoleTypes.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "allowedRoleTypes must not be empty"
+            );
+        }
+        requireText(rewardProfileCode, "rewardProfileCode");
+        if (manualCheckRequiresMemo && !manualCheckAllowed) {
+            throw new IllegalArgumentException(
+                    "manualCheckRequiresMemo requires manualCheckAllowed"
+            );
+        }
+        if (autoComplete == manualCheckAllowed) {
+            throw new IllegalArgumentException(
+                    "autoComplete and manualCheckAllowed must be opposite"
+            );
+        }
+        if (sortOrder <= 0) {
+            throw new IllegalArgumentException("sortOrder must be positive");
+        }
+        requireText(iconKey, "iconKey");
+        requireText(colorToken, "colorToken");
+        requireText(resultCopyKey, "resultCopyKey");
+        requireText(emptyStateCopyKey, "emptyStateCopyKey");
+        notes = List.copyOf(Objects.requireNonNull(notes, "notes"));
+    }
+
+    private static void requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+    }
+}

--- a/src/main/resources/db/migration/V14__final_quest_legacy_category_nullable.sql
+++ b/src/main/resources/db/migration/V14__final_quest_legacy_category_nullable.sql
@@ -1,0 +1,8 @@
+ALTER TABLE quests
+    MODIFY COLUMN category ENUM (
+        'GUILD',
+        'MAIN',
+        'PARTY',
+        'RECOMMENDED',
+        'REPEAT'
+    ) NULL;

--- a/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
@@ -63,7 +63,7 @@ class FlywayExplicitBaselineTest {
     class ApplyExplicitBaseline {
 
         @Test
-        @DisplayName("V1을 재실행하지 않고 V2부터 V13까지 적용한 뒤 JPA validate를 통과한다")
+        @DisplayName("V1을 재실행하지 않고 V2부터 V14까지 적용한 뒤 JPA validate를 통과한다")
         void migratesFromVersionTwoAndValidatesJpa() throws Exception {
             String jdbcUrl = createV1EquivalentDatabase();
             Flyway flyway = migrationFlyway(jdbcUrl);
@@ -72,11 +72,12 @@ class FlywayExplicitBaselineTest {
             MigrateResult migrateResult = flyway.migrate();
             List<HistoryRow> history = successfulHistory(jdbcUrl);
 
-            assertThat(migrateResult.migrationsExecuted).isEqualTo(12);
+            assertThat(migrateResult.migrationsExecuted).isEqualTo(13);
             assertThat(history).extracting(HistoryRow::version)
                     .containsExactly(
                             "1", "2", "3", "4", "5",
-                            "6", "7", "8", "9", "10", "11", "12", "13"
+                            "6", "7", "8", "9", "10", "11", "12", "13",
+                            "14"
                     );
             assertThat(history.getFirst().type()).isEqualTo("BASELINE");
             assertThat(history.getFirst().script())
@@ -99,7 +100,8 @@ class FlywayExplicitBaselineTest {
                             "V10__quest_definition_reward_profile_contract.sql",
                             "V11__quest_semantic_progress_contract.sql",
                             "V12__item_stable_code_and_first_step_seed.sql",
-                            "V13__first_step_reward_profile_seed.sql"
+                            "V13__first_step_reward_profile_seed.sql",
+                            "V14__final_quest_legacy_category_nullable.sql"
                     );
             assertThat(history.subList(1, history.size()))
                     .allSatisfy(row -> assertThat(row.checksum()).isNotNull());
@@ -119,7 +121,7 @@ class FlywayExplicitBaselineTest {
                         "spring.jpa.hibernate.ddl-auto"
                 )).isEqualTo("validate");
                 assertThat(context.getBean(Flyway.class).info().current().getVersion().getVersion())
-                        .isEqualTo("13");
+                        .isEqualTo("14");
             }
         }
     }

--- a/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
@@ -33,10 +33,10 @@ class FlywayHistoryChecksumTest {
     class MigrateAgain {
 
         @Test
-        @DisplayName("V1~V12 checksum을 보존하고 V13 이후 두 번째 실행은 no-op이다")
+        @DisplayName("V1~V13 checksum을 보존하고 V14 이후 두 번째 실행은 no-op이다")
         void keepsMigrationHistory() throws Exception {
-            Flyway throughV12 = flyway(MigrationVersion.fromVersion("12"));
-            MigrateResult legacy = throughV12.migrate();
+            Flyway throughV13 = flyway(MigrationVersion.fromVersion("13"));
+            MigrateResult legacy = throughV13.migrate();
             List<HistoryRow> legacyHistory = successfulHistory();
             Flyway flyway = flyway(null);
 
@@ -46,7 +46,7 @@ class FlywayHistoryChecksumTest {
             MigrateResult second = flyway.migrate();
             List<HistoryRow> secondHistory = successfulHistory();
 
-            assertThat(legacy.migrationsExecuted).isEqualTo(12);
+            assertThat(legacy.migrationsExecuted).isEqualTo(13);
             assertThat(first.migrationsExecuted).isEqualTo(1);
             assertThat(second.migrationsExecuted).isZero();
             assertThat(secondHistory).isEqualTo(firstHistory);
@@ -55,7 +55,8 @@ class FlywayHistoryChecksumTest {
             assertThat(secondHistory).extracting(HistoryRow::version)
                     .containsExactly(
                             "1", "2", "3", "4", "5",
-                            "6", "7", "8", "9", "10", "11", "12", "13"
+                            "6", "7", "8", "9", "10", "11", "12", "13",
+                            "14"
                     );
             assertThat(secondHistory).allSatisfy(history -> {
                 assertThat(history.checksum()).isNotNull();

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -38,7 +38,7 @@ class FlywayMigrationTest {
     class MigrateCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V13까지 적용되고 stable Item 기반 Reward Profile을 Seed한다")
+        @DisplayName("V1부터 V14까지 적용되고 final Quest category를 nullable로 보정한다")
         void migratesSchemaAndSeedsRewardProfiles() throws Exception {
             Flyway throughV10 = flyway(MigrationVersion.fromVersion("10"));
             MigrateResult legacyResult = throughV10.migrate();
@@ -55,11 +55,12 @@ class FlywayMigrationTest {
             assertThat(legacyResult.migrationsExecuted).isEqualTo(10);
             assertThat(semanticResult.migrationsExecuted).isEqualTo(1);
             assertThat(itemResult.migrationsExecuted).isEqualTo(1);
-            assertThat(result.migrationsExecuted).isEqualTo(1);
+            assertThat(result.migrationsExecuted).isEqualTo(2);
             assertThat(appliedVersions())
                     .containsExactly(
                             "1", "2", "3", "4", "5",
-                            "6", "7", "8", "9", "10", "11", "12", "13"
+                            "6", "7", "8", "9", "10", "11", "12", "13",
+                            "14"
                     );
             assertThat(existingTables(
                     "users",
@@ -187,8 +188,15 @@ class FlywayMigrationTest {
                             null,
                             null,
                             "NONE",
-                            null
+                            null,
+                            "MAIN"
                     )
+            );
+            QuestLegacyCategoryColumn categoryColumn =
+                    questLegacyCategoryColumn();
+            assertThat(categoryColumn.nullable()).isEqualTo("YES");
+            assertThat(categoryColumn.columnType()).isEqualTo(
+                    "enum('GUILD','MAIN','PARTY','RECOMMENDED','REPEAT')"
             );
             QuestSemanticColumns semanticColumns = questSemanticColumns();
             assertThat(semanticColumns.semanticCategoryNullable())
@@ -764,7 +772,8 @@ class FlywayMigrationTest {
                          semantic_category,
                          progress_source,
                          repeat_rule,
-                         role_template_code
+                         role_template_code,
+                         category
                      FROM quests
                      WHERE code = 'quest:test:v9-legacy'
                      """)) {
@@ -777,7 +786,27 @@ class FlywayMigrationTest {
                     resultSet.getString("semantic_category"),
                     resultSet.getString("progress_source"),
                     resultSet.getString("repeat_rule"),
-                    resultSet.getString("role_template_code")
+                    resultSet.getString("role_template_code"),
+                    resultSet.getString("category")
+            );
+        }
+    }
+
+    private QuestLegacyCategoryColumn questLegacyCategoryColumn()
+            throws SQLException {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("""
+                     SELECT is_nullable, column_type
+                     FROM information_schema.columns
+                     WHERE table_schema = DATABASE()
+                       AND table_name = 'quests'
+                       AND column_name = 'category'
+                     """)) {
+            assertThat(resultSet.next()).isTrue();
+            return new QuestLegacyCategoryColumn(
+                    resultSet.getString("is_nullable"),
+                    resultSet.getString("column_type")
             );
         }
     }
@@ -876,7 +905,14 @@ class FlywayMigrationTest {
             String semanticCategory,
             String progressSource,
             String repeatRule,
-            String roleTemplateCode
+            String roleTemplateCode,
+            String category
+    ) {
+    }
+
+    private record QuestLegacyCategoryColumn(
+            String nullable,
+            String columnType
     ) {
     }
 

--- a/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
@@ -149,7 +149,7 @@ class FlywayProfileCutoverTest {
     class StartLocalWithCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V13까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
+        @DisplayName("V1부터 V14까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
         void migratesThenValidates() {
             ConfigurableEnvironment environment =
                     (ConfigurableEnvironment) applicationContext.getEnvironment();
@@ -161,8 +161,8 @@ class FlywayProfileCutoverTest {
             assertThat(environment.getProperty(
                     "spring.flyway.baseline-on-migrate", Boolean.class
             )).isFalse();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("13");
-            assertThat(appliedMigrationCount()).isEqualTo(13);
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("14");
+            assertThat(appliedMigrationCount()).isEqualTo(14);
         }
     }
 

--- a/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
@@ -1,6 +1,10 @@
 package online.lifeasgame.migration;
 
 import online.lifeasgame.inventory.application.internal.ItemLookupApi;
+import online.lifeasgame.quest.application.QuestService;
+import online.lifeasgame.quest.application.bootstrap.QuestDefinitionBootstrapper;
+import online.lifeasgame.quest.application.command.QuestCommand;
+import online.lifeasgame.quest.domain.QuestCode;
 import online.lifeasgame.reward.application.internal.RewardProfileLookupApi;
 import online.lifeasgame.reward.application.result.RewardProfileResult;
 import org.flywaydb.core.Flyway;
@@ -27,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 @SpringBootTest
 @ActiveProfiles({"test", "migration-test"})
-@DisplayName("V13 migration 이후 JPA schema validation")
+@DisplayName("V14 migration 이후 JPA schema validation")
 class JpaValidateAfterMigrationTest {
 
     @Container
@@ -68,20 +72,65 @@ class JpaValidateAfterMigrationTest {
     @Autowired
     private RewardSettlementReader rewardSettlementReader;
 
+    @Autowired
+    private QuestService questService;
+
+    @Autowired
+    private QuestDefinitionBootstrapper questDefinitionBootstrapper;
+
     @Nested
-    @DisplayName("V1부터 V13까지 적용된 schema로 ApplicationContext를 기동할 때")
+    @DisplayName("V1부터 V14까지 적용된 schema로 ApplicationContext를 기동할 때")
     class LoadApplicationContext {
 
         @Test
         @DisplayName("ddl-auto validate 상태로 정상 기동한다")
         void loadsWithJpaValidation() {
             assertThat(applicationContext).isNotNull();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("13");
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("14");
             assertThat(applicationContext.getEnvironment().getProperty("spring.jpa.hibernate.ddl-auto"))
                     .isEqualTo("validate");
             assertThat(applicationContext.getEnvironment()
                     .getProperty("spring.flyway.baseline-on-migrate", Boolean.class))
                     .isFalse();
+        }
+
+        @Test
+        @DisplayName("신규 Seed Quest 5개를 nullable category로 Bootstrap하고 재실행은 no-op이다")
+        void bootstrapsSeedQuestsIdempotently() throws Exception {
+            var codes = java.util.List.of(
+                    QuestCode.Q_RECORD_FIRST_TRACE,
+                    QuestCode.Q_RECORD_THREE_TRACES,
+                    QuestCode.Q_RECORD_WEEKLY_LOOKBACK,
+                    QuestCode.Q_GROWTH_ONE_FOCUS,
+                    QuestCode.Q_RECOVERY_REST_TEN
+            );
+            var before = codes.stream()
+                    .map(code -> questService.getDefinition(
+                            new QuestCommand.Definition(code.value())
+                    ))
+                    .toList();
+
+            assertThat(before).allSatisfy(definition -> {
+                assertThat(definition.category()).isNull();
+                assertThat(definition.semanticCategory()).isNotNull();
+                assertThat(definition.progressSource()).isNotNull();
+                assertThat(definition.roleTemplateCode()).isNull();
+            });
+
+            questDefinitionBootstrapper.run(null);
+
+            var after = codes.stream()
+                    .map(code -> questService.getDefinition(
+                            new QuestCommand.Definition(code.value())
+                    ))
+                    .toList();
+            assertThat(after)
+                    .extracting(definition -> definition.id())
+                    .containsExactlyElementsOf(
+                            before.stream()
+                                    .map(definition -> definition.id())
+                                    .toList()
+                    );
         }
     }
 

--- a/src/test/java/online/lifeasgame/quest/api/QuestResponseContractTest.java
+++ b/src/test/java/online/lifeasgame/quest/api/QuestResponseContractTest.java
@@ -229,6 +229,56 @@ class QuestResponseContractTest {
             assertThat(player.repeatPolicy()).isEqualTo("DAILY");
             assertThat(player.roleTemplateCode()).isNull();
         }
+
+        @Test
+        @DisplayName("final-contract의 nullable legacy category를 Admin/Player 응답에 그대로 노출한다")
+        void exposesNullLegacyCategoryForFinalContract() {
+            QuestBlueprint blueprint = QuestBlueprint.finalContract(
+                    QuestCode.Q_RECORD_FIRST_TRACE,
+                    1,
+                    QuestSemanticCategory.RECORD,
+                    QuestTitle.of("첫 흔적 남기기"),
+                    "사용자가 직접 작성한 LifeLog 한 건을 남기면 완료됩니다.",
+                    QuestTarget.of(QuestTargetType.COUNT, 1),
+                    QuestProgressSource.RECORD_CREATED,
+                    RewardProfileRef.of("RP_EXP_TINY_10"),
+                    QuestRepeatRule.ONCE,
+                    null,
+                    null,
+                    QuestCompletionPolicy.AUTO
+            );
+            Quest quest = blueprint.instantiate();
+
+            AdminQuestResponse.Blueprint adminCatalog =
+                    AdminQuestWebMapper.toBlueprints(List.of(
+                                    QuestResult.Blueprint.from(blueprint)
+                            ))
+                            .blueprints()
+                            .getFirst();
+            AdminQuestResponse.Definition adminDefinition =
+                    AdminQuestWebMapper.toDefinition(
+                            QuestResult.Definition.from(quest)
+                    );
+            QuestResponse.Blueprint playerCatalog =
+                    QuestWebMapper.toBlueprint(
+                            QuestResult.Blueprint.from(blueprint)
+                    );
+            QuestResponse.PlayerQuest playerDetail =
+                    QuestWebMapper.toPlayerQuest(
+                            QuestResult.PlayerQuest.from(quest, null)
+                    );
+
+            assertThat(adminCatalog.category()).isNull();
+            assertThat(adminDefinition.category()).isNull();
+            assertThat(playerCatalog.category()).isNull();
+            assertThat(playerDetail.category()).isNull();
+            assertThat(adminDefinition.semanticCategory()).isEqualTo("RECORD");
+            assertThat(playerDetail.progressSource())
+                    .isEqualTo("RECORD_CREATED");
+            assertThat(playerDetail.rewardProfileCode())
+                    .isEqualTo("RP_EXP_TINY_10");
+            assertThat(playerDetail.roleTemplateCode()).isNull();
+        }
     }
 
     private Quest quest() {

--- a/src/test/java/online/lifeasgame/quest/application/QuestDefinitionServiceTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/QuestDefinitionServiceTest.java
@@ -2,10 +2,12 @@ package online.lifeasgame.quest.application;
 
 import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.core.event.DomainEventPublisher;
+import online.lifeasgame.quest.application.blueprint.StaticQuestBlueprintCatalog;
 import online.lifeasgame.quest.application.command.QuestCommand;
 import online.lifeasgame.quest.application.result.QuestResult;
 import online.lifeasgame.quest.domain.*;
 import online.lifeasgame.quest.domain.error.QuestError;
+import online.lifeasgame.quest.domain.seed.SeedLevel1Quest;
 import online.lifeasgame.reward.application.internal.RewardProfileLookupApi;
 import online.lifeasgame.reward.domain.error.RewardError;
 import org.junit.jupiter.api.BeforeEach;
@@ -287,6 +289,107 @@ class QuestDefinitionServiceTest {
         assertThat(result.roleTemplateCodeOrNull()).isEqualTo("ROLE_READER");
         verify(rewardProfileLookupApi).getActiveByCode("RP_EXP_30");
         verify(questWriter).create(any());
+    }
+
+    @Test
+    @DisplayName("Seed Level 1 신규 5개를 materialize하며 세 공식 Reward Profile을 active 조회한다")
+    void materializesSeedLevel1BlueprintsWithActiveProfiles() {
+        StaticQuestBlueprintCatalog staticCatalog =
+                new StaticQuestBlueprintCatalog();
+        QuestService seedService = new QuestService(
+                staticCatalog,
+                questReader,
+                questWriter,
+                rewardProfileLookupApi,
+                domainEventPublisher
+        );
+        given(questReader.findByCode(any(QuestCode.class)))
+                .willReturn(Optional.empty());
+        given(rewardProfileLookupApi.getActiveByCode(anyString()))
+                .willAnswer(invocation ->
+                        reference(invocation.getArgument(0))
+                );
+        given(questWriter.create(any())).willAnswer(
+                invocation -> invocation.getArgument(0)
+        );
+
+        var quests = SeedLevel1Quest.definitions().stream()
+                .map(definition ->
+                        seedService.ensureQuest(definition.questCode()))
+                .toList();
+
+        assertThat(quests).hasSize(5)
+                .allSatisfy(quest -> {
+                    assertThat(quest.getCategory()).isNull();
+                    assertThat(quest.getSemanticCategory()).isNotNull();
+                    assertThat(quest.roleTemplateCodeOrNull()).isNull();
+                });
+        verify(rewardProfileLookupApi)
+                .getActiveByCode("RP_EXP_TINY_10");
+        verify(rewardProfileLookupApi)
+                .getActiveByCode("RP_EXP_AND_ITEM_FIRST_STEP_20");
+        verify(rewardProfileLookupApi, times(3))
+                .getActiveByCode("RP_NONE");
+        verify(questWriter, times(5)).create(any());
+    }
+
+    @Test
+    @DisplayName("Seed Level 1 Reward Profile이 missing/inactive이면 Quest를 저장하지 않는다")
+    void doesNotMaterializeSeedWithUnavailableProfile() {
+        StaticQuestBlueprintCatalog staticCatalog =
+                new StaticQuestBlueprintCatalog();
+        QuestService seedService = new QuestService(
+                staticCatalog,
+                questReader,
+                questWriter,
+                rewardProfileLookupApi,
+                domainEventPublisher
+        );
+        given(questReader.findByCode(QuestCode.Q_RECORD_FIRST_TRACE))
+                .willReturn(Optional.empty());
+        given(rewardProfileLookupApi.getActiveByCode("RP_EXP_TINY_10"))
+                .willThrow(new DomainException(
+                        RewardError.REWARD_PROFILE_INACTIVE
+                ));
+
+        assertRewardError(
+                () -> seedService.ensureQuest(
+                        QuestCode.Q_RECORD_FIRST_TRACE
+                ),
+                RewardError.REWARD_PROFILE_INACTIVE
+        );
+
+        verifyNoInteractions(questWriter);
+    }
+
+    @Test
+    @DisplayName("Bootstrap 재실행 시 이미 존재하는 Seed Quest를 그대로 반환한다")
+    void keepsExistingSeedQuestOnEnsureReplay() {
+        StaticQuestBlueprintCatalog staticCatalog =
+                new StaticQuestBlueprintCatalog();
+        Quest existing = staticCatalog
+                .require(QuestCode.Q_RECORD_FIRST_TRACE)
+                .instantiate();
+        QuestService seedService = new QuestService(
+                staticCatalog,
+                questReader,
+                questWriter,
+                rewardProfileLookupApi,
+                domainEventPublisher
+        );
+        given(questReader.findByCode(QuestCode.Q_RECORD_FIRST_TRACE))
+                .willReturn(Optional.of(existing));
+
+        Quest replay = seedService.ensureQuest(
+                QuestCode.Q_RECORD_FIRST_TRACE
+        );
+
+        assertThat(replay).isSameAs(existing);
+        verifyNoInteractions(
+                questWriter,
+                rewardProfileLookupApi,
+                domainEventPublisher
+        );
     }
 
     private void stubExisting(Quest quest) {

--- a/src/test/java/online/lifeasgame/quest/application/QuestServiceStateContractTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/QuestServiceStateContractTest.java
@@ -3,6 +3,7 @@ package online.lifeasgame.quest.application;
 import online.lifeasgame.core.event.DomainEvent;
 import online.lifeasgame.core.event.DomainEventPublisher;
 import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.quest.application.blueprint.StaticQuestBlueprintCatalog;
 import online.lifeasgame.quest.application.command.QuestCommand;
 import online.lifeasgame.quest.application.result.QuestResult;
 import online.lifeasgame.quest.domain.*;
@@ -233,6 +234,42 @@ class QuestServiceStateContractTest {
                                                     .QUEST_ACCEPTANCE_ALREADY_EXISTS
                                     )
                     );
+        }
+
+        @Test
+        @DisplayName("신규 Seed Quest를 nullable category와 공식 code로 수락한다")
+        void acceptsSeedLevel1Quest() {
+            Quest quest = new StaticQuestBlueprintCatalog()
+                    .require(QuestCode.Q_RECORD_FIRST_TRACE)
+                    .instantiate();
+            ReflectionTestUtils.setField(quest, "id", QUEST_ID);
+            given(questReader.getByCode(
+                    QuestCode.Q_RECORD_FIRST_TRACE
+            )).willReturn(quest);
+            given(questReader.findLatest(QUEST_ID, PLAYER_ID))
+                    .willReturn(null);
+            given(questWriter.accept(any())).willAnswer(
+                    invocation -> invocation.getArgument(0)
+            );
+
+            QuestResult.Acceptance result = service.accept(
+                    PLAYER_ID,
+                    new QuestCommand.Accept(
+                            "Q_RECORD_FIRST_TRACE",
+                            null,
+                            null
+                    )
+            );
+
+            assertThat(result.code()).isEqualTo("Q_RECORD_FIRST_TRACE");
+            assertThat(result.category()).isNull();
+            assertThat(result.semanticCategory()).isEqualTo("RECORD");
+            assertThat(result.progressSource())
+                    .isEqualTo("RECORD_CREATED");
+            assertThat(result.targetType())
+                    .isEqualTo(QuestTargetType.COUNT);
+            assertThat(result.targetValue()).isEqualTo(1);
+            assertThat(result.repeatPolicy()).isEqualTo("ONCE");
         }
     }
 

--- a/src/test/java/online/lifeasgame/quest/application/blueprint/SeedLevel1QuestBlueprintAdapterTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/blueprint/SeedLevel1QuestBlueprintAdapterTest.java
@@ -1,0 +1,166 @@
+package online.lifeasgame.quest.application.blueprint;
+
+import online.lifeasgame.quest.domain.QuestBlueprint;
+import online.lifeasgame.quest.domain.QuestCategory;
+import online.lifeasgame.quest.domain.QuestCode;
+import online.lifeasgame.quest.domain.QuestCompletionPolicy;
+import online.lifeasgame.quest.domain.QuestProgressSource;
+import online.lifeasgame.quest.domain.QuestRepeatRule;
+import online.lifeasgame.quest.domain.QuestSemanticCategory;
+import online.lifeasgame.quest.domain.QuestTargetType;
+import online.lifeasgame.quest.domain.seed.SeedLevel1Quest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+@DisplayName("Content 1B Seed Level 1 Quest Blueprint adapter")
+class SeedLevel1QuestBlueprintAdapterTest {
+
+    @Test
+    @DisplayName("공식 target/source/completion/repeat/reward를 Runtime 계약으로 투영한다")
+    void mapsContentContractToRuntimeBlueprints() {
+        Map<QuestCode, QuestBlueprint> blueprints =
+                SeedLevel1Quest.definitions().stream()
+                        .map(SeedLevel1QuestBlueprintAdapter::toBlueprint)
+                        .collect(Collectors.toMap(
+                                QuestBlueprint::code,
+                                Function.identity()
+                        ));
+
+        assertThat(blueprints.values())
+                .extracting(
+                        QuestBlueprint::code,
+                        blueprint -> blueprint.target().type(),
+                        blueprint -> blueprint.target().value(),
+                        QuestBlueprint::progressSource,
+                        QuestBlueprint::completionPolicy,
+                        QuestBlueprint::repeatPolicy,
+                        QuestBlueprint::rewardProfileCodeOrNull
+                )
+                .containsExactlyInAnyOrder(
+                        tuple(
+                                QuestCode.Q_RECORD_FIRST_TRACE,
+                                QuestTargetType.COUNT,
+                                1,
+                                QuestProgressSource.RECORD_CREATED,
+                                QuestCompletionPolicy.AUTO,
+                                QuestRepeatRule.ONCE,
+                                "RP_EXP_TINY_10"
+                        ),
+                        tuple(
+                                QuestCode.Q_RECORD_THREE_TRACES,
+                                QuestTargetType.COUNT,
+                                3,
+                                QuestProgressSource.RECORD_CREATED,
+                                QuestCompletionPolicy.AUTO,
+                                QuestRepeatRule.ONCE,
+                                "RP_EXP_AND_ITEM_FIRST_STEP_20"
+                        ),
+                        tuple(
+                                QuestCode.Q_RECORD_WEEKLY_LOOKBACK,
+                                QuestTargetType.COUNT,
+                                1,
+                                QuestProgressSource.RECORD_CREATED,
+                                QuestCompletionPolicy.AUTO,
+                                QuestRepeatRule.WEEKLY,
+                                "RP_NONE"
+                        ),
+                        tuple(
+                                QuestCode.Q_GROWTH_ONE_FOCUS,
+                                QuestTargetType.MINUTES,
+                                25,
+                                QuestProgressSource.MANUAL_CHECK,
+                                QuestCompletionPolicy.USER_CONFIRM,
+                                QuestRepeatRule.DAILY,
+                                "RP_NONE"
+                        ),
+                        tuple(
+                                QuestCode.Q_RECOVERY_REST_TEN,
+                                QuestTargetType.MINUTES,
+                                10,
+                                QuestProgressSource.MANUAL_CHECK,
+                                QuestCompletionPolicy.USER_CONFIRM,
+                                QuestRepeatRule.DAILY,
+                                "RP_NONE"
+                        )
+                );
+    }
+
+    @Test
+    @DisplayName("신규 final Blueprint와 materialized Quest에 legacy category/Role을 만들지 않는다")
+    void keepsLegacyCategoryAndRoleNullForFinalContracts() {
+        assertThat(SeedLevel1Quest.definitions())
+                .map(SeedLevel1QuestBlueprintAdapter::toBlueprint)
+                .allSatisfy(blueprint -> {
+                    assertThat(blueprint.isFinalContract()).isTrue();
+                    assertThat(blueprint.category()).isNull();
+                    assertThat(blueprint.roleTemplateRef()).isNull();
+
+                    var quest = blueprint.instantiate();
+                    assertThat(quest.getCategory()).isNull();
+                    assertThat(quest.getSemanticCategory()).isNotNull();
+                    assertThat(quest.roleTemplateCodeOrNull()).isNull();
+                });
+    }
+
+    @Test
+    @DisplayName("Static Catalog는 legacy를 유지하고 신규 5개를 sortOrder 순서로 제공한다")
+    void extendsStaticCatalogWithoutReinterpretingLegacyBlueprints() {
+        StaticQuestBlueprintCatalog catalog =
+                new StaticQuestBlueprintCatalog();
+        Set<QuestCode> seedCodes = SeedLevel1Quest.definitions().stream()
+                .map(definition -> definition.questCode())
+                .collect(Collectors.toSet());
+
+        assertThat(catalog.all().stream()
+                .filter(blueprint -> seedCodes.contains(blueprint.code())))
+                .extracting(QuestBlueprint::code)
+                .containsExactly(
+                        QuestCode.Q_RECORD_FIRST_TRACE,
+                        QuestCode.Q_RECORD_THREE_TRACES,
+                        QuestCode.Q_RECORD_WEEKLY_LOOKBACK,
+                        QuestCode.Q_GROWTH_ONE_FOCUS,
+                        QuestCode.Q_RECOVERY_REST_TEN
+                );
+
+        QuestBlueprint legacy = catalog.require(QuestCode.PLAYER_WELCOME);
+        assertThat(legacy.category()).isEqualTo(QuestCategory.MAIN);
+        assertThat(legacy.semanticCategory()).isNull();
+        assertThat(legacy.progressSource()).isNull();
+    }
+
+    @Test
+    @DisplayName("공식 enum name과 stable value를 그대로 parse한다")
+    void parsesOfficialStableCodes() {
+        assertThat(SeedLevel1Quest.definitions())
+                .allSatisfy(definition -> {
+                    String stableCode = definition.questCode().value();
+                    assertThat(stableCode)
+                            .isEqualTo(definition.questCode().name());
+                    assertThat(QuestCode.parse(stableCode))
+                            .isEqualTo(definition.questCode());
+                });
+    }
+
+    @Test
+    @DisplayName("semantic category는 Content 1B 분류를 그대로 유지한다")
+    void keepsSemanticCategory() {
+        assertThat(SeedLevel1Quest.definitions())
+                .map(SeedLevel1QuestBlueprintAdapter::toBlueprint)
+                .extracting(QuestBlueprint::semanticCategory)
+                .containsExactly(
+                        QuestSemanticCategory.RECORD,
+                        QuestSemanticCategory.RECORD,
+                        QuestSemanticCategory.RECORD,
+                        QuestSemanticCategory.GROWTH,
+                        QuestSemanticCategory.RECOVERY
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/quest/application/bootstrap/QuestDefinitionBootstrapperIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/bootstrap/QuestDefinitionBootstrapperIntegrationTest.java
@@ -1,0 +1,213 @@
+package online.lifeasgame.quest.application.bootstrap;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@SpringBootTest(properties = {
+        "app.quest.definition-bootstrap.enabled=true",
+        "app.outbox.enabled=false"
+})
+@ActiveProfiles({"test", "migration-test"})
+@DisplayName("Quest Definition Bootstrapper MySQL integration")
+class QuestDefinitionBootstrapperIntegrationTest {
+
+    @Container
+    private static final MySQLContainer<?> MYSQL =
+            new MySQLContainer<>("mysql:8.0.39")
+                    .withDatabaseName("lifeasgame_quest_bootstrap")
+                    .withUsername("lifeasgame")
+                    .withPassword("lifeasgame");
+
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add(
+                "spring.datasource.driver-class-name",
+                MYSQL::getDriverClassName
+        );
+    }
+
+    @Autowired
+    private QuestDefinitionBootstrapper bootstrapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    @DisplayName("V1~V14와 Reward Seed 위에서 신규 5개를 만들고 재실행해도 중복하지 않는다")
+    void materializesSeedDefinitionsIdempotently() {
+        List<QuestRow> before = seedQuestRows();
+
+        assertThat(before).hasSize(5);
+        assertThat(before).containsExactly(
+                new QuestRow(
+                        before.get(0).id(),
+                        "Q_RECORD_FIRST_TRACE",
+                        null,
+                        "RECORD",
+                        "RECORD_CREATED",
+                        "COUNT",
+                        1,
+                        "AUTO",
+                        "ONCE",
+                        1,
+                        "RP_EXP_TINY_10",
+                        null
+                ),
+                new QuestRow(
+                        before.get(1).id(),
+                        "Q_RECORD_THREE_TRACES",
+                        null,
+                        "RECORD",
+                        "RECORD_CREATED",
+                        "COUNT",
+                        3,
+                        "AUTO",
+                        "ONCE",
+                        1,
+                        "RP_EXP_AND_ITEM_FIRST_STEP_20",
+                        null
+                ),
+                new QuestRow(
+                        before.get(2).id(),
+                        "Q_RECORD_WEEKLY_LOOKBACK",
+                        null,
+                        "RECORD",
+                        "RECORD_CREATED",
+                        "COUNT",
+                        1,
+                        "AUTO",
+                        "WEEKLY",
+                        1,
+                        "RP_NONE",
+                        null
+                ),
+                new QuestRow(
+                        before.get(3).id(),
+                        "Q_GROWTH_ONE_FOCUS",
+                        null,
+                        "GROWTH",
+                        "MANUAL_CHECK",
+                        "MINUTES",
+                        25,
+                        "USER_CONFIRM",
+                        "DAILY",
+                        1,
+                        "RP_NONE",
+                        null
+                ),
+                new QuestRow(
+                        before.get(4).id(),
+                        "Q_RECOVERY_REST_TEN",
+                        null,
+                        "RECOVERY",
+                        "MANUAL_CHECK",
+                        "MINUTES",
+                        10,
+                        "USER_CONFIRM",
+                        "DAILY",
+                        1,
+                        "RP_NONE",
+                        null
+                )
+        );
+
+        bootstrapper.run(null);
+
+        assertThat(seedQuestRows()).isEqualTo(before);
+        assertThat(seedQuestCount()).isEqualTo(5);
+    }
+
+    private List<QuestRow> seedQuestRows() {
+        return jdbcTemplate.query("""
+                SELECT
+                    id,
+                    code,
+                    category,
+                    semantic_category,
+                    progress_source,
+                    target_type,
+                    target_value,
+                    completion_policy,
+                    repeat_rule,
+                    definition_version,
+                    reward_profile_code,
+                    role_template_code
+                FROM quests
+                WHERE code IN (
+                    'Q_RECORD_FIRST_TRACE',
+                    'Q_RECORD_THREE_TRACES',
+                    'Q_RECORD_WEEKLY_LOOKBACK',
+                    'Q_GROWTH_ONE_FOCUS',
+                    'Q_RECOVERY_REST_TEN'
+                )
+                ORDER BY FIELD(
+                    code,
+                    'Q_RECORD_FIRST_TRACE',
+                    'Q_RECORD_THREE_TRACES',
+                    'Q_RECORD_WEEKLY_LOOKBACK',
+                    'Q_GROWTH_ONE_FOCUS',
+                    'Q_RECOVERY_REST_TEN'
+                )
+                """, (resultSet, rowNumber) -> new QuestRow(
+                resultSet.getLong("id"),
+                resultSet.getString("code"),
+                resultSet.getString("category"),
+                resultSet.getString("semantic_category"),
+                resultSet.getString("progress_source"),
+                resultSet.getString("target_type"),
+                resultSet.getInt("target_value"),
+                resultSet.getString("completion_policy"),
+                resultSet.getString("repeat_rule"),
+                resultSet.getInt("definition_version"),
+                resultSet.getString("reward_profile_code"),
+                resultSet.getString("role_template_code")
+        ));
+    }
+
+    private int seedQuestCount() {
+        return jdbcTemplate.queryForObject("""
+                SELECT COUNT(*)
+                FROM quests
+                WHERE code IN (
+                    'Q_RECORD_FIRST_TRACE',
+                    'Q_RECORD_THREE_TRACES',
+                    'Q_RECORD_WEEKLY_LOOKBACK',
+                    'Q_GROWTH_ONE_FOCUS',
+                    'Q_RECOVERY_REST_TEN'
+                )
+                """, Integer.class);
+    }
+
+    private record QuestRow(
+            long id,
+            String code,
+            String category,
+            String semanticCategory,
+            String progressSource,
+            String targetType,
+            int targetValue,
+            String completionPolicy,
+            String repeatRule,
+            int definitionVersion,
+            String rewardProfileCode,
+            String roleTemplateCode
+    ) {
+    }
+}

--- a/src/test/java/online/lifeasgame/quest/domain/QuestSemanticDefinitionContractTest.java
+++ b/src/test/java/online/lifeasgame/quest/domain/QuestSemanticDefinitionContractTest.java
@@ -34,6 +34,30 @@ class QuestSemanticDefinitionContractTest {
         }
 
         @Test
+        @DisplayName("final-contract는 legacy category 없이 semantic category로 생성한다")
+        void allowsNullLegacyCategory() {
+            Quest quest = Quest.createDefinition(
+                    "Q_TEST_FINAL_WITHOUT_LEGACY_CATEGORY",
+                    1,
+                    QuestSemanticCategory.RECORD,
+                    QuestTitle.of("Final without legacy category"),
+                    "final category contract",
+                    QuestTarget.of(QuestTargetType.COUNT, 1),
+                    QuestProgressSource.RECORD_CREATED,
+                    RewardProfileRef.of("RP_NONE"),
+                    QuestRepeatRule.ONCE,
+                    null,
+                    QuestCompletionPolicy.AUTO,
+                    null
+            );
+
+            assertThat(quest.isFinalContract()).isTrue();
+            assertThat(quest.getCategory()).isNull();
+            assertThat(quest.getSemanticCategory())
+                    .isEqualTo(QuestSemanticCategory.RECORD);
+        }
+
+        @Test
         @DisplayName("semantic category는 필수다")
         void requiresSemanticCategory() {
             assertQuestError(
@@ -215,6 +239,23 @@ class QuestSemanticDefinitionContractTest {
         assertThat(quest.roleTemplateCodeOrNull()).isNull();
         assertThat(quest.getCategory()).isEqualTo(QuestCategory.REPEAT);
         assertThat(quest.getRepeatRule()).isEqualTo(QuestRepeatRule.MONTHLY);
+    }
+
+    @Test
+    @DisplayName("legacy 생성은 기존 category를 계속 필수로 요구한다")
+    void requiresLegacyCategory() {
+        assertThatThrownBy(() -> Quest.create(
+                "quest:test:legacy-without-category",
+                null,
+                QuestTitle.of("Legacy without category"),
+                "invalid legacy",
+                QuestTarget.of(QuestTargetType.COUNT, 1),
+                QuestReward.of(0, RewardStats.empty()),
+                QuestRepeatRule.NONE,
+                null
+        ))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("category must not be null");
     }
 
     private Quest finalQuest(QuestRoleTemplateRef roleTemplateRef) {

--- a/src/test/java/online/lifeasgame/quest/domain/event/QuestEventDefinitionSnapshotTest.java
+++ b/src/test/java/online/lifeasgame/quest/domain/event/QuestEventDefinitionSnapshotTest.java
@@ -59,6 +59,38 @@ class QuestEventDefinitionSnapshotTest {
     }
 
     @Test
+    @DisplayName("legacy category 없는 final Snapshot은 category를 제외하고 semantic category를 유지한다")
+    void omitsNullLegacyCategoryFromFinalSnapshot() {
+        Quest quest = Quest.createDefinition(
+                "Q_TEST_FINAL_EVENT",
+                1,
+                QuestSemanticCategory.RECORD,
+                QuestTitle.of("Final Event Quest"),
+                "final event",
+                QuestTarget.of(QuestTargetType.COUNT, 1),
+                QuestProgressSource.RECORD_CREATED,
+                RewardProfileRef.of("RP_NONE"),
+                QuestRepeatRule.ONCE,
+                null,
+                QuestCompletionPolicy.AUTO,
+                null
+        );
+
+        QuestEvent event = QuestEvent.snapshot(
+                QuestEventType.QUEST_COMPLETED,
+                quest,
+                "quest:test:final-event:completed"
+        );
+
+        assertThat(event.attributes())
+                .containsEntry("questSemanticCategory", "RECORD")
+                .containsEntry("progressSource", "RECORD_CREATED")
+                .containsEntry("repeatPolicy", "ONCE")
+                .containsEntry("rewardProfileCode", "RP_NONE")
+                .doesNotContainKey("category");
+    }
+
+    @Test
     @DisplayName("legacy QuestCompleted는 version 1과 inline reward Snapshot을 유지한다")
     void snapshotsLegacyDefinition() {
         QuestEvent event = QuestEvent.snapshot(
@@ -69,6 +101,7 @@ class QuestEventDefinitionSnapshotTest {
 
         assertThat(event.type()).isEqualTo(QuestEventType.QUEST_COMPLETED);
         assertThat(event.attributes())
+                .containsEntry("category", "MAIN")
                 .containsEntry("questDefinitionVersion", 1)
                 .containsEntry("rewardExp", 7)
                 .containsEntry("rewardStats", java.util.Map.of("strength", 2))

--- a/src/test/java/online/lifeasgame/quest/domain/seed/SeedLevel1QuestTest.java
+++ b/src/test/java/online/lifeasgame/quest/domain/seed/SeedLevel1QuestTest.java
@@ -1,0 +1,390 @@
+package online.lifeasgame.quest.domain.seed;
+
+import online.lifeasgame.quest.domain.QuestCode;
+import online.lifeasgame.quest.domain.QuestRepeatRule;
+import online.lifeasgame.quest.domain.QuestSemanticCategory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DisplayName("Content 1B Seed Level 1 Quest Catalog")
+class SeedLevel1QuestTest {
+
+    @Test
+    @DisplayName("공식 5개 code와 공통 계약을 sortOrder 순서로 보존한다")
+    void preservesOfficialLedgerAndCommonContract() {
+        List<SeedLevel1QuestDefinition> definitions =
+                SeedLevel1Quest.definitions();
+
+        assertThat(definitions).hasSize(5);
+        assertThat(definitions)
+                .extracting(SeedLevel1QuestDefinition::questCode)
+                .containsExactly(
+                        QuestCode.Q_RECORD_FIRST_TRACE,
+                        QuestCode.Q_RECORD_THREE_TRACES,
+                        QuestCode.Q_RECORD_WEEKLY_LOOKBACK,
+                        QuestCode.Q_GROWTH_ONE_FOCUS,
+                        QuestCode.Q_RECOVERY_REST_TEN
+                )
+                .doesNotHaveDuplicates();
+        assertThat(definitions)
+                .extracting(SeedLevel1QuestDefinition::sortOrder)
+                .containsExactly(10, 20, 30, 40, 50)
+                .doesNotHaveDuplicates();
+        assertThat(definitions)
+                .allSatisfy(definition -> {
+                    assertThat(definition.seedLevel()).isEqualTo(1);
+                    assertThat(definition.priority())
+                            .isEqualTo(QuestContentPriority.P0);
+                    assertThat(definition.definitionVersion()).isEqualTo(1);
+                    assertThat(definition.status())
+                            .isEqualTo(QuestDefinitionStatus.ACTIVE);
+                    assertThat(definition.allowedRoleTypes())
+                            .containsExactly("ANY");
+                    assertThat(definition.manualCheckRequiresMemo()).isFalse();
+                });
+    }
+
+    @Test
+    @DisplayName("Q_RECORD_FIRST_TRACE의 Content 1B 원문 계약을 보존한다")
+    void preservesFirstTraceContract() {
+        SeedLevel1QuestDefinition definition =
+                SeedLevel1Quest.RECORD_FIRST_TRACE.definition();
+
+        assertSoftly(softly -> {
+            softly.assertThat(definition.displayNameKo())
+                    .isEqualTo("첫 흔적 남기기");
+            softly.assertThat(definition.shortDescriptionKo())
+                    .isEqualTo("오늘의 생각·행동·기억 중 하나를 짧게 남겨보세요.");
+            softly.assertThat(definition.longDescriptionKo())
+                    .isEqualTo(
+                            "사용자가 직접 작성한 LifeLog 한 건을 남기면 완료됩니다. "
+                                    + "Quick LifeLog도 실제 LifeLog로 저장되고 사용자 작성 "
+                                    + "기록이라는 조건을 충족하면 인정합니다."
+                    );
+            assertRecordFact(softly, definition);
+            softly.assertThat(definition.sourceOwnerRule()).isEqualTo(
+                    "event.playerId == questAcceptance.playerId; "
+                            + "event.occurredAt >= acceptance.acceptedAt"
+            );
+            softly.assertThat(definition.targetValue()).isEqualTo(1);
+            softly.assertThat(definition.targetUnit())
+                    .isEqualTo(QuestContentTargetUnit.DISTINCT_LIFELOG);
+            softly.assertThat(definition.repeatPolicy())
+                    .isEqualTo(QuestRepeatRule.ONCE);
+            softly.assertThat(definition.periodBoundary())
+                    .isEqualTo(QuestContentPeriodBoundary.PLAYER_LIFETIME);
+            assertAutomaticNoTimezone(softly, definition);
+            softly.assertThat(definition.rewardProfileCode())
+                    .isEqualTo("RP_EXP_TINY_10");
+            softly.assertThat(definition.cancellationPolicy()).isEqualTo(
+                    "완료 전 취소와 새 attempt 허용; 한 번 완료되면 재수락 불가"
+            );
+            softly.assertThat(definition.failurePressurePolicy())
+                    .isEqualTo("미완료/취소 페널티 없음");
+            softly.assertThat(definition.notes()).containsExactly(
+                    "허용 subtype의 사용자 작성 LifeLogRecorded 1건에서 자동 완료",
+                    "동일 eventId 또는 lifeLogId 재전달 무시"
+            );
+            assertPresentation(
+                    softly,
+                    definition,
+                    "icon.quest.record.first_trace",
+                    "quest.record.primary",
+                    "quest.q_record_first_trace.completed",
+                    "quest.q_record_first_trace.empty"
+            );
+        });
+    }
+
+    @Test
+    @DisplayName("Q_RECORD_THREE_TRACES의 distinct LifeLog 계약을 보존한다")
+    void preservesThreeTracesContract() {
+        SeedLevel1QuestDefinition definition =
+                SeedLevel1Quest.RECORD_THREE_TRACES.definition();
+
+        assertSoftly(softly -> {
+            softly.assertThat(definition.displayNameKo())
+                    .isEqualTo("흔적 세 개 이어보기");
+            softly.assertThat(definition.shortDescriptionKo()).isEqualTo(
+                    "서로 다른 순간의 기록을 세 개 남겨 작은 흐름을 만들어보세요."
+            );
+            softly.assertThat(definition.longDescriptionKo()).isEqualTo(
+                    "수락 이후 사용자가 직접 남긴 서로 다른 LifeLog 세 건을 연결합니다. "
+                            + "수정은 새 기록으로 보지 않으며 중복 전달은 진행도를 올리지 "
+                            + "않습니다."
+            );
+            assertRecordFact(softly, definition);
+            softly.assertThat(definition.sourceOwnerRule()).isEqualTo(
+                    "event.playerId == questAcceptance.playerId; "
+                            + "event.occurredAt >= acceptance.acceptedAt"
+            );
+            softly.assertThat(definition.targetValue()).isEqualTo(3);
+            softly.assertThat(definition.targetUnit())
+                    .isEqualTo(QuestContentTargetUnit.DISTINCT_LIFELOG);
+            softly.assertThat(definition.repeatPolicy())
+                    .isEqualTo(QuestRepeatRule.ONCE);
+            softly.assertThat(definition.periodBoundary()).isEqualTo(
+                    QuestContentPeriodBoundary
+                            .FROM_ACCEPTANCE_UNTIL_COMPLETION
+            );
+            assertAutomaticNoTimezone(softly, definition);
+            softly.assertThat(definition.rewardProfileCode())
+                    .isEqualTo("RP_EXP_AND_ITEM_FIRST_STEP_20");
+            assertPresentation(
+                    softly,
+                    definition,
+                    "icon.quest.record.three_traces",
+                    "quest.record.secondary",
+                    "quest.q_record_three_traces.completed",
+                    "quest.q_record_three_traces.empty"
+            );
+        });
+    }
+
+    @Test
+    @DisplayName("Q_RECORD_WEEKLY_LOOKBACK의 주간 회고와 timezone 계약을 보존한다")
+    void preservesWeeklyLookbackContract() {
+        SeedLevel1QuestDefinition definition =
+                SeedLevel1Quest.RECORD_WEEKLY_LOOKBACK.definition();
+
+        assertSoftly(softly -> {
+            softly.assertThat(definition.displayNameKo())
+                    .isEqualTo("이번 주 흔적 돌아보기");
+            softly.assertThat(definition.shortDescriptionKo()).isEqualTo(
+                    "이번 주 기록 중 하나를 골라 지금의 나에게 남길 한 줄을 적어보세요."
+            );
+            softly.assertThat(definition.longDescriptionKo()).isEqualTo(
+                    "별도 회고 전용 Entity를 만들지 않고 LifeLog subtype REFLECTION과 "
+                            + "reflectionScope WEEKLY_LOOKBACK 메타데이터로 주간 회고를 "
+                            + "식별합니다."
+            );
+            assertRecordFact(softly, definition);
+            softly.assertThat(definition.sourceOwnerRule()).isEqualTo(
+                    "event.playerId == questAcceptance.playerId; "
+                            + "event.subtype == REFLECTION; "
+                            + "event.reflectionScope == WEEKLY_LOOKBACK; "
+                            + "event.periodKey == acceptance.periodKey"
+            );
+            softly.assertThat(definition.targetValue()).isEqualTo(1);
+            softly.assertThat(definition.targetUnit())
+                    .isEqualTo(QuestContentTargetUnit.WEEKLY_REFLECTION);
+            softly.assertThat(definition.repeatPolicy())
+                    .isEqualTo(QuestRepeatRule.WEEKLY);
+            softly.assertThat(definition.periodBoundary()).isEqualTo(
+                    QuestContentPeriodBoundary
+                            .MONDAY_00_00_INCLUSIVE_TO_NEXT_MONDAY_00_00_EXCLUSIVE
+            );
+            softly.assertThat(definition.periodBoundary().value()).isEqualTo(
+                    "MONDAY_00:00_INCLUSIVE_TO_NEXT_MONDAY_00:00_EXCLUSIVE"
+            );
+            assertAutomaticPlayerTimezone(softly, definition);
+            softly.assertThat(definition.rewardProfileCode())
+                    .isEqualTo("RP_NONE");
+            assertPresentation(
+                    softly,
+                    definition,
+                    "icon.quest.record.weekly_lookback",
+                    "quest.record.reflection",
+                    "quest.q_record_weekly_lookback.completed",
+                    "quest.q_record_weekly_lookback.empty"
+            );
+        });
+    }
+
+    @Test
+    @DisplayName("Q_GROWTH_ONE_FOCUS의 manual focus 정책을 보존한다")
+    void preservesGrowthFocusContract() {
+        SeedLevel1QuestDefinition definition =
+                SeedLevel1Quest.GROWTH_ONE_FOCUS.definition();
+
+        assertSoftly(softly -> {
+            softly.assertThat(definition.displayNameKo())
+                    .isEqualTo("한 가지에 25분 집중하기");
+            softly.assertThat(definition.shortDescriptionKo())
+                    .isEqualTo("지금 가장 작은 한 가지를 골라 25분만 집중해보세요.");
+            softly.assertThat(definition.longDescriptionKo()).isEqualTo(
+                    "사용자는 시작 전에 집중할 한 가지를 1~80자 자유 텍스트로 입력하고, "
+                            + "집중을 마친 뒤 직접 완료를 확인합니다. 서버는 집중 내용이나 "
+                            + "성과를 평가하지 않습니다."
+            );
+            assertManualConfirmation(softly, definition);
+            softly.assertThat(definition.semanticCategory())
+                    .isEqualTo(QuestSemanticCategory.GROWTH);
+            softly.assertThat(definition.targetValue()).isEqualTo(25);
+            softly.assertThat(definition.repeatPolicy())
+                    .isEqualTo(QuestRepeatRule.DAILY);
+            softly.assertThat(definition.rewardProfileCode())
+                    .isEqualTo("RP_NONE");
+            softly.assertThat(definition.notes()).containsExactly(
+                    "Focus enum 신설 금지",
+                    "focusLabel은 후속 Manual API에서 1~80자 필수",
+                    "추천 Role은 optional이며 현재 single roleTemplateCode로 축약 금지"
+            );
+            assertPresentation(
+                    softly,
+                    definition,
+                    "icon.quest.growth.one_focus",
+                    "quest.growth.primary",
+                    "quest.q_growth_one_focus.completed",
+                    "quest.q_growth_one_focus.empty"
+            );
+        });
+    }
+
+    @Test
+    @DisplayName("Q_RECOVERY_REST_TEN의 manual recovery와 무압박 정책을 보존한다")
+    void preservesRecoveryRestContract() {
+        SeedLevel1QuestDefinition definition =
+                SeedLevel1Quest.RECOVERY_REST_TEN.definition();
+
+        assertSoftly(softly -> {
+            softly.assertThat(definition.displayNameKo())
+                    .isEqualTo("10분 쉬어가기");
+            softly.assertThat(definition.shortDescriptionKo())
+                    .isEqualTo("아무것도 증명하지 않아도 되는 10분을 가져보세요.");
+            softly.assertThat(definition.longDescriptionKo()).isEqualTo(
+                    "사용자가 10분 정도 쉬었다고 직접 확인하면 완료합니다. P0에서는 "
+                            + "Timer, Exercise, LifeLog를 필수 원본으로 요구하지 않습니다."
+            );
+            assertManualConfirmation(softly, definition);
+            softly.assertThat(definition.semanticCategory())
+                    .isEqualTo(QuestSemanticCategory.RECOVERY);
+            softly.assertThat(definition.targetValue()).isEqualTo(10);
+            softly.assertThat(definition.repeatPolicy())
+                    .isEqualTo(QuestRepeatRule.DAILY);
+            softly.assertThat(definition.rewardProfileCode())
+                    .isEqualTo("RP_NONE");
+            softly.assertThat(definition.failurePressurePolicy())
+                    .isEqualTo("미완료 불이익/연속 수행 압박 금지");
+            softly.assertThat(definition.notes()).containsExactly(
+                    "Timer 증빙 강제 금지",
+                    "부분 시간 누적 금지",
+                    "미완료 불이익/연속 수행 압박 금지"
+            );
+            assertPresentation(
+                    softly,
+                    definition,
+                    "icon.quest.recovery.rest_ten",
+                    "quest.recovery.calm",
+                    "quest.q_recovery_rest_ten.completed",
+                    "quest.q_recovery_rest_ten.empty"
+            );
+        });
+    }
+
+    @Test
+    @DisplayName("Catalog와 collection metadata는 외부에서 변경할 수 없다")
+    void isImmutable() {
+        SeedLevel1QuestDefinition definition =
+                SeedLevel1Quest.RECORD_FIRST_TRACE.definition();
+
+        assertThatThrownBy(() ->
+                SeedLevel1Quest.definitions().add(definition)
+        ).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() ->
+                definition.allowedRoleTypes().add("ROLE")
+        ).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() ->
+                definition.notes().add("changed")
+        ).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    private void assertRecordFact(
+            org.assertj.core.api.SoftAssertions softly,
+            SeedLevel1QuestDefinition definition
+    ) {
+        softly.assertThat(definition.semanticCategory())
+                .isEqualTo(QuestSemanticCategory.RECORD);
+        softly.assertThat(definition.progressMode())
+                .isEqualTo(QuestProgressMode.EVENT_COUNT);
+        softly.assertThat(definition.progressSourceType())
+                .isEqualTo(QuestProgressSourceType.DURABLE_OUTBOX_FACT);
+        softly.assertThat(definition.sourceEventType())
+                .isEqualTo("LifeLogRecorded");
+        softly.assertThat(definition.sourceEntityType())
+                .isEqualTo("LIFE_LOG");
+    }
+
+    private void assertAutomaticNoTimezone(
+            org.assertj.core.api.SoftAssertions softly,
+            SeedLevel1QuestDefinition definition
+    ) {
+        softly.assertThat(definition.autoComplete()).isTrue();
+        softly.assertThat(definition.manualCheckAllowed()).isFalse();
+        softly.assertThat(definition.timezonePolicy())
+                .isEqualTo(QuestContentTimezonePolicy.NOT_APPLICABLE);
+        softly.assertThat(definition.timezoneFallback()).isNull();
+        softly.assertThat(definition.roleContextPolicy()).isEqualTo(
+                QuestRoleContextPolicy.OPTIONAL_SOURCE_ROLE_CONTEXT
+        );
+    }
+
+    private void assertAutomaticPlayerTimezone(
+            org.assertj.core.api.SoftAssertions softly,
+            SeedLevel1QuestDefinition definition
+    ) {
+        softly.assertThat(definition.autoComplete()).isTrue();
+        softly.assertThat(definition.manualCheckAllowed()).isFalse();
+        softly.assertThat(definition.timezonePolicy())
+                .isEqualTo(QuestContentTimezonePolicy.PLAYER_PROFILE_TIMEZONE);
+        softly.assertThat(definition.timezoneFallback())
+                .isEqualTo("Asia/Seoul");
+        softly.assertThat(definition.roleContextPolicy()).isEqualTo(
+                QuestRoleContextPolicy.OPTIONAL_SOURCE_ROLE_CONTEXT
+        );
+    }
+
+    private void assertManualConfirmation(
+            org.assertj.core.api.SoftAssertions softly,
+            SeedLevel1QuestDefinition definition
+    ) {
+        softly.assertThat(definition.progressMode())
+                .isEqualTo(QuestProgressMode.MANUAL_CHECK);
+        softly.assertThat(definition.progressSourceType())
+                .isEqualTo(QuestProgressSourceType.USER_CONFIRMATION);
+        softly.assertThat(definition.sourceEventType())
+                .isEqualTo("NONE_DIRECT_COMMAND");
+        softly.assertThat(definition.sourceEntityType())
+                .isEqualTo("QUEST_ACCEPTANCE");
+        softly.assertThat(definition.sourceOwnerRule())
+                .isEqualTo("command.playerId == questAcceptance.playerId");
+        softly.assertThat(definition.targetUnit())
+                .isEqualTo(QuestContentTargetUnit.MINUTE_INTENT);
+        softly.assertThat(definition.autoComplete()).isFalse();
+        softly.assertThat(definition.manualCheckAllowed()).isTrue();
+        softly.assertThat(definition.periodBoundary()).isEqualTo(
+                QuestContentPeriodBoundary.LOCAL_DAY_00_00_TO_NEXT_DAY_00_00
+        );
+        softly.assertThat(definition.periodBoundary().value())
+                .isEqualTo("LOCAL_DAY_00:00_TO_NEXT_DAY_00:00");
+        softly.assertThat(definition.timezonePolicy())
+                .isEqualTo(QuestContentTimezonePolicy.PLAYER_PROFILE_TIMEZONE);
+        softly.assertThat(definition.timezoneFallback())
+                .isEqualTo("Asia/Seoul");
+        softly.assertThat(definition.roleContextPolicy()).isEqualTo(
+                QuestRoleContextPolicy.OPTIONAL_RECOMMENDED_ROLE_CONTEXT
+        );
+    }
+
+    private void assertPresentation(
+            org.assertj.core.api.SoftAssertions softly,
+            SeedLevel1QuestDefinition definition,
+            String iconKey,
+            String colorToken,
+            String resultCopyKey,
+            String emptyStateCopyKey
+    ) {
+        softly.assertThat(definition.iconKey()).isEqualTo(iconKey);
+        softly.assertThat(definition.colorToken()).isEqualTo(colorToken);
+        softly.assertThat(definition.resultCopyKey()).isEqualTo(resultCopyKey);
+        softly.assertThat(definition.emptyStateCopyKey())
+                .isEqualTo(emptyStateCopyKey);
+        softly.assertThat(definition.recommendedNextAction()).isNull();
+    }
+}

--- a/src/test/java/online/lifeasgame/quest/domain/seed/SeedLevel1QuestTest.java
+++ b/src/test/java/online/lifeasgame/quest/domain/seed/SeedLevel1QuestTest.java
@@ -47,6 +47,13 @@ class SeedLevel1QuestTest {
                     assertThat(definition.allowedRoleTypes())
                             .containsExactly("ANY");
                     assertThat(definition.manualCheckRequiresMemo()).isFalse();
+                    assertThat(definition.availabilityStartAt()).isNull();
+                    assertThat(definition.availabilityEndAt()).isNull();
+                    assertThat(definition.completionPolicy()).isNotBlank();
+                    assertThat(definition.cancellationPolicy()).isNotBlank();
+                    assertThat(definition.failurePressurePolicy()).isNotBlank();
+                    assertThat(definition.recommendedNextAction()).isNotBlank();
+                    assertThat(definition.notes()).isNotBlank();
                 });
     }
 
@@ -75,6 +82,11 @@ class SeedLevel1QuestTest {
             softly.assertThat(definition.targetValue()).isEqualTo(1);
             softly.assertThat(definition.targetUnit())
                     .isEqualTo(QuestContentTargetUnit.DISTINCT_LIFELOG);
+            softly.assertThat(definition.completionPolicy()).isEqualTo(
+                    "허용 subtype의 사용자 작성 LifeLogRecorded 1건을 수신하면 goal reached와 "
+                            + "QuestCompleted를 한 번만 확정한다. 동일 eventId 또는 "
+                            + "lifeLogId 재전달은 무시한다."
+            );
             softly.assertThat(definition.repeatPolicy())
                     .isEqualTo(QuestRepeatRule.ONCE);
             softly.assertThat(definition.periodBoundary())
@@ -83,13 +95,18 @@ class SeedLevel1QuestTest {
             softly.assertThat(definition.rewardProfileCode())
                     .isEqualTo("RP_EXP_TINY_10");
             softly.assertThat(definition.cancellationPolicy()).isEqualTo(
-                    "완료 전 취소와 새 attempt 허용; 한 번 완료되면 재수락 불가"
+                    "완료 전 취소 가능; 재수락 시 새 attempt로 시작하며 새 acceptedAt 이후 "
+                            + "이벤트만 인정; 한 번 완료되면 재수락 불가"
             );
             softly.assertThat(definition.failurePressurePolicy())
-                    .isEqualTo("미완료/취소 페널티 없음");
-            softly.assertThat(definition.notes()).containsExactly(
-                    "허용 subtype의 사용자 작성 LifeLogRecorded 1건에서 자동 완료",
-                    "동일 eventId 또는 lifeLogId 재전달 무시"
+                    .isEqualTo("미완료·취소에 페널티, 연속 수행 손실, 죄책감 문구 없음");
+            softly.assertThat(definition.recommendedNextAction())
+                    .isEqualTo("Q_RECORD_THREE_TRACES 또는 방금 남긴 LifeLog 보기");
+            softly.assertThat(definition.notes()).isEqualTo(
+                    "허용 subtype: QUICK_NOTE|ACTIVITY|STUDY|PROJECT|MEMORY|REFLECTION|"
+                            + "MOOD|HEALTH_NOTE. SYSTEM_GENERATED는 제외. 기록 생성 후 "
+                            + "삭제되어도 이미 확정된 완료 사실과 보상은 되돌리지 않는다. "
+                            + "삭제 사실은 별도 정책이며 Quest 진행도 감소 원인이 아니다."
             );
             assertPresentation(
                     softly,
@@ -127,6 +144,11 @@ class SeedLevel1QuestTest {
             softly.assertThat(definition.targetValue()).isEqualTo(3);
             softly.assertThat(definition.targetUnit())
                     .isEqualTo(QuestContentTargetUnit.DISTINCT_LIFELOG);
+            softly.assertThat(definition.completionPolicy()).isEqualTo(
+                    "서로 다른 eventId이면서 서로 다른 lifeLogId인 LifeLogRecorded 세 건만 "
+                            + "누적한다. 세 번째 고유 기록에서 goal reached와 "
+                            + "QuestCompleted를 한 번만 확정한다."
+            );
             softly.assertThat(definition.repeatPolicy())
                     .isEqualTo(QuestRepeatRule.ONCE);
             softly.assertThat(definition.periodBoundary()).isEqualTo(
@@ -136,6 +158,20 @@ class SeedLevel1QuestTest {
             assertAutomaticNoTimezone(softly, definition);
             softly.assertThat(definition.rewardProfileCode())
                     .isEqualTo("RP_EXP_AND_ITEM_FIRST_STEP_20");
+            softly.assertThat(definition.cancellationPolicy()).isEqualTo(
+                    "완료 전 취소 가능; 재수락 시 진행도 0으로 새 attempt 시작; 이전 "
+                            + "attempt의 기록 이벤트는 새 attempt에 이월하지 않음"
+            );
+            softly.assertThat(definition.failurePressurePolicy())
+                    .isEqualTo("기간 만료와 연속 수행 압박 없음; 중단해도 실패 낙인 없음");
+            softly.assertThat(definition.recommendedNextAction()).isEqualTo(
+                    "Mailbox에서 첫걸음의 조각 확인 또는 ROUTE_RECORD_START 다음 단계 확인"
+            );
+            softly.assertThat(definition.notes()).isEqualTo(
+                    "수행 기간 제한 없음. 동일 LifeLog 수정 이벤트는 진행도 증가 없음. "
+                            + "동일 이벤트 재전달은 eventId 멱등 처리. 기록 삭제 후에도 "
+                            + "이미 누적·완료된 사실은 유지한다."
+            );
             assertPresentation(
                     softly,
                     definition,
@@ -174,6 +210,11 @@ class SeedLevel1QuestTest {
             softly.assertThat(definition.targetValue()).isEqualTo(1);
             softly.assertThat(definition.targetUnit())
                     .isEqualTo(QuestContentTargetUnit.WEEKLY_REFLECTION);
+            softly.assertThat(definition.completionPolicy()).isEqualTo(
+                    "해당 주기 안에 생성된 REFLECTION LifeLog 중 "
+                            + "reflectionScope=WEEKLY_LOOKBACK인 고유 기록 1건을 수신하면 "
+                            + "자동 완료한다. 본문 내용은 판정하지 않는다."
+            );
             softly.assertThat(definition.repeatPolicy())
                     .isEqualTo(QuestRepeatRule.WEEKLY);
             softly.assertThat(definition.periodBoundary()).isEqualTo(
@@ -186,6 +227,22 @@ class SeedLevel1QuestTest {
             assertAutomaticPlayerTimezone(softly, definition);
             softly.assertThat(definition.rewardProfileCode())
                     .isEqualTo("RP_NONE");
+            softly.assertThat(definition.cancellationPolicy()).isEqualTo(
+                    "해당 주기 내 완료 전 취소 가능; 다음 주기에 새 acceptance 생성 가능; "
+                            + "이전 주기 미완료는 EXPIRED가 아니라 CLOSED_INCOMPLETE로 "
+                            + "기록하되 사용자에게 실패로 표현하지 않음"
+            );
+            softly.assertThat(definition.failurePressurePolicy())
+                    .isEqualTo("미완료 페널티·연속 주차 손실·재촉 알림 없음");
+            softly.assertThat(definition.recommendedNextAction()).isEqualTo(
+                    "ROUTE_RECORD_START의 준비된 마지막 Step을 직접 advance하거나 "
+                            + "회고 LifeLog 보기"
+            );
+            softly.assertThat(definition.notes()).isEqualTo(
+                    "회고 전용 subtype 신설 불필요. REFLECTION + reflectionScope로 구분. "
+                            + "Quick LifeLog는 인정하지 않음. 다음 주기 재수행 가능. "
+                            + "주기당 Player별 완료 1회."
+            );
             assertPresentation(
                     softly,
                     definition,
@@ -217,14 +274,28 @@ class SeedLevel1QuestTest {
             softly.assertThat(definition.semanticCategory())
                     .isEqualTo(QuestSemanticCategory.GROWTH);
             softly.assertThat(definition.targetValue()).isEqualTo(25);
+            softly.assertThat(definition.completionPolicy()).isEqualTo(
+                    "focusLabel 필수, memo 선택. 사용자가 약 25분의 집중을 마쳤다고 확인하면 "
+                            + "완료한다. 타이머 증빙·성과 검증·텍스트 분석은 하지 않는다."
+            );
             softly.assertThat(definition.repeatPolicy())
                     .isEqualTo(QuestRepeatRule.DAILY);
             softly.assertThat(definition.rewardProfileCode())
                     .isEqualTo("RP_NONE");
-            softly.assertThat(definition.notes()).containsExactly(
-                    "Focus enum 신설 금지",
-                    "focusLabel은 후속 Manual API에서 1~80자 필수",
-                    "추천 Role은 optional이며 현재 single roleTemplateCode로 축약 금지"
+            softly.assertThat(definition.cancellationPolicy()).isEqualTo(
+                    "당일 완료 전 취소 가능; 같은 일자 재수락 시 새 attempt로 시작; "
+                            + "완료 후 같은 periodKey 재완료 불가"
+            );
+            softly.assertThat(definition.failurePressurePolicy())
+                    .isEqualTo("미완료·짧게 끝냄·성과 없음에 페널티나 평가 문구 없음");
+            softly.assertThat(definition.recommendedNextAction()).isEqualTo(
+                    "집중 중 알게 된 점을 짧은 LifeLog로 남기거나 오늘은 여기서 마치기"
+            );
+            softly.assertThat(definition.notes()).isEqualTo(
+                    "Focus 유형 domain enum은 P0에 만들지 않는다. 선택형 preset은 FE "
+                            + "제안값일 뿐 저장·판정 필수값이 아니다. 필수 입력은 "
+                            + "focusLabel 하나. 추천 Role Template: "
+                            + "ROLE_JOB_SEEKER|ROLE_BACKEND_DEVELOPER."
             );
             assertPresentation(
                     softly,
@@ -256,16 +327,31 @@ class SeedLevel1QuestTest {
             softly.assertThat(definition.semanticCategory())
                     .isEqualTo(QuestSemanticCategory.RECOVERY);
             softly.assertThat(definition.targetValue()).isEqualTo(10);
+            softly.assertThat(definition.completionPolicy()).isEqualTo(
+                    "한 번의 휴식 세션을 사용자가 직접 확인하면 완료한다. 부분 수행 시간은 "
+                            + "누적하지 않으며 메모와 휴식 이유는 요구하지 않는다."
+            );
             softly.assertThat(definition.repeatPolicy())
                     .isEqualTo(QuestRepeatRule.DAILY);
             softly.assertThat(definition.rewardProfileCode())
                     .isEqualTo("RP_NONE");
+            softly.assertThat(definition.cancellationPolicy()).isEqualTo(
+                    "언제든 완료 전 취소 가능; 같은 일자 재수락 가능; 미완료 attempt는 "
+                            + "일자 경계에서 CLOSED_INCOMPLETE 처리"
+            );
             softly.assertThat(definition.failurePressurePolicy())
-                    .isEqualTo("미완료 불이익/연속 수행 압박 금지");
-            softly.assertThat(definition.notes()).containsExactly(
-                    "Timer 증빙 강제 금지",
-                    "부분 시간 누적 금지",
-                    "미완료 불이익/연속 수행 압박 금지"
+                    .isEqualTo(
+                            "실패·연속 수행·손실·마감 압박 없음. 미완료 상태에서도 휴식을 "
+                                    + "권리처럼 표현하며 재촉하지 않음"
+                    );
+            softly.assertThat(definition.recommendedNextAction()).isEqualTo(
+                    "조금 더 쉬거나, 상태가 괜찮다면 짧은 LifeLog를 남기기"
+            );
+            softly.assertThat(definition.notes()).isEqualTo(
+                    "10의 단위는 minute. P0 인정 원본은 수동 확인. Rest Timer는 P1 "
+                            + "보조 입력 후보이며 완료 증빙으로 강제하지 않는다. "
+                            + "Exercise와 일반 LifeLog는 이 Quest의 완료 원본으로 "
+                            + "사용하지 않는다."
             );
             assertPresentation(
                     softly,
@@ -290,9 +376,47 @@ class SeedLevel1QuestTest {
         assertThatThrownBy(() ->
                 definition.allowedRoleTypes().add("ROLE")
         ).isInstanceOf(UnsupportedOperationException.class);
-        assertThatThrownBy(() ->
-                definition.notes().add("changed")
-        ).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    @DisplayName("필수 정책 원문은 blank를 거부하고 availability null은 허용한다")
+    void validatesRequiredPolicyTextAndOptionalAvailability() {
+        SeedLevel1QuestDefinition source =
+                SeedLevel1Quest.RECORD_FIRST_TRACE.definition();
+
+        assertThatThrownBy(() -> copyWithPolicies(
+                source,
+                " ",
+                source.cancellationPolicy(),
+                source.failurePressurePolicy()
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("completionPolicy");
+        assertThatThrownBy(() -> copyWithPolicies(
+                source,
+                source.completionPolicy(),
+                " ",
+                source.failurePressurePolicy()
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("cancellationPolicy");
+        assertThatThrownBy(() -> copyWithPolicies(
+                source,
+                source.completionPolicy(),
+                source.cancellationPolicy(),
+                " "
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("failurePressurePolicy");
+
+        SeedLevel1QuestDefinition copied = copyWithPolicies(
+                source,
+                source.completionPolicy(),
+                source.cancellationPolicy(),
+                source.failurePressurePolicy()
+        );
+        assertThat(copied.availabilityStartAt()).isNull();
+        assertThat(copied.availabilityEndAt()).isNull();
     }
 
     private void assertRecordFact(
@@ -385,6 +509,53 @@ class SeedLevel1QuestTest {
         softly.assertThat(definition.resultCopyKey()).isEqualTo(resultCopyKey);
         softly.assertThat(definition.emptyStateCopyKey())
                 .isEqualTo(emptyStateCopyKey);
-        softly.assertThat(definition.recommendedNextAction()).isNull();
+    }
+
+    private SeedLevel1QuestDefinition copyWithPolicies(
+            SeedLevel1QuestDefinition source,
+            String completionPolicy,
+            String cancellationPolicy,
+            String failurePressurePolicy
+    ) {
+        return new SeedLevel1QuestDefinition(
+                source.questCode(),
+                source.seedLevel(),
+                source.priority(),
+                source.definitionVersion(),
+                source.status(),
+                source.displayNameKo(),
+                source.shortDescriptionKo(),
+                source.longDescriptionKo(),
+                source.semanticCategory(),
+                source.progressMode(),
+                source.progressSourceType(),
+                source.sourceEventType(),
+                source.sourceEntityType(),
+                source.sourceOwnerRule(),
+                source.targetValue(),
+                source.targetUnit(),
+                completionPolicy,
+                source.autoComplete(),
+                source.repeatPolicy(),
+                source.periodBoundary(),
+                source.timezonePolicy(),
+                source.timezoneFallback(),
+                source.availabilityStartAt(),
+                source.availabilityEndAt(),
+                source.roleContextPolicy(),
+                source.allowedRoleTypes(),
+                source.rewardProfileCode(),
+                source.manualCheckAllowed(),
+                source.manualCheckRequiresMemo(),
+                cancellationPolicy,
+                failurePressurePolicy,
+                source.recommendedNextAction(),
+                source.sortOrder(),
+                source.iconKey(),
+                source.colorToken(),
+                source.resultCopyKey(),
+                source.emptyStateCopyKey(),
+                source.notes()
+        );
     }
 }

--- a/src/test/resources/application-migration-test.yml
+++ b/src/test/resources/application-migration-test.yml
@@ -17,3 +17,8 @@ spring:
     redis:
       repositories:
         enabled: false
+
+app:
+  quest:
+    definition-bootstrap:
+      enabled: true

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -28,6 +28,10 @@ lifeasgame:
     base-url: http://localhost:8080
 
 app:
+  quest:
+    definition-bootstrap:
+      enabled: false
+
   error:
     docs:
       base: "/errors"


### PR DESCRIPTION
## What

- Content 1B 기준 Seed Level 1 Quest 5종을 추가했습니다.
- 전체 Content1B Definition 값을 immutable Seed Catalog에 보존했습니다.
- 신규 final-contract Quest가 legacy category placeholder를 요구하지 않도록 보정했습니다.
- 기존 RewardProfile active validation과 Bootstrap을 재사용했습니다.

## Seed

```text
Q_RECORD_FIRST_TRACE
Q_RECORD_THREE_TRACES
Q_RECORD_WEEKLY_LOOKBACK
Q_GROWTH_ONE_FOCUS
Q_RECOVERY_REST_TEN
```

## Compatibility

- 기존 legacy Quest category와 Blueprint를 유지합니다.
- 신규 Seed 1 Quest는 `category=null`, `semanticCategory`를 사용합니다.
- Trigger와 Manual Check 실행은 후속 PR로 분리합니다.

## Migration

- `V14__final_quest_legacy_category_nullable.sql`
- 기존 V1~V13은 수정하지 않았습니다.

## Test

- [ ] `./gradlew clean test`
- [ ] `./gradlew build`
- [ ] Content1B Seed Catalog
- [ ] Quest Blueprint/Bootstrap
- [ ] RewardProfile validation
- [ ] category nullable compatibility
- [ ] API/Event contract
- [ ] V1~V14 checksum / JPA validate

## Out of Scope

- LifeLogRecorded Adapter
- Manual Check API
- QuestCompleted → RewardSettlement
- Mailbox / Claim / Achievement / Route
- Role Seed
- Frontend

Closes #211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added five Level 1 quests covering recording, growth, and recovery activities.
  * Seed quests are automatically added to the quest catalog and can be bootstrapped safely without creating duplicates.
  * Added support for quests without a legacy category while preserving semantic categories and progress details.
  * Added new quest progress, targeting, scheduling, priority, and role-context options.
  * Added configuration to enable or disable quest definition bootstrapping.

* **Bug Fixes**
  * Prevented errors when quest categories are unavailable.
  * Updated database migrations to allow category-free quests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->