### PR TITLE
[Quest] Add Level 1 manual check completion API

### DIFF
--- a/src/main/java/online/lifeasgame/quest/api/player/QuestController.java
+++ b/src/main/java/online/lifeasgame/quest/api/player/QuestController.java
@@ -55,6 +55,17 @@ public class QuestController implements QuestSpecV1 {
     }
 
     @Override
+    @PostMapping("/{questCode}/manual-check")
+    public ResponseEntity<ApiResponse<QuestResponse.Acceptance>> manualCheck(
+            @PathVariable String questCode
+    ) {
+        QuestResult.Acceptance result = questFacade.manualCheck(
+                QuestWebMapper.toManualCheckCommand(questCode)
+        );
+        return ApiResponses.ok(QuestWebMapper.toAcceptance(result));
+    }
+
+    @Override
     @DeleteMapping("/{questCode}")
     public ResponseEntity<ApiResponse<QuestResponse.Canceled>> cancel(
             @PathVariable String questCode,

--- a/src/main/java/online/lifeasgame/quest/api/player/mapper/QuestWebMapper.java
+++ b/src/main/java/online/lifeasgame/quest/api/player/mapper/QuestWebMapper.java
@@ -125,6 +125,12 @@ public final class QuestWebMapper {
         );
     }
 
+    public static QuestCommand.ManualCheck toManualCheckCommand(
+            String questCode
+    ) {
+        return new QuestCommand.ManualCheck(questCode);
+    }
+
     public static QuestResponse.Canceled toCanceled(QuestResult.Canceled result) {
         return new QuestResponse.Canceled(
                 result.playerId(),

--- a/src/main/java/online/lifeasgame/quest/api/player/spec/QuestSpecV1.java
+++ b/src/main/java/online/lifeasgame/quest/api/player/spec/QuestSpecV1.java
@@ -36,6 +36,14 @@ public interface QuestSpecV1 {
             @Valid @RequestBody QuestRequest.Accept request
     );
 
+    @Operation(
+            summary = "Level 1 Manual Check Quest 완료",
+            description = "수락한 Level 1 Manual Check Quest를 확인하고 완료합니다."
+    )
+    ResponseEntity<ApiResponse<QuestResponse.Acceptance>> manualCheck(
+            @PathVariable String questCode
+    );
+
     @Operation(summary = "퀘스트 포기", description = "진행중 퀘스트를 포기(CANCELED) 처리합니다. (멱등키 권장)")
     ResponseEntity<ApiResponse<QuestResponse.Canceled>> cancel(
             @PathVariable String questCode,

--- a/src/main/java/online/lifeasgame/quest/application/QuestAcceptanceCompletionService.java
+++ b/src/main/java/online/lifeasgame/quest/application/QuestAcceptanceCompletionService.java
@@ -12,7 +12,7 @@ import online.lifeasgame.quest.domain.event.QuestEventType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Instant;
+import java.time.Clock;
 
 @Service
 @RequiredArgsConstructor
@@ -21,16 +21,36 @@ public class QuestAcceptanceCompletionService {
     private final QuestReader questReader;
     private final QuestWriter questWriter;
     private final DomainEventPublisher domainEventPublisher;
+    private final Clock clock;
 
     @Transactional
     public QuestResult.Acceptance complete(Long acceptanceId) {
-        QuestAcceptance acceptance = questReader.getAcceptance(acceptanceId);
+        return complete(null, acceptanceId);
+    }
+
+    @Transactional
+    public QuestResult.Acceptance completeForPlayer(
+            Long playerId,
+            Long acceptanceId
+    ) {
+        return complete(playerId, acceptanceId);
+    }
+
+    private QuestResult.Acceptance complete(
+            Long playerId,
+            Long acceptanceId
+    ) {
+        QuestAcceptance acceptance =
+                questReader.getAcceptanceForUpdate(acceptanceId);
+        if (playerId != null && !playerId.equals(acceptance.getPlayerId())) {
+            throw new DomainException(QuestError.QUEST_ACCEPTANCE_NOT_FOUND);
+        }
         Quest quest = questReader.getById(acceptance.getQuestId());
         if (!quest.requiresUserConfirmation()) {
             throw new DomainException(QuestError.QUEST_COMPLETION_POLICY_NOT_USER_CONFIRM);
         }
 
-        boolean changed = acceptance.complete(Instant.now());
+        boolean changed = acceptance.complete(clock.instant());
         if (changed) {
             questWriter.saveAcceptance(acceptance);
             publishCompleted(acceptance, quest);

--- a/src/main/java/online/lifeasgame/quest/application/QuestFacade.java
+++ b/src/main/java/online/lifeasgame/quest/application/QuestFacade.java
@@ -13,6 +13,7 @@ import java.util.List;
 public class QuestFacade {
 
     private final QuestService questService;
+    private final QuestManualCheckService questManualCheckService;
     private final CurrentPlayerAccessor currentPlayerAccessor;
 
     public List<QuestResult.Acceptance> list(QuestCommand.PlayerQuests command) {
@@ -33,5 +34,12 @@ public class QuestFacade {
     public QuestResult.Canceled cancel(QuestCommand.Cancel command) {
         Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
         return questService.cancel(playerId, command);
+    }
+
+    public QuestResult.Acceptance manualCheck(
+            QuestCommand.ManualCheck command
+    ) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        return questManualCheckService.check(playerId, command);
     }
 }

--- a/src/main/java/online/lifeasgame/quest/application/QuestManualCheckService.java
+++ b/src/main/java/online/lifeasgame/quest/application/QuestManualCheckService.java
@@ -154,6 +154,10 @@ public class QuestManualCheckService {
                 )
                 .occurredAt(checkedAt)
                 .periodKey(acceptance.getPeriodKey())
+                .acceptanceAttempt(
+                        acceptance.getId(),
+                        acceptance.getAcceptedAt()
+                )
                 .correlationId(
                         "manual-check:acceptance:%d:accepted-at:%d".formatted(
                                 acceptance.getId(),

--- a/src/main/java/online/lifeasgame/quest/application/QuestManualCheckService.java
+++ b/src/main/java/online/lifeasgame/quest/application/QuestManualCheckService.java
@@ -1,0 +1,168 @@
+package online.lifeasgame.quest.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.quest.application.automation.QuestSignal;
+import online.lifeasgame.quest.application.automation.QuestSignalAcceptancePolicy;
+import online.lifeasgame.quest.application.automation.QuestSignalProcessingService;
+import online.lifeasgame.quest.application.command.QuestCommand;
+import online.lifeasgame.quest.application.result.QuestResult;
+import online.lifeasgame.quest.domain.*;
+import online.lifeasgame.quest.domain.error.QuestError;
+import org.springframework.stereotype.Service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Objects;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class QuestManualCheckService {
+
+    private static final Set<QuestCode> ALLOWED_CODES = Set.of(
+            QuestCode.Q_GROWTH_ONE_FOCUS,
+            QuestCode.Q_RECOVERY_REST_TEN
+    );
+
+    private final QuestReader questReader;
+    private final QuestSignalProcessingService signalProcessingService;
+    private final QuestAcceptanceCompletionService completionService;
+    private final PlayerTimezoneResolver playerTimezoneResolver;
+    private final Clock clock;
+
+    public QuestResult.Acceptance check(
+            Long playerId,
+            QuestCommand.ManualCheck command
+    ) {
+        QuestCode questCode = QuestCode.parse(command.questCode());
+        Quest quest = questReader.getByCode(questCode);
+        assertManualCheckDefinition(questCode, quest);
+
+        Instant checkedAt = clock.instant();
+        ZoneId playerZone = Objects.requireNonNull(
+                playerTimezoneResolver.resolve(playerId),
+                "playerTimezone"
+        );
+        LocalDate currentDate = checkedAt.atZone(playerZone).toLocalDate();
+        QuestAcceptance acceptance = questReader.findLatest(
+                quest.getId(),
+                playerId
+        );
+        assertCurrentAcceptance(
+                acceptance,
+                quest.getId(),
+                playerId,
+                currentDate
+        );
+
+        if (acceptance.isCanceled()) {
+            throw new DomainException(
+                    QuestError.QUEST_MANUAL_CHECK_NOT_ALLOWED
+            );
+        }
+        if (acceptance.isInProgress()) {
+            signalProcessingService.process(
+                    manualCheckSignal(
+                            questCode,
+                            quest,
+                            acceptance,
+                            playerId,
+                            checkedAt
+                    )
+            );
+            QuestAcceptance refreshed = questReader.findLatest(
+                    quest.getId(),
+                    playerId
+            );
+            assertSameAttempt(acceptance, refreshed);
+            acceptance = refreshed;
+        }
+
+        if (!acceptance.isGoalReached() && !acceptance.isCompleted()) {
+            throw new DomainException(
+                    QuestError.QUEST_MANUAL_CHECK_NOT_ALLOWED
+            );
+        }
+        return completionService.completeForPlayer(
+                playerId,
+                acceptance.getId()
+        );
+    }
+
+    private void assertManualCheckDefinition(
+            QuestCode questCode,
+            Quest quest
+    ) {
+        if (!ALLOWED_CODES.contains(questCode)
+                || quest.getProgressSource()
+                != QuestProgressSource.MANUAL_CHECK
+                || !quest.requiresUserConfirmation()
+                || quest.target().type() != QuestTargetType.MINUTES
+                || quest.getRepeatRule() != QuestRepeatRule.DAILY) {
+            throw new DomainException(
+                    QuestError.QUEST_MANUAL_CHECK_NOT_ALLOWED
+            );
+        }
+    }
+
+    private void assertCurrentAcceptance(
+            QuestAcceptance acceptance,
+            Long questId,
+            Long playerId,
+            LocalDate currentDate
+    ) {
+        if (acceptance == null
+                || !questId.equals(acceptance.getQuestId())
+                || !playerId.equals(acceptance.getPlayerId())
+                || !acceptance.getPeriod().contains(currentDate)) {
+            throw new DomainException(
+                    QuestError.QUEST_ACCEPTANCE_NOT_FOUND
+            );
+        }
+    }
+
+    private void assertSameAttempt(
+            QuestAcceptance expected,
+            QuestAcceptance actual
+    ) {
+        if (actual == null
+                || !expected.getId().equals(actual.getId())
+                || !expected.getAcceptedAt().equals(actual.getAcceptedAt())) {
+            throw new DomainException(
+                    QuestError.QUEST_ACCEPTANCE_NOT_FOUND
+            );
+        }
+    }
+
+    private QuestSignal manualCheckSignal(
+            QuestCode questCode,
+            Quest quest,
+            QuestAcceptance acceptance,
+            Long playerId,
+            Instant checkedAt
+    ) {
+        return QuestSignal.setProgress(
+                        questCode,
+                        playerId,
+                        quest.target().value()
+                )
+                .acceptancePolicy(
+                        QuestSignalAcceptancePolicy.EXISTING_ONLY
+                )
+                .occurredAt(checkedAt)
+                .periodKey(acceptance.getPeriodKey())
+                .correlationId(
+                        "manual-check:acceptance:%d:accepted-at:%d".formatted(
+                                acceptance.getId(),
+                                acceptance.getAcceptedAt().toEpochMilli()
+                        )
+                )
+                .attribute("acceptanceId", acceptance.getId())
+                .attribute("manualCheck", true)
+                .attribute("source", "USER_CONFIRMATION")
+                .build();
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/application/QuestReader.java
+++ b/src/main/java/online/lifeasgame/quest/application/QuestReader.java
@@ -59,6 +59,11 @@ class QuestReader {
                 .orElseThrow(() -> new DomainException(QuestError.QUEST_ACCEPTANCE_NOT_FOUND));
     }
 
+    QuestAcceptance getAcceptanceForUpdate(Long acceptanceId) {
+        return questAcceptanceRepository.findByIdForUpdate(acceptanceId)
+                .orElseThrow(() -> new DomainException(QuestError.QUEST_ACCEPTANCE_NOT_FOUND));
+    }
+
     List<QuestAcceptance> findQuestAcceptances(Long questId, QuestStatus status) {
         if (status == null) {
             return questAcceptanceRepository.findAllByQuestId(questId);

--- a/src/main/java/online/lifeasgame/quest/application/automation/QuestSignal.java
+++ b/src/main/java/online/lifeasgame/quest/application/automation/QuestSignal.java
@@ -13,6 +13,10 @@ import java.util.Map;
 public final class QuestSignal {
 
     public static final int MAX_CORRELATION_ID_LENGTH = 120;
+    static final String ACCEPTANCE_ATTEMPT_ID =
+            "acceptanceAttemptId";
+    static final String ACCEPTANCE_ATTEMPT_ACCEPTED_AT =
+            "acceptanceAttemptAcceptedAt";
 
     private final QuestCode questCode;
     private final Long playerId;
@@ -94,6 +98,42 @@ public final class QuestSignal {
         return type == QuestSignalType.SET_PROGRESS;
     }
 
+    boolean isManualCheckReplayCandidate() {
+        return acceptancePolicy
+                == QuestSignalAcceptancePolicy.EXISTING_ONLY
+                && isSetOperation()
+                && Boolean.TRUE.equals(attributes.get("manualCheck"))
+                && "USER_CONFIRMATION".equals(attributes.get("source"))
+                && hasCompleteAcceptanceAttemptContext();
+    }
+
+    boolean hasAcceptanceAttemptContext() {
+        return attributes.containsKey(ACCEPTANCE_ATTEMPT_ID)
+                || attributes.containsKey(
+                        ACCEPTANCE_ATTEMPT_ACCEPTED_AT
+                );
+    }
+
+    boolean matchesAcceptanceAttempt(Long id, Instant acceptedAt) {
+        return hasCompleteAcceptanceAttemptContext()
+                && id.equals(attributes.get(ACCEPTANCE_ATTEMPT_ID))
+                && acceptedAt.toString().equals(
+                        attributes.get(
+                                ACCEPTANCE_ATTEMPT_ACCEPTED_AT
+                        )
+                );
+    }
+
+    private boolean hasCompleteAcceptanceAttemptContext() {
+        Object id = attributes.get(ACCEPTANCE_ATTEMPT_ID);
+        Object acceptedAt =
+                attributes.get(ACCEPTANCE_ATTEMPT_ACCEPTED_AT);
+        return id instanceof Long value
+                && value > 0
+                && acceptedAt instanceof String text
+                && !text.isBlank();
+    }
+
     private String normalizeCorrelation(String raw) {
         if (raw == null || raw.isBlank()) {
             throw new DomainException(QuestError.QUEST_SIGNAL_CORRELATION_REQUIRED);
@@ -156,6 +196,24 @@ public final class QuestSignal {
 
         public Builder periodKey(String periodKey) {
             this.periodKey = periodKey;
+            return this;
+        }
+
+        public Builder acceptanceAttempt(
+                Long acceptanceId,
+                Instant acceptedAt
+        ) {
+            Guard.notNull(acceptanceId, "acceptanceId");
+            Guard.minValue(acceptanceId, 1L, "acceptanceId");
+            Guard.notNull(acceptedAt, "acceptedAt");
+            this.attributes.put(
+                    ACCEPTANCE_ATTEMPT_ID,
+                    acceptanceId
+            );
+            this.attributes.put(
+                    ACCEPTANCE_ATTEMPT_ACCEPTED_AT,
+                    acceptedAt.toString()
+            );
             return this;
         }
 

--- a/src/main/java/online/lifeasgame/quest/application/automation/QuestSignalFingerprint.java
+++ b/src/main/java/online/lifeasgame/quest/application/automation/QuestSignalFingerprint.java
@@ -7,6 +7,7 @@ import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
 import java.time.temporal.TemporalAccessor;
 import java.util.*;
 
@@ -14,8 +15,15 @@ import java.util.*;
 public class QuestSignalFingerprint {
 
     public String fingerprint(QuestSignal signal) {
+        return fingerprintWithOccurredAt(signal, signal.occurredAt());
+    }
+
+    String fingerprintWithOccurredAt(
+            QuestSignal signal,
+            Instant occurredAt
+    ) {
         StringBuilder canonical = new StringBuilder();
-        appendCommon(canonical, signal);
+        appendCommon(canonical, signal, occurredAt);
         append(
                 canonical,
                 "acceptancePolicy",
@@ -28,14 +36,15 @@ public class QuestSignalFingerprint {
 
     String legacyFingerprint(QuestSignal signal) {
         StringBuilder canonical = new StringBuilder();
-        appendCommon(canonical, signal);
+        appendCommon(canonical, signal, signal.occurredAt());
         append(canonical, "attributes", signal.attributes());
         return sha256(canonical.toString());
     }
 
     private void appendCommon(
             StringBuilder canonical,
-            QuestSignal signal
+            QuestSignal signal,
+            Instant occurredAt
     ) {
         append(canonical, "questCode", signal.questCode().value());
         append(canonical, "playerId", signal.playerId());
@@ -45,7 +54,7 @@ public class QuestSignalFingerprint {
         } else {
             append(canonical, "progressDelta", signal.progressDelta());
         }
-        append(canonical, "occurredAt", signal.occurredAt());
+        append(canonical, "occurredAt", occurredAt);
     }
 
     private void append(StringBuilder target, String key, Object value) {

--- a/src/main/java/online/lifeasgame/quest/application/automation/QuestSignalProcessingAttempt.java
+++ b/src/main/java/online/lifeasgame/quest/application/automation/QuestSignalProcessingAttempt.java
@@ -248,9 +248,16 @@ public class QuestSignalProcessingAttempt {
         if (signal.occurredAt().isBefore(acceptance.getAcceptedAt())) {
             return false;
         }
-        return Objects.equals(
+        if (!Objects.equals(
                 signal.periodKey(),
                 acceptance.getPeriodKey()
+        )) {
+            return false;
+        }
+        return !signal.hasAcceptanceAttemptContext()
+                || signal.matchesAcceptanceAttempt(
+                acceptance.getId(),
+                acceptance.getAcceptedAt()
         );
     }
 

--- a/src/main/java/online/lifeasgame/quest/application/automation/QuestSignalReceiptReplayRecovery.java
+++ b/src/main/java/online/lifeasgame/quest/application/automation/QuestSignalReceiptReplayRecovery.java
@@ -51,6 +51,15 @@ public class QuestSignalReceiptReplayRecovery {
                 )) {
             return QuestSignalProcessingResult.replayed(receipt.getId());
         }
+        if (signal.isManualCheckReplayCandidate()
+                && receipt.hasFingerprint(
+                        signalFingerprint.fingerprintWithOccurredAt(
+                                signal,
+                                receipt.getOccurredAt()
+                        )
+                )) {
+            return QuestSignalProcessingResult.replayed(receipt.getId());
+        }
         throw new DomainException(
                 QuestError.QUEST_SIGNAL_RECEIPT_PAYLOAD_CONFLICT
         );

--- a/src/main/java/online/lifeasgame/quest/application/command/QuestCommand.java
+++ b/src/main/java/online/lifeasgame/quest/application/command/QuestCommand.java
@@ -83,6 +83,9 @@ public final class QuestCommand {
     ) {
     }
 
+    public record ManualCheck(String questCode) {
+    }
+
     public record AdjustProgress(
             Integer delta
     ) {

--- a/src/main/java/online/lifeasgame/quest/domain/error/QuestError.java
+++ b/src/main/java/online/lifeasgame/quest/domain/error/QuestError.java
@@ -57,6 +57,11 @@ public enum QuestError implements ErrorCode {
             "Quest does not require user confirmation",
             409
     ),
+    QUEST_MANUAL_CHECK_NOT_ALLOWED(
+            "QUE-409-QUEST-MANUAL-CHECK-NOT-ALLOWED",
+            "Quest does not support manual check",
+            409
+    ),
     QUEST_TRANSITION_TIME_REQUIRED(
             "QUE-400-QUEST-TRANSITION-TIME-REQUIRED",
             "Quest transition time is required",

--- a/src/main/java/online/lifeasgame/quest/domain/repository/QuestAcceptanceRepository.java
+++ b/src/main/java/online/lifeasgame/quest/domain/repository/QuestAcceptanceRepository.java
@@ -11,6 +11,8 @@ public interface QuestAcceptanceRepository {
 
     Optional<QuestAcceptance> findById(Long acceptanceId);
 
+    Optional<QuestAcceptance> findByIdForUpdate(Long acceptanceId);
+
     List<QuestAcceptance> findAllByPlayerId(Long playerId);
 
     List<QuestAcceptance> findAllByPlayerIdAndStatus(Long playerId, QuestStatus status);

--- a/src/main/java/online/lifeasgame/quest/infra/JpaQuestAcceptanceRepository.java
+++ b/src/main/java/online/lifeasgame/quest/infra/JpaQuestAcceptanceRepository.java
@@ -1,13 +1,23 @@
 package online.lifeasgame.quest.infra;
 
+import jakarta.persistence.LockModeType;
 import online.lifeasgame.quest.domain.QuestAcceptance;
 import online.lifeasgame.quest.domain.QuestStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface JpaQuestAcceptanceRepository extends JpaRepository<QuestAcceptance, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select acceptance from QuestAcceptance acceptance where acceptance.id = :acceptanceId")
+    Optional<QuestAcceptance> findByIdForUpdate(
+            @Param("acceptanceId") Long acceptanceId
+    );
+
     List<QuestAcceptance> findAllByPlayerId(Long playerId);
 
     List<QuestAcceptance> findAllByPlayerIdAndStatus(Long playerId, QuestStatus status);

--- a/src/main/java/online/lifeasgame/quest/infra/QuestAcceptanceRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/quest/infra/QuestAcceptanceRepositoryAdapter.java
@@ -26,6 +26,11 @@ public class QuestAcceptanceRepositoryAdapter implements QuestAcceptanceReposito
     }
 
     @Override
+    public Optional<QuestAcceptance> findByIdForUpdate(Long acceptanceId) {
+        return jpaQuestAcceptanceRepository.findByIdForUpdate(acceptanceId);
+    }
+
+    @Override
     public List<QuestAcceptance> findAllByPlayerId(Long playerId) {
         return jpaQuestAcceptanceRepository.findAllByPlayerId(playerId);
     }

--- a/src/test/java/online/lifeasgame/quest/api/player/QuestControllerQuestManualCheckTest.java
+++ b/src/test/java/online/lifeasgame/quest/api/player/QuestControllerQuestManualCheckTest.java
@@ -1,0 +1,149 @@
+package online.lifeasgame.quest.api.player;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.platform.security.jwt.JwtPrincipal;
+import online.lifeasgame.platform.security.jwt.JwtProvider;
+import online.lifeasgame.platform.web.error.docs.ErrorDocLinker;
+import online.lifeasgame.quest.application.QuestFacade;
+import online.lifeasgame.quest.application.command.QuestCommand;
+import online.lifeasgame.quest.application.result.QuestResult;
+import online.lifeasgame.quest.domain.QuestTargetType;
+import online.lifeasgame.quest.domain.error.QuestError;
+import online.lifeasgame.support.WebMvcTestConfig;
+import online.lifeasgame.system.bootstrap.error.handler.AppErrorProperties;
+import online.lifeasgame.system.bootstrap.security.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = QuestController.class)
+@Import({
+        SecurityConfig.class,
+        WebMvcTestConfig.class
+})
+@DisplayName("QuestController manual-check")
+class QuestControllerQuestManualCheckTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private QuestFacade questFacade;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private AppErrorProperties appErrorProperties;
+
+    @MockitoBean
+    private ErrorDocLinker errorDocLinker;
+
+    @Test
+    @DisplayName("Request body 없이 기존 Acceptance DTO를 200으로 반환한다")
+    void returnsAcceptanceWithoutBody() throws Exception {
+        when(questFacade.manualCheck(
+                new QuestCommand.ManualCheck("Q_GROWTH_ONE_FOCUS")
+        )).thenReturn(acceptance());
+
+        mockMvc.perform(authenticatedPost("Q_GROWTH_ONE_FOCUS"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("COMMON-200"))
+                .andExpect(jsonPath("$.result.id").value(21700))
+                .andExpect(jsonPath("$.result.code")
+                        .value("Q_GROWTH_ONE_FOCUS"))
+                .andExpect(jsonPath("$.result.targetValue").value(25))
+                .andExpect(jsonPath("$.result.progressValue").value(25))
+                .andExpect(jsonPath("$.result.status")
+                        .value("COMPLETED"))
+                .andExpect(jsonPath("$.result.completedAt")
+                        .value("2026-07-31T03:00:00Z"));
+
+        verify(questFacade).manualCheck(
+                new QuestCommand.ManualCheck("Q_GROWTH_ONE_FOCUS")
+        );
+    }
+
+    @Test
+    @DisplayName("허용하지 않은 Quest는 안정된 409를 반환한다")
+    void rejectsWrongQuest() throws Exception {
+        when(questFacade.manualCheck(argThat(command ->
+                command.questCode().equals("Q_RECORD_FIRST_TRACE")
+        ))).thenThrow(new DomainException(
+                QuestError.QUEST_MANUAL_CHECK_NOT_ALLOWED
+        ));
+
+        mockMvc.perform(authenticatedPost("Q_RECORD_FIRST_TRACE"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code")
+                        .value("QUE-409-QUEST-MANUAL-CHECK-NOT-ALLOWED"));
+    }
+
+    private MockHttpServletRequestBuilder authenticatedPost(
+            String questCode
+    ) {
+        return post(
+                "/api/v1/players/quests/{questCode}/manual-check",
+                questCode
+        )
+                .with(authentication(
+                        new UsernamePasswordAuthenticationToken(
+                                new JwtPrincipal(217L, 217001L),
+                                null,
+                                List.of(new SimpleGrantedAuthority(
+                                        "ROLE_USER"
+                                ))
+                        )
+                ))
+                .header("Authorization", "Bearer test-token");
+    }
+
+    private QuestResult.Acceptance acceptance() {
+        Instant checkedAt = Instant.parse("2026-07-31T03:00:00Z");
+        return new QuestResult.Acceptance(
+                21700L,
+                2170L,
+                217001L,
+                "Q_GROWTH_ONE_FOCUS",
+                "한 가지에 25분 집중하기",
+                null,
+                "manual check",
+                QuestTargetType.MINUTES,
+                25,
+                25,
+                "COMPLETED",
+                "USER_CONFIRM",
+                "DAILY",
+                LocalDate.of(2026, 7, 31),
+                LocalDate.of(2026, 7, 31),
+                Instant.parse("2026-07-31T01:00:00Z"),
+                null,
+                checkedAt,
+                checkedAt,
+                null,
+                "GROWTH",
+                "MANUAL_CHECK",
+                "DAILY",
+                null
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/quest/application/QuestAcceptanceCompletionServiceTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/QuestAcceptanceCompletionServiceTest.java
@@ -18,7 +18,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneOffset;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -34,6 +36,8 @@ class QuestAcceptanceCompletionServiceTest {
     private static final Instant GOAL_REACHED_AT = Instant.parse("2026-07-23T03:00:00Z");
     private static final Instant ACCEPTED_AT =
             Instant.parse("2026-07-23T02:00:00Z");
+    private static final Instant COMPLETED_AT =
+            Instant.parse("2026-07-23T04:00:00Z");
 
     @Mock
     private QuestReader questReader;
@@ -51,7 +55,8 @@ class QuestAcceptanceCompletionServiceTest {
         service = new QuestAcceptanceCompletionService(
                 questReader,
                 questWriter,
-                domainEventPublisher
+                domainEventPublisher,
+                Clock.fixed(COMPLETED_AT, ZoneOffset.UTC)
         );
     }
 
@@ -64,7 +69,8 @@ class QuestAcceptanceCompletionServiceTest {
         void completesAndPublishesEvent() {
             Quest quest = profileQuest(QuestCompletionPolicy.USER_CONFIRM);
             QuestAcceptance acceptance = goalReachedAcceptance(quest);
-            given(questReader.getAcceptance(ACCEPTANCE_ID)).willReturn(acceptance);
+            given(questReader.getAcceptanceForUpdate(ACCEPTANCE_ID))
+                    .willReturn(acceptance);
             given(questReader.getById(QUEST_ID)).willReturn(quest);
 
             QuestResult.Acceptance result = service.complete(ACCEPTANCE_ID);
@@ -74,8 +80,9 @@ class QuestAcceptanceCompletionServiceTest {
             assertThat(result.completionPolicy())
                     .isEqualTo(QuestCompletionPolicy.USER_CONFIRM.name());
             assertThat(result.goalReachedAt()).isEqualTo(GOAL_REACHED_AT);
-            assertThat(result.completedAt()).isNotNull();
+            assertThat(result.completedAt()).isEqualTo(COMPLETED_AT);
             verify(questWriter).saveAcceptance(acceptance);
+            verify(questReader).getAcceptanceForUpdate(ACCEPTANCE_ID);
 
             ArgumentCaptor<DomainEvent> eventCaptor = ArgumentCaptor.forClass(DomainEvent.class);
             verify(domainEventPublisher).publish(eventCaptor.capture());
@@ -106,7 +113,8 @@ class QuestAcceptanceCompletionServiceTest {
         void isIdempotent() {
             Quest quest = quest(QuestCompletionPolicy.USER_CONFIRM);
             QuestAcceptance acceptance = goalReachedAcceptance(quest);
-            given(questReader.getAcceptance(ACCEPTANCE_ID)).willReturn(acceptance);
+            given(questReader.getAcceptanceForUpdate(ACCEPTANCE_ID))
+                    .willReturn(acceptance);
             given(questReader.getById(QUEST_ID)).willReturn(quest);
 
             QuestResult.Acceptance first = service.complete(ACCEPTANCE_ID);
@@ -146,7 +154,8 @@ class QuestAcceptanceCompletionServiceTest {
         void rejectsAutoPolicy() {
             Quest quest = quest(QuestCompletionPolicy.AUTO);
             QuestAcceptance acceptance = goalReachedAcceptance(quest);
-            given(questReader.getAcceptance(ACCEPTANCE_ID)).willReturn(acceptance);
+            given(questReader.getAcceptanceForUpdate(ACCEPTANCE_ID))
+                    .willReturn(acceptance);
             given(questReader.getById(QUEST_ID)).willReturn(quest);
 
             assertQuestError(
@@ -168,13 +177,31 @@ class QuestAcceptanceCompletionServiceTest {
                     null
             );
             ReflectionTestUtils.setField(acceptance, "id", ACCEPTANCE_ID);
-            given(questReader.getAcceptance(ACCEPTANCE_ID)).willReturn(acceptance);
+            given(questReader.getAcceptanceForUpdate(ACCEPTANCE_ID))
+                    .willReturn(acceptance);
             given(questReader.getById(QUEST_ID)).willReturn(quest);
 
             assertQuestError(
                     () -> service.complete(ACCEPTANCE_ID),
                     QuestError.QUEST_ACCEPTANCE_COMPLETION_NOT_ALLOWED
             );
+            verifyNoInteractions(questWriter, domainEventPublisher);
+        }
+
+        @Test
+        @DisplayName("Public 완료는 다른 Player Acceptance를 not found로 숨긴다")
+        void rejectsOtherPlayer() {
+            Quest quest = quest(QuestCompletionPolicy.USER_CONFIRM);
+            QuestAcceptance acceptance = goalReachedAcceptance(quest);
+            given(questReader.getAcceptanceForUpdate(ACCEPTANCE_ID))
+                    .willReturn(acceptance);
+
+            assertQuestError(
+                    () -> service.completeForPlayer(99L, ACCEPTANCE_ID),
+                    QuestError.QUEST_ACCEPTANCE_NOT_FOUND
+            );
+
+            verify(questReader, never()).getById(anyLong());
             verifyNoInteractions(questWriter, domainEventPublisher);
         }
     }

--- a/src/test/java/online/lifeasgame/quest/application/QuestManualCheckFacadeTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/QuestManualCheckFacadeTest.java
@@ -1,0 +1,43 @@
+package online.lifeasgame.quest.application;
+
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.quest.application.command.QuestCommand;
+import online.lifeasgame.quest.application.result.QuestResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("QuestFacade manual-check")
+class QuestManualCheckFacadeTest {
+
+    @Test
+    @DisplayName("인증된 CurrentPlayer로 Manual Check를 수행한다")
+    void usesCurrentPlayer() {
+        QuestService questService = mock(QuestService.class);
+        QuestManualCheckService manualCheckService =
+                mock(QuestManualCheckService.class);
+        CurrentPlayerAccessor currentPlayerAccessor =
+                mock(CurrentPlayerAccessor.class);
+        QuestCommand.ManualCheck command =
+                new QuestCommand.ManualCheck("Q_GROWTH_ONE_FOCUS");
+        QuestResult.Acceptance expected =
+                mock(QuestResult.Acceptance.class);
+        when(currentPlayerAccessor.currentPlayerIdOrThrow())
+                .thenReturn(217001L);
+        when(manualCheckService.check(217001L, command))
+                .thenReturn(expected);
+        QuestFacade facade = new QuestFacade(
+                questService,
+                manualCheckService,
+                currentPlayerAccessor
+        );
+
+        assertThat(facade.manualCheck(command)).isSameAs(expected);
+        verify(currentPlayerAccessor).currentPlayerIdOrThrow();
+        verify(manualCheckService).check(217001L, command);
+    }
+}

--- a/src/test/java/online/lifeasgame/quest/application/QuestManualCheckIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/QuestManualCheckIntegrationTest.java
@@ -1,0 +1,445 @@
+package online.lifeasgame.quest.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.quest.application.automation.QuestProgressStore;
+import online.lifeasgame.quest.application.command.QuestCommand;
+import online.lifeasgame.quest.application.result.QuestResult;
+import online.lifeasgame.quest.domain.QuestCode;
+import online.lifeasgame.quest.domain.QuestStatus;
+import online.lifeasgame.quest.domain.error.QuestError;
+import online.lifeasgame.quest.domain.event.QuestEventType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles({"test", "migration-test"})
+@Import(
+        QuestManualCheckIntegrationTest.MutableClockConfiguration.class
+)
+@DisplayName("QuestManualCheck MySQL 통합")
+class QuestManualCheckIntegrationTest {
+
+    private static final Long PLAYER_ID = 217001L;
+    private static final Instant ACCEPTED_AT =
+            Instant.parse("2026-07-31T01:00:00Z");
+
+    @Container
+    private static final MySQLContainer<?> MYSQL =
+            new MySQLContainer<>("mysql:8.0.39")
+                    .withDatabaseName("lifeasgame_manual_check")
+                    .withUsername("lifeasgame")
+                    .withPassword("lifeasgame");
+
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add(
+                "spring.datasource.driver-class-name",
+                MYSQL::getDriverClassName
+        );
+        registry.add("app.outbox.enabled", () -> false);
+    }
+
+    @Autowired
+    private QuestService questService;
+
+    @Autowired
+    private QuestManualCheckService manualCheckService;
+
+    @MockitoSpyBean
+    private QuestAcceptanceCompletionService completionService;
+
+    @MockitoBean
+    private QuestProgressStore questProgressStore;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private MutableClock clock;
+
+    @BeforeEach
+    void setUp() {
+        clock.set(ACCEPTED_AT);
+        jdbcTemplate.update("DELETE FROM outbox_events");
+        jdbcTemplate.update(
+                "DELETE FROM quest_signal_receipts WHERE player_id = ?",
+                PLAYER_ID
+        );
+        jdbcTemplate.update(
+                "DELETE FROM quest_acceptances WHERE player_id = ?",
+                PLAYER_ID
+        );
+    }
+
+    @Test
+    @DisplayName("순차 중복은 Receipt와 세 Event를 한 번씩 남긴다")
+    void appliesSequentialDuplicateExactlyOnce() {
+        accept(QuestCode.Q_GROWTH_ONE_FOCUS);
+        Instant checkedAt = ACCEPTED_AT.plusSeconds(60);
+        clock.set(checkedAt);
+
+        QuestResult.Acceptance first = check(
+                QuestCode.Q_GROWTH_ONE_FOCUS
+        );
+        QuestResult.Acceptance replay = check(
+                QuestCode.Q_GROWTH_ONE_FOCUS
+        );
+
+        assertThat(first.status()).isEqualTo(
+                QuestStatus.COMPLETED.name()
+        );
+        assertThat(replay.completedAt()).isEqualTo(first.completedAt());
+        assertThat(first.completedAt()).isEqualTo(checkedAt);
+        assertThat(progress(QuestCode.Q_GROWTH_ONE_FOCUS)).isEqualTo(25);
+        assertThat(status(QuestCode.Q_GROWTH_ONE_FOCUS))
+                .isEqualTo(QuestStatus.COMPLETED.name());
+        assertThat(receiptCount()).isEqualTo(1);
+        assertThat(correlations()).containsExactly(
+                correlation(first.id(), first.acceptedAt())
+        );
+        assertThat(eventTypes()).containsExactly(
+                QuestEventType.QUEST_PROGRESS.name(),
+                QuestEventType.QUEST_GOAL_REACHED.name(),
+                QuestEventType.QUEST_COMPLETED.name()
+        );
+    }
+
+    @Test
+    @DisplayName("동시 중복도 row lock으로 Completed Event를 한 번만 남긴다")
+    void appliesConcurrentDuplicateExactlyOnce() throws Exception {
+        accept(QuestCode.Q_RECOVERY_REST_TEN);
+        clock.set(ACCEPTED_AT.plusSeconds(60));
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        try {
+            Future<QuestResult.Acceptance> first = executor.submit(() -> {
+                ready.countDown();
+                start.await();
+                return check(QuestCode.Q_RECOVERY_REST_TEN);
+            });
+            Future<QuestResult.Acceptance> second = executor.submit(() -> {
+                ready.countDown();
+                start.await();
+                return check(QuestCode.Q_RECOVERY_REST_TEN);
+            });
+            assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+            start.countDown();
+
+            assertThat(List.of(
+                    first.get(20, TimeUnit.SECONDS),
+                    second.get(20, TimeUnit.SECONDS)
+            )).extracting(QuestResult.Acceptance::status)
+                    .containsOnly(QuestStatus.COMPLETED.name());
+        } finally {
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(5, TimeUnit.SECONDS))
+                    .isTrue();
+        }
+
+        assertThat(progress(QuestCode.Q_RECOVERY_REST_TEN)).isEqualTo(10);
+        assertThat(receiptCount()).isEqualTo(1);
+        assertThat(eventTypes()).containsExactly(
+                QuestEventType.QUEST_PROGRESS.name(),
+                QuestEventType.QUEST_GOAL_REACHED.name(),
+                QuestEventType.QUEST_COMPLETED.name()
+        );
+    }
+
+    @Test
+    @DisplayName("Signal 후 completion 실패는 GOAL_REACHED에서 재시도된다")
+    void retriesCompletionAfterSignalCheckpoint() {
+        accept(QuestCode.Q_GROWTH_ONE_FOCUS);
+        clock.set(ACCEPTED_AT.plusSeconds(60));
+        doThrow(new RuntimeException("forced completion failure"))
+                .doCallRealMethod()
+                .when(completionService)
+                .completeForPlayer(eq(PLAYER_ID), anyLong());
+
+        assertThatThrownBy(
+                () -> check(QuestCode.Q_GROWTH_ONE_FOCUS)
+        ).isInstanceOf(RuntimeException.class)
+                .hasMessage("forced completion failure");
+
+        assertThat(status(QuestCode.Q_GROWTH_ONE_FOCUS))
+                .isEqualTo(QuestStatus.GOAL_REACHED.name());
+        assertThat(receiptCount()).isEqualTo(1);
+        assertThat(eventTypes()).containsExactly(
+                QuestEventType.QUEST_PROGRESS.name(),
+                QuestEventType.QUEST_GOAL_REACHED.name()
+        );
+
+        QuestResult.Acceptance retried = check(
+                QuestCode.Q_GROWTH_ONE_FOCUS
+        );
+
+        assertThat(retried.status()).isEqualTo(
+                QuestStatus.COMPLETED.name()
+        );
+        assertThat(receiptCount()).isEqualTo(1);
+        assertThat(eventTypes()).containsExactly(
+                QuestEventType.QUEST_PROGRESS.name(),
+                QuestEventType.QUEST_GOAL_REACHED.name(),
+                QuestEventType.QUEST_COMPLETED.name()
+        );
+    }
+
+    @Test
+    @DisplayName("cancel 후 같은 날 재수락은 acceptedAt으로 새 attempt가 된다")
+    void separatesCanceledAndReacceptedAttempt() {
+        accept(QuestCode.Q_GROWTH_ONE_FOCUS);
+        clock.set(ACCEPTED_AT.plusSeconds(60));
+        doThrow(new RuntimeException("stop before completion"))
+                .doCallRealMethod()
+                .when(completionService)
+                .completeForPlayer(eq(PLAYER_ID), anyLong());
+        assertThatThrownBy(
+                () -> check(QuestCode.Q_GROWTH_ONE_FOCUS)
+        ).isInstanceOf(RuntimeException.class);
+
+        questService.cancel(
+                PLAYER_ID,
+                new QuestCommand.Cancel(
+                        QuestCode.Q_GROWTH_ONE_FOCUS.value(),
+                        "new manual attempt"
+                )
+        );
+        Instant restartedAt = ACCEPTED_AT.plusSeconds(120);
+        clock.set(restartedAt);
+        QuestResult.Acceptance restarted =
+                questService.accept(
+                        PLAYER_ID,
+                        new QuestCommand.Accept(
+                                QuestCode.Q_GROWTH_ONE_FOCUS.value(),
+                                null,
+                                null
+                        )
+                );
+        clock.set(restartedAt.plusSeconds(60));
+
+        QuestResult.Acceptance completed = check(
+                QuestCode.Q_GROWTH_ONE_FOCUS
+        );
+
+        assertThat(restarted.id()).isEqualTo(completed.id());
+        assertThat(restarted.acceptedAt()).isEqualTo(restartedAt);
+        assertThat(completed.status()).isEqualTo(
+                QuestStatus.COMPLETED.name()
+        );
+        assertThat(receiptCount()).isEqualTo(2);
+        assertThat(correlations()).containsExactly(
+                correlation(restarted.id(), ACCEPTED_AT),
+                correlation(restarted.id(), restartedAt)
+        );
+        assertThat(eventTypes()).containsExactly(
+                QuestEventType.QUEST_PROGRESS.name(),
+                QuestEventType.QUEST_GOAL_REACHED.name(),
+                QuestEventType.QUEST_PROGRESS.name(),
+                QuestEventType.QUEST_GOAL_REACHED.name(),
+                QuestEventType.QUEST_COMPLETED.name()
+        );
+    }
+
+    @Test
+    @DisplayName("Asia/Seoul 자정 경계와 Clock timestamp를 결정적으로 적용한다")
+    void usesPlayerTimezoneAndClock() {
+        Instant beforeLocalMidnight =
+                Instant.parse("2026-07-31T14:59:00Z");
+        clock.set(beforeLocalMidnight);
+        accept(QuestCode.Q_RECOVERY_REST_TEN);
+        clock.set(Instant.parse("2026-07-31T15:01:00Z"));
+
+        assertThatThrownBy(
+                () -> check(QuestCode.Q_RECOVERY_REST_TEN)
+        ).isInstanceOfSatisfying(
+                DomainException.class,
+                exception -> assertThat(exception.getErrorCode())
+                        .isEqualTo(QuestError.QUEST_ACCEPTANCE_NOT_FOUND)
+        );
+        assertThat(receiptCount()).isZero();
+
+        QuestResult.Acceptance current = questService.accept(
+                PLAYER_ID,
+                new QuestCommand.Accept(
+                        QuestCode.Q_RECOVERY_REST_TEN.value(),
+                        null,
+                        null
+                )
+        );
+        Instant checkedAt = Instant.parse("2026-07-31T15:02:00Z");
+        clock.set(checkedAt);
+        QuestResult.Acceptance completed = check(
+                QuestCode.Q_RECOVERY_REST_TEN
+        );
+
+        assertThat(current.periodStart()).isEqualTo(
+                java.time.LocalDate.of(2026, 8, 1)
+        );
+        assertThat(completed.completedAt()).isEqualTo(checkedAt);
+    }
+
+    private void accept(QuestCode questCode) {
+        questService.accept(
+                PLAYER_ID,
+                new QuestCommand.Accept(
+                        questCode.value(),
+                        null,
+                        null
+                )
+        );
+    }
+
+    private QuestResult.Acceptance check(QuestCode questCode) {
+        return manualCheckService.check(
+                PLAYER_ID,
+                new QuestCommand.ManualCheck(questCode.value())
+        );
+    }
+
+    private int receiptCount() {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM quest_signal_receipts WHERE player_id = ?",
+                Integer.class,
+                PLAYER_ID
+        );
+    }
+
+    private List<String> correlations() {
+        return jdbcTemplate.queryForList(
+                """
+                SELECT correlation_id
+                FROM quest_signal_receipts
+                WHERE player_id = ?
+                ORDER BY id
+                """,
+                String.class,
+                PLAYER_ID
+        );
+    }
+
+    private int progress(QuestCode questCode) {
+        return jdbcTemplate.queryForObject(
+                """
+                SELECT acceptance.progress_value
+                FROM quest_acceptances acceptance
+                JOIN quests quest ON quest.id = acceptance.quest_id
+                WHERE acceptance.player_id = ?
+                  AND quest.code = ?
+                ORDER BY acceptance.id DESC
+                LIMIT 1
+                """,
+                Integer.class,
+                PLAYER_ID,
+                questCode.value()
+        );
+    }
+
+    private String status(QuestCode questCode) {
+        return jdbcTemplate.queryForObject(
+                """
+                SELECT acceptance.status
+                FROM quest_acceptances acceptance
+                JOIN quests quest ON quest.id = acceptance.quest_id
+                WHERE acceptance.player_id = ?
+                  AND quest.code = ?
+                ORDER BY acceptance.id DESC
+                LIMIT 1
+                """,
+                String.class,
+                PLAYER_ID,
+                questCode.value()
+        );
+    }
+
+    private List<String> eventTypes() {
+        return jdbcTemplate.queryForList(
+                """
+                SELECT JSON_UNQUOTE(JSON_EXTRACT(payload, '$.type'))
+                FROM outbox_events
+                WHERE event_type = 'quest.event.v1'
+                  AND JSON_EXTRACT(payload, '$.playerId') = ?
+                ORDER BY id
+                """,
+                String.class,
+                PLAYER_ID
+        );
+    }
+
+    private String correlation(Long acceptanceId, Instant acceptedAt) {
+        return "manual-check:acceptance:%d:accepted-at:%d".formatted(
+                acceptanceId,
+                acceptedAt.toEpochMilli()
+        );
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class MutableClockConfiguration {
+
+        @Bean
+        @Primary
+        MutableClock manualCheckClock() {
+            return new MutableClock();
+        }
+    }
+
+    static final class MutableClock extends Clock {
+
+        private volatile Instant current = ACCEPTED_AT;
+
+        void set(Instant instant) {
+            current = instant;
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return Clock.fixed(current, zone);
+        }
+
+        @Override
+        public Instant instant() {
+            return current;
+        }
+    }
+}

--- a/src/test/java/online/lifeasgame/quest/application/QuestManualCheckIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/QuestManualCheckIntegrationTest.java
@@ -2,6 +2,8 @@ package online.lifeasgame.quest.application;
 
 import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.quest.application.automation.QuestProgressStore;
+import online.lifeasgame.quest.application.automation.QuestSignal;
+import online.lifeasgame.quest.application.automation.QuestSignalProcessingService;
 import online.lifeasgame.quest.application.command.QuestCommand;
 import online.lifeasgame.quest.application.result.QuestResult;
 import online.lifeasgame.quest.domain.QuestCode;
@@ -35,13 +37,16 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 
 @Testcontainers
@@ -84,6 +89,9 @@ class QuestManualCheckIntegrationTest {
 
     @MockitoSpyBean
     private QuestAcceptanceCompletionService completionService;
+
+    @MockitoSpyBean
+    private QuestSignalProcessingService signalProcessingService;
 
     @MockitoBean
     private QuestProgressStore questProgressStore;
@@ -142,26 +150,41 @@ class QuestManualCheckIntegrationTest {
     }
 
     @Test
-    @DisplayName("동시 중복도 row lock으로 Completed Event를 한 번만 남긴다")
+    @DisplayName("서로 다른 checkedAt의 동시 중복도 exact-once다")
     void appliesConcurrentDuplicateExactlyOnce() throws Exception {
         accept(QuestCode.Q_RECOVERY_REST_TEN);
-        clock.set(ACCEPTED_AT.plusSeconds(60));
+        Instant firstCheckedAt = ACCEPTED_AT.plusSeconds(60);
+        Instant secondCheckedAt = ACCEPTED_AT.plusSeconds(61);
         ExecutorService executor = Executors.newFixedThreadPool(2);
         CountDownLatch ready = new CountDownLatch(2);
         CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch processingReady = new CountDownLatch(2);
+        CountDownLatch process = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            processingReady.countDown();
+            assertThat(process.await(5, TimeUnit.SECONDS)).isTrue();
+            return invocation.callRealMethod();
+        }).when(signalProcessingService).process(any(QuestSignal.class));
         try {
-            Future<QuestResult.Acceptance> first = executor.submit(() -> {
-                ready.countDown();
-                start.await();
-                return check(QuestCode.Q_RECOVERY_REST_TEN);
-            });
-            Future<QuestResult.Acceptance> second = executor.submit(() -> {
-                ready.countDown();
-                start.await();
-                return check(QuestCode.Q_RECOVERY_REST_TEN);
-            });
+            Future<QuestResult.Acceptance> first = submitCheck(
+                    executor,
+                    ready,
+                    start,
+                    QuestCode.Q_RECOVERY_REST_TEN,
+                    firstCheckedAt
+            );
+            Future<QuestResult.Acceptance> second = submitCheck(
+                    executor,
+                    ready,
+                    start,
+                    QuestCode.Q_RECOVERY_REST_TEN,
+                    secondCheckedAt
+            );
             assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
             start.countDown();
+            assertThat(processingReady.await(5, TimeUnit.SECONDS))
+                    .isTrue();
+            process.countDown();
 
             assertThat(List.of(
                     first.get(20, TimeUnit.SECONDS),
@@ -222,59 +245,102 @@ class QuestManualCheckIntegrationTest {
     }
 
     @Test
-    @DisplayName("cancel 후 같은 날 재수락은 acceptedAt으로 새 attempt가 된다")
-    void separatesCanceledAndReacceptedAttempt() {
+    @DisplayName("Signal 직전 cancel/reaccept된 새 attempt를 변경하지 않는다")
+    void isolatesCanceledAndReacceptedAttemptBeforeProcessing()
+            throws Exception {
         accept(QuestCode.Q_GROWTH_ONE_FOCUS);
-        clock.set(ACCEPTED_AT.plusSeconds(60));
-        doThrow(new RuntimeException("stop before completion"))
-                .doCallRealMethod()
-                .when(completionService)
-                .completeForPlayer(eq(PLAYER_ID), anyLong());
-        assertThatThrownBy(
-                () -> check(QuestCode.Q_GROWTH_ONE_FOCUS)
-        ).isInstanceOf(RuntimeException.class);
-
-        questService.cancel(
-                PLAYER_ID,
-                new QuestCommand.Cancel(
-                        QuestCode.Q_GROWTH_ONE_FOCUS.value(),
-                        "new manual attempt"
-                )
-        );
+        Instant oldAttemptCheckedAt = ACCEPTED_AT.plusSeconds(180);
         Instant restartedAt = ACCEPTED_AT.plusSeconds(120);
-        clock.set(restartedAt);
-        QuestResult.Acceptance restarted =
-                questService.accept(
-                        PLAYER_ID,
-                        new QuestCommand.Accept(
-                                QuestCode.Q_GROWTH_ONE_FOCUS.value(),
-                                null,
-                                null
-                        )
-                );
-        clock.set(restartedAt.plusSeconds(60));
+        CountDownLatch processingEntered = new CountDownLatch(1);
+        CountDownLatch process = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            processingEntered.countDown();
+            assertThat(process.await(5, TimeUnit.SECONDS)).isTrue();
+            return invocation.callRealMethod();
+        }).when(signalProcessingService).process(any(QuestSignal.class));
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<QuestResult.Acceptance> oldAttempt =
+                    executor.submit(() -> checkWithThreadClock(
+                            QuestCode.Q_GROWTH_ONE_FOCUS,
+                            oldAttemptCheckedAt
+                    ));
+            assertThat(processingEntered.await(5, TimeUnit.SECONDS))
+                    .isTrue();
 
-        QuestResult.Acceptance completed = check(
-                QuestCode.Q_GROWTH_ONE_FOCUS
-        );
+            clock.set(restartedAt);
+            questService.cancel(
+                    PLAYER_ID,
+                    new QuestCommand.Cancel(
+                            QuestCode.Q_GROWTH_ONE_FOCUS.value(),
+                            "processing race"
+                    )
+            );
+            QuestResult.Acceptance restarted = questService.accept(
+                    PLAYER_ID,
+                    new QuestCommand.Accept(
+                            QuestCode.Q_GROWTH_ONE_FOCUS.value(),
+                            null,
+                            null
+                    )
+            );
+            assertThat(oldAttemptCheckedAt).isAfter(restartedAt);
+            assertThat(restarted.acceptedAt()).isEqualTo(restartedAt);
 
-        assertThat(restarted.id()).isEqualTo(completed.id());
-        assertThat(restarted.acceptedAt()).isEqualTo(restartedAt);
-        assertThat(completed.status()).isEqualTo(
-                QuestStatus.COMPLETED.name()
-        );
-        assertThat(receiptCount()).isEqualTo(2);
-        assertThat(correlations()).containsExactly(
-                correlation(restarted.id(), ACCEPTED_AT),
-                correlation(restarted.id(), restartedAt)
-        );
-        assertThat(eventTypes()).containsExactly(
-                QuestEventType.QUEST_PROGRESS.name(),
-                QuestEventType.QUEST_GOAL_REACHED.name(),
-                QuestEventType.QUEST_PROGRESS.name(),
-                QuestEventType.QUEST_GOAL_REACHED.name(),
-                QuestEventType.QUEST_COMPLETED.name()
-        );
+            process.countDown();
+            assertThatThrownBy(
+                    () -> oldAttempt.get(20, TimeUnit.SECONDS)
+            ).isInstanceOfSatisfying(
+                    ExecutionException.class,
+                    exception -> assertThat(exception.getCause())
+                            .isInstanceOfSatisfying(
+                                    DomainException.class,
+                                    cause -> assertThat(
+                                            cause.getErrorCode()
+                                    ).isEqualTo(
+                                            QuestError
+                                                    .QUEST_ACCEPTANCE_NOT_FOUND
+                                    )
+                            )
+            );
+
+            assertThat(status(QuestCode.Q_GROWTH_ONE_FOCUS))
+                    .isEqualTo(QuestStatus.IN_PROGRESS.name());
+            assertThat(progress(QuestCode.Q_GROWTH_ONE_FOCUS)).isZero();
+            assertThat(receiptCount()).isEqualTo(1);
+            assertThat(correlations()).containsExactly(
+                    correlation(restarted.id(), ACCEPTED_AT)
+            );
+            assertThat(eventTypes()).isEmpty();
+
+            Instant newAttemptCheckedAt =
+                    restartedAt.plusSeconds(120);
+            clock.set(newAttemptCheckedAt);
+            QuestResult.Acceptance completed = check(
+                    QuestCode.Q_GROWTH_ONE_FOCUS
+            );
+
+            assertThat(completed.id()).isEqualTo(restarted.id());
+            assertThat(completed.acceptedAt()).isEqualTo(restartedAt);
+            assertThat(completed.status()).isEqualTo(
+                    QuestStatus.COMPLETED.name()
+            );
+            assertThat(receiptCount()).isEqualTo(2);
+            assertThat(correlations()).containsExactly(
+                    correlation(restarted.id(), ACCEPTED_AT),
+                    correlation(restarted.id(), restartedAt)
+            );
+            assertThat(eventTypes()).containsExactly(
+                    QuestEventType.QUEST_PROGRESS.name(),
+                    QuestEventType.QUEST_GOAL_REACHED.name(),
+                    QuestEventType.QUEST_COMPLETED.name()
+            );
+        } finally {
+            process.countDown();
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(5, TimeUnit.SECONDS))
+                    .isTrue();
+        }
     }
 
     @Test
@@ -331,6 +397,37 @@ class QuestManualCheckIntegrationTest {
                 PLAYER_ID,
                 new QuestCommand.ManualCheck(questCode.value())
         );
+    }
+
+    private Future<QuestResult.Acceptance> submitCheck(
+            ExecutorService executor,
+            CountDownLatch ready,
+            CountDownLatch start,
+            QuestCode questCode,
+            Instant checkedAt
+    ) {
+        return executor.submit(() -> {
+            clock.setForCurrentThread(checkedAt);
+            try {
+                ready.countDown();
+                start.await();
+                return check(questCode);
+            } finally {
+                clock.clearCurrentThread();
+            }
+        });
+    }
+
+    private QuestResult.Acceptance checkWithThreadClock(
+            QuestCode questCode,
+            Instant checkedAt
+    ) {
+        clock.setForCurrentThread(checkedAt);
+        try {
+            return check(questCode);
+        } finally {
+            clock.clearCurrentThread();
+        }
     }
 
     private int receiptCount() {
@@ -422,9 +519,19 @@ class QuestManualCheckIntegrationTest {
     static final class MutableClock extends Clock {
 
         private volatile Instant current = ACCEPTED_AT;
+        private final ThreadLocal<Instant> currentThread =
+                new ThreadLocal<>();
 
         void set(Instant instant) {
             current = instant;
+        }
+
+        void setForCurrentThread(Instant instant) {
+            currentThread.set(instant);
+        }
+
+        void clearCurrentThread() {
+            currentThread.remove();
         }
 
         @Override
@@ -434,12 +541,13 @@ class QuestManualCheckIntegrationTest {
 
         @Override
         public Clock withZone(ZoneId zone) {
-            return Clock.fixed(current, zone);
+            return Clock.fixed(instant(), zone);
         }
 
         @Override
         public Instant instant() {
-            return current;
+            Instant threadInstant = currentThread.get();
+            return threadInstant == null ? current : threadInstant;
         }
     }
 }

--- a/src/test/java/online/lifeasgame/quest/application/QuestManualCheckServiceTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/QuestManualCheckServiceTest.java
@@ -1,0 +1,409 @@
+package online.lifeasgame.quest.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.quest.application.automation.QuestSignal;
+import online.lifeasgame.quest.application.automation.QuestSignalAcceptancePolicy;
+import online.lifeasgame.quest.application.automation.QuestSignalProcessingService;
+import online.lifeasgame.quest.application.command.QuestCommand;
+import online.lifeasgame.quest.application.result.QuestResult;
+import online.lifeasgame.quest.domain.*;
+import online.lifeasgame.quest.domain.error.QuestError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("QuestManualCheckService")
+class QuestManualCheckServiceTest {
+
+    private static final Long PLAYER_ID = 217L;
+    private static final Long QUEST_ID = 2170L;
+    private static final Long ACCEPTANCE_ID = 21700L;
+    private static final Instant CHECKED_AT =
+            Instant.parse("2026-07-31T03:00:00Z");
+    private static final Instant ACCEPTED_AT =
+            Instant.parse("2026-07-31T01:00:00Z");
+    private static final ZoneId PLAYER_ZONE = ZoneId.of("Asia/Seoul");
+
+    @Mock
+    private QuestReader questReader;
+
+    @Mock
+    private QuestSignalProcessingService signalProcessingService;
+
+    @Mock
+    private QuestAcceptanceCompletionService completionService;
+
+    @Mock
+    private PlayerTimezoneResolver playerTimezoneResolver;
+
+    private QuestManualCheckService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new QuestManualCheckService(
+                questReader,
+                signalProcessingService,
+                completionService,
+                playerTimezoneResolver,
+                Clock.fixed(CHECKED_AT, ZoneId.of("UTC"))
+        );
+        lenient().when(playerTimezoneResolver.resolve(PLAYER_ID))
+                .thenReturn(PLAYER_ZONE);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "Q_GROWTH_ONE_FOCUS,25",
+            "Q_RECOVERY_REST_TEN,10"
+    })
+    @DisplayName("허용 Quest target을 SET하고 현재 Acceptance를 완료한다")
+    void setsTargetAndCompletes(String rawCode, int target) {
+        QuestCode code = QuestCode.parse(rawCode);
+        Quest quest = manualQuest(code, target);
+        QuestAcceptance inProgress = acceptance(quest, PLAYER_ID, ACCEPTED_AT);
+        ReflectionTestUtils.setField(
+                inProgress,
+                "periodKey",
+                "2026-W31"
+        );
+        QuestAcceptance goalReached = acceptance(
+                quest,
+                PLAYER_ID,
+                ACCEPTED_AT
+        );
+        ReflectionTestUtils.setField(
+                goalReached,
+                "periodKey",
+                "2026-W31"
+        );
+        goalReached.setProgress(target, quest, CHECKED_AT);
+        QuestResult.Acceptance completed =
+                QuestResult.Acceptance.from(goalReached, quest);
+
+        given(questReader.getByCode(code)).willReturn(quest);
+        given(questReader.findLatest(QUEST_ID, PLAYER_ID))
+                .willReturn(inProgress, goalReached);
+        given(completionService.completeForPlayer(
+                PLAYER_ID,
+                ACCEPTANCE_ID
+        )).willReturn(completed);
+
+        QuestResult.Acceptance result = service.check(
+                PLAYER_ID,
+                new QuestCommand.ManualCheck(rawCode)
+        );
+
+        assertThat(result).isSameAs(completed);
+        ArgumentCaptor<QuestSignal> signalCaptor =
+                ArgumentCaptor.forClass(QuestSignal.class);
+        verify(signalProcessingService).process(signalCaptor.capture());
+        QuestSignal signal = signalCaptor.getValue();
+        assertThat(signal.questCode()).isEqualTo(code);
+        assertThat(signal.playerId()).isEqualTo(PLAYER_ID);
+        assertThat(signal.isSetOperation()).isTrue();
+        assertThat(signal.progressValue()).isEqualTo(target);
+        assertThat(signal.acceptancePolicy())
+                .isEqualTo(QuestSignalAcceptancePolicy.EXISTING_ONLY);
+        assertThat(signal.occurredAt()).isEqualTo(CHECKED_AT);
+        assertThat(signal.periodKey()).isEqualTo("2026-W31");
+        assertThat(signal.correlationId()).isEqualTo(
+                "manual-check:acceptance:21700:accepted-at:"
+                        + ACCEPTED_AT.toEpochMilli()
+        );
+        assertThat(signal.attributes())
+                .containsEntry("acceptanceId", ACCEPTANCE_ID)
+                .containsEntry("manualCheck", true)
+                .containsEntry("source", "USER_CONFIRMATION");
+        verify(completionService).completeForPlayer(
+                PLAYER_ID,
+                ACCEPTANCE_ID
+        );
+    }
+
+    @Test
+    @DisplayName("GOAL_REACHED는 Signal 없이 completion만 재시도한다")
+    void completesGoalReachedWithoutSignal() {
+        Quest quest = manualQuest(QuestCode.Q_GROWTH_ONE_FOCUS, 25);
+        QuestAcceptance acceptance = acceptance(
+                quest,
+                PLAYER_ID,
+                ACCEPTED_AT
+        );
+        acceptance.setProgress(25, quest, CHECKED_AT);
+        QuestResult.Acceptance expected =
+                QuestResult.Acceptance.from(acceptance, quest);
+        given(questReader.getByCode(QuestCode.Q_GROWTH_ONE_FOCUS))
+                .willReturn(quest);
+        given(questReader.findLatest(QUEST_ID, PLAYER_ID))
+                .willReturn(acceptance);
+        given(completionService.completeForPlayer(
+                PLAYER_ID,
+                ACCEPTANCE_ID
+        )).willReturn(expected);
+
+        assertThat(service.check(
+                PLAYER_ID,
+                new QuestCommand.ManualCheck("Q_GROWTH_ONE_FOCUS")
+        )).isSameAs(expected);
+
+        verifyNoInteractions(signalProcessingService);
+    }
+
+    @Test
+    @DisplayName("COMPLETED는 lock 기반 completion no-op 결과를 반환한다")
+    void returnsCompletedNoOp() {
+        Quest quest = manualQuest(QuestCode.Q_RECOVERY_REST_TEN, 10);
+        QuestAcceptance acceptance = acceptance(
+                quest,
+                PLAYER_ID,
+                ACCEPTED_AT
+        );
+        acceptance.setProgress(10, quest, CHECKED_AT);
+        acceptance.complete(CHECKED_AT.plusSeconds(1));
+        QuestResult.Acceptance expected =
+                QuestResult.Acceptance.from(acceptance, quest);
+        given(questReader.getByCode(QuestCode.Q_RECOVERY_REST_TEN))
+                .willReturn(quest);
+        given(questReader.findLatest(QUEST_ID, PLAYER_ID))
+                .willReturn(acceptance);
+        given(completionService.completeForPlayer(
+                PLAYER_ID,
+                ACCEPTANCE_ID
+        )).willReturn(expected);
+
+        QuestResult.Acceptance result = service.check(
+                PLAYER_ID,
+                new QuestCommand.ManualCheck("Q_RECOVERY_REST_TEN")
+        );
+
+        assertThat(result.completedAt()).isEqualTo(
+                CHECKED_AT.plusSeconds(1)
+        );
+        verifyNoInteractions(signalProcessingService);
+    }
+
+    @Test
+    @DisplayName("CANCELED Acceptance는 restart하지 않고 거부한다")
+    void rejectsCanceled() {
+        Quest quest = manualQuest(QuestCode.Q_GROWTH_ONE_FOCUS, 25);
+        QuestAcceptance acceptance = acceptance(
+                quest,
+                PLAYER_ID,
+                ACCEPTED_AT
+        );
+        acceptance.cancel();
+        given(questReader.getByCode(QuestCode.Q_GROWTH_ONE_FOCUS))
+                .willReturn(quest);
+        given(questReader.findLatest(QUEST_ID, PLAYER_ID))
+                .willReturn(acceptance);
+
+        assertError(
+                () -> service.check(
+                        PLAYER_ID,
+                        new QuestCommand.ManualCheck(
+                                "Q_GROWTH_ONE_FOCUS"
+                        )
+                ),
+                QuestError.QUEST_MANUAL_CHECK_NOT_ALLOWED
+        );
+        verifyNoInteractions(
+                signalProcessingService,
+                completionService
+        );
+    }
+
+    @Test
+    @DisplayName("Acceptance가 없으면 auto-create하지 않는다")
+    void rejectsMissingAcceptance() {
+        Quest quest = manualQuest(QuestCode.Q_GROWTH_ONE_FOCUS, 25);
+        given(questReader.getByCode(QuestCode.Q_GROWTH_ONE_FOCUS))
+                .willReturn(quest);
+        given(questReader.findLatest(QUEST_ID, PLAYER_ID))
+                .willReturn(null);
+
+        assertError(
+                () -> service.check(
+                        PLAYER_ID,
+                        new QuestCommand.ManualCheck(
+                                "Q_GROWTH_ONE_FOCUS"
+                        )
+                ),
+                QuestError.QUEST_ACCEPTANCE_NOT_FOUND
+        );
+        verifyNoInteractions(
+                signalProcessingService,
+                completionService
+        );
+    }
+
+    @Test
+    @DisplayName("이전 local DAILY period Acceptance는 거부한다")
+    void rejectsOldPeriod() {
+        Quest quest = manualQuest(QuestCode.Q_GROWTH_ONE_FOCUS, 25);
+        QuestAcceptance acceptance = QuestAcceptance.start(
+                QUEST_ID,
+                PLAYER_ID,
+                TimePeriod.daily(LocalDate.of(2026, 7, 30)),
+                ACCEPTED_AT.minusSeconds(86400),
+                null
+        );
+        ReflectionTestUtils.setField(
+                acceptance,
+                "id",
+                ACCEPTANCE_ID
+        );
+        given(questReader.getByCode(QuestCode.Q_GROWTH_ONE_FOCUS))
+                .willReturn(quest);
+        given(questReader.findLatest(QUEST_ID, PLAYER_ID))
+                .willReturn(acceptance);
+
+        assertError(
+                () -> service.check(
+                        PLAYER_ID,
+                        new QuestCommand.ManualCheck(
+                                "Q_GROWTH_ONE_FOCUS"
+                        )
+                ),
+                QuestError.QUEST_ACCEPTANCE_NOT_FOUND
+        );
+    }
+
+    @Test
+    @DisplayName("다른 Player Acceptance는 not found로 숨긴다")
+    void rejectsOtherPlayer() {
+        Quest quest = manualQuest(QuestCode.Q_GROWTH_ONE_FOCUS, 25);
+        QuestAcceptance acceptance = acceptance(
+                quest,
+                999L,
+                ACCEPTED_AT
+        );
+        given(questReader.getByCode(QuestCode.Q_GROWTH_ONE_FOCUS))
+                .willReturn(quest);
+        given(questReader.findLatest(QUEST_ID, PLAYER_ID))
+                .willReturn(acceptance);
+
+        assertError(
+                () -> service.check(
+                        PLAYER_ID,
+                        new QuestCommand.ManualCheck(
+                                "Q_GROWTH_ONE_FOCUS"
+                        )
+                ),
+                QuestError.QUEST_ACCEPTANCE_NOT_FOUND
+        );
+    }
+
+    @Test
+    @DisplayName("allowlist 밖 Quest는 안정된 409로 거부한다")
+    void rejectsOtherQuest() {
+        QuestCode code = QuestCode.Q_RECORD_FIRST_TRACE;
+        Quest quest = manualQuest(code, 1);
+        given(questReader.getByCode(code)).willReturn(quest);
+
+        assertError(
+                () -> service.check(
+                        PLAYER_ID,
+                        new QuestCommand.ManualCheck(code.value())
+                ),
+                QuestError.QUEST_MANUAL_CHECK_NOT_ALLOWED
+        );
+    }
+
+    @Test
+    @DisplayName("허용 code라도 runtime Definition이 다르면 거부한다")
+    void rejectsWrongDefinition() {
+        Quest quest = Quest.createDefinition(
+                QuestCode.Q_GROWTH_ONE_FOCUS.value(),
+                1,
+                QuestSemanticCategory.GROWTH,
+                QuestTitle.of("잘못된 수동 퀘스트"),
+                "wrong source",
+                QuestTarget.of(QuestTargetType.MINUTES, 25),
+                QuestProgressSource.COUNT,
+                RewardProfileRef.of("RP_NONE"),
+                QuestRepeatRule.DAILY,
+                null,
+                QuestCompletionPolicy.USER_CONFIRM,
+                null
+        );
+        ReflectionTestUtils.setField(quest, "id", QUEST_ID);
+        given(questReader.getByCode(QuestCode.Q_GROWTH_ONE_FOCUS))
+                .willReturn(quest);
+
+        assertError(
+                () -> service.check(
+                        PLAYER_ID,
+                        new QuestCommand.ManualCheck(
+                                "Q_GROWTH_ONE_FOCUS"
+                        )
+                ),
+                QuestError.QUEST_MANUAL_CHECK_NOT_ALLOWED
+        );
+    }
+
+    private Quest manualQuest(QuestCode code, int target) {
+        Quest quest = Quest.createDefinition(
+                code.value(),
+                1,
+                QuestSemanticCategory.GROWTH,
+                QuestTitle.of("수동 확인 퀘스트"),
+                "manual check",
+                QuestTarget.of(QuestTargetType.MINUTES, target),
+                QuestProgressSource.MANUAL_CHECK,
+                RewardProfileRef.of("RP_NONE"),
+                QuestRepeatRule.DAILY,
+                null,
+                QuestCompletionPolicy.USER_CONFIRM,
+                null
+        );
+        ReflectionTestUtils.setField(quest, "id", QUEST_ID);
+        return quest;
+    }
+
+    private QuestAcceptance acceptance(
+            Quest quest,
+            Long playerId,
+            Instant acceptedAt
+    ) {
+        QuestAcceptance acceptance = QuestAcceptance.start(
+                quest.getId(),
+                playerId,
+                TimePeriod.daily(LocalDate.of(2026, 7, 31)),
+                acceptedAt,
+                null
+        );
+        ReflectionTestUtils.setField(
+                acceptance,
+                "id",
+                ACCEPTANCE_ID
+        );
+        return acceptance;
+    }
+
+    private void assertError(Runnable action, QuestError error) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(
+                        DomainException.class,
+                        exception -> assertThat(exception.getErrorCode())
+                                .isEqualTo(error)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/quest/application/QuestManualCheckServiceTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/QuestManualCheckServiceTest.java
@@ -130,6 +130,14 @@ class QuestManualCheckServiceTest {
         );
         assertThat(signal.attributes())
                 .containsEntry("acceptanceId", ACCEPTANCE_ID)
+                .containsEntry(
+                        "acceptanceAttemptId",
+                        ACCEPTANCE_ID
+                )
+                .containsEntry(
+                        "acceptanceAttemptAcceptedAt",
+                        ACCEPTED_AT.toString()
+                )
                 .containsEntry("manualCheck", true)
                 .containsEntry("source", "USER_CONFIRMATION");
         verify(completionService).completeForPlayer(

--- a/src/test/java/online/lifeasgame/quest/application/automation/QuestSignalFingerprintTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/automation/QuestSignalFingerprintTest.java
@@ -121,6 +121,22 @@ class QuestSignalFingerprintTest {
         }
 
         @Test
+        @DisplayName("override helper는 current schema에서 occurredAt만 바꾼다")
+        void overridesOnlyOccurredAt() {
+            QuestSignal stored = manualSignal(OCCURRED_AT);
+            QuestSignal replay = manualSignal(
+                    OCCURRED_AT.plusSeconds(1)
+            );
+
+            assertThat(fingerprint.fingerprint(replay))
+                    .isNotEqualTo(fingerprint.fingerprint(stored));
+            assertThat(fingerprint.fingerprintWithOccurredAt(
+                    replay,
+                    stored.occurredAt()
+            )).isEqualTo(fingerprint.fingerprint(stored));
+        }
+
+        @Test
         @DisplayName("Acceptance policy와 periodKey를 각각 semantic 값에 포함한다")
         void includesAcceptanceContext() {
             QuestSignal autoCreate = signal(Map.of(), 1);
@@ -169,6 +185,29 @@ class QuestSignalFingerprintTest {
                 .occurredAt(OCCURRED_AT)
                 .correlationId("source:collection:195")
                 .attributes(attributes)
+                .build();
+    }
+
+    private QuestSignal manualSignal(Instant occurredAt) {
+        Instant acceptedAt =
+                Instant.parse("2026-07-24T00:00:00Z");
+        return QuestSignal.setProgress(
+                        QuestCode.Q_GROWTH_ONE_FOCUS,
+                        195L,
+                        25
+                )
+                .occurredAt(occurredAt)
+                .correlationId(
+                        "manual-check:acceptance:1950:accepted-at:"
+                                + acceptedAt.toEpochMilli()
+                )
+                .acceptancePolicy(
+                        QuestSignalAcceptancePolicy.EXISTING_ONLY
+                )
+                .acceptanceAttempt(1950L, acceptedAt)
+                .attribute("acceptanceId", 1950L)
+                .attribute("manualCheck", true)
+                .attribute("source", "USER_CONFIRMATION")
                 .build();
     }
 }

--- a/src/test/java/online/lifeasgame/quest/application/automation/QuestSignalProcessingAttemptTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/automation/QuestSignalProcessingAttemptTest.java
@@ -373,6 +373,149 @@ class QuestSignalProcessingAttemptTest {
                     .isEqualTo(QuestStatus.IN_PROGRESS);
             verify(questAcceptanceRepository).save(acceptance);
         }
+
+        @Test
+        @DisplayName("expected attempt id와 acceptedAt이 일치하면 진행한다")
+        void acceptsMatchingAttemptContext() {
+            Quest quest = quest(
+                    QuestCompletionPolicy.AUTO,
+                    QuestRepeatRule.NONE,
+                    2
+            );
+            QuestAcceptance acceptance = acceptance(
+                    quest,
+                    TimePeriod.forever(),
+                    908L
+            );
+            QuestSignal signal = manualAttemptSignal(
+                    908L,
+                    acceptance.getAcceptedAt()
+            );
+            stubReceipt(signal);
+            given(questService.ensureQuest(signal.questCode()))
+                    .willReturn(quest);
+            given(questAcceptanceRepository.findLatestByQuestAndPlayer(
+                    QUEST_ID,
+                    PLAYER_ID
+            )).willReturn(Optional.of(acceptance));
+            given(questAcceptanceRepository.save(any())).willAnswer(
+                    invocation -> invocation.getArgument(0)
+            );
+
+            attempt.process(signal, FINGERPRINT);
+
+            assertThat(acceptance.getProgressValue()).isEqualTo(1);
+            verify(questAcceptanceRepository).save(acceptance);
+            assertThat(publishedEvents(1)).extracting(QuestEvent::type)
+                    .containsExactly(QuestEventType.QUEST_PROGRESS);
+        }
+
+        @Test
+        @DisplayName("expected attempt acceptedAt이 다르면 Receipt만 저장한다")
+        void rejectsDifferentAttemptAcceptedAt() {
+            Quest quest = quest(
+                    QuestCompletionPolicy.AUTO,
+                    QuestRepeatRule.NONE,
+                    2
+            );
+            QuestAcceptance acceptance = acceptance(
+                    quest,
+                    TimePeriod.forever(),
+                    909L
+            );
+            QuestSignal signal = manualAttemptSignal(
+                    909L,
+                    acceptance.getAcceptedAt().plusSeconds(1)
+            );
+            stubReceipt(signal);
+            given(questService.ensureQuest(signal.questCode()))
+                    .willReturn(quest);
+            given(questAcceptanceRepository.findLatestByQuestAndPlayer(
+                    QUEST_ID,
+                    PLAYER_ID
+            )).willReturn(Optional.of(acceptance));
+
+            attempt.process(signal, FINGERPRINT);
+
+            assertThat(acceptance.getProgressValue()).isZero();
+            verify(questAcceptanceRepository, never()).save(any());
+            verifyNoInteractions(questProgressStore, domainEventPublisher);
+        }
+
+        @Test
+        @DisplayName("expected acceptance id가 다르면 Receipt만 저장한다")
+        void rejectsDifferentAttemptId() {
+            Quest quest = quest(
+                    QuestCompletionPolicy.AUTO,
+                    QuestRepeatRule.NONE,
+                    2
+            );
+            QuestAcceptance acceptance = acceptance(
+                    quest,
+                    TimePeriod.forever(),
+                    910L
+            );
+            QuestSignal signal = manualAttemptSignal(
+                    911L,
+                    acceptance.getAcceptedAt()
+            );
+            stubReceipt(signal);
+            given(questService.ensureQuest(signal.questCode()))
+                    .willReturn(quest);
+            given(questAcceptanceRepository.findLatestByQuestAndPlayer(
+                    QUEST_ID,
+                    PLAYER_ID
+            )).willReturn(Optional.of(acceptance));
+
+            attempt.process(signal, FINGERPRINT);
+
+            assertThat(acceptance.getProgressValue()).isZero();
+            verify(questAcceptanceRepository, never()).save(any());
+            verifyNoInteractions(questProgressStore, domainEventPublisher);
+        }
+
+        @Test
+        @DisplayName("불완전한 attempt context는 parsing 없이 거부한다")
+        void rejectsMalformedAttemptContext() {
+            Quest quest = quest(
+                    QuestCompletionPolicy.AUTO,
+                    QuestRepeatRule.NONE,
+                    2
+            );
+            QuestAcceptance acceptance = acceptance(
+                    quest,
+                    TimePeriod.forever(),
+                    912L
+            );
+            QuestSignal signal = QuestSignal.setProgress(
+                            QuestCode.PLAYER_WELCOME,
+                            PLAYER_ID,
+                            1
+                    )
+                    .occurredAt(OCCURRED_AT)
+                    .correlationId("manual-check:malformed")
+                    .acceptancePolicy(
+                            QuestSignalAcceptancePolicy.EXISTING_ONLY
+                    )
+                    .attribute(
+                            QuestSignal.ACCEPTANCE_ATTEMPT_ID,
+                            acceptance.getId()
+                    )
+                    .build();
+            stubReceipt(signal);
+            given(questService.ensureQuest(signal.questCode()))
+                    .willReturn(quest);
+            given(questAcceptanceRepository.findLatestByQuestAndPlayer(
+                    QUEST_ID,
+                    PLAYER_ID
+            )).willReturn(Optional.of(acceptance));
+
+            attempt.process(signal, FINGERPRINT);
+
+            assertThat(acceptance.getProgressValue()).isZero();
+            verify(questAcceptanceRepository, never()).save(any());
+            verifyNoInteractions(questProgressStore, domainEventPublisher);
+        }
     }
 
     @Nested
@@ -670,6 +813,26 @@ class QuestSignalProcessingAttemptTest {
                 )
                 .periodKey(periodKey)
                 .attribute("lifeLogId", 195L)
+                .build();
+    }
+
+    private QuestSignal manualAttemptSignal(
+            Long acceptanceId,
+            Instant acceptedAt
+    ) {
+        return QuestSignal.setProgress(
+                        QuestCode.PLAYER_WELCOME,
+                        PLAYER_ID,
+                        1
+                )
+                .occurredAt(OCCURRED_AT)
+                .correlationId("manual-check:attempt:195")
+                .acceptancePolicy(
+                        QuestSignalAcceptancePolicy.EXISTING_ONLY
+                )
+                .acceptanceAttempt(acceptanceId, acceptedAt)
+                .attribute("manualCheck", true)
+                .attribute("source", "USER_CONFIRMATION")
                 .build();
     }
 

--- a/src/test/java/online/lifeasgame/quest/application/automation/QuestSignalReceiptReplayRecoveryTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/automation/QuestSignalReceiptReplayRecoveryTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -28,6 +29,12 @@ class QuestSignalReceiptReplayRecoveryTest {
     private static final String CURRENT_FINGERPRINT = "a".repeat(64);
     private static final String LEGACY_FINGERPRINT = "b".repeat(64);
     private static final Long RECEIPT_ID = 195L;
+    private static final Instant STORED_AT =
+            Instant.parse("2026-07-24T01:00:00Z");
+    private static final Instant RETRIED_AT =
+            Instant.parse("2026-07-24T01:00:01Z");
+    private static final Instant ACCEPTED_AT =
+            Instant.parse("2026-07-24T00:00:00Z");
 
     @Mock
     private QuestSignalReceiptRepository receiptRepository;
@@ -135,6 +142,132 @@ class QuestSignalReceiptReplayRecoveryTest {
         verifyNoInteractions(signalFingerprint);
     }
 
+    @Test
+    @DisplayName("같은 Manual Check는 stored occurredAt으로 재계산해 replay한다")
+    void replaysManualCheckWithDifferentOccurredAt() {
+        QuestSignal stored = manualSignal(
+                STORED_AT,
+                25,
+                ACCEPTED_AT,
+                null
+        );
+        QuestSignal retried = manualSignal(
+                RETRIED_AT,
+                25,
+                ACCEPTED_AT,
+                null
+        );
+        QuestSignalFingerprint realFingerprint =
+                new QuestSignalFingerprint();
+        QuestSignalReceiptReplayRecovery realRecovery =
+                realRecovery(stored, realFingerprint);
+
+        assertThat(realRecovery.recover(
+                retried,
+                realFingerprint.fingerprint(retried)
+        )).contains(
+                QuestSignalProcessingResult.replayed(RECEIPT_ID)
+        );
+    }
+
+    @Test
+    @DisplayName("Manual Check라도 progressValue가 다르면 conflict다")
+    void rejectsDifferentManualCheckProgress() {
+        assertManualConflict(
+                manualSignal(STORED_AT, 25, ACCEPTED_AT, null),
+                manualSignal(RETRIED_AT, 10, ACCEPTED_AT, null)
+        );
+    }
+
+    @Test
+    @DisplayName("Manual Check attempt acceptedAt이 다르면 conflict다")
+    void rejectsDifferentManualCheckAttempt() {
+        assertManualConflict(
+                manualSignal(STORED_AT, 25, ACCEPTED_AT, null),
+                manualSignal(
+                        RETRIED_AT,
+                        25,
+                        ACCEPTED_AT.plusSeconds(1),
+                        null
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("Manual Check periodKey가 다르면 conflict다")
+    void rejectsDifferentManualCheckPeriodKey() {
+        assertManualConflict(
+                manualSignal(
+                        STORED_AT,
+                        25,
+                        ACCEPTED_AT,
+                        "2026-W30"
+                ),
+                manualSignal(
+                        RETRIED_AT,
+                        25,
+                        ACCEPTED_AT,
+                        "2026-W31"
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("manualCheck/source marker가 다르면 conflict다")
+    void rejectsDifferentManualCheckMarkers() {
+        QuestSignal stored = manualSignal(
+                STORED_AT,
+                25,
+                ACCEPTED_AT,
+                null
+        );
+        assertManualConflict(
+                stored,
+                manualSignal(
+                        RETRIED_AT,
+                        25,
+                        ACCEPTED_AT,
+                        null,
+                        false,
+                        "USER_CONFIRMATION"
+                )
+        );
+        assertManualConflict(
+                stored,
+                manualSignal(
+                        RETRIED_AT,
+                        25,
+                        ACCEPTED_AT,
+                        null,
+                        true,
+                        "OTHER"
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("일반 EXISTING_ONLY의 occurredAt 차이는 계속 conflict다")
+    void rejectsDifferentOccurredAtForGeneralExistingOnlySignal() {
+        QuestSignal stored = existingOnlySignal(STORED_AT);
+        QuestSignal retried = existingOnlySignal(RETRIED_AT);
+        QuestSignalFingerprint realFingerprint =
+                new QuestSignalFingerprint();
+        QuestSignalReceiptReplayRecovery realRecovery =
+                realRecovery(stored, realFingerprint);
+
+        assertThatThrownBy(() -> realRecovery.recover(
+                retried,
+                realFingerprint.fingerprint(retried)
+        )).isInstanceOfSatisfying(
+                DomainException.class,
+                exception -> assertThat(exception.getErrorCode())
+                        .isEqualTo(
+                                QuestError
+                                        .QUEST_SIGNAL_RECEIPT_PAYLOAD_CONFLICT
+                        )
+        );
+    }
+
     private void stubReceipt(QuestSignal signal) {
         given(receiptRepository.findByIdentity(
                 signal.questCode().value(),
@@ -165,6 +298,56 @@ class QuestSignalReceiptReplayRecoveryTest {
         );
     }
 
+    private void assertManualConflict(
+            QuestSignal stored,
+            QuestSignal retried
+    ) {
+        QuestSignalFingerprint realFingerprint =
+                new QuestSignalFingerprint();
+        QuestSignalReceiptReplayRecovery realRecovery =
+                realRecovery(stored, realFingerprint);
+
+        assertThatThrownBy(() -> realRecovery.recover(
+                retried,
+                realFingerprint.fingerprint(retried)
+        )).isInstanceOfSatisfying(
+                DomainException.class,
+                exception -> assertThat(exception.getErrorCode())
+                        .isEqualTo(
+                                QuestError
+                                        .QUEST_SIGNAL_RECEIPT_PAYLOAD_CONFLICT
+                        )
+        );
+    }
+
+    private QuestSignalReceiptReplayRecovery realRecovery(
+            QuestSignal stored,
+            QuestSignalFingerprint realFingerprint
+    ) {
+        QuestSignalReceipt storedReceipt = QuestSignalReceipt.create(
+                stored.questCode().value(),
+                stored.playerId(),
+                stored.correlationId(),
+                stored.type().name(),
+                realFingerprint.fingerprint(stored),
+                stored.occurredAt()
+        );
+        ReflectionTestUtils.setField(
+                storedReceipt,
+                "id",
+                RECEIPT_ID
+        );
+        given(receiptRepository.findByIdentity(
+                stored.questCode().value(),
+                stored.playerId(),
+                stored.correlationId()
+        )).willReturn(Optional.of(storedReceipt));
+        return new QuestSignalReceiptReplayRecovery(
+                receiptRepository,
+                realFingerprint
+        );
+    }
+
     private QuestSignal signal(
             QuestSignalAcceptancePolicy acceptancePolicy,
             String periodKey
@@ -178,6 +361,66 @@ class QuestSignalReceiptReplayRecoveryTest {
                 .correlationId("source:collection:195")
                 .acceptancePolicy(acceptancePolicy)
                 .periodKey(periodKey)
+                .build();
+    }
+
+    private QuestSignal manualSignal(
+            Instant occurredAt,
+            int progressValue,
+            Instant attemptAcceptedAt,
+            String periodKey
+    ) {
+        return manualSignal(
+                occurredAt,
+                progressValue,
+                attemptAcceptedAt,
+                periodKey,
+                true,
+                "USER_CONFIRMATION"
+        );
+    }
+
+    private QuestSignal manualSignal(
+            Instant occurredAt,
+            int progressValue,
+            Instant attemptAcceptedAt,
+            String periodKey,
+            boolean manualCheck,
+            String source
+    ) {
+        return QuestSignal.setProgress(
+                        QuestCode.Q_GROWTH_ONE_FOCUS,
+                        195L,
+                        progressValue
+                )
+                .occurredAt(occurredAt)
+                .correlationId(
+                        "manual-check:acceptance:1950:accepted-at:"
+                                + ACCEPTED_AT.toEpochMilli()
+                )
+                .acceptancePolicy(
+                        QuestSignalAcceptancePolicy.EXISTING_ONLY
+                )
+                .periodKey(periodKey)
+                .acceptanceAttempt(1950L, attemptAcceptedAt)
+                .attribute("acceptanceId", 1950L)
+                .attribute("manualCheck", manualCheck)
+                .attribute("source", source)
+                .build();
+    }
+
+    private QuestSignal existingOnlySignal(Instant occurredAt) {
+        return QuestSignal.addProgress(
+                        QuestCode.Q_RECORD_THREE_TRACES,
+                        195L,
+                        1
+                )
+                .occurredAt(occurredAt)
+                .correlationId("lifelog:195")
+                .acceptancePolicy(
+                        QuestSignalAcceptancePolicy.EXISTING_ONLY
+                )
+                .attribute("lifeLogId", 195L)
                 .build();
     }
 }


### PR DESCRIPTION
## What

Content 1B Level 1 Quest 중 사용자 확인으로 완료하는 다음 Quest에
Player Manual Check API를 추가한다.

- `Q_GROWTH_ONE_FOCUS`
- `Q_RECOVERY_REST_TEN`

```http
POST /api/v1/players/quests/{questCode}/manual-check
```

사용자가 이미 수락한 현재 DAILY Acceptance를 확인하면
Quest target까지 진행하고 `USER_CONFIRM` 완료로 전환한다.

## API Contract

- 인증된 Current Player를 사용한다.
- Request body는 받지 않는다.
- `acceptanceId`, `playerId`, `duration`, `memo`, `focusLabel`을 입력받지 않는다.
- 성공과 멱등 재요청 모두 `200 OK`를 반환한다.
- 기존 `QuestResponse.Acceptance` 응답을 재사용한다.
- Acceptance가 없으면 자동으로 수락하지 않는다.

## Supported Quests

다음 두 Quest만 Manual Check를 허용한다.

```text
Q_GROWTH_ONE_FOCUS
Q_RECOVERY_REST_TEN
```

Runtime Definition도 다음 계약을 만족해야 한다.

- `progressSource = MANUAL_CHECK`
- `completionPolicy = USER_CONFIRM`
- `targetType = MINUTES`
- `repeatPolicy = DAILY`

## State Transition

### IN_PROGRESS

```text
SET_PROGRESS(target)
→ QUEST_PROGRESS
→ GOAL_REACHED
→ QUEST_GOAL_REACHED
→ COMPLETED
→ QUEST_COMPLETED
```

`Q_GROWTH_ONE_FOCUS`는 progress를 `25`로,
`Q_RECOVERY_REST_TEN`은 progress를 `10`으로 설정한다.

기존 progress에 target을 더하지 않는다.

### GOAL_REACHED

Progress와 Goal Event를 다시 만들지 않고 completion만 재시도한다.

### COMPLETED

상태와 timestamp를 변경하지 않고 기존 Acceptance를 반환한다.

### CANCELED

Manual Check를 거부하며 자동 restart 또는 auto-accept하지 않는다.

## Idempotency

기존 `QuestSignalReceipt`를 재사용한다.

Manual Check Signal:

- `SET_PROGRESS`
- `EXISTING_ONLY`
- `occurredAt = Application Clock`
- `periodKey = Acceptance.periodKey`

Correlation은 Acceptance attempt를 구분한다.

```text
manual-check:acceptance:{acceptanceId}:accepted-at:{acceptedAtEpochMilli}
```

같은 attempt의 중복·재시도는 progress와 Event를 다시 적용하지 않는다.

취소 후 같은 period에 재수락하면 기존 row를 재사용하더라도
새 `acceptedAt`으로 다른 attempt가 되어 Manual Check를 다시 수행할 수 있다.

## Completion Safety

- Current Player와 Acceptance owner가 일치해야 한다.
- Completion 조회에 DB row lock을 적용한다.
- `Application Clock`을 사용한다.
- 동시 요청에서도 `QUEST_COMPLETED`는 최초 한 번만 발생한다.

Signal 반영 후 completion이 실패한 경우 Acceptance는 `GOAL_REACHED`에 남는다.
같은 요청을 재시도하면 Signal은 replay되고 completion만 이어서 수행한다.

## Timezone

현재 DAILY Acceptance 판정은 Player timezone resolver를 사용한다.

Player timezone source가 없는 현재 단계에서는 기존 Quest fallback인
`Asia/Seoul`을 유지한다.

## Migration

신규 Migration 없음.

기존 V1~V16과 Quest/Receipt schema를 변경하지 않는다.

## Test

- Manual Check API contract
- Current Player ownership
- GROWTH target 25
- RECOVERY target 10
- current period Acceptance
- no Acceptance / old period / canceled rejection
- wrong Quest/Definition rejection
- `IN_PROGRESS → GOAL_REACHED → COMPLETED`
- GOAL_REACHED completion retry
- COMPLETED no-op
- sequential duplicate exact-once
- concurrent duplicate exact-once
- cancel/reaccept same-day attempt separation
- completion failure checkpoint retry
- Clock/timezone boundary
- existing LifeLog Quest and legacy Signal regression

## Out of Scope

- focus label
- memo
- custom duration
- timer or elapsed-time verification
- auto acceptance
- RewardSettlement
- EXP or Item grant
- Mailbox / Claim / Inventory
- Achievement
- Notification
- QuestRoute
- Role ownership
- Frontend
- generic Manual Action framework

Closes #217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manual check functionality for eligible quests.
  * Players can submit a quest code to verify and complete supported manual-check quests.
  * Added safeguards to prevent checks for canceled, outdated, mismatched, or unsupported quests.
  * Improved handling of retries and concurrent submissions to prevent duplicate completion.

* **Bug Fixes**
  * Ensured players cannot complete another player’s quest acceptance.
  * Improved recovery when manual-check processing is interrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->