### PR TITLE
[LifeLog] Add Content 1B recorded fact metadata contract

### DIFF
--- a/src/main/java/online/lifeasgame/lifelog/api/player/mapper/PlayerCollectionWebMapper.java
+++ b/src/main/java/online/lifeasgame/lifelog/api/player/mapper/PlayerCollectionWebMapper.java
@@ -3,6 +3,7 @@ package online.lifeasgame.lifelog.api.player.mapper;
 import online.lifeasgame.lifelog.api.player.request.PlayerCollectionRequest;
 import online.lifeasgame.lifelog.api.player.response.PlayerCollectionResponse;
 import online.lifeasgame.lifelog.application.command.CollectionCommand;
+import online.lifeasgame.lifelog.application.record.LifeLogRecordMetadataCommand;
 import online.lifeasgame.lifelog.application.result.CollectionResult;
 
 import java.util.List;
@@ -33,7 +34,11 @@ public final class PlayerCollectionWebMapper {
                 request.quantity(),
                 request.conditionNote(),
                 request.acquiredFrom(),
-                request.tags()
+                request.tags(),
+                new LifeLogRecordMetadataCommand(
+                        request.lifeLogSubtype(),
+                        request.reflectionScope()
+                )
         );
     }
 

--- a/src/main/java/online/lifeasgame/lifelog/api/player/mapper/PlayerExerciseWebMapper.java
+++ b/src/main/java/online/lifeasgame/lifelog/api/player/mapper/PlayerExerciseWebMapper.java
@@ -3,6 +3,7 @@ package online.lifeasgame.lifelog.api.player.mapper;
 import online.lifeasgame.lifelog.api.player.request.PlayerExerciseRequest;
 import online.lifeasgame.lifelog.api.player.response.PlayerExerciseResponse;
 import online.lifeasgame.lifelog.application.command.ExerciseCommand;
+import online.lifeasgame.lifelog.application.record.LifeLogRecordMetadataCommand;
 import online.lifeasgame.lifelog.application.result.ExerciseResult;
 
 import java.time.LocalDate;
@@ -34,7 +35,11 @@ public final class PlayerExerciseWebMapper {
                 request.distanceKm(),
                 request.calories(),
                 request.exercisedOn(),
-                request.memo()
+                request.memo(),
+                new LifeLogRecordMetadataCommand(
+                        request.lifeLogSubtype(),
+                        request.reflectionScope()
+                )
         );
     }
 

--- a/src/main/java/online/lifeasgame/lifelog/api/player/mapper/PlayerMediaLogWebMapper.java
+++ b/src/main/java/online/lifeasgame/lifelog/api/player/mapper/PlayerMediaLogWebMapper.java
@@ -3,6 +3,7 @@ package online.lifeasgame.lifelog.api.player.mapper;
 import online.lifeasgame.lifelog.api.player.request.PlayerMediaLogRequest;
 import online.lifeasgame.lifelog.api.player.response.PlayerMediaLogResponse;
 import online.lifeasgame.lifelog.application.command.MediaLogCommand;
+import online.lifeasgame.lifelog.application.record.LifeLogRecordMetadataCommand;
 import online.lifeasgame.lifelog.application.result.MediaLogResult;
 
 import java.util.List;
@@ -34,7 +35,11 @@ public final class PlayerMediaLogWebMapper {
                 request.currentEpisode(),
                 request.totalEpisode(),
                 request.status(),
-                request.tags()
+                request.tags(),
+                new LifeLogRecordMetadataCommand(
+                        request.lifeLogSubtype(),
+                        request.reflectionScope()
+                )
         );
     }
 

--- a/src/main/java/online/lifeasgame/lifelog/api/player/request/PlayerCollectionRequest.java
+++ b/src/main/java/online/lifeasgame/lifelog/api/player/request/PlayerCollectionRequest.java
@@ -18,8 +18,31 @@ public final class PlayerCollectionRequest {
             @NotNull @Min(1) Integer quantity,
             String conditionNote,
             String acquiredFrom,
-            Set<String> tags
+            Set<String> tags,
+            String lifeLogSubtype,
+            String reflectionScope
     ) {
+        public Create(
+                String category,
+                String title,
+                String originalTitle,
+                Integer quantity,
+                String conditionNote,
+                String acquiredFrom,
+                Set<String> tags
+        ) {
+            this(
+                    category,
+                    title,
+                    originalTitle,
+                    quantity,
+                    conditionNote,
+                    acquiredFrom,
+                    tags,
+                    null,
+                    null
+            );
+        }
     }
 
     public record Update(

--- a/src/main/java/online/lifeasgame/lifelog/api/player/request/PlayerExerciseRequest.java
+++ b/src/main/java/online/lifeasgame/lifelog/api/player/request/PlayerExerciseRequest.java
@@ -17,8 +17,30 @@ public final class PlayerExerciseRequest {
             @DecimalMin("0.0") Double distanceKm,
             @Min(0) Integer calories,
             @NotNull LocalDate exercisedOn,
-            String memo
-    ) {}
+            String memo,
+            String lifeLogSubtype,
+            String reflectionScope
+    ) {
+        public Create(
+                String category,
+                Integer durationMinutes,
+                Double distanceKm,
+                Integer calories,
+                LocalDate exercisedOn,
+                String memo
+        ) {
+            this(
+                    category,
+                    durationMinutes,
+                    distanceKm,
+                    calories,
+                    exercisedOn,
+                    memo,
+                    null,
+                    null
+            );
+        }
+    }
 
     public record Update(
             String category,

--- a/src/main/java/online/lifeasgame/lifelog/api/player/request/PlayerMediaLogRequest.java
+++ b/src/main/java/online/lifeasgame/lifelog/api/player/request/PlayerMediaLogRequest.java
@@ -16,8 +16,31 @@ public final class PlayerMediaLogRequest {
             @Min(0) Integer currentEpisode,
             @Min(1) Integer totalEpisode,
             @NotBlank String status,
-            Set<String> tags
+            Set<String> tags,
+            String lifeLogSubtype,
+            String reflectionScope
     ) {
+        public Create(
+                String category,
+                String title,
+                String originalTitle,
+                Integer currentEpisode,
+                Integer totalEpisode,
+                String status,
+                Set<String> tags
+        ) {
+            this(
+                    category,
+                    title,
+                    originalTitle,
+                    currentEpisode,
+                    totalEpisode,
+                    status,
+                    tags,
+                    null,
+                    null
+            );
+        }
     }
 
     public record Update(

--- a/src/main/java/online/lifeasgame/lifelog/application/CollectionLogService.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/CollectionLogService.java
@@ -4,15 +4,18 @@ import lombok.RequiredArgsConstructor;
 import online.lifeasgame.core.event.DomainEventPublisher;
 import online.lifeasgame.core.support.IdGenerator;
 import online.lifeasgame.lifelog.application.command.CollectionCommand;
+import online.lifeasgame.lifelog.application.record.LifeLogRecordMetadataCommand;
+import online.lifeasgame.lifelog.application.record.LifeLogRecordService;
 import online.lifeasgame.lifelog.application.result.CollectionResult;
 import online.lifeasgame.lifelog.domain.*;
 import online.lifeasgame.lifelog.domain.event.CollectionLogged;
 import online.lifeasgame.lifelog.domain.event.LifeLogRecorded;
-import online.lifeasgame.lifelog.domain.event.LifeLogType;
+import online.lifeasgame.lifelog.domain.record.LifeLogEntryMode;
+import online.lifeasgame.lifelog.domain.record.LifeLogRecord;
+import online.lifeasgame.lifelog.domain.record.LifeLogSourceType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
 
@@ -22,11 +25,34 @@ public class CollectionLogService {
 
     private final CollectionLogReader collectionLogReader;
     private final CollectionLogWriter collectionLogWriter;
+    private final LifeLogRecordService lifeLogRecordService;
     private final DomainEventPublisher domainEventPublisher;
-    private final Clock clock;
 
     @Transactional
     public CollectionResult.Created create(Long playerId, CollectionCommand.Create command) {
+        return create(
+                playerId,
+                command,
+                LifeLogEntryMode.FULL,
+                command.lifeLogMetadata()
+        );
+    }
+
+    @Transactional
+    public CollectionResult.Created createQuick(
+            Long playerId,
+            CollectionCommand.Create command,
+            LifeLogRecordMetadataCommand metadata
+    ) {
+        return create(playerId, command, LifeLogEntryMode.QUICK, metadata);
+    }
+
+    private CollectionResult.Created create(
+            Long playerId,
+            CollectionCommand.Create command,
+            LifeLogEntryMode entryMode,
+            LifeLogRecordMetadataCommand metadata
+    ) {
         Title title = Title.of(command.title(), command.originalTitle());
 
         CollectionLog saved = collectionLogWriter.create(
@@ -41,7 +67,14 @@ public class CollectionLogService {
                 )
         );
 
-        Instant occurredAt = clock.instant();
+        LifeLogRecord record = lifeLogRecordService.create(
+                playerId,
+                LifeLogSourceType.COLLECTION,
+                saved.getId(),
+                entryMode,
+                metadata
+        );
+        Instant occurredAt = record.getOccurredAt();
         domainEventPublisher.publishAll(List.of(
                 new CollectionLogged(
                         playerId,
@@ -50,16 +83,17 @@ public class CollectionLogService {
                         saved.getQuantity().value(),
                         occurredAt
                 ),
-                LifeLogRecorded.of(
+                LifeLogRecorded.from(
                         IdGenerator.newEventId(),
-                        playerId,
-                        saved.getId(),
-                        LifeLogType.COLLECTION,
-                        occurredAt
+                        record
                 )
         ));
 
-        return new CollectionResult.Created(saved.getId(), occurredAt);
+        return new CollectionResult.Created(
+                saved.getId(),
+                record.getId(),
+                occurredAt
+        );
     }
 
     @Transactional

--- a/src/main/java/online/lifeasgame/lifelog/application/ExerciseLogService.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/ExerciseLogService.java
@@ -4,17 +4,20 @@ import lombok.RequiredArgsConstructor;
 import online.lifeasgame.core.event.DomainEventPublisher;
 import online.lifeasgame.core.support.IdGenerator;
 import online.lifeasgame.lifelog.application.command.ExerciseCommand;
+import online.lifeasgame.lifelog.application.record.LifeLogRecordMetadataCommand;
+import online.lifeasgame.lifelog.application.record.LifeLogRecordService;
 import online.lifeasgame.lifelog.application.result.ExerciseResult;
 import online.lifeasgame.lifelog.domain.ExerciseCategory;
 import online.lifeasgame.lifelog.domain.ExerciseLog;
 import online.lifeasgame.lifelog.domain.ExerciseMetrics;
 import online.lifeasgame.lifelog.domain.event.ExerciseLogged;
 import online.lifeasgame.lifelog.domain.event.LifeLogRecorded;
-import online.lifeasgame.lifelog.domain.event.LifeLogType;
+import online.lifeasgame.lifelog.domain.record.LifeLogEntryMode;
+import online.lifeasgame.lifelog.domain.record.LifeLogRecord;
+import online.lifeasgame.lifelog.domain.record.LifeLogSourceType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
 
@@ -24,11 +27,34 @@ public class ExerciseLogService {
 
     private final ExerciseLogReader exerciseLogReader;
     private final ExerciseLogWriter exerciseLogWriter;
+    private final LifeLogRecordService lifeLogRecordService;
     private final DomainEventPublisher domainEventPublisher;
-    private final Clock clock;
 
     @Transactional
     public ExerciseResult.Created create(Long playerId, ExerciseCommand.Create command) {
+        return create(
+                playerId,
+                command,
+                LifeLogEntryMode.FULL,
+                command.lifeLogMetadata()
+        );
+    }
+
+    @Transactional
+    public ExerciseResult.Created createQuick(
+            Long playerId,
+            ExerciseCommand.Create command,
+            LifeLogRecordMetadataCommand metadata
+    ) {
+        return create(playerId, command, LifeLogEntryMode.QUICK, metadata);
+    }
+
+    private ExerciseResult.Created create(
+            Long playerId,
+            ExerciseCommand.Create command,
+            LifeLogEntryMode entryMode,
+            LifeLogRecordMetadataCommand metadata
+    ) {
         ExerciseLog saved = exerciseLogWriter.create(
                 ExerciseLog.create(
                         playerId,
@@ -39,7 +65,14 @@ public class ExerciseLogService {
                 )
         );
 
-        Instant occurredAt = clock.instant();
+        LifeLogRecord record = lifeLogRecordService.create(
+                playerId,
+                LifeLogSourceType.EXERCISE,
+                saved.getId(),
+                entryMode,
+                metadata
+        );
+        Instant occurredAt = record.getOccurredAt();
         domainEventPublisher.publishAll(List.of(
                 new ExerciseLogged(
                         playerId,
@@ -50,16 +83,17 @@ public class ExerciseLogService {
                         saved.getMetrics().calories(),
                         occurredAt
                 ),
-                LifeLogRecorded.of(
+                LifeLogRecorded.from(
                         IdGenerator.newEventId(),
-                        playerId,
-                        saved.getId(),
-                        LifeLogType.EXERCISE,
-                        occurredAt
+                        record
                 )
         ));
 
-        return new ExerciseResult.Created(saved.getId(), occurredAt);
+        return new ExerciseResult.Created(
+                saved.getId(),
+                record.getId(),
+                occurredAt
+        );
     }
 
     @Transactional

--- a/src/main/java/online/lifeasgame/lifelog/application/MediaLogService.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/MediaLogService.java
@@ -4,15 +4,18 @@ import lombok.RequiredArgsConstructor;
 import online.lifeasgame.core.event.DomainEventPublisher;
 import online.lifeasgame.core.support.IdGenerator;
 import online.lifeasgame.lifelog.application.command.MediaLogCommand;
+import online.lifeasgame.lifelog.application.record.LifeLogRecordMetadataCommand;
+import online.lifeasgame.lifelog.application.record.LifeLogRecordService;
 import online.lifeasgame.lifelog.application.result.MediaLogResult;
 import online.lifeasgame.lifelog.domain.*;
 import online.lifeasgame.lifelog.domain.event.LifeLogRecorded;
-import online.lifeasgame.lifelog.domain.event.LifeLogType;
 import online.lifeasgame.lifelog.domain.event.MediaLogAdvanced;
+import online.lifeasgame.lifelog.domain.record.LifeLogEntryMode;
+import online.lifeasgame.lifelog.domain.record.LifeLogRecord;
+import online.lifeasgame.lifelog.domain.record.LifeLogSourceType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
 
@@ -22,11 +25,34 @@ public class MediaLogService {
 
     private final MediaLogReader mediaLogReader;
     private final MediaLogWriter mediaLogWriter;
+    private final LifeLogRecordService lifeLogRecordService;
     private final DomainEventPublisher domainEventPublisher;
-    private final Clock clock;
 
     @Transactional
     public MediaLogResult.Created create(Long playerId, MediaLogCommand.Create command) {
+        return create(
+                playerId,
+                command,
+                LifeLogEntryMode.FULL,
+                command.lifeLogMetadata()
+        );
+    }
+
+    @Transactional
+    public MediaLogResult.Created createQuick(
+            Long playerId,
+            MediaLogCommand.Create command,
+            LifeLogRecordMetadataCommand metadata
+    ) {
+        return create(playerId, command, LifeLogEntryMode.QUICK, metadata);
+    }
+
+    private MediaLogResult.Created create(
+            Long playerId,
+            MediaLogCommand.Create command,
+            LifeLogEntryMode entryMode,
+            LifeLogRecordMetadataCommand metadata
+    ) {
         MediaLog saved = mediaLogWriter.create(
                 MediaLog.create(
                         playerId,
@@ -38,18 +64,26 @@ public class MediaLogService {
                 )
         );
 
-        Instant recordedAt = clock.instant();
+        LifeLogRecord record = lifeLogRecordService.create(
+                playerId,
+                LifeLogSourceType.MEDIA,
+                saved.getId(),
+                entryMode,
+                metadata
+        );
+        Instant recordedAt = record.getOccurredAt();
         domainEventPublisher.publish(
-                LifeLogRecorded.of(
+                LifeLogRecorded.from(
                         IdGenerator.newEventId(),
-                        playerId,
-                        saved.getId(),
-                        LifeLogType.MEDIA,
-                        recordedAt
+                        record
                 )
         );
 
-        return new MediaLogResult.Created(saved.getId(), recordedAt);
+        return new MediaLogResult.Created(
+                saved.getId(),
+                record.getId(),
+                recordedAt
+        );
     }
 
     @Transactional

--- a/src/main/java/online/lifeasgame/lifelog/application/command/CollectionCommand.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/command/CollectionCommand.java
@@ -1,5 +1,7 @@
 package online.lifeasgame.lifelog.application.command;
 
+import online.lifeasgame.lifelog.application.record.LifeLogRecordMetadataCommand;
+
 import java.util.Set;
 
 public final class CollectionCommand {
@@ -14,8 +16,29 @@ public final class CollectionCommand {
             Integer quantity,
             String conditionNote,
             String acquiredFrom,
-            Set<String> tags
+            Set<String> tags,
+            LifeLogRecordMetadataCommand lifeLogMetadata
     ) {
+        public Create(
+                String category,
+                String title,
+                String originalTitle,
+                Integer quantity,
+                String conditionNote,
+                String acquiredFrom,
+                Set<String> tags
+        ) {
+            this(
+                    category,
+                    title,
+                    originalTitle,
+                    quantity,
+                    conditionNote,
+                    acquiredFrom,
+                    tags,
+                    LifeLogRecordMetadataCommand.none()
+            );
+        }
     }
 
     public record Update(

--- a/src/main/java/online/lifeasgame/lifelog/application/command/ExerciseCommand.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/command/ExerciseCommand.java
@@ -1,5 +1,7 @@
 package online.lifeasgame.lifelog.application.command;
 
+import online.lifeasgame.lifelog.application.record.LifeLogRecordMetadataCommand;
+
 import java.time.LocalDate;
 
 public final class ExerciseCommand {
@@ -13,8 +15,27 @@ public final class ExerciseCommand {
             Double distanceKm,
             Integer calories,
             LocalDate exercisedOn,
-            String memo
+            String memo,
+            LifeLogRecordMetadataCommand lifeLogMetadata
     ) {
+        public Create(
+                String category,
+                Integer durationMinutes,
+                Double distanceKm,
+                Integer calories,
+                LocalDate exercisedOn,
+                String memo
+        ) {
+            this(
+                    category,
+                    durationMinutes,
+                    distanceKm,
+                    calories,
+                    exercisedOn,
+                    memo,
+                    LifeLogRecordMetadataCommand.none()
+            );
+        }
     }
 
     public record Update(

--- a/src/main/java/online/lifeasgame/lifelog/application/command/MediaLogCommand.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/command/MediaLogCommand.java
@@ -1,6 +1,7 @@
 package online.lifeasgame.lifelog.application.command;
 
 import jakarta.validation.constraints.Min;
+import online.lifeasgame.lifelog.application.record.LifeLogRecordMetadataCommand;
 
 import java.util.Set;
 
@@ -16,8 +17,29 @@ public final class MediaLogCommand {
             Integer currentEpisode,
             Integer totalEpisode,
             String status,
-            Set<String> tags
+            Set<String> tags,
+            LifeLogRecordMetadataCommand lifeLogMetadata
     ) {
+        public Create(
+                String category,
+                String title,
+                String originalTitle,
+                Integer currentEpisode,
+                Integer totalEpisode,
+                String status,
+                Set<String> tags
+        ) {
+            this(
+                    category,
+                    title,
+                    originalTitle,
+                    currentEpisode,
+                    totalEpisode,
+                    status,
+                    tags,
+                    LifeLogRecordMetadataCommand.none()
+            );
+        }
     }
 
     public record Rate(Double score) {

--- a/src/main/java/online/lifeasgame/lifelog/application/record/DefaultPlayerTimezoneResolver.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/record/DefaultPlayerTimezoneResolver.java
@@ -1,0 +1,17 @@
+package online.lifeasgame.lifelog.application.record;
+
+import org.springframework.stereotype.Component;
+
+import java.time.ZoneId;
+
+@Component
+public class DefaultPlayerTimezoneResolver
+        implements PlayerTimezoneResolver {
+
+    public static final ZoneId FALLBACK = ZoneId.of("Asia/Seoul");
+
+    @Override
+    public ZoneId resolve(Long playerId) {
+        return FALLBACK;
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/application/record/LifeLogRecordMetadataCommand.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/record/LifeLogRecordMetadataCommand.java
@@ -1,0 +1,34 @@
+package online.lifeasgame.lifelog.application.record;
+
+import online.lifeasgame.lifelog.domain.record.LifeLogReflectionScope;
+import online.lifeasgame.lifelog.domain.record.LifeLogSubtype;
+
+public record LifeLogRecordMetadataCommand(
+        String lifeLogSubtype,
+        String reflectionScope
+) {
+
+    public static LifeLogRecordMetadataCommand none() {
+        return new LifeLogRecordMetadataCommand(null, null);
+    }
+
+    public boolean isPresent() {
+        return lifeLogSubtype != null || reflectionScope != null;
+    }
+
+    public Resolved resolve() {
+        if (!isPresent()) {
+            return new Resolved(null, null);
+        }
+        LifeLogSubtype subtype = LifeLogSubtype.parse(lifeLogSubtype);
+        LifeLogReflectionScope scope =
+                LifeLogReflectionScope.parse(reflectionScope);
+        return new Resolved(subtype, scope);
+    }
+
+    public record Resolved(
+            LifeLogSubtype subtype,
+            LifeLogReflectionScope reflectionScope
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/application/record/LifeLogRecordService.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/record/LifeLogRecordService.java
@@ -1,0 +1,70 @@
+package online.lifeasgame.lifelog.application.record;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.lifelog.domain.record.LifeLogEntryMode;
+import online.lifeasgame.lifelog.domain.record.LifeLogPeriodKey;
+import online.lifeasgame.lifelog.domain.record.LifeLogRecord;
+import online.lifeasgame.lifelog.domain.record.LifeLogReflectionScope;
+import online.lifeasgame.lifelog.domain.record.LifeLogSourceType;
+import online.lifeasgame.lifelog.domain.record.repository.LifeLogRecordRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.MANDATORY)
+public class LifeLogRecordService {
+
+    private final LifeLogRecordRepository repository;
+    private final PlayerTimezoneResolver timezoneResolver;
+    private final Clock clock;
+
+    public LifeLogRecord create(
+            Long playerId,
+            LifeLogSourceType sourceType,
+            Long sourceId,
+            LifeLogEntryMode entryMode,
+            LifeLogRecordMetadataCommand metadata
+    ) {
+        LifeLogRecordMetadataCommand command =
+                metadata == null
+                        ? LifeLogRecordMetadataCommand.none()
+                        : metadata;
+        LifeLogRecordMetadataCommand.Resolved resolved =
+                command.resolve();
+        Instant occurredAt = clock.instant();
+
+        if (resolved.subtype() == null) {
+            return repository.saveAndFlush(LifeLogRecord.legacy(
+                    playerId,
+                    sourceType,
+                    sourceId,
+                    entryMode,
+                    occurredAt
+            ));
+        }
+
+        LifeLogPeriodKey periodKey =
+                resolved.reflectionScope()
+                        == LifeLogReflectionScope.WEEKLY_LOOKBACK
+                        ? LifeLogPeriodKey.weekly(
+                                occurredAt,
+                                timezoneResolver.resolve(playerId)
+                        )
+                        : null;
+        return repository.saveAndFlush(LifeLogRecord.contentReady(
+                playerId,
+                sourceType,
+                sourceId,
+                resolved.subtype(),
+                entryMode,
+                resolved.reflectionScope(),
+                periodKey,
+                occurredAt
+        ));
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/application/record/PlayerTimezoneResolver.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/record/PlayerTimezoneResolver.java
@@ -1,0 +1,8 @@
+package online.lifeasgame.lifelog.application.record;
+
+import java.time.ZoneId;
+
+public interface PlayerTimezoneResolver {
+
+    ZoneId resolve(Long playerId);
+}

--- a/src/main/java/online/lifeasgame/lifelog/application/result/CollectionResult.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/result/CollectionResult.java
@@ -12,6 +12,7 @@ public final class CollectionResult {
 
     public record Created(
             Long id,
+            Long lifeLogId,
             Instant recordedAt
     ) {
     }

--- a/src/main/java/online/lifeasgame/lifelog/application/result/ExerciseResult.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/result/ExerciseResult.java
@@ -12,6 +12,7 @@ public final class ExerciseResult {
 
     public record Created(
             Long id,
+            Long lifeLogId,
             Instant recordedAt
     ) {
     }

--- a/src/main/java/online/lifeasgame/lifelog/application/result/MediaLogResult.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/result/MediaLogResult.java
@@ -13,6 +13,7 @@ public final class MediaLogResult {
 
     public record Created(
             Long id,
+            Long lifeLogId,
             Instant recordedAt
     ) {
     }

--- a/src/main/java/online/lifeasgame/lifelog/domain/event/LifeLogRecorded.java
+++ b/src/main/java/online/lifeasgame/lifelog/domain/event/LifeLogRecorded.java
@@ -2,54 +2,148 @@ package online.lifeasgame.lifelog.domain.event;
 
 import online.lifeasgame.core.event.DomainEvent;
 import online.lifeasgame.core.guard.Guard;
+import online.lifeasgame.lifelog.domain.record.LifeLogEntryMode;
+import online.lifeasgame.lifelog.domain.record.LifeLogRecord;
+import online.lifeasgame.lifelog.domain.record.LifeLogReflectionScope;
+import online.lifeasgame.lifelog.domain.record.LifeLogSubtype;
 
 import java.time.Instant;
 
 public record LifeLogRecorded(
         String eventId,
+        String eventType,
         int eventVersion,
+        Instant occurredAt,
         Long playerId,
         Long lifeLogId,
-        LifeLogType lifeLogType,
+        Integer sourceDefinitionVersion,
+        LifeLogSubtype subtype,
+        LifeLogEntryMode entryMode,
+        LifeLogReflectionScope reflectionScope,
+        String periodKey,
         Long primaryRoleId,
-        Instant occurredAt
+        LifeLogType legacyLifeLogType
 ) implements DomainEvent {
 
+    public static final String EVENT_TYPE = "LifeLogRecorded";
     public static final int EVENT_VERSION = 1;
 
     public LifeLogRecorded {
         eventId = Guard.notBlank(eventId, "eventId");
+        if (!EVENT_TYPE.equals(eventType)) {
+            throw new IllegalArgumentException(
+                    "eventType must be " + EVENT_TYPE
+            );
+        }
         if (eventVersion != EVENT_VERSION) {
             throw new IllegalArgumentException(
                     "eventVersion must be " + EVENT_VERSION
             );
         }
-        Guard.notNull(playerId, "playerId");
-        Guard.notNull(lifeLogId, "lifeLogId");
-        Guard.notNull(lifeLogType, "lifeLogType");
+        Guard.notNull(occurredAt, "occurredAt");
+        positive(playerId, "playerId");
+        positive(lifeLogId, "lifeLogId");
         if (primaryRoleId != null) {
             throw new IllegalArgumentException(
                     "primaryRoleId must be null until Role Domain is available"
             );
         }
-        Guard.notNull(occurredAt, "occurredAt");
+
+        if (sourceDefinitionVersion == null) {
+            if (subtype != null
+                    || entryMode != null
+                    || reflectionScope != null
+                    || periodKey != null
+                    || legacyLifeLogType == null) {
+                throw new IllegalArgumentException(
+                        "legacy Fact metadata contract is invalid"
+                );
+            }
+        } else {
+            if (sourceDefinitionVersion < 1) {
+                throw new IllegalArgumentException(
+                        "sourceDefinitionVersion must be at least 1"
+                );
+            }
+            Guard.notNull(entryMode, "entryMode");
+            if (legacyLifeLogType != null) {
+                throw new IllegalArgumentException(
+                        "physical source type is forbidden in new Fact"
+                );
+            }
+            LifeLogRecord.validateReflection(
+                    subtype,
+                    reflectionScope,
+                    periodKey
+            );
+        }
     }
 
-    public static LifeLogRecorded of(
+    public static LifeLogRecorded from(
             String eventId,
+            LifeLogRecord record
+    ) {
+        Guard.notNull(record, "record");
+        return new LifeLogRecorded(
+                eventId,
+                EVENT_TYPE,
+                EVENT_VERSION,
+                record.getOccurredAt(),
+                record.getPlayerId(),
+                record.getId(),
+                record.getSourceDefinitionVersion(),
+                record.getSubtype(),
+                record.getEntryMode(),
+                record.getReflectionScope(),
+                record.getPeriodKey(),
+                record.getPrimaryRoleId(),
+                null
+        );
+    }
+
+    public static LifeLogRecorded legacy(
+            String eventId,
+            int eventVersion,
             Long playerId,
             Long lifeLogId,
             LifeLogType lifeLogType,
+            Long primaryRoleId,
             Instant occurredAt
     ) {
         return new LifeLogRecorded(
                 eventId,
-                EVENT_VERSION,
+                EVENT_TYPE,
+                eventVersion,
+                occurredAt,
                 playerId,
                 lifeLogId,
-                lifeLogType,
                 null,
-                occurredAt
+                null,
+                null,
+                null,
+                null,
+                primaryRoleId,
+                lifeLogType
         );
+    }
+
+    public boolean isContentReady() {
+        return sourceDefinitionVersion != null
+                && subtype != null
+                && entryMode != null;
+    }
+
+    public LifeLogRecorded requireContentReady() {
+        if (!isContentReady()) {
+            throw new IllegalStateException(
+                    "LifeLogRecorded is not content-ready"
+            );
+        }
+        return this;
+    }
+
+    private static void positive(Long value, String name) {
+        Guard.notNull(value, name);
+        Guard.minValue(value, 1L, name);
     }
 }

--- a/src/main/java/online/lifeasgame/lifelog/domain/record/LifeLogEntryMode.java
+++ b/src/main/java/online/lifeasgame/lifelog/domain/record/LifeLogEntryMode.java
@@ -1,0 +1,6 @@
+package online.lifeasgame.lifelog.domain.record;
+
+public enum LifeLogEntryMode {
+    FULL,
+    QUICK
+}

--- a/src/main/java/online/lifeasgame/lifelog/domain/record/LifeLogPeriodKey.java
+++ b/src/main/java/online/lifeasgame/lifelog/domain/record/LifeLogPeriodKey.java
@@ -1,0 +1,52 @@
+package online.lifeasgame.lifelog.domain.record;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.WeekFields;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+public record LifeLogPeriodKey(String value) {
+
+    private static final Pattern WEEKLY_PATTERN =
+            Pattern.compile("\\d{4}-W\\d{2}");
+
+    public LifeLogPeriodKey {
+        Objects.requireNonNull(value, "periodKey must not be null");
+        if (!WEEKLY_PATTERN.matcher(value).matches()) {
+            throw new IllegalArgumentException(
+                    "periodKey must use YYYY-Www format"
+            );
+        }
+        int week = Integer.parseInt(value.substring(6));
+        int year = Integer.parseInt(value.substring(0, 4));
+        int maximumWeek = LocalDate.of(year, 12, 28)
+                .get(WeekFields.ISO.weekOfWeekBasedYear());
+        if (week < 1 || week > maximumWeek) {
+            throw new IllegalArgumentException(
+                    "periodKey week is not valid for its ISO year"
+            );
+        }
+    }
+
+    public static LifeLogPeriodKey weekly(
+            Instant occurredAt,
+            ZoneId zoneId
+    ) {
+        ZonedDateTime local = Objects.requireNonNull(
+                occurredAt,
+                "occurredAt must not be null"
+        ).atZone(Objects.requireNonNull(
+                zoneId,
+                "zoneId must not be null"
+        ));
+        WeekFields iso = WeekFields.ISO;
+        int year = local.get(iso.weekBasedYear());
+        int week = local.get(iso.weekOfWeekBasedYear());
+        return new LifeLogPeriodKey(
+                "%04d-W%02d".formatted(year, week)
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/domain/record/LifeLogRecord.java
+++ b/src/main/java/online/lifeasgame/lifelog/domain/record/LifeLogRecord.java
@@ -1,0 +1,207 @@
+package online.lifeasgame.lifelog.domain.record;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import online.lifeasgame.core.annotation.AggregateRoot;
+import online.lifeasgame.core.guard.Guard;
+import online.lifeasgame.platform.persistence.jpa.AbstractTime;
+
+import java.time.Instant;
+
+@Getter
+@Entity
+@AggregateRoot
+@Table(
+        name = "life_log_records",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_life_log_record_source",
+                columnNames = {"source_type", "source_id"}
+        )
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LifeLogRecord extends AbstractTime {
+
+    public static final int SOURCE_DEFINITION_VERSION = 1;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "player_id", nullable = false, updatable = false)
+    private Long playerId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(
+            name = "source_type",
+            nullable = false,
+            length = 20,
+            updatable = false
+    )
+    private LifeLogSourceType sourceType;
+
+    @Column(name = "source_id", nullable = false, updatable = false)
+    private Long sourceId;
+
+    @Column(
+            name = "source_definition_version",
+            nullable = false,
+            updatable = false
+    )
+    private int sourceDefinitionVersion;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "subtype", length = 20, updatable = false)
+    private LifeLogSubtype subtype;
+
+    @Enumerated(EnumType.STRING)
+    @Column(
+            name = "entry_mode",
+            nullable = false,
+            length = 20,
+            updatable = false
+    )
+    private LifeLogEntryMode entryMode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reflection_scope", length = 30, updatable = false)
+    private LifeLogReflectionScope reflectionScope;
+
+    @Column(name = "period_key", length = 20, updatable = false)
+    private String periodKey;
+
+    @Column(name = "primary_role_id", updatable = false)
+    private Long primaryRoleId;
+
+    @Column(name = "occurred_at", nullable = false, updatable = false)
+    private Instant occurredAt;
+
+    private LifeLogRecord(
+            Long playerId,
+            LifeLogSourceType sourceType,
+            Long sourceId,
+            int sourceDefinitionVersion,
+            LifeLogSubtype subtype,
+            LifeLogEntryMode entryMode,
+            LifeLogReflectionScope reflectionScope,
+            String periodKey,
+            Long primaryRoleId,
+            Instant occurredAt
+    ) {
+        this.playerId = positive(playerId, "playerId");
+        this.sourceType = Guard.notNull(sourceType, "sourceType");
+        this.sourceId = positive(sourceId, "sourceId");
+        if (sourceDefinitionVersion < 1) {
+            throw new IllegalArgumentException(
+                    "sourceDefinitionVersion must be at least 1"
+            );
+        }
+        this.sourceDefinitionVersion = sourceDefinitionVersion;
+        this.subtype = subtype;
+        this.entryMode = Guard.notNull(entryMode, "entryMode");
+        validateReflection(subtype, reflectionScope, periodKey);
+        this.reflectionScope = reflectionScope;
+        this.periodKey = periodKey;
+        if (primaryRoleId != null) {
+            throw new IllegalArgumentException(
+                    "primaryRoleId must be null until Role Domain is available"
+            );
+        }
+        this.primaryRoleId = null;
+        this.occurredAt = Guard.notNull(occurredAt, "occurredAt");
+    }
+
+    public static LifeLogRecord legacy(
+            Long playerId,
+            LifeLogSourceType sourceType,
+            Long sourceId,
+            LifeLogEntryMode entryMode,
+            Instant occurredAt
+    ) {
+        return new LifeLogRecord(
+                playerId,
+                sourceType,
+                sourceId,
+                SOURCE_DEFINITION_VERSION,
+                null,
+                entryMode,
+                null,
+                null,
+                null,
+                occurredAt
+        );
+    }
+
+    public static LifeLogRecord contentReady(
+            Long playerId,
+            LifeLogSourceType sourceType,
+            Long sourceId,
+            LifeLogSubtype subtype,
+            LifeLogEntryMode entryMode,
+            LifeLogReflectionScope reflectionScope,
+            LifeLogPeriodKey periodKey,
+            Instant occurredAt
+    ) {
+        return new LifeLogRecord(
+                playerId,
+                sourceType,
+                sourceId,
+                SOURCE_DEFINITION_VERSION,
+                Guard.notNull(subtype, "subtype"),
+                entryMode,
+                reflectionScope,
+                periodKey == null ? null : periodKey.value(),
+                null,
+                occurredAt
+        );
+    }
+
+    public boolean isContentReady() {
+        return subtype != null;
+    }
+
+    private static Long positive(Long value, String name) {
+        Guard.notNull(value, name);
+        Guard.minValue(value, 1L, name);
+        return value;
+    }
+
+    public static void validateReflection(
+            LifeLogSubtype subtype,
+            LifeLogReflectionScope reflectionScope,
+            String periodKey
+    ) {
+        if (subtype != LifeLogSubtype.REFLECTION) {
+            if (reflectionScope != null || periodKey != null) {
+                throw new IllegalArgumentException(
+                        "reflection metadata requires REFLECTION subtype"
+                );
+            }
+            return;
+        }
+        if (reflectionScope == null) {
+            if (periodKey != null) {
+                throw new IllegalArgumentException(
+                        "periodKey requires reflectionScope"
+                );
+            }
+            return;
+        }
+        if (reflectionScope != LifeLogReflectionScope.WEEKLY_LOOKBACK
+                || periodKey == null) {
+            throw new IllegalArgumentException(
+                    "WEEKLY_LOOKBACK requires periodKey"
+            );
+        }
+        new LifeLogPeriodKey(periodKey);
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/domain/record/LifeLogReflectionScope.java
+++ b/src/main/java/online/lifeasgame/lifelog/domain/record/LifeLogReflectionScope.java
@@ -1,0 +1,19 @@
+package online.lifeasgame.lifelog.domain.record;
+
+public enum LifeLogReflectionScope {
+    WEEKLY_LOOKBACK;
+
+    public static LifeLogReflectionScope parse(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return valueOf(value);
+        } catch (IllegalArgumentException exception) {
+            throw new IllegalArgumentException(
+                    "reflectionScope must be an official scope",
+                    exception
+            );
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/domain/record/LifeLogSourceType.java
+++ b/src/main/java/online/lifeasgame/lifelog/domain/record/LifeLogSourceType.java
@@ -1,0 +1,7 @@
+package online.lifeasgame.lifelog.domain.record;
+
+public enum LifeLogSourceType {
+    COLLECTION,
+    EXERCISE,
+    MEDIA
+}

--- a/src/main/java/online/lifeasgame/lifelog/domain/record/LifeLogSubtype.java
+++ b/src/main/java/online/lifeasgame/lifelog/domain/record/LifeLogSubtype.java
@@ -1,0 +1,28 @@
+package online.lifeasgame.lifelog.domain.record;
+
+public enum LifeLogSubtype {
+    QUICK_NOTE,
+    ACTIVITY,
+    STUDY,
+    PROJECT,
+    MEMORY,
+    REFLECTION,
+    MOOD,
+    HEALTH_NOTE;
+
+    public static LifeLogSubtype parse(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(
+                    "lifeLogSubtype must be an official subtype"
+            );
+        }
+        try {
+            return valueOf(value);
+        } catch (IllegalArgumentException exception) {
+            throw new IllegalArgumentException(
+                    "lifeLogSubtype must be an official subtype",
+                    exception
+            );
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/domain/record/repository/LifeLogRecordRepository.java
+++ b/src/main/java/online/lifeasgame/lifelog/domain/record/repository/LifeLogRecordRepository.java
@@ -1,0 +1,16 @@
+package online.lifeasgame.lifelog.domain.record.repository;
+
+import online.lifeasgame.lifelog.domain.record.LifeLogRecord;
+import online.lifeasgame.lifelog.domain.record.LifeLogSourceType;
+
+import java.util.Optional;
+
+public interface LifeLogRecordRepository {
+
+    LifeLogRecord saveAndFlush(LifeLogRecord record);
+
+    Optional<LifeLogRecord> findBySource(
+            LifeLogSourceType sourceType,
+            Long sourceId
+    );
+}

--- a/src/main/java/online/lifeasgame/lifelog/infra/LifeLogRecordJpaRepository.java
+++ b/src/main/java/online/lifeasgame/lifelog/infra/LifeLogRecordJpaRepository.java
@@ -1,0 +1,16 @@
+package online.lifeasgame.lifelog.infra;
+
+import online.lifeasgame.lifelog.domain.record.LifeLogRecord;
+import online.lifeasgame.lifelog.domain.record.LifeLogSourceType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LifeLogRecordJpaRepository
+        extends JpaRepository<LifeLogRecord, Long> {
+
+    Optional<LifeLogRecord> findBySourceTypeAndSourceId(
+            LifeLogSourceType sourceType,
+            Long sourceId
+    );
+}

--- a/src/main/java/online/lifeasgame/lifelog/infra/LifeLogRecordRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/lifelog/infra/LifeLogRecordRepositoryAdapter.java
@@ -1,0 +1,33 @@
+package online.lifeasgame.lifelog.infra;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.lifelog.domain.record.LifeLogRecord;
+import online.lifeasgame.lifelog.domain.record.LifeLogSourceType;
+import online.lifeasgame.lifelog.domain.record.repository.LifeLogRecordRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class LifeLogRecordRepositoryAdapter
+        implements LifeLogRecordRepository {
+
+    private final LifeLogRecordJpaRepository jpaRepository;
+
+    @Override
+    public LifeLogRecord saveAndFlush(LifeLogRecord record) {
+        return jpaRepository.saveAndFlush(record);
+    }
+
+    @Override
+    public Optional<LifeLogRecord> findBySource(
+            LifeLogSourceType sourceType,
+            Long sourceId
+    ) {
+        return jpaRepository.findBySourceTypeAndSourceId(
+                sourceType,
+                sourceId
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/quick/api/QuickRecordRequest.java
+++ b/src/main/java/online/lifeasgame/lifelog/quick/api/QuickRecordRequest.java
@@ -13,9 +13,19 @@ public final class QuickRecordRequest {
 
     public record Create(
             @NotBlank String type,
+            String lifeLogSubtype,
+            String reflectionScope,
             @Valid PlayerCollectionRequest.Create collection,
             @Valid PlayerExerciseRequest.Create exercise,
             @Valid PlayerMediaLogRequest.Create media
     ) {
+        public Create(
+                String type,
+                PlayerCollectionRequest.Create collection,
+                PlayerExerciseRequest.Create exercise,
+                PlayerMediaLogRequest.Create media
+        ) {
+            this(type, null, null, collection, exercise, media);
+        }
     }
 }

--- a/src/main/java/online/lifeasgame/lifelog/quick/api/QuickRecordWebMapper.java
+++ b/src/main/java/online/lifeasgame/lifelog/quick/api/QuickRecordWebMapper.java
@@ -16,6 +16,8 @@ public final class QuickRecordWebMapper {
     ) {
         return new QuickRecordCommand.Create(
                 request.type(),
+                request.lifeLogSubtype(),
+                request.reflectionScope(),
                 request.collection() == null
                         ? null
                         : PlayerCollectionWebMapper.toCreateCommand(

--- a/src/main/java/online/lifeasgame/lifelog/quick/application/QuickRecordCommand.java
+++ b/src/main/java/online/lifeasgame/lifelog/quick/application/QuickRecordCommand.java
@@ -4,6 +4,7 @@ import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.lifelog.application.command.CollectionCommand;
 import online.lifeasgame.lifelog.application.command.ExerciseCommand;
 import online.lifeasgame.lifelog.application.command.MediaLogCommand;
+import online.lifeasgame.lifelog.application.record.LifeLogRecordMetadataCommand;
 import online.lifeasgame.lifelog.domain.event.LifeLogType;
 import online.lifeasgame.lifelog.quick.domain.error.QuickRecordError;
 
@@ -19,10 +20,21 @@ public final class QuickRecordCommand {
 
     public record Create(
             String type,
+            String lifeLogSubtype,
+            String reflectionScope,
             CollectionCommand.Create collection,
             ExerciseCommand.Create exercise,
             MediaLogCommand.Create media
     ) {
+        public Create(
+                String type,
+                CollectionCommand.Create collection,
+                ExerciseCommand.Create exercise,
+                MediaLogCommand.Create media
+        ) {
+            this(type, null, null, collection, exercise, media);
+        }
+
         public Create {
             collection = copy(collection);
             exercise = copy(exercise);
@@ -43,8 +55,21 @@ public final class QuickRecordCommand {
                     && media == null) {
                 throw invalid();
             }
+            LifeLogRecordMetadataCommand nestedMetadata =
+                    switch (selectedType) {
+                        case COLLECTION -> collection.lifeLogMetadata();
+                        case EXERCISE -> exercise.lifeLogMetadata();
+                        case MEDIA -> media.lifeLogMetadata();
+                    };
+            if (nestedMetadata != null && nestedMetadata.isPresent()) {
+                throw invalid();
+            }
             return new Selected(
                     selectedType,
+                    new LifeLogRecordMetadataCommand(
+                            lifeLogSubtype,
+                            reflectionScope
+                    ),
                     collection,
                     exercise,
                     media
@@ -54,6 +79,7 @@ public final class QuickRecordCommand {
 
     public record Selected(
             LifeLogType type,
+            LifeLogRecordMetadataCommand lifeLogMetadata,
             CollectionCommand.Create collection,
             ExerciseCommand.Create exercise,
             MediaLogCommand.Create media
@@ -90,7 +116,8 @@ public final class QuickRecordCommand {
                 value.quantity(),
                 value.conditionNote(),
                 value.acquiredFrom(),
-                copyTags(value.tags())
+                copyTags(value.tags()),
+                value.lifeLogMetadata()
         );
     }
 
@@ -106,7 +133,8 @@ public final class QuickRecordCommand {
                 value.distanceKm(),
                 value.calories(),
                 value.exercisedOn(),
-                value.memo()
+                value.memo(),
+                value.lifeLogMetadata()
         );
     }
 
@@ -123,7 +151,8 @@ public final class QuickRecordCommand {
                 value.currentEpisode(),
                 value.totalEpisode(),
                 value.status(),
-                copyTags(value.tags())
+                copyTags(value.tags()),
+                value.lifeLogMetadata()
         );
     }
 

--- a/src/main/java/online/lifeasgame/lifelog/quick/application/QuickRecordRequestHasher.java
+++ b/src/main/java/online/lifeasgame/lifelog/quick/application/QuickRecordRequestHasher.java
@@ -3,6 +3,7 @@ package online.lifeasgame.lifelog.quick.application;
 import online.lifeasgame.lifelog.application.command.CollectionCommand;
 import online.lifeasgame.lifelog.application.command.ExerciseCommand;
 import online.lifeasgame.lifelog.application.command.MediaLogCommand;
+import online.lifeasgame.lifelog.application.record.LifeLogRecordMetadataCommand;
 import online.lifeasgame.lifelog.domain.CollectionCategory;
 import online.lifeasgame.lifelog.domain.ExerciseCategory;
 import online.lifeasgame.lifelog.domain.MediaCategory;
@@ -24,6 +25,7 @@ public class QuickRecordRequestHasher {
     public String hash(QuickRecordCommand.Selected selected) {
         StringBuilder canonical = new StringBuilder();
         appendText(canonical, "type", selected.type().name());
+        appendLifeLogMetadata(canonical, selected.lifeLogMetadata());
         switch (selected.type()) {
             case COLLECTION ->
                     appendCollection(canonical, selected.collection());
@@ -32,6 +34,31 @@ public class QuickRecordRequestHasher {
             case MEDIA -> appendMedia(canonical, selected.media());
         }
         return sha256(canonical.toString());
+    }
+
+    private void appendLifeLogMetadata(
+            StringBuilder target,
+            LifeLogRecordMetadataCommand metadata
+    ) {
+        if (!metadata.isPresent()) {
+            return;
+        }
+        LifeLogRecordMetadataCommand.Resolved resolved =
+                metadata.resolve();
+        appendOptionalText(
+                target,
+                "lifeLogSubtype",
+                resolved.subtype() == null
+                        ? null
+                        : resolved.subtype().name()
+        );
+        appendOptionalText(
+                target,
+                "reflectionScope",
+                resolved.reflectionScope() == null
+                        ? null
+                        : resolved.reflectionScope().name()
+        );
     }
 
     private void appendCollection(

--- a/src/main/java/online/lifeasgame/lifelog/quick/application/QuickRecordService.java
+++ b/src/main/java/online/lifeasgame/lifelog/quick/application/QuickRecordService.java
@@ -85,9 +85,10 @@ public class QuickRecordService {
         return switch (selected.type()) {
             case COLLECTION -> {
                 CollectionResult.Created created =
-                        collectionLogService.create(
+                        collectionLogService.createQuick(
                                 playerId,
-                                selected.collection()
+                                selected.collection(),
+                                selected.lifeLogMetadata()
                         );
                 yield new SourceSnapshot(
                         LifeLogType.COLLECTION,
@@ -97,9 +98,10 @@ public class QuickRecordService {
             }
             case EXERCISE -> {
                 ExerciseResult.Created created =
-                        exerciseLogService.create(
+                        exerciseLogService.createQuick(
                                 playerId,
-                                selected.exercise()
+                                selected.exercise(),
+                                selected.lifeLogMetadata()
                         );
                 yield new SourceSnapshot(
                         LifeLogType.EXERCISE,
@@ -109,9 +111,10 @@ public class QuickRecordService {
             }
             case MEDIA -> {
                 MediaLogResult.Created created =
-                        mediaLogService.create(
+                        mediaLogService.createQuick(
                                 playerId,
-                                selected.media()
+                                selected.media(),
+                                selected.lifeLogMetadata()
                         );
                 yield new SourceSnapshot(
                         LifeLogType.MEDIA,

--- a/src/main/java/online/lifeasgame/platform/outbox/application/codec/LifeLogRecordedOutboxCodec.java
+++ b/src/main/java/online/lifeasgame/platform/outbox/application/codec/LifeLogRecordedOutboxCodec.java
@@ -1,0 +1,297 @@
+package online.lifeasgame.platform.outbox.application.codec;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.lifelog.domain.event.LifeLogRecorded;
+import online.lifeasgame.lifelog.domain.event.LifeLogType;
+import online.lifeasgame.lifelog.domain.record.LifeLogEntryMode;
+import online.lifeasgame.lifelog.domain.record.LifeLogReflectionScope;
+import online.lifeasgame.lifelog.domain.record.LifeLogSubtype;
+import online.lifeasgame.platform.outbox.domain.error.OutboxError;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+final class LifeLogRecordedOutboxCodec
+        implements OutboxEventCodec<LifeLogRecorded> {
+
+    static final String ALIAS = "lifelog.recorded.v1";
+
+    private static final Set<String> NEW_FIELDS = Set.of(
+            "eventId",
+            "eventType",
+            "eventVersion",
+            "occurredAt",
+            "playerId",
+            "lifeLogId",
+            "sourceDefinitionVersion",
+            "subtype",
+            "entryMode",
+            "reflectionScope",
+            "periodKey",
+            "primaryRoleId"
+    );
+    private static final Set<String> LEGACY_REQUIRED_FIELDS = Set.of(
+            "eventId",
+            "eventVersion",
+            "playerId",
+            "lifeLogId",
+            "lifeLogType",
+            "occurredAt"
+    );
+    private static final Set<String> LEGACY_FIELDS = Set.of(
+            "eventId",
+            "eventVersion",
+            "playerId",
+            "lifeLogId",
+            "lifeLogType",
+            "primaryRoleId",
+            "occurredAt"
+    );
+
+    private final ObjectMapper objectMapper;
+
+    LifeLogRecordedOutboxCodec(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public String alias() {
+        return ALIAS;
+    }
+
+    @Override
+    public Class<LifeLogRecorded> eventType() {
+        return LifeLogRecorded.class;
+    }
+
+    @Override
+    public String encode(LifeLogRecorded event) {
+        try {
+            ObjectNode payload = objectMapper.createObjectNode();
+            payload.put("eventId", event.eventId());
+            payload.put("eventType", event.eventType());
+            payload.put("eventVersion", event.eventVersion());
+            payload.put("occurredAt", event.occurredAt().toString());
+            payload.put("playerId", event.playerId());
+            payload.put("lifeLogId", event.lifeLogId());
+            putNullable(
+                    payload,
+                    "sourceDefinitionVersion",
+                    event.sourceDefinitionVersion()
+            );
+            putNullable(
+                    payload,
+                    "subtype",
+                    name(event.subtype())
+            );
+            putNullable(
+                    payload,
+                    "entryMode",
+                    name(event.entryMode())
+            );
+            putNullable(
+                    payload,
+                    "reflectionScope",
+                    name(event.reflectionScope())
+            );
+            putNullable(payload, "periodKey", event.periodKey());
+            putNullable(payload, "primaryRoleId", event.primaryRoleId());
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException exception) {
+            throw failed(exception);
+        }
+    }
+
+    @Override
+    public LifeLogRecorded decode(String payload) {
+        try {
+            JsonNode root = objectMapper.readTree(payload);
+            if (root == null || !root.isObject()) {
+                throw new IllegalArgumentException(
+                        "LifeLogRecorded payload must be an object"
+                );
+            }
+            if (root.has("lifeLogType")) {
+                return decodeLegacy(root);
+            }
+            return decodeNew(root);
+        } catch (JsonProcessingException exception) {
+            throw failed(exception);
+        } catch (RuntimeException exception) {
+            throw failed(exception);
+        }
+    }
+
+    private LifeLogRecorded decodeLegacy(JsonNode root) {
+        Set<String> fields = fieldNames(root);
+        if (!LEGACY_FIELDS.containsAll(fields)
+                || !fields.containsAll(LEGACY_REQUIRED_FIELDS)) {
+            throw new IllegalArgumentException(
+                    "Unknown or missing legacy LifeLogRecorded field"
+            );
+        }
+        return LifeLogRecorded.legacy(
+                requiredText(root, "eventId"),
+                requiredInt(root, "eventVersion"),
+                requiredLong(root, "playerId"),
+                requiredLong(root, "lifeLogId"),
+                LifeLogType.valueOf(requiredText(root, "lifeLogType")),
+                nullableLong(root, "primaryRoleId"),
+                Instant.parse(requiredText(root, "occurredAt"))
+        );
+    }
+
+    private LifeLogRecorded decodeNew(JsonNode root) {
+        if (!fieldNames(root).equals(NEW_FIELDS)) {
+            throw new IllegalArgumentException(
+                    "Unknown or missing LifeLogRecorded field"
+            );
+        }
+        return new LifeLogRecorded(
+                requiredText(root, "eventId"),
+                requiredText(root, "eventType"),
+                requiredInt(root, "eventVersion"),
+                Instant.parse(requiredText(root, "occurredAt")),
+                requiredLong(root, "playerId"),
+                requiredLong(root, "lifeLogId"),
+                nullableInt(root, "sourceDefinitionVersion"),
+                nullableEnum(root, "subtype", LifeLogSubtype.class),
+                nullableEnum(root, "entryMode", LifeLogEntryMode.class),
+                nullableEnum(
+                        root,
+                        "reflectionScope",
+                        LifeLogReflectionScope.class
+                ),
+                nullableText(root, "periodKey"),
+                nullableLong(root, "primaryRoleId"),
+                null
+        );
+    }
+
+    private static Set<String> fieldNames(JsonNode root) {
+        Set<String> fields = new HashSet<>();
+        Iterator<String> names = root.fieldNames();
+        names.forEachRemaining(fields::add);
+        return fields;
+    }
+
+    private static String requiredText(JsonNode root, String field) {
+        JsonNode value = root.get(field);
+        if (value == null || !value.isTextual() || value.asText().isBlank()) {
+            throw new IllegalArgumentException(field + " must be text");
+        }
+        return value.asText();
+    }
+
+    private static String nullableText(JsonNode root, String field) {
+        JsonNode value = root.get(field);
+        if (value == null || value.isNull()) {
+            return null;
+        }
+        if (!value.isTextual()) {
+            throw new IllegalArgumentException(field + " must be text");
+        }
+        return value.asText();
+    }
+
+    private static int requiredInt(JsonNode root, String field) {
+        JsonNode value = root.get(field);
+        if (value == null || !value.isIntegralNumber()) {
+            throw new IllegalArgumentException(field + " must be integer");
+        }
+        return value.intValue();
+    }
+
+    private static Integer nullableInt(JsonNode root, String field) {
+        JsonNode value = root.get(field);
+        if (value == null || value.isNull()) {
+            return null;
+        }
+        if (!value.isIntegralNumber() || !value.canConvertToInt()) {
+            throw new IllegalArgumentException(field + " must be integer");
+        }
+        return value.intValue();
+    }
+
+    private static Long requiredLong(JsonNode root, String field) {
+        Long value = nullableLong(root, field);
+        if (value == null) {
+            throw new IllegalArgumentException(field + " must be integer");
+        }
+        return value;
+    }
+
+    private static Long nullableLong(JsonNode root, String field) {
+        JsonNode value = root.get(field);
+        if (value == null || value.isNull()) {
+            return null;
+        }
+        if (!value.isIntegralNumber() || !value.canConvertToLong()) {
+            throw new IllegalArgumentException(field + " must be integer");
+        }
+        return value.longValue();
+    }
+
+    private static <E extends Enum<E>> E nullableEnum(
+            JsonNode root,
+            String field,
+            Class<E> type
+    ) {
+        String value = nullableText(root, field);
+        return value == null ? null : Enum.valueOf(type, value);
+    }
+
+    private static String name(Enum<?> value) {
+        return value == null ? null : value.name();
+    }
+
+    private static void putNullable(
+            ObjectNode target,
+            String field,
+            String value
+    ) {
+        if (value == null) {
+            target.putNull(field);
+        } else {
+            target.put(field, value);
+        }
+    }
+
+    private static void putNullable(
+            ObjectNode target,
+            String field,
+            Integer value
+    ) {
+        if (value == null) {
+            target.putNull(field);
+        } else {
+            target.put(field, value);
+        }
+    }
+
+    private static void putNullable(
+            ObjectNode target,
+            String field,
+            Long value
+    ) {
+        if (value == null) {
+            target.putNull(field);
+        } else {
+            target.put(field, value);
+        }
+    }
+
+    private static DomainException failed(Exception exception) {
+        return new DomainException(
+                OutboxError.OUTBOX_EVENT_CODEC_FAILED,
+                null,
+                exception
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/platform/outbox/application/codec/LifeLogRecordedOutboxCodec.java
+++ b/src/main/java/online/lifeasgame/platform/outbox/application/codec/LifeLogRecordedOutboxCodec.java
@@ -202,7 +202,9 @@ final class LifeLogRecordedOutboxCodec
 
     private static int requiredInt(JsonNode root, String field) {
         JsonNode value = root.get(field);
-        if (value == null || !value.isIntegralNumber()) {
+        if (value == null
+                || !value.isIntegralNumber()
+                || !value.canConvertToInt()) {
             throw new IllegalArgumentException(field + " must be integer");
         }
         return value.intValue();

--- a/src/main/java/online/lifeasgame/platform/outbox/application/codec/OutboxEventCodecRegistry.java
+++ b/src/main/java/online/lifeasgame/platform/outbox/application/codec/OutboxEventCodecRegistry.java
@@ -63,11 +63,7 @@ public class OutboxEventCodecRegistry {
                         ExerciseLogged.class,
                         objectMapper
                 ),
-                codec(
-                        "lifelog.recorded.v1",
-                        LifeLogRecorded.class,
-                        objectMapper
-                ),
+                new LifeLogRecordedOutboxCodec(objectMapper),
                 codec(
                         "lifelog.media-advanced.v1",
                         MediaLogAdvanced.class,

--- a/src/main/resources/db/migration/V15__canonical_lifelog_record_metadata.sql
+++ b/src/main/resources/db/migration/V15__canonical_lifelog_record_metadata.sql
@@ -45,13 +45,18 @@ CREATE TABLE life_log_records (
         )
         OR
         (
-            subtype = 'REFLECTION'
+            subtype IS NOT NULL
+            AND subtype = 'REFLECTION'
             AND reflection_scope = 'WEEKLY_LOOKBACK'
+            AND period_key IS NOT NULL
             AND period_key REGEXP '^[0-9]{4}-W(0[1-9]|[1-4][0-9]|5[0-3])$'
         )
     ),
     CONSTRAINT ck_life_log_record_non_reflection_metadata CHECK (
-        subtype = 'REFLECTION'
+        (
+            subtype IS NOT NULL
+            AND subtype = 'REFLECTION'
+        )
         OR (
             reflection_scope IS NULL
             AND period_key IS NULL

--- a/src/main/resources/db/migration/V15__canonical_lifelog_record_metadata.sql
+++ b/src/main/resources/db/migration/V15__canonical_lifelog_record_metadata.sql
@@ -1,0 +1,64 @@
+CREATE TABLE life_log_records (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    player_id BIGINT NOT NULL,
+    source_type VARCHAR(20) NOT NULL,
+    source_id BIGINT NOT NULL,
+    source_definition_version INT NOT NULL,
+    subtype VARCHAR(20) NULL,
+    entry_mode VARCHAR(20) NOT NULL,
+    reflection_scope VARCHAR(30) NULL,
+    period_key VARCHAR(20) NULL,
+    primary_role_id BIGINT NULL,
+    occurred_at DATETIME(6) NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_life_log_record_source
+        UNIQUE (source_type, source_id),
+    CONSTRAINT ck_life_log_record_source_type
+        CHECK (source_type IN ('COLLECTION', 'EXERCISE', 'MEDIA')),
+    CONSTRAINT ck_life_log_record_definition_version
+        CHECK (source_definition_version >= 1),
+    CONSTRAINT ck_life_log_record_subtype CHECK (
+        subtype IS NULL
+        OR subtype IN (
+            'QUICK_NOTE',
+            'ACTIVITY',
+            'STUDY',
+            'PROJECT',
+            'MEMORY',
+            'REFLECTION',
+            'MOOD',
+            'HEALTH_NOTE'
+        )
+    ),
+    CONSTRAINT ck_life_log_record_entry_mode
+        CHECK (entry_mode IN ('FULL', 'QUICK')),
+    CONSTRAINT ck_life_log_record_reflection_scope CHECK (
+        reflection_scope IS NULL
+        OR reflection_scope = 'WEEKLY_LOOKBACK'
+    ),
+    CONSTRAINT ck_life_log_record_reflection_pairing CHECK (
+        (
+            reflection_scope IS NULL
+            AND period_key IS NULL
+        )
+        OR
+        (
+            subtype = 'REFLECTION'
+            AND reflection_scope = 'WEEKLY_LOOKBACK'
+            AND period_key REGEXP '^[0-9]{4}-W(0[1-9]|[1-4][0-9]|5[0-3])$'
+        )
+    ),
+    CONSTRAINT ck_life_log_record_non_reflection_metadata CHECK (
+        subtype = 'REFLECTION'
+        OR (
+            reflection_scope IS NULL
+            AND period_key IS NULL
+        )
+    ),
+    CONSTRAINT ck_life_log_record_primary_role
+        CHECK (primary_role_id IS NULL)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_0900_ai_ci;

--- a/src/test/java/online/lifeasgame/lifelog/api/player/mapper/LifeLogRecordMetadataWebMapperTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/api/player/mapper/LifeLogRecordMetadataWebMapperTest.java
@@ -1,0 +1,114 @@
+package online.lifeasgame.lifelog.api.player.mapper;
+
+import online.lifeasgame.lifelog.api.player.request.PlayerCollectionRequest;
+import online.lifeasgame.lifelog.api.player.request.PlayerExerciseRequest;
+import online.lifeasgame.lifelog.api.player.request.PlayerMediaLogRequest;
+import online.lifeasgame.lifelog.quick.api.QuickRecordRequest;
+import online.lifeasgame.lifelog.quick.api.QuickRecordWebMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("LifeLog canonical metadata Web mapping")
+class LifeLogRecordMetadataWebMapperTest {
+
+    @Test
+    @DisplayName("세 direct create API의 nullable metadata를 command로 보존한다")
+    void mapsDirectMetadata() {
+        var collection = PlayerCollectionWebMapper.toCreateCommand(
+                new PlayerCollectionRequest.Create(
+                        "BOOK",
+                        "title",
+                        null,
+                        1,
+                        null,
+                        null,
+                        Set.of(),
+                        "MEMORY",
+                        null
+                )
+        );
+        var exercise = PlayerExerciseWebMapper.toCreateCommand(
+                new PlayerExerciseRequest.Create(
+                        "RUNNING",
+                        10,
+                        null,
+                        null,
+                        LocalDate.of(2026, 7, 29),
+                        null,
+                        "ACTIVITY",
+                        null
+                )
+        );
+        var media = PlayerMediaLogWebMapper.toCreateCommand(
+                new PlayerMediaLogRequest.Create(
+                        "BOOK",
+                        "title",
+                        null,
+                        0,
+                        1,
+                        "PLANNED",
+                        Set.of(),
+                        "STUDY",
+                        null
+                )
+        );
+
+        assertThat(collection.lifeLogMetadata().lifeLogSubtype())
+                .isEqualTo("MEMORY");
+        assertThat(exercise.lifeLogMetadata().lifeLogSubtype())
+                .isEqualTo("ACTIVITY");
+        assertThat(media.lifeLogMetadata().lifeLogSubtype())
+                .isEqualTo("STUDY");
+    }
+
+    @Test
+    @DisplayName("기존 direct client 입력은 metadata null command로 계속 mapping한다")
+    void mapsLegacyDirectInputWithoutMetadata() {
+        var command = PlayerCollectionWebMapper.toCreateCommand(
+                new PlayerCollectionRequest.Create(
+                        "BOOK",
+                        "title",
+                        null,
+                        1,
+                        null,
+                        null,
+                        Set.of()
+                )
+        );
+
+        assertThat(command.lifeLogMetadata().isPresent()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Quick Record는 top-level metadata만 selected command로 전달한다")
+    void mapsQuickTopLevelMetadata() {
+        var command = QuickRecordWebMapper.toCommand(
+                new QuickRecordRequest.Create(
+                        "COLLECTION",
+                        "REFLECTION",
+                        "WEEKLY_LOOKBACK",
+                        new PlayerCollectionRequest.Create(
+                                "BOOK",
+                                "weekly",
+                                null,
+                                1,
+                                null,
+                                null,
+                                Set.of()
+                        ),
+                        null,
+                        null
+                )
+        ).selected();
+
+        assertThat(command.lifeLogMetadata().lifeLogSubtype())
+                .isEqualTo("REFLECTION");
+        assertThat(command.lifeLogMetadata().reflectionScope())
+                .isEqualTo("WEEKLY_LOOKBACK");
+    }
+}

--- a/src/test/java/online/lifeasgame/lifelog/application/LifeLogRecordedApplicationServiceTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/application/LifeLogRecordedApplicationServiceTest.java
@@ -5,6 +5,8 @@ import online.lifeasgame.core.event.DomainEventPublisher;
 import online.lifeasgame.lifelog.application.command.CollectionCommand;
 import online.lifeasgame.lifelog.application.command.ExerciseCommand;
 import online.lifeasgame.lifelog.application.command.MediaLogCommand;
+import online.lifeasgame.lifelog.application.record.LifeLogRecordMetadataCommand;
+import online.lifeasgame.lifelog.application.record.LifeLogRecordService;
 import online.lifeasgame.lifelog.application.result.CollectionResult;
 import online.lifeasgame.lifelog.application.result.ExerciseResult;
 import online.lifeasgame.lifelog.application.result.MediaLogResult;
@@ -18,20 +20,22 @@ import online.lifeasgame.lifelog.domain.Quantity;
 import online.lifeasgame.lifelog.domain.event.CollectionLogged;
 import online.lifeasgame.lifelog.domain.event.ExerciseLogged;
 import online.lifeasgame.lifelog.domain.event.LifeLogRecorded;
-import online.lifeasgame.lifelog.domain.event.LifeLogType;
+import online.lifeasgame.lifelog.domain.record.LifeLogEntryMode;
+import online.lifeasgame.lifelog.domain.record.LifeLogRecord;
+import online.lifeasgame.lifelog.domain.record.LifeLogSourceType;
+import online.lifeasgame.lifelog.domain.record.LifeLogSubtype;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -42,25 +46,37 @@ class LifeLogRecordedApplicationServiceTest {
     private static final Long PLAYER_ID = 197L;
     private static final Instant OCCURRED_AT =
             Instant.parse("2026-07-24T10:00:00Z");
-    private static final Clock CLOCK =
-            Clock.fixed(OCCURRED_AT, ZoneOffset.UTC);
 
     @Test
-    @DisplayName("Collection create는 저장 후 subtype Event와 Fact를 각각 한 번 발행한다")
-    void recordsCollectionCreate() {
+    @DisplayName("Collection direct legacy create는 FULL header와 non-ready Fact를 한 번 만든다")
+    void recordsLegacyCollectionCreate() {
         CollectionLogReader reader = mock(CollectionLogReader.class);
         CollectionLogWriter writer = mock(CollectionLogWriter.class);
+        LifeLogRecordService recordService =
+                mock(LifeLogRecordService.class);
         RecordingPublisher publisher = new RecordingPublisher();
         CollectionLog saved = mock(CollectionLog.class);
         when(saved.getId()).thenReturn(101L);
         when(saved.getCategory()).thenReturn(CollectionCategory.BOOK);
         when(saved.getQuantity()).thenReturn(Quantity.of(2));
         when(writer.create(any(CollectionLog.class))).thenReturn(saved);
+        LifeLogRecord canonical = record(
+                1001L,
+                LifeLogEntryMode.FULL,
+                null
+        );
+        when(recordService.create(
+                eq(PLAYER_ID),
+                eq(LifeLogSourceType.COLLECTION),
+                eq(101L),
+                eq(LifeLogEntryMode.FULL),
+                any(LifeLogRecordMetadataCommand.class)
+        )).thenReturn(canonical);
         CollectionLogService service = new CollectionLogService(
                 reader,
                 writer,
-                publisher,
-                CLOCK
+                recordService,
+                publisher
         );
 
         CollectionResult.Created result = service.create(
@@ -78,39 +94,51 @@ class LifeLogRecordedApplicationServiceTest {
 
         verify(writer).create(any(CollectionLog.class));
         assertThat(result.id()).isEqualTo(101L);
+        assertThat(result.lifeLogId()).isEqualTo(1001L);
         assertThat(publisher.events())
                 .filteredOn(CollectionLogged.class::isInstance)
-                .singleElement()
-                .satisfies(event -> {
-                    CollectionLogged logged = (CollectionLogged) event;
-                    assertThat(logged.playerId()).isEqualTo(PLAYER_ID);
-                    assertThat(logged.collectionLogId()).isEqualTo(101L);
-                    assertThat(logged.occurredAt()).isEqualTo(OCCURRED_AT);
-                });
+                .singleElement();
         assertRecorded(
                 publisher.events(),
-                101L,
-                LifeLogType.COLLECTION
+                1001L,
+                LifeLogEntryMode.FULL,
+                null
         );
         assertThat(publisher.events()).hasSize(2);
     }
 
     @Test
-    @DisplayName("Exercise create는 저장 후 subtype Event와 Fact를 각각 한 번 발행한다")
-    void recordsExerciseCreate() {
+    @DisplayName("Exercise content-ready direct create는 FULL Definition Snapshot을 발행한다")
+    void recordsContentReadyExerciseCreate() {
         ExerciseLogReader reader = mock(ExerciseLogReader.class);
         ExerciseLogWriter writer = mock(ExerciseLogWriter.class);
+        LifeLogRecordService recordService =
+                mock(LifeLogRecordService.class);
         RecordingPublisher publisher = new RecordingPublisher();
         ExerciseLog saved = mock(ExerciseLog.class);
         when(saved.getId()).thenReturn(102L);
         when(saved.getCategory()).thenReturn(ExerciseCategory.RUNNING);
-        when(saved.getMetrics()).thenReturn(ExerciseMetrics.of(30, 5.0, 250));
+        when(saved.getMetrics()).thenReturn(
+                ExerciseMetrics.of(30, 5.0, 250)
+        );
         when(writer.create(any(ExerciseLog.class))).thenReturn(saved);
+        LifeLogRecord canonical = record(
+                1002L,
+                LifeLogEntryMode.FULL,
+                LifeLogSubtype.ACTIVITY
+        );
+        when(recordService.create(
+                eq(PLAYER_ID),
+                eq(LifeLogSourceType.EXERCISE),
+                eq(102L),
+                eq(LifeLogEntryMode.FULL),
+                any(LifeLogRecordMetadataCommand.class)
+        )).thenReturn(canonical);
         ExerciseLogService service = new ExerciseLogService(
                 reader,
                 writer,
-                publisher,
-                CLOCK
+                recordService,
+                publisher
         );
 
         ExerciseResult.Created result = service.create(
@@ -121,43 +149,56 @@ class LifeLogRecordedApplicationServiceTest {
                         5.0,
                         250,
                         LocalDate.of(2026, 7, 24),
-                        "Private exercise memo"
+                        "Private exercise memo",
+                        new LifeLogRecordMetadataCommand(
+                                "ACTIVITY",
+                                null
+                        )
                 )
         );
 
-        verify(writer).create(any(ExerciseLog.class));
         assertThat(result.id()).isEqualTo(102L);
+        assertThat(result.lifeLogId()).isEqualTo(1002L);
         assertThat(publisher.events())
                 .filteredOn(ExerciseLogged.class::isInstance)
-                .singleElement()
-                .satisfies(event -> {
-                    ExerciseLogged logged = (ExerciseLogged) event;
-                    assertThat(logged.playerId()).isEqualTo(PLAYER_ID);
-                    assertThat(logged.exerciseLogId()).isEqualTo(102L);
-                    assertThat(logged.occurredAt()).isEqualTo(OCCURRED_AT);
-                });
+                .singleElement();
         assertRecorded(
                 publisher.events(),
-                102L,
-                LifeLogType.EXERCISE
+                1002L,
+                LifeLogEntryMode.FULL,
+                LifeLogSubtype.ACTIVITY
         );
         assertThat(publisher.events()).hasSize(2);
     }
 
     @Test
-    @DisplayName("Media create는 저장 후 Fact를 정확히 한 번 발행한다")
-    void recordsMediaCreate() {
+    @DisplayName("Media content-ready direct create도 Fact를 정확히 한 번 발행한다")
+    void recordsMediaCreateOnce() {
         MediaLogReader reader = mock(MediaLogReader.class);
         MediaLogWriter writer = mock(MediaLogWriter.class);
+        LifeLogRecordService recordService =
+                mock(LifeLogRecordService.class);
         RecordingPublisher publisher = new RecordingPublisher();
         MediaLog saved = mock(MediaLog.class);
         when(saved.getId()).thenReturn(103L);
         when(writer.create(any(MediaLog.class))).thenReturn(saved);
+        LifeLogRecord canonical = record(
+                1003L,
+                LifeLogEntryMode.FULL,
+                LifeLogSubtype.STUDY
+        );
+        when(recordService.create(
+                eq(PLAYER_ID),
+                eq(LifeLogSourceType.MEDIA),
+                eq(103L),
+                eq(LifeLogEntryMode.FULL),
+                any(LifeLogRecordMetadataCommand.class)
+        )).thenReturn(canonical);
         MediaLogService service = new MediaLogService(
                 reader,
                 writer,
-                publisher,
-                CLOCK
+                recordService,
+                publisher
         );
 
         MediaLogResult.Created result = service.create(
@@ -169,20 +210,27 @@ class LifeLogRecordedApplicationServiceTest {
                         0,
                         1,
                         "PLANNED",
-                        Set.of("private-tag")
+                        Set.of("private-tag"),
+                        new LifeLogRecordMetadataCommand("STUDY", null)
                 )
         );
 
-        verify(writer).create(any(MediaLog.class));
         assertThat(result.id()).isEqualTo(103L);
-        assertRecorded(publisher.events(), 103L, LifeLogType.MEDIA);
+        assertThat(result.lifeLogId()).isEqualTo(1003L);
+        assertRecorded(
+                publisher.events(),
+                1003L,
+                LifeLogEntryMode.FULL,
+                LifeLogSubtype.STUDY
+        );
         assertThat(publisher.events()).hasSize(1);
     }
 
     private void assertRecorded(
             List<DomainEvent> events,
             Long lifeLogId,
-            LifeLogType type
+            LifeLogEntryMode entryMode,
+            LifeLogSubtype subtype
     ) {
         assertThat(events)
                 .filteredOn(LifeLogRecorded.class::isInstance)
@@ -190,14 +238,40 @@ class LifeLogRecordedApplicationServiceTest {
                 .satisfies(event -> {
                     LifeLogRecorded recorded = (LifeLogRecorded) event;
                     assertThat(recorded.eventId()).isNotBlank();
+                    assertThat(recorded.eventType())
+                            .isEqualTo("LifeLogRecorded");
                     assertThat(recorded.eventVersion()).isEqualTo(1);
                     assertThat(recorded.playerId()).isEqualTo(PLAYER_ID);
-                    assertThat(recorded.lifeLogId()).isEqualTo(lifeLogId);
-                    assertThat(recorded.lifeLogType()).isEqualTo(type);
+                    assertThat(recorded.lifeLogId())
+                            .isEqualTo(lifeLogId);
+                    assertThat(recorded.sourceDefinitionVersion())
+                            .isEqualTo(1);
+                    assertThat(recorded.subtype()).isEqualTo(subtype);
+                    assertThat(recorded.entryMode())
+                            .isEqualTo(entryMode);
+                    assertThat(recorded.legacyLifeLogType()).isNull();
                     assertThat(recorded.primaryRoleId()).isNull();
                     assertThat(recorded.occurredAt())
                             .isEqualTo(OCCURRED_AT);
+                    assertThat(recorded.isContentReady())
+                            .isEqualTo(subtype != null);
                 });
+    }
+
+    private LifeLogRecord record(
+            Long id,
+            LifeLogEntryMode entryMode,
+            LifeLogSubtype subtype
+    ) {
+        LifeLogRecord record = mock(LifeLogRecord.class);
+        when(record.getId()).thenReturn(id);
+        when(record.getPlayerId()).thenReturn(PLAYER_ID);
+        when(record.getSourceDefinitionVersion()).thenReturn(1);
+        when(record.getEntryMode()).thenReturn(entryMode);
+        when(record.getSubtype()).thenReturn(subtype);
+        when(record.getPrimaryRoleId()).thenReturn(null);
+        when(record.getOccurredAt()).thenReturn(OCCURRED_AT);
+        return record;
     }
 
     private static class RecordingPublisher implements DomainEventPublisher {

--- a/src/test/java/online/lifeasgame/lifelog/application/LifeLogRecordedOutboxIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/application/LifeLogRecordedOutboxIntegrationTest.java
@@ -382,15 +382,21 @@ class LifeLogRecordedOutboxIntegrationTest {
         assertThat(event.sourceDefinitionVersion()).isEqualTo(1);
         assertThat(event.entryMode()).isEqualTo(LifeLogEntryMode.FULL);
         assertThat(event.legacyLifeLogType()).isNull();
-        if (type == LifeLogType.COLLECTION) {
-            assertThat(event.subtype()).isNull();
-            assertThat(event.isContentReady()).isFalse();
-        } else {
-            assertThat(event.subtype()).isIn(
-                    LifeLogSubtype.ACTIVITY,
-                    LifeLogSubtype.STUDY
-            );
-            assertThat(event.isContentReady()).isTrue();
+        switch (type) {
+            case COLLECTION -> {
+                assertThat(event.subtype()).isNull();
+                assertThat(event.isContentReady()).isFalse();
+            }
+            case EXERCISE -> {
+                assertThat(event.subtype())
+                        .isEqualTo(LifeLogSubtype.ACTIVITY);
+                assertThat(event.isContentReady()).isTrue();
+            }
+            case MEDIA -> {
+                assertThat(event.subtype())
+                        .isEqualTo(LifeLogSubtype.STUDY);
+                assertThat(event.isContentReady()).isTrue();
+            }
         }
         assertThat(event.primaryRoleId()).isNull();
         assertThat(event.occurredAt()).isEqualTo(OCCURRED_AT);

--- a/src/test/java/online/lifeasgame/lifelog/application/LifeLogRecordedOutboxIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/application/LifeLogRecordedOutboxIntegrationTest.java
@@ -6,8 +6,11 @@ import online.lifeasgame.core.event.DomainEvent;
 import online.lifeasgame.lifelog.application.command.CollectionCommand;
 import online.lifeasgame.lifelog.application.command.ExerciseCommand;
 import online.lifeasgame.lifelog.application.command.MediaLogCommand;
+import online.lifeasgame.lifelog.application.record.LifeLogRecordMetadataCommand;
 import online.lifeasgame.lifelog.domain.event.LifeLogRecorded;
 import online.lifeasgame.lifelog.domain.event.LifeLogType;
+import online.lifeasgame.lifelog.domain.record.LifeLogEntryMode;
+import online.lifeasgame.lifelog.domain.record.LifeLogSubtype;
 import online.lifeasgame.platform.outbox.OutboxProperties;
 import online.lifeasgame.platform.outbox.application.OutboxRelayResult;
 import online.lifeasgame.platform.outbox.application.OutboxRelayScheduler;
@@ -61,12 +64,17 @@ class LifeLogRecordedOutboxIntegrationTest {
             Instant.parse("2026-07-24T11:00:00.123456Z");
     private static final Set<String> PAYLOAD_FIELDS = Set.of(
             "eventId",
+            "eventType",
             "eventVersion",
+            "occurredAt",
             "playerId",
             "lifeLogId",
-            "lifeLogType",
-            "primaryRoleId",
-            "occurredAt"
+            "sourceDefinitionVersion",
+            "subtype",
+            "entryMode",
+            "reflectionScope",
+            "periodKey",
+            "primaryRoleId"
     );
     private static final List<String> FORBIDDEN_FIELDS = List.of(
             "title",
@@ -143,6 +151,7 @@ class LifeLogRecordedOutboxIntegrationTest {
     void setUp() {
         jdbcTemplate.update("DELETE FROM collection_log_tags");
         jdbcTemplate.update("DELETE FROM media_log_tags");
+        jdbcTemplate.update("DELETE FROM life_log_records");
         jdbcTemplate.update("DELETE FROM collection_logs");
         jdbcTemplate.update("DELETE FROM exercise_logs");
         jdbcTemplate.update("DELETE FROM media_logs");
@@ -165,6 +174,7 @@ class LifeLogRecordedOutboxIntegrationTest {
         ).id();
 
         assertThat(count("collection_logs")).isEqualTo(1);
+        assertThat(count("life_log_records")).isEqualTo(1);
         assertThat(countByAlias()).isEqualTo(1);
         assertRecorded(sourceId, LifeLogType.COLLECTION);
         assertThat(countByAlias("lifelog.collection-logged.v1"))
@@ -180,6 +190,7 @@ class LifeLogRecordedOutboxIntegrationTest {
         ).id();
 
         assertThat(count("exercise_logs")).isEqualTo(1);
+        assertThat(count("life_log_records")).isEqualTo(1);
         assertThat(countByAlias()).isEqualTo(1);
         assertRecorded(sourceId, LifeLogType.EXERCISE);
         assertThat(countByAlias("lifelog.exercise-logged.v1"))
@@ -195,6 +206,7 @@ class LifeLogRecordedOutboxIntegrationTest {
         ).id();
 
         assertThat(count("media_logs")).isEqualTo(1);
+        assertThat(count("life_log_records")).isEqualTo(1);
         assertThat(countByAlias()).isEqualTo(1);
         assertRecorded(sourceId, LifeLogType.MEDIA);
         assertThat(count("outbox_events")).isEqualTo(1);
@@ -209,6 +221,7 @@ class LifeLogRecordedOutboxIntegrationTest {
         });
 
         assertThat(count("collection_logs")).isZero();
+        assertThat(count("life_log_records")).isZero();
         assertThat(countByAlias()).isZero();
         assertThat(count("outbox_events")).isZero();
     }
@@ -230,11 +243,12 @@ class LifeLogRecordedOutboxIntegrationTest {
             assertThat(fields).containsExactlyInAnyOrderElementsOf(
                     PAYLOAD_FIELDS
             );
+            assertThat(json.get("eventType").asText())
+                    .isEqualTo("LifeLogRecorded");
             assertThat(json.get("eventVersion").asInt()).isEqualTo(1);
             assertThat(json.get("primaryRoleId").isNull()).isTrue();
             assertThat(payload)
                     .doesNotContain(LifeLogRecorded.class.getName())
-                    .doesNotContain(LifeLogRecorded.class.getSimpleName())
                     .doesNotContain("Private collection title")
                     .doesNotContain("Private original title")
                     .doesNotContain("Private condition")
@@ -260,6 +274,51 @@ class LifeLogRecordedOutboxIntegrationTest {
         assertThat(result.published()).isEqualTo(1);
         assertThat(result.failed()).isZero();
         assertThat(probe.events()).containsExactly(expected);
+    }
+
+    @Test
+    @DisplayName("Relay는 저장돼 있던 legacy v1 JSON도 decode해 전달한다")
+    void relaysLegacyPayload() {
+        mediaLogService.create(PLAYER_ID, mediaCommand());
+        String eventId = "21300000-0000-0000-0000-000000000001";
+        String payload = """
+                {
+                  "eventId": "%s",
+                  "eventVersion": 1,
+                  "playerId": 199,
+                  "lifeLogId": 51,
+                  "lifeLogType": "EXERCISE",
+                  "primaryRoleId": null,
+                  "occurredAt": "2026-07-24T11:00:00.123456Z"
+                }
+                """.formatted(eventId);
+        int updated = jdbcTemplate.update(
+                """
+                UPDATE outbox_events
+                SET payload = ?
+                WHERE event_type = ?
+                """,
+                payload,
+                ALIAS
+        );
+        assertThat(updated).isEqualTo(1);
+        LifeLogRecorded decoded = (LifeLogRecorded) codecRegistry.decode(
+                ALIAS,
+                payload
+        );
+        assertThat(decoded.legacyLifeLogType())
+                .isEqualTo(LifeLogType.EXERCISE);
+
+        OutboxRelayResult result = relayService.relayBatch();
+
+        assertThat(result.published())
+                .as("relay=%s, lastError=%s", result, lastError())
+                .isEqualTo(1);
+        assertThat(probe.events()).singleElement().satisfies(event -> {
+            assertThat(event.legacyLifeLogType())
+                    .isEqualTo(LifeLogType.EXERCISE);
+            assertThat(event.isContentReady()).isFalse();
+        });
     }
 
     @Test
@@ -291,7 +350,11 @@ class LifeLogRecordedOutboxIntegrationTest {
                 5.0,
                 250,
                 LocalDate.of(2026, 7, 24),
-                "Private exercise memo"
+                "Private exercise memo",
+                new LifeLogRecordMetadataCommand(
+                        "ACTIVITY",
+                        null
+                )
         );
     }
 
@@ -303,19 +366,48 @@ class LifeLogRecordedOutboxIntegrationTest {
                 0,
                 1,
                 "PLANNED",
-                Set.of("private-tag")
+                Set.of("private-tag"),
+                new LifeLogRecordMetadataCommand("STUDY", null)
         );
     }
 
     private void assertRecorded(Long sourceId, LifeLogType type) {
         LifeLogRecorded event = onlyRecordedEvent();
+        Long headerId = headerId(type, sourceId);
         assertThat(event.eventId()).isNotBlank();
+        assertThat(event.eventType()).isEqualTo("LifeLogRecorded");
         assertThat(event.eventVersion()).isEqualTo(1);
         assertThat(event.playerId()).isEqualTo(PLAYER_ID);
-        assertThat(event.lifeLogId()).isEqualTo(sourceId);
-        assertThat(event.lifeLogType()).isEqualTo(type);
+        assertThat(event.lifeLogId()).isEqualTo(headerId);
+        assertThat(event.sourceDefinitionVersion()).isEqualTo(1);
+        assertThat(event.entryMode()).isEqualTo(LifeLogEntryMode.FULL);
+        assertThat(event.legacyLifeLogType()).isNull();
+        if (type == LifeLogType.COLLECTION) {
+            assertThat(event.subtype()).isNull();
+            assertThat(event.isContentReady()).isFalse();
+        } else {
+            assertThat(event.subtype()).isIn(
+                    LifeLogSubtype.ACTIVITY,
+                    LifeLogSubtype.STUDY
+            );
+            assertThat(event.isContentReady()).isTrue();
+        }
         assertThat(event.primaryRoleId()).isNull();
         assertThat(event.occurredAt()).isEqualTo(OCCURRED_AT);
+    }
+
+    private Long headerId(LifeLogType type, Long sourceId) {
+        return jdbcTemplate.queryForObject(
+                """
+                SELECT id
+                FROM life_log_records
+                WHERE source_type = ?
+                  AND source_id = ?
+                """,
+                Long.class,
+                type.name(),
+                sourceId
+        );
     }
 
     private LifeLogRecorded onlyRecordedEvent() {
@@ -371,6 +463,13 @@ class LifeLogRecordedOutboxIntegrationTest {
                 """,
                 Integer.class,
                 alias
+        );
+    }
+
+    private String lastError() {
+        return jdbcTemplate.queryForObject(
+                "SELECT last_error FROM outbox_events",
+                String.class
         );
     }
 

--- a/src/test/java/online/lifeasgame/lifelog/domain/event/LifeLogRecordedTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/domain/event/LifeLogRecordedTest.java
@@ -1,5 +1,8 @@
 package online.lifeasgame.lifelog.domain.event;
 
+import online.lifeasgame.lifelog.domain.record.LifeLogEntryMode;
+import online.lifeasgame.lifelog.domain.record.LifeLogReflectionScope;
+import online.lifeasgame.lifelog.domain.record.LifeLogSubtype;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -15,96 +18,158 @@ class LifeLogRecordedTest {
             Instant.parse("2026-07-24T09:00:00Z");
 
     @Test
-    @DisplayName("Factory는 v1과 null primaryRoleId를 고정한다")
-    void createsVersionOneWithoutPrimaryRole() {
-        LifeLogRecorded event = LifeLogRecorded.of(
-                "event-199",
-                197L,
-                199L,
-                LifeLogType.COLLECTION,
-                OCCURRED_AT
-        );
+    @DisplayName("Content-ready Fact는 공식 type/version과 Definition Snapshot을 보존한다")
+    void createsContentReadyFact() {
+        LifeLogRecorded event = contentReady();
 
-        assertThat(event.eventId()).isEqualTo("event-199");
+        assertThat(event.eventId()).isEqualTo("event-213");
+        assertThat(event.eventType())
+                .isEqualTo(LifeLogRecorded.EVENT_TYPE);
         assertThat(event.eventVersion())
                 .isEqualTo(LifeLogRecorded.EVENT_VERSION);
         assertThat(event.playerId()).isEqualTo(197L);
-        assertThat(event.lifeLogId()).isEqualTo(199L);
-        assertThat(event.lifeLogType()).isEqualTo(LifeLogType.COLLECTION);
+        assertThat(event.lifeLogId()).isEqualTo(213L);
+        assertThat(event.sourceDefinitionVersion()).isEqualTo(1);
+        assertThat(event.subtype()).isEqualTo(LifeLogSubtype.ACTIVITY);
+        assertThat(event.entryMode()).isEqualTo(LifeLogEntryMode.FULL);
         assertThat(event.primaryRoleId()).isNull();
+        assertThat(event.legacyLifeLogType()).isNull();
         assertThat(event.occurredAt()).isEqualTo(OCCURRED_AT);
+        assertThat(event.isContentReady()).isTrue();
+        assertThat(event.requireContentReady()).isSameAs(event);
     }
 
     @Test
-    @DisplayName("필수 필드와 Event version을 검증한다")
-    void validatesContract() {
-        assertThatThrownBy(() -> new LifeLogRecorded(
-                " ",
+    @DisplayName("metadata 없는 신규 legacy create Fact는 Content consumer 사용을 거부한다")
+    void marksNewLegacyCreateAsNotContentReady() {
+        LifeLogRecorded event = new LifeLogRecorded(
+                "event-legacy-create",
+                LifeLogRecorded.EVENT_TYPE,
                 1,
+                OCCURRED_AT,
                 197L,
-                199L,
-                LifeLogType.EXERCISE,
-                null,
-                OCCURRED_AT
-        )).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new LifeLogRecorded(
-                "event-199",
-                2,
-                197L,
-                199L,
-                LifeLogType.EXERCISE,
-                null,
-                OCCURRED_AT
-        )).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new LifeLogRecorded(
-                "event-199",
+                214L,
                 1,
                 null,
-                199L,
-                LifeLogType.EXERCISE,
-                null,
-                OCCURRED_AT
-        )).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new LifeLogRecorded(
-                "event-199",
-                1,
-                197L,
-                null,
-                LifeLogType.EXERCISE,
-                null,
-                OCCURRED_AT
-        )).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new LifeLogRecorded(
-                "event-199",
-                1,
-                197L,
-                199L,
+                LifeLogEntryMode.FULL,
                 null,
                 null,
-                OCCURRED_AT
-        )).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new LifeLogRecorded(
-                "event-199",
-                1,
-                197L,
-                199L,
-                LifeLogType.EXERCISE,
                 null,
                 null
-        )).isInstanceOf(NullPointerException.class);
+        );
+
+        assertThat(event.isContentReady()).isFalse();
+        assertThatThrownBy(event::requireContentReady)
+                .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    @DisplayName("Role Domain 전에는 primaryRoleId 입력을 거부한다")
-    void rejectsPrimaryRoleId() {
-        assertThatThrownBy(() -> new LifeLogRecorded(
-                "event-199",
+    @DisplayName("과거 transport Fact는 physical type을 decode용으로만 보존한다")
+    void supportsLegacyTransportFact() {
+        LifeLogRecorded event = LifeLogRecorded.legacy(
+                "legacy-event",
                 1,
                 197L,
-                199L,
-                LifeLogType.MEDIA,
-                31L,
+                51L,
+                LifeLogType.EXERCISE,
+                null,
                 OCCURRED_AT
+        );
+
+        assertThat(event.legacyLifeLogType())
+                .isEqualTo(LifeLogType.EXERCISE);
+        assertThat(event.sourceDefinitionVersion()).isNull();
+        assertThat(event.entryMode()).isNull();
+        assertThat(event.isContentReady()).isFalse();
+    }
+
+    @Test
+    @DisplayName("eventType, version, Definition version과 primaryRole 계약을 검증한다")
+    void validatesFactContract() {
+        assertThatThrownBy(() -> withContract(
+                "OtherEvent",
+                1,
+                1,
+                null
         )).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> withContract(
+                LifeLogRecorded.EVENT_TYPE,
+                2,
+                1,
+                null
+        )).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> withContract(
+                LifeLogRecorded.EVENT_TYPE,
+                1,
+                0,
+                null
+        )).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> withContract(
+                LifeLogRecorded.EVENT_TYPE,
+                1,
+                1,
+                31L
+        )).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("weekly reflection은 periodKey pairing을 요구한다")
+    void validatesReflectionPairing() {
+        assertThatThrownBy(() -> new LifeLogRecorded(
+                "event-weekly",
+                LifeLogRecorded.EVENT_TYPE,
+                1,
+                OCCURRED_AT,
+                197L,
+                213L,
+                1,
+                LifeLogSubtype.REFLECTION,
+                LifeLogEntryMode.QUICK,
+                LifeLogReflectionScope.WEEKLY_LOOKBACK,
+                null,
+                null,
+                null
+        )).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private LifeLogRecorded contentReady() {
+        return new LifeLogRecorded(
+                "event-213",
+                LifeLogRecorded.EVENT_TYPE,
+                1,
+                OCCURRED_AT,
+                197L,
+                213L,
+                1,
+                LifeLogSubtype.ACTIVITY,
+                LifeLogEntryMode.FULL,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    private LifeLogRecorded withContract(
+            String eventType,
+            int eventVersion,
+            int sourceDefinitionVersion,
+            Long primaryRoleId
+    ) {
+        return new LifeLogRecorded(
+                "event-213",
+                eventType,
+                eventVersion,
+                OCCURRED_AT,
+                197L,
+                213L,
+                sourceDefinitionVersion,
+                LifeLogSubtype.ACTIVITY,
+                LifeLogEntryMode.FULL,
+                null,
+                null,
+                primaryRoleId,
+                null
+        );
     }
 }

--- a/src/test/java/online/lifeasgame/lifelog/domain/record/LifeLogRecordTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/domain/record/LifeLogRecordTest.java
@@ -1,0 +1,135 @@
+package online.lifeasgame.lifelog.domain.record;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("canonical LifeLogRecord 계약")
+class LifeLogRecordTest {
+
+    private static final Instant OCCURRED_AT =
+            Instant.parse("2026-07-29T15:30:00Z");
+
+    @Test
+    @DisplayName("공식 subtype만 exact value로 parse한다")
+    void parsesOfficialSubtypeStrictly() {
+        assertThat(LifeLogSubtype.parse("QUICK_NOTE"))
+                .isEqualTo(LifeLogSubtype.QUICK_NOTE);
+        assertThat(LifeLogSubtype.parse("HEALTH_NOTE"))
+                .isEqualTo(LifeLogSubtype.HEALTH_NOTE);
+
+        assertThatThrownBy(() -> LifeLogSubtype.parse("COLLECTION"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> LifeLogSubtype.parse("activity"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> LifeLogSubtype.parse(" ACTIVITY "))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("legacy factory는 subtype null과 FULL/QUICK을 허용한다")
+    void createsLegacyRecordWithoutSubtype() {
+        LifeLogRecord full = LifeLogRecord.legacy(
+                1L,
+                LifeLogSourceType.COLLECTION,
+                1L,
+                LifeLogEntryMode.FULL,
+                OCCURRED_AT
+        );
+        LifeLogRecord quick = LifeLogRecord.legacy(
+                1L,
+                LifeLogSourceType.MEDIA,
+                1L,
+                LifeLogEntryMode.QUICK,
+                OCCURRED_AT
+        );
+
+        assertThat(full.getSourceDefinitionVersion()).isEqualTo(1);
+        assertThat(full.getSubtype()).isNull();
+        assertThat(full.isContentReady()).isFalse();
+        assertThat(quick.getEntryMode()).isEqualTo(LifeLogEntryMode.QUICK);
+        assertThat(quick.getPrimaryRoleId()).isNull();
+    }
+
+    @Test
+    @DisplayName("content-ready factory는 subtype을 필수로 요구한다")
+    void requiresContentReadySubtype() {
+        assertThatThrownBy(() -> LifeLogRecord.contentReady(
+                1L,
+                LifeLogSourceType.EXERCISE,
+                1L,
+                null,
+                LifeLogEntryMode.FULL,
+                null,
+                null,
+                OCCURRED_AT
+        )).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("weekly reflection pairing과 primaryRole null 계약을 보존한다")
+    void validatesReflectionAndRoleContract() {
+        LifeLogPeriodKey periodKey =
+                new LifeLogPeriodKey("2026-W31");
+        LifeLogRecord record = LifeLogRecord.contentReady(
+                1L,
+                LifeLogSourceType.COLLECTION,
+                1L,
+                LifeLogSubtype.REFLECTION,
+                LifeLogEntryMode.FULL,
+                LifeLogReflectionScope.WEEKLY_LOOKBACK,
+                periodKey,
+                OCCURRED_AT
+        );
+
+        assertThat(record.getPeriodKey()).isEqualTo("2026-W31");
+        assertThat(record.getPrimaryRoleId()).isNull();
+        assertThatThrownBy(() -> LifeLogRecord.contentReady(
+                1L,
+                LifeLogSourceType.COLLECTION,
+                1L,
+                LifeLogSubtype.ACTIVITY,
+                LifeLogEntryMode.FULL,
+                LifeLogReflectionScope.WEEKLY_LOOKBACK,
+                periodKey,
+                OCCURRED_AT
+        )).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("Asia/Seoul 연말연초도 ISO week-based year로 계산한다")
+    void calculatesIsoWeeklyPeriodAtYearBoundary() {
+        ZoneId seoul = ZoneId.of("Asia/Seoul");
+
+        assertThat(LifeLogPeriodKey.weekly(
+                Instant.parse("2026-12-31T15:30:00Z"),
+                seoul
+        ).value()).isEqualTo("2026-W53");
+        assertThat(LifeLogPeriodKey.weekly(
+                Instant.parse("2027-01-03T14:59:59Z"),
+                seoul
+        ).value()).isEqualTo("2026-W53");
+        assertThat(LifeLogPeriodKey.weekly(
+                Instant.parse("2027-01-03T15:00:00Z"),
+                seoul
+        ).value()).isEqualTo("2027-W01");
+    }
+
+    @Test
+    @DisplayName("periodKey는 weekly 형식과 범위를 검증한다")
+    void validatesPeriodKey() {
+        assertThatThrownBy(() -> new LifeLogPeriodKey("2026-31"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new LifeLogPeriodKey("2026-W00"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new LifeLogPeriodKey("2026-W54"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new LifeLogPeriodKey("2025-W53"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/online/lifeasgame/lifelog/quick/application/QuickRecordRequestHasherTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/quick/application/QuickRecordRequestHasherTest.java
@@ -4,6 +4,7 @@ import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.lifelog.application.command.CollectionCommand;
 import online.lifeasgame.lifelog.application.command.ExerciseCommand;
 import online.lifeasgame.lifelog.application.command.MediaLogCommand;
+import online.lifeasgame.lifelog.application.record.LifeLogRecordMetadataCommand;
 import online.lifeasgame.lifelog.domain.event.LifeLogType;
 import online.lifeasgame.lifelog.quick.domain.error.QuickRecordError;
 import org.junit.jupiter.api.DisplayName;
@@ -56,6 +57,21 @@ class QuickRecordRequestHasherTest {
         assertInvalid(new QuickRecordCommand.Create(
                 "DIARY",
                 collection("title", Set.of()),
+                null,
+                null
+        ));
+        assertInvalid(new QuickRecordCommand.Create(
+                "COLLECTION",
+                new CollectionCommand.Create(
+                        "BOOK",
+                        "title",
+                        null,
+                        1,
+                        null,
+                        null,
+                        Set.of(),
+                        new LifeLogRecordMetadataCommand("MEMORY", null)
+                ),
                 null,
                 null
         ));
@@ -135,6 +151,39 @@ class QuickRecordRequestHasherTest {
                 exercise,
                 media
         )).hasSize(4);
+    }
+
+    @Test
+    @DisplayName("Content metadata는 hash에 포함되고 legacy null metadata hash는 유지한다")
+    void hashesContentMetadataWithoutChangingLegacyShape() {
+        QuickRecordCommand.Create legacy = new QuickRecordCommand.Create(
+                "COLLECTION",
+                collection("title", Set.of("tag")),
+                null,
+                null
+        );
+        QuickRecordCommand.Create activity = new QuickRecordCommand.Create(
+                "COLLECTION",
+                "ACTIVITY",
+                null,
+                collection("title", Set.of("tag")),
+                null,
+                null
+        );
+        QuickRecordCommand.Create memory = new QuickRecordCommand.Create(
+                "COLLECTION",
+                "MEMORY",
+                null,
+                collection("title", Set.of("tag")),
+                null,
+                null
+        );
+
+        assertThat(Set.of(
+                hash(legacy),
+                hash(activity),
+                hash(memory)
+        )).hasSize(3);
     }
 
     @Test

--- a/src/test/java/online/lifeasgame/lifelog/quick/application/QuickRecordServiceIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/quick/application/QuickRecordServiceIntegrationTest.java
@@ -9,6 +9,10 @@ import online.lifeasgame.lifelog.application.command.CollectionCommand;
 import online.lifeasgame.lifelog.application.command.ExerciseCommand;
 import online.lifeasgame.lifelog.application.command.MediaLogCommand;
 import online.lifeasgame.lifelog.domain.event.LifeLogType;
+import online.lifeasgame.lifelog.domain.record.LifeLogEntryMode;
+import online.lifeasgame.lifelog.domain.record.LifeLogRecord;
+import online.lifeasgame.lifelog.domain.record.LifeLogSourceType;
+import online.lifeasgame.lifelog.domain.record.repository.LifeLogRecordRepository;
 import online.lifeasgame.lifelog.quick.domain.QuickRecordRequestReceipt;
 import online.lifeasgame.lifelog.quick.domain.error.QuickRecordError;
 import online.lifeasgame.lifelog.quick.domain.repository.QuickRecordRequestReceiptRepository;
@@ -106,6 +110,9 @@ class QuickRecordServiceIntegrationTest {
     private FailingQuickRecordReceiptRepository receiptRepository;
 
     @Autowired
+    private FailingLifeLogRecordRepository lifeLogRecordRepository;
+
+    @Autowired
     private ApplicationContext applicationContext;
 
     private ExecutorService executor;
@@ -115,12 +122,14 @@ class QuickRecordServiceIntegrationTest {
         jdbcTemplate.update("DELETE FROM quick_record_request_receipts");
         jdbcTemplate.update("DELETE FROM collection_log_tags");
         jdbcTemplate.update("DELETE FROM media_log_tags");
+        jdbcTemplate.update("DELETE FROM life_log_records");
         jdbcTemplate.update("DELETE FROM collection_logs");
         jdbcTemplate.update("DELETE FROM exercise_logs");
         jdbcTemplate.update("DELETE FROM media_logs");
         jdbcTemplate.update("DELETE FROM outbox_events");
         eventPublisher.reset();
         receiptRepository.reset();
+        lifeLogRecordRepository.reset();
         executor = Executors.newFixedThreadPool(2);
     }
 
@@ -146,6 +155,7 @@ class QuickRecordServiceIntegrationTest {
         assertThat(count("exercise_logs")).isZero();
         assertThat(count("media_logs")).isZero();
         assertThat(receiptCount()).isEqualTo(1);
+        assertThat(count("life_log_records")).isEqualTo(1);
         assertThat(outboxCount(RECORDED_ALIAS)).isEqualTo(1);
         assertThat(outboxCount(COLLECTION_ALIAS)).isEqualTo(1);
         assertThat(outboxCount()).isEqualTo(2);
@@ -174,6 +184,7 @@ class QuickRecordServiceIntegrationTest {
         assertThat(count("exercise_logs")).isEqualTo(1);
         assertThat(count("media_logs")).isZero();
         assertThat(receiptCount()).isEqualTo(1);
+        assertThat(count("life_log_records")).isEqualTo(1);
         assertThat(outboxCount(RECORDED_ALIAS)).isEqualTo(1);
         assertThat(outboxCount(EXERCISE_ALIAS)).isEqualTo(1);
         assertThat(outboxCount()).isEqualTo(2);
@@ -195,6 +206,7 @@ class QuickRecordServiceIntegrationTest {
         assertThat(count("media_logs")).isEqualTo(1);
         assertThat(count("media_log_tags")).isEqualTo(1);
         assertThat(receiptCount()).isEqualTo(1);
+        assertThat(count("life_log_records")).isEqualTo(1);
         assertThat(outboxCount(RECORDED_ALIAS)).isEqualTo(1);
         assertThat(outboxCount(MEDIA_ADVANCED_ALIAS)).isZero();
         assertThat(outboxCount()).isEqualTo(1);
@@ -222,6 +234,7 @@ class QuickRecordServiceIntegrationTest {
         assertSameSnapshot(first, replay);
         assertThat(count("collection_logs")).isEqualTo(1);
         assertThat(receiptCount()).isEqualTo(1);
+        assertThat(count("life_log_records")).isEqualTo(1);
         assertThat(outboxCount(RECORDED_ALIAS)).isEqualTo(1);
         assertThat(outboxCount(COLLECTION_ALIAS)).isEqualTo(1);
         assertThat(outboxCount()).isEqualTo(2);
@@ -256,6 +269,7 @@ class QuickRecordServiceIntegrationTest {
         assertThat(count("collection_logs")).isEqualTo(1);
         assertThat(count("media_logs")).isZero();
         assertThat(receiptCount()).isEqualTo(1);
+        assertThat(count("life_log_records")).isEqualTo(1);
         assertThat(outboxCount()).isEqualTo(2);
     }
 
@@ -276,6 +290,7 @@ class QuickRecordServiceIntegrationTest {
         assertThat(first.sourceId()).isNotEqualTo(second.sourceId());
         assertThat(count("media_logs")).isEqualTo(2);
         assertThat(receiptCount()).isEqualTo(2);
+        assertThat(count("life_log_records")).isEqualTo(2);
         assertThat(outboxCount(RECORDED_ALIAS)).isEqualTo(2);
     }
 
@@ -304,6 +319,7 @@ class QuickRecordServiceIntegrationTest {
         assertSameSnapshot(results.getFirst(), results.getLast());
         assertThat(count("media_logs")).isEqualTo(1);
         assertThat(receiptCount()).isEqualTo(1);
+        assertThat(count("life_log_records")).isEqualTo(1);
         assertThat(outboxCount(RECORDED_ALIAS)).isEqualTo(1);
         assertThat(outboxCount()).isEqualTo(1);
     }
@@ -344,6 +360,7 @@ class QuickRecordServiceIntegrationTest {
                 .isIn("Concurrent first", "Concurrent second");
         assertThat(count("collection_logs")).isEqualTo(1);
         assertThat(receiptCount()).isEqualTo(1);
+        assertThat(count("life_log_records")).isEqualTo(1);
         assertThat(outboxCount(RECORDED_ALIAS)).isEqualTo(1);
         assertThat(outboxCount(COLLECTION_ALIAS)).isEqualTo(1);
         assertThat(outboxCount()).isEqualTo(2);
@@ -389,6 +406,87 @@ class QuickRecordServiceIntegrationTest {
                 .hasMessage("forced outbox failure");
 
         assertNoQuickRecordMutation();
+    }
+
+    @Test
+    @DisplayName("canonical header 저장 실패는 Source와 Receipt/Outbox를 함께 rollback한다")
+    void rollsBackHeaderFailure() {
+        lifeLogRecordRepository.failNext();
+
+        assertThatThrownBy(() -> quickRecordService.record(
+                PLAYER_ID,
+                "header-failure",
+                mediaCommand("Header rollback")
+        )).isInstanceOf(IllegalStateException.class)
+                .hasMessage("forced header failure");
+
+        assertNoQuickRecordMutation();
+    }
+
+    @Test
+    @DisplayName("Content-ready Quick metadata는 QUICK weekly Snapshot으로 저장한다")
+    void recordsContentReadyWeeklyMetadata() throws Exception {
+        QuickRecordCommand.Create command = new QuickRecordCommand.Create(
+                "MEDIA",
+                "REFLECTION",
+                "WEEKLY_LOOKBACK",
+                null,
+                null,
+                new MediaLogCommand.Create(
+                        "MOVIE",
+                        "Weekly reflection",
+                        null,
+                        0,
+                        1,
+                        "PLANNED",
+                        Set.of()
+                )
+        );
+
+        QuickRecordResult.Recorded result = quickRecordService.record(
+                PLAYER_ID,
+                "weekly-reflection",
+                command
+        );
+        QuickRecordResult.Recorded replay = quickRecordService.record(
+                PLAYER_ID,
+                "weekly-reflection",
+                command
+        );
+        QuickRecordCommand.Create changedMetadata =
+                new QuickRecordCommand.Create(
+                        "MEDIA",
+                        "STUDY",
+                        null,
+                        null,
+                        null,
+                        command.media()
+                );
+        assertConflict(() -> quickRecordService.record(
+                PLAYER_ID,
+                "weekly-reflection",
+                changedMetadata
+        ));
+        JsonNode json = recordedPayload();
+
+        assertThat(replay.replay()).isTrue();
+        assertSameSnapshot(result, replay);
+        assertThat(count("life_log_records")).isEqualTo(1);
+        assertThat(outboxCount(RECORDED_ALIAS)).isEqualTo(1);
+        assertThat(json.get("lifeLogId").asLong())
+                .isEqualTo(headerId(result));
+        assertThat(json.get("sourceDefinitionVersion").asInt())
+                .isEqualTo(1);
+        assertThat(json.get("subtype").asText())
+                .isEqualTo("REFLECTION");
+        assertThat(json.get("entryMode").asText())
+                .isEqualTo(LifeLogEntryMode.QUICK.name());
+        assertThat(json.get("reflectionScope").asText())
+                .isEqualTo("WEEKLY_LOOKBACK");
+        assertThat(json.get("periodKey").asText())
+                .isEqualTo("2026-W30");
+        assertThat(json.has("lifeLogType")).isFalse();
+        assertThat(json.has("sourceType")).isFalse();
     }
 
     @Test
@@ -489,6 +587,7 @@ class QuickRecordServiceIntegrationTest {
         assertThat(count("collection_logs")).isZero();
         assertThat(count("exercise_logs")).isZero();
         assertThat(count("media_logs")).isZero();
+        assertThat(count("life_log_records")).isZero();
         assertThat(receiptCount()).isZero();
         assertThat(outboxCount()).isZero();
     }
@@ -532,6 +631,25 @@ class QuickRecordServiceIntegrationTest {
     private void assertRecordedPayload(
             QuickRecordResult.Recorded result
     ) throws Exception {
+        JsonNode json = recordedPayload();
+        assertThat(json.get("eventType").asText())
+                .isEqualTo("LifeLogRecorded");
+        assertThat(json.get("eventVersion").asInt()).isEqualTo(1);
+        assertThat(json.get("playerId").asLong()).isEqualTo(PLAYER_ID);
+        assertThat(json.get("lifeLogId").asLong())
+                .isEqualTo(headerId(result));
+        assertThat(json.get("sourceDefinitionVersion").asInt())
+                .isEqualTo(1);
+        assertThat(json.get("subtype").isNull()).isTrue();
+        assertThat(json.get("entryMode").asText())
+                .isEqualTo(LifeLogEntryMode.QUICK.name());
+        assertThat(json.has("lifeLogType")).isFalse();
+        assertThat(json.has("sourceType")).isFalse();
+        assertThat(json.get("occurredAt").asText())
+                .isEqualTo(RECORDED_AT.toString());
+    }
+
+    private JsonNode recordedPayload() throws Exception {
         String payload = jdbcTemplate.queryForObject(
                 """
                 SELECT payload
@@ -541,14 +659,21 @@ class QuickRecordServiceIntegrationTest {
                 String.class,
                 RECORDED_ALIAS
         );
-        JsonNode json = objectMapper.readTree(payload);
-        assertThat(json.get("playerId").asLong()).isEqualTo(PLAYER_ID);
-        assertThat(json.get("lifeLogId").asLong())
-                .isEqualTo(result.sourceId());
-        assertThat(json.get("lifeLogType").asText())
-                .isEqualTo(result.sourceType().name());
-        assertThat(json.get("occurredAt").asText())
-                .isEqualTo(RECORDED_AT.toString());
+        return objectMapper.readTree(payload);
+    }
+
+    private Long headerId(QuickRecordResult.Recorded result) {
+        return jdbcTemplate.queryForObject(
+                """
+                SELECT id
+                FROM life_log_records
+                WHERE source_type = ?
+                  AND source_id = ?
+                """,
+                Long.class,
+                result.sourceType().name(),
+                result.sourceId()
+        );
     }
 
     private int count(String table) {
@@ -656,6 +781,15 @@ class QuickRecordServiceIntegrationTest {
         ) {
             return new FailingQuickRecordReceiptRepository(delegate);
         }
+
+        @Bean
+        @Primary
+        FailingLifeLogRecordRepository lifeLogRecordRepository(
+                @Qualifier("lifeLogRecordRepositoryAdapter")
+                LifeLogRecordRepository delegate
+        ) {
+            return new FailingLifeLogRecordRepository(delegate);
+        }
     }
 
     static class FailingDomainEventPublisher
@@ -745,6 +879,45 @@ class QuickRecordServiceIntegrationTest {
 
         void reset() {
             failNextCompletion.set(false);
+        }
+    }
+
+    static class FailingLifeLogRecordRepository
+            implements LifeLogRecordRepository {
+
+        private final LifeLogRecordRepository delegate;
+        private final AtomicBoolean failNext = new AtomicBoolean();
+
+        FailingLifeLogRecordRepository(
+                LifeLogRecordRepository delegate
+        ) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public LifeLogRecord saveAndFlush(LifeLogRecord record) {
+            if (failNext.getAndSet(false)) {
+                throw new IllegalStateException(
+                        "forced header failure"
+                );
+            }
+            return delegate.saveAndFlush(record);
+        }
+
+        @Override
+        public Optional<LifeLogRecord> findBySource(
+                LifeLogSourceType sourceType,
+                Long sourceId
+        ) {
+            return delegate.findBySource(sourceType, sourceId);
+        }
+
+        void failNext() {
+            failNext.set(true);
+        }
+
+        void reset() {
+            failNext.set(false);
         }
     }
 }

--- a/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
@@ -63,7 +63,7 @@ class FlywayExplicitBaselineTest {
     class ApplyExplicitBaseline {
 
         @Test
-        @DisplayName("V1을 재실행하지 않고 V2부터 V14까지 적용한 뒤 JPA validate를 통과한다")
+        @DisplayName("V1을 재실행하지 않고 V2부터 V15까지 적용한 뒤 JPA validate를 통과한다")
         void migratesFromVersionTwoAndValidatesJpa() throws Exception {
             String jdbcUrl = createV1EquivalentDatabase();
             Flyway flyway = migrationFlyway(jdbcUrl);
@@ -72,12 +72,12 @@ class FlywayExplicitBaselineTest {
             MigrateResult migrateResult = flyway.migrate();
             List<HistoryRow> history = successfulHistory(jdbcUrl);
 
-            assertThat(migrateResult.migrationsExecuted).isEqualTo(13);
+            assertThat(migrateResult.migrationsExecuted).isEqualTo(14);
             assertThat(history).extracting(HistoryRow::version)
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
-                            "14"
+                            "14", "15"
                     );
             assertThat(history.getFirst().type()).isEqualTo("BASELINE");
             assertThat(history.getFirst().script())
@@ -101,7 +101,8 @@ class FlywayExplicitBaselineTest {
                             "V11__quest_semantic_progress_contract.sql",
                             "V12__item_stable_code_and_first_step_seed.sql",
                             "V13__first_step_reward_profile_seed.sql",
-                            "V14__final_quest_legacy_category_nullable.sql"
+                            "V14__final_quest_legacy_category_nullable.sql",
+                            "V15__canonical_lifelog_record_metadata.sql"
                     );
             assertThat(history.subList(1, history.size()))
                     .allSatisfy(row -> assertThat(row.checksum()).isNotNull());
@@ -121,7 +122,7 @@ class FlywayExplicitBaselineTest {
                         "spring.jpa.hibernate.ddl-auto"
                 )).isEqualTo("validate");
                 assertThat(context.getBean(Flyway.class).info().current().getVersion().getVersion())
-                        .isEqualTo("14");
+                        .isEqualTo("15");
             }
         }
     }

--- a/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
@@ -33,10 +33,10 @@ class FlywayHistoryChecksumTest {
     class MigrateAgain {
 
         @Test
-        @DisplayName("V1~V13 checksum을 보존하고 V14 이후 두 번째 실행은 no-op이다")
+        @DisplayName("V1~V14 checksum을 보존하고 V15 이후 두 번째 실행은 no-op이다")
         void keepsMigrationHistory() throws Exception {
-            Flyway throughV13 = flyway(MigrationVersion.fromVersion("13"));
-            MigrateResult legacy = throughV13.migrate();
+            Flyway throughV14 = flyway(MigrationVersion.fromVersion("14"));
+            MigrateResult legacy = throughV14.migrate();
             List<HistoryRow> legacyHistory = successfulHistory();
             Flyway flyway = flyway(null);
 
@@ -46,7 +46,7 @@ class FlywayHistoryChecksumTest {
             MigrateResult second = flyway.migrate();
             List<HistoryRow> secondHistory = successfulHistory();
 
-            assertThat(legacy.migrationsExecuted).isEqualTo(13);
+            assertThat(legacy.migrationsExecuted).isEqualTo(14);
             assertThat(first.migrationsExecuted).isEqualTo(1);
             assertThat(second.migrationsExecuted).isZero();
             assertThat(secondHistory).isEqualTo(firstHistory);
@@ -56,7 +56,7 @@ class FlywayHistoryChecksumTest {
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
-                            "14"
+                            "14", "15"
                     );
             assertThat(secondHistory).allSatisfy(history -> {
                 assertThat(history.checksum()).isNotNull();

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -266,6 +266,7 @@ class FlywayMigrationTest {
                     "ck_life_log_record_primary_role"
             );
             assertThat(lifeLogRecordCount()).isZero();
+            assertLifeLogRecordReflectionCheckContract();
             insertCanonicalHeadersWithSameSourceId();
             assertThat(canonicalLifeLogIds()).hasSize(2)
                     .doesNotHaveDuplicates();
@@ -689,6 +690,108 @@ class FlywayMigrationTest {
                      """)) {
             resultSet.next();
             return resultSet.getInt(1);
+        }
+    }
+
+    private void assertLifeLogRecordReflectionCheckContract()
+            throws SQLException {
+        insertLifeLogRecord(21301, null, null, null);
+        insertLifeLogRecord(21302, "REFLECTION", null, null);
+        insertLifeLogRecord(
+                21303,
+                "REFLECTION",
+                "WEEKLY_LOOKBACK",
+                "2026-W31"
+        );
+        insertLifeLogRecord(21304, "ACTIVITY", null, null);
+        assertThat(lifeLogRecordCount()).isEqualTo(4);
+
+        assertLifeLogRecordInsertRejected(
+                21305,
+                "REFLECTION",
+                "WEEKLY_LOOKBACK",
+                null
+        );
+        assertLifeLogRecordInsertRejected(
+                21306,
+                null,
+                "WEEKLY_LOOKBACK",
+                null
+        );
+        assertLifeLogRecordInsertRejected(
+                21307,
+                "ACTIVITY",
+                "WEEKLY_LOOKBACK",
+                "2026-W31"
+        );
+        assertLifeLogRecordInsertRejected(
+                21308,
+                "REFLECTION",
+                "WEEKLY_LOOKBACK",
+                "invalid"
+        );
+        assertThat(lifeLogRecordCount()).isEqualTo(4);
+    }
+
+    private void assertLifeLogRecordInsertRejected(
+            long sourceId,
+            String subtype,
+            String reflectionScope,
+            String periodKey
+    ) throws SQLException {
+        int countBefore = lifeLogRecordCount();
+
+        assertThatThrownBy(() -> insertLifeLogRecord(
+                sourceId,
+                subtype,
+                reflectionScope,
+                periodKey
+        )).isInstanceOf(SQLException.class);
+
+        assertThat(lifeLogRecordCount()).isEqualTo(countBefore);
+    }
+
+    private void insertLifeLogRecord(
+            long sourceId,
+            String subtype,
+            String reflectionScope,
+            String periodKey
+    ) throws SQLException {
+        try (Connection connection = MYSQL.createConnection("");
+             var statement = connection.prepareStatement("""
+                     INSERT INTO life_log_records (
+                         player_id,
+                         source_type,
+                         source_id,
+                         source_definition_version,
+                         subtype,
+                         entry_mode,
+                         reflection_scope,
+                         period_key,
+                         primary_role_id,
+                         occurred_at,
+                         created_at,
+                         updated_at
+                     ) VALUES (
+                         213,
+                         'COLLECTION',
+                         ?,
+                         1,
+                         ?,
+                         'FULL',
+                         ?,
+                         ?,
+                         NULL,
+                         CURRENT_TIMESTAMP(6),
+                         CURRENT_TIMESTAMP(6),
+                         CURRENT_TIMESTAMP(6)
+                     )
+                     """)) {
+            statement.setLong(1, sourceId);
+            statement.setString(2, subtype);
+            statement.setString(3, reflectionScope);
+            statement.setString(4, periodKey);
+            statement.executeUpdate();
         }
     }
 

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -38,7 +38,7 @@ class FlywayMigrationTest {
     class MigrateCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V14까지 적용되고 final Quest category를 nullable로 보정한다")
+        @DisplayName("V1부터 V15까지 적용되고 canonical LifeLog header를 추가한다")
         void migratesSchemaAndSeedsRewardProfiles() throws Exception {
             Flyway throughV10 = flyway(MigrationVersion.fromVersion("10"));
             MigrateResult legacyResult = throughV10.migrate();
@@ -48,6 +48,7 @@ class FlywayMigrationTest {
             insertLegacyItemsWithoutCode();
             MigrateResult itemResult =
                     flyway(MigrationVersion.fromVersion("12")).migrate();
+            insertLegacyLifeLogs();
             Flyway flyway = flyway();
 
             MigrateResult result = flyway.migrate();
@@ -55,12 +56,12 @@ class FlywayMigrationTest {
             assertThat(legacyResult.migrationsExecuted).isEqualTo(10);
             assertThat(semanticResult.migrationsExecuted).isEqualTo(1);
             assertThat(itemResult.migrationsExecuted).isEqualTo(1);
-            assertThat(result.migrationsExecuted).isEqualTo(2);
+            assertThat(result.migrationsExecuted).isEqualTo(3);
             assertThat(appliedVersions())
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
-                            "14"
+                            "14", "15"
                     );
             assertThat(existingTables(
                     "users",
@@ -76,7 +77,8 @@ class FlywayMigrationTest {
                     "player_growth_changes",
                     "quest_signal_receipts",
                     "outbox_events",
-                    "quick_record_request_receipts"
+                    "quick_record_request_receipts",
+                    "life_log_records"
             )).containsExactlyInAnyOrder(
                     "users",
                     "player",
@@ -91,7 +93,8 @@ class FlywayMigrationTest {
                     "player_growth_changes",
                     "quest_signal_receipts",
                     "outbox_events",
-                    "quick_record_request_receipts"
+                    "quick_record_request_receipts",
+                    "life_log_records"
             );
             assertThat(existingTables(
                     "quick_lifelog_entries",
@@ -224,6 +227,54 @@ class FlywayMigrationTest {
                     "quick_record_request_receipts",
                     "uq_quick_record_request_receipt_identity"
             )).containsExactly("player_id", "idempotency_key");
+            assertThat(uniqueIndexColumns(
+                    "life_log_records",
+                    "uq_life_log_record_source"
+            )).containsExactly("source_type", "source_id");
+            assertThat(lifeLogRecordColumnNames()).containsExactlyInAnyOrder(
+                    "id",
+                    "player_id",
+                    "source_type",
+                    "source_id",
+                    "source_definition_version",
+                    "subtype",
+                    "entry_mode",
+                    "reflection_scope",
+                    "period_key",
+                    "primary_role_id",
+                    "occurred_at",
+                    "created_at",
+                    "updated_at"
+            );
+            assertThat(lifeLogRecordColumnNames()).doesNotContain(
+                    "title",
+                    "body",
+                    "content",
+                    "memo",
+                    "tags",
+                    "attachment",
+                    "location"
+            );
+            assertThat(lifeLogRecordCheckConstraints()).containsExactlyInAnyOrder(
+                    "ck_life_log_record_source_type",
+                    "ck_life_log_record_definition_version",
+                    "ck_life_log_record_subtype",
+                    "ck_life_log_record_entry_mode",
+                    "ck_life_log_record_reflection_scope",
+                    "ck_life_log_record_reflection_pairing",
+                    "ck_life_log_record_non_reflection_metadata",
+                    "ck_life_log_record_primary_role"
+            );
+            assertThat(lifeLogRecordCount()).isZero();
+            insertCanonicalHeadersWithSameSourceId();
+            assertThat(canonicalLifeLogIds()).hasSize(2)
+                    .doesNotHaveDuplicates();
+            assertThatThrownBy(
+                    FlywayMigrationTest.this
+                            ::insertDuplicateCanonicalSource
+            ).isInstanceOfSatisfying(SQLException.class, exception ->
+                    assertThat(exception.getSQLState()).startsWith("23")
+            );
             assertThat(itemCodeColumn()).isEqualTo(new ItemCodeColumn("YES", 80));
             assertThat(uniqueIndexColumns("items", "uq_item_code"))
                     .containsExactly("code");
@@ -549,6 +600,161 @@ class FlywayMigrationTest {
                     )
                     """);
         }
+    }
+
+    private void insertLegacyLifeLogs() throws SQLException {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement()) {
+            statement.executeUpdate("""
+                    INSERT INTO collection_logs (
+                        quantity_value,
+                        created_at,
+                        player_id,
+                        updated_at,
+                        title_value,
+                        category
+                    ) VALUES (
+                        1,
+                        CURRENT_TIMESTAMP(6),
+                        213,
+                        CURRENT_TIMESTAMP(6),
+                        'Legacy collection',
+                        'BOOK'
+                    )
+                    """);
+            statement.executeUpdate("""
+                    INSERT INTO exercise_logs (
+                        duration_minutes,
+                        exercised_on,
+                        created_at,
+                        player_id,
+                        updated_at,
+                        category
+                    ) VALUES (
+                        10,
+                        '2026-07-29',
+                        CURRENT_TIMESTAMP(6),
+                        213,
+                        CURRENT_TIMESTAMP(6),
+                        'WALKING'
+                    )
+                    """);
+        }
+    }
+
+    private List<String> lifeLogRecordColumnNames() throws SQLException {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("""
+                     SELECT column_name
+                     FROM information_schema.columns
+                     WHERE table_schema = DATABASE()
+                       AND table_name = 'life_log_records'
+                     ORDER BY ordinal_position
+                     """)) {
+            List<String> columns = new ArrayList<>();
+            while (resultSet.next()) {
+                columns.add(resultSet.getString("column_name"));
+            }
+            return columns;
+        }
+    }
+
+    private List<String> lifeLogRecordCheckConstraints()
+            throws SQLException {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("""
+                     SELECT constraint_name
+                     FROM information_schema.table_constraints
+                     WHERE table_schema = DATABASE()
+                       AND table_name = 'life_log_records'
+                       AND constraint_type = 'CHECK'
+                     ORDER BY constraint_name
+                     """)) {
+            List<String> constraints = new ArrayList<>();
+            while (resultSet.next()) {
+                constraints.add(resultSet.getString("constraint_name"));
+            }
+            return constraints;
+        }
+    }
+
+    private int lifeLogRecordCount() throws SQLException {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("""
+                     SELECT COUNT(*)
+                     FROM life_log_records
+                     """)) {
+            resultSet.next();
+            return resultSet.getInt(1);
+        }
+    }
+
+    private void insertCanonicalHeadersWithSameSourceId()
+            throws SQLException {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement()) {
+            statement.executeUpdate(canonicalHeaderInsert("COLLECTION"));
+            statement.executeUpdate(canonicalHeaderInsert("EXERCISE"));
+        }
+    }
+
+    private List<Long> canonicalLifeLogIds() throws SQLException {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("""
+                     SELECT id
+                     FROM life_log_records
+                     WHERE source_id = 1
+                     ORDER BY id
+                     """)) {
+            List<Long> ids = new ArrayList<>();
+            while (resultSet.next()) {
+                ids.add(resultSet.getLong("id"));
+            }
+            return ids;
+        }
+    }
+
+    private void insertDuplicateCanonicalSource() throws SQLException {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement()) {
+            statement.executeUpdate(canonicalHeaderInsert("COLLECTION"));
+        }
+    }
+
+    private String canonicalHeaderInsert(String sourceType) {
+        return """
+                INSERT INTO life_log_records (
+                    player_id,
+                    source_type,
+                    source_id,
+                    source_definition_version,
+                    subtype,
+                    entry_mode,
+                    reflection_scope,
+                    period_key,
+                    primary_role_id,
+                    occurred_at,
+                    created_at,
+                    updated_at
+                ) VALUES (
+                    213,
+                    '%s',
+                    1,
+                    1,
+                    NULL,
+                    'FULL',
+                    NULL,
+                    NULL,
+                    NULL,
+                    CURRENT_TIMESTAMP(6),
+                    CURRENT_TIMESTAMP(6),
+                    CURRENT_TIMESTAMP(6)
+                )
+                """.formatted(sourceType);
     }
 
     private void insertLegacyItemsWithoutCode() throws SQLException {

--- a/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
@@ -149,7 +149,7 @@ class FlywayProfileCutoverTest {
     class StartLocalWithCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V14까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
+        @DisplayName("V1부터 V15까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
         void migratesThenValidates() {
             ConfigurableEnvironment environment =
                     (ConfigurableEnvironment) applicationContext.getEnvironment();
@@ -161,8 +161,8 @@ class FlywayProfileCutoverTest {
             assertThat(environment.getProperty(
                     "spring.flyway.baseline-on-migrate", Boolean.class
             )).isFalse();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("14");
-            assertThat(appliedMigrationCount()).isEqualTo(14);
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("15");
+            assertThat(appliedMigrationCount()).isEqualTo(15);
         }
     }
 

--- a/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 @SpringBootTest
 @ActiveProfiles({"test", "migration-test"})
-@DisplayName("V14 migration 이후 JPA schema validation")
+@DisplayName("V15 migration 이후 JPA schema validation")
 class JpaValidateAfterMigrationTest {
 
     @Container
@@ -79,14 +79,14 @@ class JpaValidateAfterMigrationTest {
     private QuestDefinitionBootstrapper questDefinitionBootstrapper;
 
     @Nested
-    @DisplayName("V1부터 V14까지 적용된 schema로 ApplicationContext를 기동할 때")
+    @DisplayName("V1부터 V15까지 적용된 schema로 ApplicationContext를 기동할 때")
     class LoadApplicationContext {
 
         @Test
         @DisplayName("ddl-auto validate 상태로 정상 기동한다")
         void loadsWithJpaValidation() {
             assertThat(applicationContext).isNotNull();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("14");
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("15");
             assertThat(applicationContext.getEnvironment().getProperty("spring.jpa.hibernate.ddl-auto"))
                     .isEqualTo("validate");
             assertThat(applicationContext.getEnvironment()

--- a/src/test/java/online/lifeasgame/platform/outbox/application/codec/LifeLogRecordedCodecTest.java
+++ b/src/test/java/online/lifeasgame/platform/outbox/application/codec/LifeLogRecordedCodecTest.java
@@ -1,76 +1,171 @@
 package online.lifeasgame.platform.outbox.application.codec;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.lifelog.domain.event.LifeLogRecorded;
 import online.lifeasgame.lifelog.domain.event.LifeLogType;
+import online.lifeasgame.lifelog.domain.record.LifeLogEntryMode;
+import online.lifeasgame.lifelog.domain.record.LifeLogReflectionScope;
+import online.lifeasgame.lifelog.domain.record.LifeLogSubtype;
+import online.lifeasgame.platform.outbox.domain.error.OutboxError;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("LifeLogRecorded Outbox Codec")
 class LifeLogRecordedCodecTest {
 
     private static final Instant OCCURRED_AT =
             Instant.parse("2026-07-24T09:15:30.123456Z");
+    private static final Set<String> CONTENT_FIELDS = Set.of(
+            "eventId",
+            "eventType",
+            "eventVersion",
+            "occurredAt",
+            "playerId",
+            "lifeLogId",
+            "sourceDefinitionVersion",
+            "subtype",
+            "entryMode",
+            "reflectionScope",
+            "periodKey",
+            "primaryRoleId"
+    );
 
+    private ObjectMapper objectMapper;
     private OutboxEventCodecRegistry registry;
 
     @BeforeEach
     void setUp() {
-        ObjectMapper objectMapper = JsonMapper.builder()
+        objectMapper = JsonMapper.builder()
                 .addModule(new JavaTimeModule())
                 .build();
         registry = new OutboxEventCodecRegistry(objectMapper);
     }
 
     @Test
-    @DisplayName("stable alias와 모든 필드를 그대로 round-trip한다")
-    void roundTripsEveryField() {
-        LifeLogRecorded source = LifeLogRecorded.of(
-                "d05c05d8-75a8-436d-b2f6-e0d63107927d",
-                197L,
-                199L,
-                LifeLogType.MEDIA,
-                OCCURRED_AT
-        );
+    @DisplayName("stable alias와 Content 1B payload를 정확히 round-trip한다")
+    void roundTripsContentPayload() throws Exception {
+        LifeLogRecorded source = contentReadyEvent();
 
         OutboxEventEnvelope envelope = registry.encode(source);
         LifeLogRecorded decoded = (LifeLogRecorded) registry.decode(
                 envelope.eventType(),
                 envelope.payload()
         );
+        JsonNode json = objectMapper.readTree(envelope.payload());
+        Set<String> fields = new HashSet<>();
+        json.fieldNames().forEachRemaining(fields::add);
 
         assertThat(envelope.eventType()).isEqualTo("lifelog.recorded.v1");
         assertThat(envelope.occurredAt()).isEqualTo(OCCURRED_AT);
+        assertThat(fields).containsExactlyInAnyOrderElementsOf(CONTENT_FIELDS);
+        assertThat(json.get("eventType").asText())
+                .isEqualTo("LifeLogRecorded");
+        assertThat(json.get("eventVersion").asInt()).isEqualTo(1);
         assertThat(decoded).isEqualTo(source);
-        assertThat(decoded.eventVersion()).isEqualTo(1);
-        assertThat(decoded.primaryRoleId()).isNull();
+        assertThat(decoded.isContentReady()).isTrue();
     }
 
     @Test
-    @DisplayName("Alias와 payload에 Java class name을 노출하지 않는다")
-    void doesNotExposeJavaClassName() {
-        LifeLogRecorded event = LifeLogRecorded.of(
-                "839d32ae-c695-4bb0-9d48-65372ac78e99",
-                197L,
-                199L,
-                LifeLogType.COLLECTION,
-                OCCURRED_AT
+    @DisplayName("과거 v1 JSON fixture를 decode하고 contentReady false로 표시한다")
+    void decodesLegacyFixture() {
+        String fixture = """
+                {
+                  "eventId": "d05c05d8-75a8-436d-b2f6-e0d63107927d",
+                  "eventVersion": 1,
+                  "playerId": 197,
+                  "lifeLogId": 51,
+                  "lifeLogType": "EXERCISE",
+                  "primaryRoleId": null,
+                  "occurredAt": "2026-07-24T09:15:30.123456Z"
+                }
+                """;
+
+        LifeLogRecorded decoded = (LifeLogRecorded) registry.decode(
+                "lifelog.recorded.v1",
+                fixture
         );
 
-        OutboxEventEnvelope envelope = registry.encode(event);
+        assertThat(decoded.eventType()).isEqualTo("LifeLogRecorded");
+        assertThat(decoded.eventVersion()).isEqualTo(1);
+        assertThat(decoded.lifeLogId()).isEqualTo(51L);
+        assertThat(decoded.legacyLifeLogType())
+                .isEqualTo(LifeLogType.EXERCISE);
+        assertThat(decoded.sourceDefinitionVersion()).isNull();
+        assertThat(decoded.isContentReady()).isFalse();
+    }
 
-        assertThat(envelope.eventType())
-                .doesNotContain(LifeLogRecorded.class.getSimpleName())
-                .doesNotContain(LifeLogRecorded.class.getName());
-        assertThat(envelope.payload())
-                .doesNotContain(LifeLogRecorded.class.getSimpleName())
-                .doesNotContain(LifeLogRecorded.class.getName());
+    @Test
+    @DisplayName("new encode는 physical source와 private content key를 노출하지 않는다")
+    void excludesPhysicalAndPrivateFields() throws Exception {
+        String payload = registry.encode(contentReadyEvent()).payload();
+        JsonNode json = objectMapper.readTree(payload);
+
+        assertThat(json.has("lifeLogType")).isFalse();
+        assertThat(json.has("sourceType")).isFalse();
+        assertThat(json.has("title")).isFalse();
+        assertThat(json.has("body")).isFalse();
+        assertThat(json.has("content")).isFalse();
+        assertThat(json.has("memo")).isFalse();
+        assertThat(json.has("tags")).isFalse();
+        assertThat(payload).doesNotContain(LifeLogRecorded.class.getName());
+    }
+
+    @Test
+    @DisplayName("unknown field와 invalid payload는 stable codec error로 실패한다")
+    void rejectsUnknownAndInvalidPayload() {
+        String unknown = registry.encode(contentReadyEvent()).payload()
+                .replace(
+                        "\"primaryRoleId\":null",
+                        "\"primaryRoleId\":null,\"title\":\"private\""
+                );
+        String invalid = registry.encode(contentReadyEvent()).payload()
+                .replace("\"eventType\":\"LifeLogRecorded\"",
+                        "\"eventType\":\"Other\""
+                );
+
+        assertCodecFailure(unknown);
+        assertCodecFailure(invalid);
+        assertCodecFailure("{\"eventId\":\"incomplete\"}");
+    }
+
+    private void assertCodecFailure(String payload) {
+        assertThatThrownBy(() -> registry.decode(
+                "lifelog.recorded.v1",
+                payload
+        )).isInstanceOfSatisfying(
+                DomainException.class,
+                exception -> assertThat(exception.getErrorCode())
+                        .isEqualTo(OutboxError.OUTBOX_EVENT_CODEC_FAILED)
+        );
+    }
+
+    private LifeLogRecorded contentReadyEvent() {
+        return new LifeLogRecorded(
+                "d05c05d8-75a8-436d-b2f6-e0d63107927d",
+                "LifeLogRecorded",
+                1,
+                OCCURRED_AT,
+                197L,
+                213L,
+                1,
+                LifeLogSubtype.REFLECTION,
+                LifeLogEntryMode.QUICK,
+                LifeLogReflectionScope.WEEKLY_LOOKBACK,
+                "2026-W30",
+                null,
+                null
+        );
     }
 }

--- a/src/test/java/online/lifeasgame/platform/outbox/application/codec/LifeLogRecordedCodecTest.java
+++ b/src/test/java/online/lifeasgame/platform/outbox/application/codec/LifeLogRecordedCodecTest.java
@@ -140,6 +140,42 @@ class LifeLogRecordedCodecTest {
         assertCodecFailure("{\"eventId\":\"incomplete\"}");
     }
 
+    @Test
+    @DisplayName("new와 legacy payload의 int 범위 밖 eventVersion을 거부한다")
+    void rejectsOutOfRangeEventVersion() {
+        String newPayload = registry.encode(contentReadyEvent()).payload()
+                .replace(
+                        "\"eventVersion\":1",
+                        "\"eventVersion\":4294967297"
+                );
+        String legacyPayload = """
+                {
+                  "eventId": "d05c05d8-75a8-436d-b2f6-e0d63107927d",
+                  "eventVersion": 4294967297,
+                  "playerId": 197,
+                  "lifeLogId": 51,
+                  "lifeLogType": "EXERCISE",
+                  "primaryRoleId": null,
+                  "occurredAt": "2026-07-24T09:15:30.123456Z"
+                }
+                """;
+
+        assertCodecFailure(newPayload);
+        assertCodecFailure(legacyPayload);
+    }
+
+    @Test
+    @DisplayName("int 범위 안의 unsupported eventVersion도 stable codec error로 거부한다")
+    void rejectsUnsupportedInRangeEventVersion() {
+        String payload = registry.encode(contentReadyEvent()).payload()
+                .replace(
+                        "\"eventVersion\":1",
+                        "\"eventVersion\":2147483647"
+                );
+
+        assertCodecFailure(payload);
+    }
+
     private void assertCodecFailure(String payload) {
         assertThatThrownBy(() -> registry.decode(
                 "lifelog.recorded.v1",

--- a/src/test/java/online/lifeasgame/platform/outbox/application/codec/OutboxEventCodecRegistryTest.java
+++ b/src/test/java/online/lifeasgame/platform/outbox/application/codec/OutboxEventCodecRegistryTest.java
@@ -13,8 +13,9 @@ import online.lifeasgame.inventory.domain.event.InventoryItemAdded;
 import online.lifeasgame.lifelog.domain.event.CollectionLogged;
 import online.lifeasgame.lifelog.domain.event.ExerciseLogged;
 import online.lifeasgame.lifelog.domain.event.LifeLogRecorded;
-import online.lifeasgame.lifelog.domain.event.LifeLogType;
 import online.lifeasgame.lifelog.domain.event.MediaLogAdvanced;
+import online.lifeasgame.lifelog.domain.record.LifeLogEntryMode;
+import online.lifeasgame.lifelog.domain.record.LifeLogSubtype;
 import online.lifeasgame.platform.outbox.domain.error.OutboxError;
 import online.lifeasgame.quest.domain.event.QuestEvent;
 import online.lifeasgame.quest.domain.event.QuestEventType;
@@ -90,12 +91,18 @@ class OutboxEventCodecRegistryTest {
                     ),
                     new LifeLogRecorded(
                             "2a294fd2-1e08-49b9-a9f2-a3a4e3c17cb6",
+                            "LifeLogRecorded",
                             1,
+                            OCCURRED_AT,
                             197L,
                             52L,
-                            LifeLogType.EXERCISE,
+                            1,
+                            LifeLogSubtype.ACTIVITY,
+                            LifeLogEntryMode.FULL,
                             null,
-                            OCCURRED_AT
+                            null,
+                            null,
+                            null
                     ),
                     new MediaLogAdvanced(
                             197L,


### PR DESCRIPTION
## What

- Collection/Exercise/Media content를 유지하면서 공통 global LifeLog identity header를 추가했습니다.
- Content 1B semantic subtype, entry mode, reflection scope, period key를 저장합니다.
- `lifelog.recorded.v1` Alias와 eventVersion 1을 유지했습니다.
- Legacy Outbox payload decode와 신규 Content 1B payload encode를 함께 지원합니다.
- Quick Record replay에서 canonical header와 Fact가 중복 생성되지 않도록 했습니다.

## Contract

```text
LifeLogRecorded
- eventId
- eventType
- eventVersion
- occurredAt
- playerId
- lifeLogId
- sourceDefinitionVersion
- subtype
- entryMode
- reflectionScope?
- periodKey?
- primaryRoleId?
```

## Compatibility

- 기존 Collection/Exercise/Media table을 통합하지 않았습니다.
- 기존 row를 semantic subtype으로 backfill하지 않았습니다.
- 기존 client는 metadata 없이 source create를 유지할 수 있습니다.
- physical category를 semantic subtype으로 자동 추론하지 않았습니다.

## Migration

- `V15__canonical_lifelog_record_metadata.sql`
- 기존 V1~V14는 수정하지 않았습니다.

## Test

- [ ] `./gradlew clean test`
- [ ] `./gradlew build`
- [ ] global LifeLog identity
- [ ] FULL / QUICK metadata
- [ ] weekly reflection period key
- [ ] legacy codec compatibility
- [ ] Content 1B payload
- [ ] source/header/outbox atomicity
- [ ] Quick Record replay
- [ ] V1~V15 checksum / JPA validate

## Out of Scope

- LifeLogRecorded → Quest Adapter
- Manual Check API
- Generic LifeLog content rewrite
- QuestCompleted → RewardSettlement
- Achievement / Route
- Role
- Frontend

Closes #213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional life-log subtype and reflection-scope fields to collection, exercise, media, and quick record inputs.
  * Quick records now carry this metadata through to the stored life-log records and resulting events.
  * Weekly reflection is supported via period key metadata, and “content-ready” life-log events are now emitted alongside legacy events.
  * Created responses now include the additional created life-log identifier where applicable.
* **Bug Fixes**
  * Improved timestamp handling and event payload construction so recorded timestamps and related rollbacks stay consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->