### PR TITLE
[Reward] Unify QuestCompleted contract and connect settlements

### DIFF
--- a/src/main/java/online/lifeasgame/quest/application/QuestAcceptanceCompletionService.java
+++ b/src/main/java/online/lifeasgame/quest/application/QuestAcceptanceCompletionService.java
@@ -3,12 +3,11 @@ package online.lifeasgame.quest.application;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.core.event.DomainEventPublisher;
+import online.lifeasgame.quest.application.event.QuestCompletionEventFactory;
 import online.lifeasgame.quest.application.result.QuestResult;
 import online.lifeasgame.quest.domain.Quest;
 import online.lifeasgame.quest.domain.QuestAcceptance;
 import online.lifeasgame.quest.domain.error.QuestError;
-import online.lifeasgame.quest.domain.event.QuestEvent;
-import online.lifeasgame.quest.domain.event.QuestEventType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +20,7 @@ public class QuestAcceptanceCompletionService {
     private final QuestReader questReader;
     private final QuestWriter questWriter;
     private final DomainEventPublisher domainEventPublisher;
+    private final QuestCompletionEventFactory completionEventFactory;
     private final Clock clock;
 
     @Transactional
@@ -60,25 +60,14 @@ public class QuestAcceptanceCompletionService {
 
     private void publishCompleted(QuestAcceptance acceptance, Quest quest) {
         domainEventPublisher.publish(
-                QuestEvent.builder(QuestEventType.QUEST_COMPLETED)
-                        .questId(quest.getId())
-                        .questCode(quest.getCode())
-                        .playerId(acceptance.getPlayerId())
-                        .attribute("acceptanceId", acceptance.getId())
-                        .attribute("progress", acceptance.getProgressValue())
-                        .attribute("target", quest.target().value())
-                        .attribute("goalReachedAt", acceptance.getGoalReachedAt())
-                        .attribute("completedAt", acceptance.getCompletedAt())
-                        .attribute("completionPolicy", quest.getCompletionPolicy().name())
-                        .definitionSnapshot(quest)
-                        .occurredAt(acceptance.getCompletedAt())
-                        .correlationId(
-                                "quest:%d:acceptance:%d:completed".formatted(
-                                        quest.getId(),
-                                        acceptance.getId()
-                                )
+                completionEventFactory.create(
+                        acceptance,
+                        quest,
+                        "quest:%d:acceptance:%d:completed".formatted(
+                                quest.getId(),
+                                acceptance.getId()
                         )
-                        .build()
+                )
         );
     }
 }

--- a/src/main/java/online/lifeasgame/quest/application/QuestService.java
+++ b/src/main/java/online/lifeasgame/quest/application/QuestService.java
@@ -285,7 +285,7 @@ public class QuestService {
     public QuestResult.Acceptance adjustAcceptanceProgress(Long acceptanceId, QuestCommand.AdjustProgress command) {
         QuestAcceptance acceptance = questReader.getAcceptance(acceptanceId);
         Quest quest = questReader.getById(acceptance.getQuestId());
-        Instant transitionAt = Instant.now();
+        Instant transitionAt = clock.instant();
         acceptance.addProgress(command.delta(), quest, transitionAt);
         publishProgress(acceptance, quest, transitionAt, "admin-progress");
         if (acceptance.isGoalReached()) {
@@ -303,7 +303,7 @@ public class QuestService {
         QuestStatus questStatus = QuestStatus.parse(command.status());
         QuestAcceptance acceptance = questReader.getAcceptance(acceptanceId);
         Quest quest = questReader.getById(acceptance.getQuestId());
-        Instant transitionAt = Instant.now();
+        Instant transitionAt = clock.instant();
         boolean changed = acceptance.changeStatus(questStatus, transitionAt);
         if (changed && acceptance.isGoalReached()) {
             publishGoalReached(acceptance, quest, transitionAt, "admin-goal-reached");

--- a/src/main/java/online/lifeasgame/quest/application/QuestService.java
+++ b/src/main/java/online/lifeasgame/quest/application/QuestService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.core.event.DomainEventPublisher;
 import online.lifeasgame.quest.application.command.QuestCommand;
+import online.lifeasgame.quest.application.event.QuestCompletionEventFactory;
 import online.lifeasgame.quest.application.result.QuestResult;
 import online.lifeasgame.quest.domain.*;
 import online.lifeasgame.quest.domain.error.QuestError;
@@ -35,6 +36,7 @@ public class QuestService {
     private final QuestWriter questWriter;
     private final RewardProfileLookupApi rewardProfileLookupApi;
     private final DomainEventPublisher domainEventPublisher;
+    private final QuestCompletionEventFactory completionEventFactory;
     private final PlayerTimezoneResolver playerTimezoneResolver;
     private final Clock clock;
 
@@ -364,20 +366,11 @@ public class QuestService {
             String suffix
     ) {
         domainEventPublisher.publish(
-                QuestEvent.builder(QuestEventType.QUEST_COMPLETED)
-                        .questId(quest.getId())
-                        .questCode(quest.getCode())
-                        .playerId(acceptance.getPlayerId())
-                        .attribute("acceptanceId", acceptance.getId())
-                        .attribute("progress", acceptance.getProgressValue())
-                        .attribute("target", quest.target().value())
-                        .attribute("goalReachedAt", acceptance.getGoalReachedAt())
-                        .attribute("completedAt", acceptance.getCompletedAt())
-                        .attribute("completionPolicy", quest.getCompletionPolicy().name())
-                        .definitionSnapshot(quest)
-                        .occurredAt(acceptance.getCompletedAt())
-                        .correlationId(correlation(acceptance, suffix))
-                        .build()
+                completionEventFactory.create(
+                        acceptance,
+                        quest,
+                        correlation(acceptance, suffix)
+                )
         );
     }
 

--- a/src/main/java/online/lifeasgame/quest/application/automation/QuestSignalProcessingAttempt.java
+++ b/src/main/java/online/lifeasgame/quest/application/automation/QuestSignalProcessingAttempt.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import online.lifeasgame.core.event.DomainEventPublisher;
 import online.lifeasgame.quest.application.PlayerTimezoneResolver;
 import online.lifeasgame.quest.application.QuestService;
+import online.lifeasgame.quest.application.event.QuestCompletionEventFactory;
 import online.lifeasgame.quest.domain.*;
 import online.lifeasgame.quest.domain.event.QuestEvent;
 import online.lifeasgame.quest.domain.event.QuestEventType;
@@ -30,6 +31,7 @@ public class QuestSignalProcessingAttempt {
     private final QuestAcceptanceRepository questAcceptanceRepository;
     private final QuestProgressStore questProgressStore;
     private final DomainEventPublisher domainEventPublisher;
+    private final QuestCompletionEventFactory completionEventFactory;
     private final PlayerTimezoneResolver playerTimezoneResolver;
     private final Clock clock;
 
@@ -89,7 +91,7 @@ public class QuestSignalProcessingAttempt {
             if (quest.isAutoCompletion()
                     && acceptance.complete(signal.occurredAt())) {
                 acceptance = questAcceptanceRepository.save(acceptance);
-                publishCompleted(signal, quest, acceptance, progressValue);
+                publishCompleted(signal, quest, acceptance);
             }
         }
 
@@ -348,32 +350,15 @@ public class QuestSignalProcessingAttempt {
     private void publishCompleted(
             QuestSignal signal,
             Quest quest,
-            QuestAcceptance acceptance,
-            int progressValue
+            QuestAcceptance acceptance
     ) {
         domainEventPublisher.publish(
-                QuestEvent.builder(QuestEventType.QUEST_COMPLETED)
-                        .attributes(signal.attributes())
-                        .questId(quest.getId())
-                        .questCode(quest.getCode())
-                        .playerId(signal.playerId())
-                        .attribute("acceptanceId", acceptance.getId())
-                        .attribute("progress", progressValue)
-                        .attribute("target", quest.target().value())
-                        .attribute("repeatRule", quest.getRepeatRule().name())
-                        .attribute(
-                                "completionPolicy",
-                                quest.getCompletionPolicy().name()
-                        )
-                        .attribute(
-                                "goalReachedAt",
-                                acceptance.getGoalReachedAt()
-                        )
-                        .attribute("completedAt", acceptance.getCompletedAt())
-                        .definitionSnapshot(quest)
-                        .occurredAt(acceptance.getCompletedAt())
-                        .correlationId(correlation(signal, "completed"))
-                        .build()
+                completionEventFactory.create(
+                        acceptance,
+                        quest,
+                        correlation(signal, "completed"),
+                        signal.attributes()
+                )
         );
     }
 

--- a/src/main/java/online/lifeasgame/quest/application/event/QuestCompletionEventFactory.java
+++ b/src/main/java/online/lifeasgame/quest/application/event/QuestCompletionEventFactory.java
@@ -1,0 +1,85 @@
+package online.lifeasgame.quest.application.event;
+
+import online.lifeasgame.quest.domain.Quest;
+import online.lifeasgame.quest.domain.QuestAcceptance;
+import online.lifeasgame.quest.domain.event.QuestEvent;
+import online.lifeasgame.quest.domain.event.QuestEventType;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class QuestCompletionEventFactory {
+
+    public QuestEvent create(
+            QuestAcceptance acceptance,
+            Quest quest,
+            String correlationId
+    ) {
+        return create(acceptance, quest, correlationId, Map.of());
+    }
+
+    public QuestEvent create(
+            QuestAcceptance acceptance,
+            Quest quest,
+            String correlationId,
+            Map<String, Object> contextAttributes
+    ) {
+        validate(acceptance, quest, correlationId);
+        return QuestEvent.builder(QuestEventType.QUEST_COMPLETED)
+                .attributes(contextAttributes)
+                .questId(quest.getId())
+                .questCode(quest.getCode())
+                .playerId(acceptance.getPlayerId())
+                .attribute("acceptanceId", acceptance.getId())
+                .attribute("progress", acceptance.getProgressValue())
+                .attribute("target", quest.target().value())
+                .attribute("repeatRule", quest.getRepeatRule().name())
+                .attribute(
+                        "completionPolicy",
+                        quest.getCompletionPolicy().name()
+                )
+                .attribute("goalReachedAt", acceptance.getGoalReachedAt())
+                .attribute("completedAt", acceptance.getCompletedAt())
+                .definitionSnapshot(quest)
+                .occurredAt(acceptance.getCompletedAt())
+                .correlationId(correlationId)
+                .build();
+    }
+
+    private void validate(
+            QuestAcceptance acceptance,
+            Quest quest,
+            String correlationId
+    ) {
+        require(acceptance != null, "acceptance must not be null");
+        require(quest != null, "quest must not be null");
+        require(
+                acceptance.getId() != null && acceptance.getId() > 0,
+                "acceptance must be persisted"
+        );
+        require(
+                quest.getId() != null && quest.getId() > 0,
+                "quest must be persisted"
+        );
+        require(acceptance.isCompleted(), "acceptance must be completed");
+        require(
+                acceptance.getGoalReachedAt() != null,
+                "goalReachedAt must not be null"
+        );
+        require(
+                acceptance.getCompletedAt() != null,
+                "completedAt must not be null"
+        );
+        require(
+                correlationId != null && !correlationId.isBlank(),
+                "correlationId must not be blank"
+        );
+    }
+
+    private void require(boolean condition, String message) {
+        if (!condition) {
+            throw new IllegalArgumentException(message);
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/application/event/QuestCompletionEventFactory.java
+++ b/src/main/java/online/lifeasgame/quest/application/event/QuestCompletionEventFactory.java
@@ -7,6 +7,7 @@ import online.lifeasgame.quest.domain.event.QuestEventType;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
+import java.util.Objects;
 
 @Component
 public class QuestCompletionEventFactory {
@@ -61,6 +62,10 @@ public class QuestCompletionEventFactory {
         require(
                 quest.getId() != null && quest.getId() > 0,
                 "quest must be persisted"
+        );
+        require(
+                Objects.equals(acceptance.getQuestId(), quest.getId()),
+                "acceptance must belong to quest"
         );
         require(acceptance.isCompleted(), "acceptance must be completed");
         require(

--- a/src/main/java/online/lifeasgame/quest/application/saga/QuestRewardSaga.java
+++ b/src/main/java/online/lifeasgame/quest/application/saga/QuestRewardSaga.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Instant;
+import java.time.Clock;
 
 @Slf4j
 @Component
@@ -18,6 +18,7 @@ import java.time.Instant;
 public class QuestRewardSaga {
 
     private final DomainEventPublisher domainEventPublisher;
+    private final Clock clock;
 
     @EventListener
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -38,7 +39,7 @@ public class QuestRewardSaga {
                         .questCode(event.questCode())
                         .playerId(event.playerId())
                         .attributes(event.attributes())
-                        .occurredAt(Instant.now())
+                        .occurredAt(clock.instant())
                         .correlationId(correlation)
                         .build()
         );

--- a/src/main/java/online/lifeasgame/quest/domain/QuestAcceptance.java
+++ b/src/main/java/online/lifeasgame/quest/domain/QuestAcceptance.java
@@ -143,10 +143,6 @@ public class QuestAcceptance extends AbstractTime {
         );
     }
 
-    public void addProgress(int delta, Quest quest) {
-        addProgress(delta, quest, Instant.now());
-    }
-
     public void addProgress(int delta, Quest quest, Instant reachedAt) {
         assertProgressAllowed();
         Guard.notNull(quest, "quest");
@@ -155,10 +151,6 @@ public class QuestAcceptance extends AbstractTime {
         if (quest.target().reachedBy(this.progressValue)) {
             reachGoal(reachedAt);
         }
-    }
-
-    public void setProgress(int value, Quest quest) {
-        setProgress(value, quest, Instant.now());
     }
 
     public void setProgress(int value, Quest quest, Instant reachedAt) {

--- a/src/main/java/online/lifeasgame/reward/application/QuestCompletionRewardService.java
+++ b/src/main/java/online/lifeasgame/reward/application/QuestCompletionRewardService.java
@@ -1,0 +1,50 @@
+package online.lifeasgame.reward.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.reward.application.event.QuestRewardReadyFact;
+import online.lifeasgame.reward.domain.RewardSettlement;
+import online.lifeasgame.reward.domain.RewardSettlementLine;
+import online.lifeasgame.reward.domain.RewardSettlementSourceType;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QuestCompletionRewardService {
+
+    private final RewardSettlementCreateService settlementCreateService;
+    private final RewardSettlementExpProcessService expProcessService;
+
+    public void process(QuestRewardReadyFact fact) {
+        RewardSettlement settlement = settlementCreateService.create(
+                fact.playerId(),
+                RewardSettlementSourceType.QUEST_COMPLETION,
+                fact.acceptanceId(),
+                fact.rewardProfileCode()
+        );
+
+        for (RewardSettlementLine line : settlement.getLines()) {
+            switch (line.getRewardType()) {
+                case EXP -> processExp(settlement.getId(), line.getId());
+                case ITEM -> {
+                    // ITEM settlement lines intentionally remain PENDING.
+                }
+            }
+        }
+    }
+
+    private void processExp(Long settlementId, Long lineId) {
+        try {
+            expProcessService.process(settlementId, lineId);
+        } catch (DomainException exception) {
+            log.warn(
+                    "Quest reward EXP failed: settlementId={}, lineId={}, failureCode={}",
+                    settlementId,
+                    lineId,
+                    exception.getErrorCode().code()
+            );
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/application/QuestCompletionRewardService.java
+++ b/src/main/java/online/lifeasgame/reward/application/QuestCompletionRewardService.java
@@ -6,6 +6,7 @@ import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.reward.application.event.QuestRewardReadyFact;
 import online.lifeasgame.reward.domain.RewardSettlement;
 import online.lifeasgame.reward.domain.RewardSettlementLine;
+import online.lifeasgame.reward.domain.RewardSettlementLineStatus;
 import online.lifeasgame.reward.domain.RewardSettlementSourceType;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 public class QuestCompletionRewardService {
 
     private final RewardSettlementCreateService settlementCreateService;
+    private final RewardSettlementReader settlementReader;
     private final RewardSettlementExpProcessService expProcessService;
 
     public void process(QuestRewardReadyFact fact) {
@@ -27,7 +29,13 @@ public class QuestCompletionRewardService {
 
         for (RewardSettlementLine line : settlement.getLines()) {
             switch (line.getRewardType()) {
-                case EXP -> processExp(settlement.getId(), line.getId());
+                case EXP -> {
+                    if (line.getStatus() == RewardSettlementLineStatus.FAILED) {
+                        logFailed(settlement.getId(), line);
+                    } else {
+                        processExp(settlement.getId(), line.getId());
+                    }
+                }
                 case ITEM -> {
                     // ITEM settlement lines intentionally remain PENDING.
                 }
@@ -39,12 +47,29 @@ public class QuestCompletionRewardService {
         try {
             expProcessService.process(settlementId, lineId);
         } catch (DomainException exception) {
-            log.warn(
-                    "Quest reward EXP failed: settlementId={}, lineId={}, failureCode={}",
-                    settlementId,
-                    lineId,
-                    exception.getErrorCode().code()
-            );
+            RewardSettlement fresh =
+                    settlementReader.getByIdInNewTransactionOrThrow(
+                            settlementId
+                    );
+            RewardSettlementLine freshLine =
+                    fresh.getLineByIdOrThrow(lineId);
+            if (freshLine.getStatus()
+                    != RewardSettlementLineStatus.FAILED) {
+                throw exception;
+            }
+            logFailed(settlementId, freshLine);
         }
+    }
+
+    private void logFailed(
+            Long settlementId,
+            RewardSettlementLine line
+    ) {
+        log.warn(
+                "Quest reward EXP failed: settlementId={}, lineId={}, failureCode={}",
+                settlementId,
+                line.getId(),
+                line.getFailureCode()
+        );
     }
 }

--- a/src/main/java/online/lifeasgame/reward/application/RewardSettlementCreateService.java
+++ b/src/main/java/online/lifeasgame/reward/application/RewardSettlementCreateService.java
@@ -1,10 +1,14 @@
 package online.lifeasgame.reward.application;
 
 import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.reward.domain.RewardSettlement;
 import online.lifeasgame.reward.domain.RewardSettlementSourceType;
+import online.lifeasgame.reward.domain.error.RewardError;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -19,8 +23,18 @@ public class RewardSettlementCreateService {
             Long sourceId,
             String rewardProfileCode
     ) {
-        return settlementReader.findByIdentity(playerId, sourceType, sourceId)
+        RewardSettlement settlement = settlementReader
+                .findByIdentity(playerId, sourceType, sourceId)
                 .orElseGet(() -> createNew(playerId, sourceType, sourceId, rewardProfileCode));
+        if (!Objects.equals(
+                settlement.getRewardProfileCode(),
+                rewardProfileCode
+        )) {
+            throw new DomainException(
+                    RewardError.REWARD_SETTLEMENT_SOURCE_PROFILE_CONFLICT
+            );
+        }
+        return settlement;
     }
 
     private RewardSettlement createNew(

--- a/src/main/java/online/lifeasgame/reward/application/RewardSettlementReader.java
+++ b/src/main/java/online/lifeasgame/reward/application/RewardSettlementReader.java
@@ -50,6 +50,14 @@ public class RewardSettlementReader {
                 .orElseThrow(() -> new DomainException(RewardError.REWARD_SETTLEMENT_NOT_FOUND));
     }
 
+    @Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
+    public RewardSettlement getByIdInNewTransactionOrThrow(Long id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new DomainException(
+                        RewardError.REWARD_SETTLEMENT_NOT_FOUND
+                ));
+    }
+
     @Transactional(propagation = Propagation.MANDATORY)
     public RewardSettlement getByIdForUpdateOrThrow(Long id) {
         return findByIdForUpdate(id)

--- a/src/main/java/online/lifeasgame/reward/application/event/QuestRewardReadyBridge.java
+++ b/src/main/java/online/lifeasgame/reward/application/event/QuestRewardReadyBridge.java
@@ -1,0 +1,23 @@
+package online.lifeasgame.reward.application.event;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.quest.domain.event.QuestEvent;
+import online.lifeasgame.quest.domain.event.QuestEventType;
+import online.lifeasgame.reward.application.QuestCompletionRewardService;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class QuestRewardReadyBridge {
+
+    private final QuestCompletionRewardService rewardService;
+
+    @EventListener
+    public void onQuestEvent(QuestEvent event) {
+        if (event.type() != QuestEventType.QUEST_REWARD_READY) {
+            return;
+        }
+        QuestRewardReadyFact.from(event).ifPresent(rewardService::process);
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/application/event/QuestRewardReadyFact.java
+++ b/src/main/java/online/lifeasgame/reward/application/event/QuestRewardReadyFact.java
@@ -46,10 +46,9 @@ public record QuestRewardReadyFact(
                 attributes.get("acceptanceId"),
                 RewardError.REWARD_SETTLEMENT_SOURCE_ID_REQUIRED
         );
-        Integer definitionVersion =
-                attributes.get("questDefinitionVersion") instanceof Number value
-                        ? value.intValue()
-                        : null;
+        Integer definitionVersion = positiveIntegerOrNull(
+                attributes.get("questDefinitionVersion")
+        );
         return Optional.of(new QuestRewardReadyFact(
                 playerId,
                 acceptanceId,
@@ -78,6 +77,25 @@ public record QuestRewardReadyFact(
             throw invalid(error);
         }
         return value;
+    }
+
+    private static Integer positiveIntegerOrNull(Object value) {
+        if (!(value instanceof Number number)) {
+            return null;
+        }
+        try {
+            Integer result = switch (number) {
+                case Byte item -> (int) item;
+                case Short item -> (int) item;
+                case Integer item -> item;
+                case Long item -> Math.toIntExact(item);
+                case BigInteger item -> item.intValueExact();
+                default -> null;
+            };
+            return result != null && result > 0 ? result : null;
+        } catch (ArithmeticException exception) {
+            return null;
+        }
     }
 
     private static Long positiveNumber(Object value, RewardError error) {

--- a/src/main/java/online/lifeasgame/reward/application/event/QuestRewardReadyFact.java
+++ b/src/main/java/online/lifeasgame/reward/application/event/QuestRewardReadyFact.java
@@ -47,8 +47,8 @@ public record QuestRewardReadyFact(
                 RewardError.REWARD_SETTLEMENT_SOURCE_ID_REQUIRED
         );
         Integer definitionVersion =
-                attributes.get("questDefinitionVersion") instanceof Integer value
-                        ? value
+                attributes.get("questDefinitionVersion") instanceof Number value
+                        ? value.intValue()
                         : null;
         return Optional.of(new QuestRewardReadyFact(
                 playerId,

--- a/src/main/java/online/lifeasgame/reward/application/event/QuestRewardReadyFact.java
+++ b/src/main/java/online/lifeasgame/reward/application/event/QuestRewardReadyFact.java
@@ -4,7 +4,6 @@ import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.quest.domain.event.QuestEvent;
 import online.lifeasgame.reward.domain.error.RewardError;
 
-import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.util.Map;
@@ -64,10 +63,14 @@ public record QuestRewardReadyFact(
     }
 
     private static String profileCode(Object value) {
-        if (!(value instanceof String code) || code.isBlank()) {
+        if (!(value instanceof String code)) {
             throw invalid(RewardError.REWARD_PROFILE_CODE_REQUIRED);
         }
-        return code;
+        String normalized = code.strip();
+        if (normalized.isBlank()) {
+            throw invalid(RewardError.REWARD_PROFILE_CODE_REQUIRED);
+        }
+        return normalized;
     }
 
     private static Long positive(Long value, RewardError error) {
@@ -88,18 +91,13 @@ public record QuestRewardReadyFact(
                 case Integer item -> item.longValue();
                 case Long item -> item;
                 case BigInteger item -> item.longValueExact();
-                case BigDecimal item -> item.longValueExact();
-                case Float item ->
-                        BigDecimal.valueOf(item.doubleValue()).longValueExact();
-                case Double item ->
-                        BigDecimal.valueOf(item).longValueExact();
                 default -> throw invalid(error);
             };
             if (result <= 0) {
                 throw invalid(error);
             }
             return result;
-        } catch (ArithmeticException | NumberFormatException exception) {
+        } catch (ArithmeticException exception) {
             throw new DomainException(error, null, exception);
         }
     }

--- a/src/main/java/online/lifeasgame/reward/application/event/QuestRewardReadyFact.java
+++ b/src/main/java/online/lifeasgame/reward/application/event/QuestRewardReadyFact.java
@@ -1,0 +1,110 @@
+package online.lifeasgame.reward.application.event;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.quest.domain.event.QuestEvent;
+import online.lifeasgame.reward.domain.error.RewardError;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public record QuestRewardReadyFact(
+        Long playerId,
+        Long acceptanceId,
+        String rewardProfileCode,
+        Long questId,
+        String questCode,
+        Integer questDefinitionVersion,
+        Instant occurredAt,
+        String correlationId
+) {
+    private static final Set<String> FINAL_MARKERS = Set.of(
+            "questSemanticCategory",
+            "progressSource",
+            "repeatPolicy"
+    );
+
+    public static Optional<QuestRewardReadyFact> from(QuestEvent event) {
+        Map<String, Object> attributes = event.attributes();
+        if (!attributes.containsKey("rewardProfileCode")) {
+            if (attributes.keySet().stream().anyMatch(FINAL_MARKERS::contains)) {
+                throw invalid(RewardError.REWARD_PROFILE_CODE_REQUIRED);
+            }
+            return Optional.empty();
+        }
+
+        String rewardProfileCode = profileCode(
+                attributes.get("rewardProfileCode")
+        );
+        Long playerId = positive(
+                event.playerId(),
+                RewardError.REWARD_SETTLEMENT_PLAYER_ID_REQUIRED
+        );
+        Long acceptanceId = positiveNumber(
+                attributes.get("acceptanceId"),
+                RewardError.REWARD_SETTLEMENT_SOURCE_ID_REQUIRED
+        );
+        Integer definitionVersion =
+                attributes.get("questDefinitionVersion") instanceof Integer value
+                        ? value
+                        : null;
+        return Optional.of(new QuestRewardReadyFact(
+                playerId,
+                acceptanceId,
+                rewardProfileCode,
+                event.questId(),
+                event.questCode(),
+                definitionVersion,
+                event.occurredAt(),
+                event.correlationId()
+        ));
+    }
+
+    private static String profileCode(Object value) {
+        if (!(value instanceof String code) || code.isBlank()) {
+            throw invalid(RewardError.REWARD_PROFILE_CODE_REQUIRED);
+        }
+        return code;
+    }
+
+    private static Long positive(Long value, RewardError error) {
+        if (value == null || value <= 0) {
+            throw invalid(error);
+        }
+        return value;
+    }
+
+    private static Long positiveNumber(Object value, RewardError error) {
+        if (!(value instanceof Number number)) {
+            throw invalid(error);
+        }
+        try {
+            long result = switch (number) {
+                case Byte item -> item.longValue();
+                case Short item -> item.longValue();
+                case Integer item -> item.longValue();
+                case Long item -> item;
+                case BigInteger item -> item.longValueExact();
+                case BigDecimal item -> item.longValueExact();
+                case Float item ->
+                        BigDecimal.valueOf(item.doubleValue()).longValueExact();
+                case Double item ->
+                        BigDecimal.valueOf(item).longValueExact();
+                default -> throw invalid(error);
+            };
+            if (result <= 0) {
+                throw invalid(error);
+            }
+            return result;
+        } catch (ArithmeticException | NumberFormatException exception) {
+            throw new DomainException(error, null, exception);
+        }
+    }
+
+    private static DomainException invalid(RewardError error) {
+        return new DomainException(error);
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/domain/error/RewardError.java
+++ b/src/main/java/online/lifeasgame/reward/domain/error/RewardError.java
@@ -82,6 +82,11 @@ public enum RewardError implements ErrorCode {
     REWARD_SETTLEMENT_SOURCE_ID_REQUIRED(
             "RWD-400-SETTLEMENT-SOURCE-ID-REQUIRED", "Reward settlement source id must be positive", 400
     ),
+    REWARD_SETTLEMENT_SOURCE_PROFILE_CONFLICT(
+            "RWD-409-SETTLEMENT-SOURCE-PROFILE-CONFLICT",
+            "Reward settlement source has a conflicting reward profile",
+            409
+    ),
     REWARD_SETTLEMENT_PROFILE_REQUIRED(
             "RWD-400-SETTLEMENT-PROFILE-REQUIRED", "Reward settlement requires a reward profile", 400
     ),

--- a/src/test/java/online/lifeasgame/quest/application/QuestAcceptanceCompletionServiceTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/QuestAcceptanceCompletionServiceTest.java
@@ -3,6 +3,7 @@ package online.lifeasgame.quest.application;
 import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.core.event.DomainEvent;
 import online.lifeasgame.core.event.DomainEventPublisher;
+import online.lifeasgame.quest.application.event.QuestCompletionEventFactory;
 import online.lifeasgame.quest.application.result.QuestResult;
 import online.lifeasgame.quest.domain.*;
 import online.lifeasgame.quest.domain.error.QuestError;
@@ -56,6 +57,7 @@ class QuestAcceptanceCompletionServiceTest {
                 questReader,
                 questWriter,
                 domainEventPublisher,
+                new QuestCompletionEventFactory(),
                 Clock.fixed(COMPLETED_AT, ZoneOffset.UTC)
         );
     }

--- a/src/test/java/online/lifeasgame/quest/application/QuestDefinitionServiceTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/QuestDefinitionServiceTest.java
@@ -4,6 +4,7 @@ import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.core.event.DomainEventPublisher;
 import online.lifeasgame.quest.application.blueprint.StaticQuestBlueprintCatalog;
 import online.lifeasgame.quest.application.command.QuestCommand;
+import online.lifeasgame.quest.application.event.QuestCompletionEventFactory;
 import online.lifeasgame.quest.application.result.QuestResult;
 import online.lifeasgame.quest.domain.*;
 import online.lifeasgame.quest.domain.error.QuestError;
@@ -58,6 +59,7 @@ class QuestDefinitionServiceTest {
                 questWriter,
                 rewardProfileLookupApi,
                 domainEventPublisher,
+                new QuestCompletionEventFactory(),
                 ignored -> ZoneId.of("Asia/Seoul"),
                 Clock.systemUTC()
         );
@@ -306,6 +308,7 @@ class QuestDefinitionServiceTest {
                 questWriter,
                 rewardProfileLookupApi,
                 domainEventPublisher,
+                new QuestCompletionEventFactory(),
                 ignored -> ZoneId.of("Asia/Seoul"),
                 Clock.systemUTC()
         );
@@ -350,6 +353,7 @@ class QuestDefinitionServiceTest {
                 questWriter,
                 rewardProfileLookupApi,
                 domainEventPublisher,
+                new QuestCompletionEventFactory(),
                 ignored -> ZoneId.of("Asia/Seoul"),
                 Clock.systemUTC()
         );
@@ -384,6 +388,7 @@ class QuestDefinitionServiceTest {
                 questWriter,
                 rewardProfileLookupApi,
                 domainEventPublisher,
+                new QuestCompletionEventFactory(),
                 ignored -> ZoneId.of("Asia/Seoul"),
                 Clock.systemUTC()
         );

--- a/src/test/java/online/lifeasgame/quest/application/QuestServiceStateContractTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/QuestServiceStateContractTest.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -117,6 +118,90 @@ class QuestServiceStateContractTest {
                     );
             assertThat(event.correlationId())
                     .isEqualTo("quest:193:acceptance:1930:admin-completed");
+        }
+    }
+
+    @Nested
+    @DisplayName("Admin이 AUTO Quest 진행도를 목표까지 조정할 때")
+    class AdjustAutoProgress {
+
+        @Test
+        @DisplayName("Factory canonical QUEST_COMPLETED를 admin-completed correlation으로 발행한다")
+        void publishesCanonicalCompletion() {
+            Quest quest = new StaticQuestBlueprintCatalog()
+                    .require(QuestCode.Q_RECORD_FIRST_TRACE)
+                    .instantiate();
+            ReflectionTestUtils.setField(quest, "id", QUEST_ID);
+            QuestAcceptance acceptance = QuestAcceptance.start(
+                    QUEST_ID,
+                    PLAYER_ID,
+                    TimePeriod.forever(),
+                    ACCEPTED_AT.minusSeconds(60),
+                    null
+            );
+            ReflectionTestUtils.setField(
+                    acceptance,
+                    "id",
+                    ACCEPTANCE_ID
+            );
+            given(questReader.getAcceptance(ACCEPTANCE_ID))
+                    .willReturn(acceptance);
+            given(questReader.getById(QUEST_ID)).willReturn(quest);
+
+            QuestResult.Acceptance result =
+                    service.adjustAcceptanceProgress(
+                            ACCEPTANCE_ID,
+                            new QuestCommand.AdjustProgress(1)
+                    );
+
+            assertThat(result.status())
+                    .isEqualTo(QuestStatus.COMPLETED.name());
+            ArgumentCaptor<DomainEvent> eventCaptor =
+                    ArgumentCaptor.forClass(DomainEvent.class);
+            verify(domainEventPublisher, times(3))
+                    .publish(eventCaptor.capture());
+            List<QuestEvent> events = eventCaptor.getAllValues().stream()
+                    .map(QuestEvent.class::cast)
+                    .toList();
+            assertThat(events)
+                    .extracting(QuestEvent::type)
+                    .containsExactly(
+                            QuestEventType.QUEST_PROGRESS,
+                            QuestEventType.QUEST_GOAL_REACHED,
+                            QuestEventType.QUEST_COMPLETED
+                    );
+
+            QuestEvent completed = events.get(2);
+            assertThat(completed.questId()).isEqualTo(QUEST_ID);
+            assertThat(completed.questCode())
+                    .isEqualTo(QuestCode.Q_RECORD_FIRST_TRACE.value());
+            assertThat(completed.playerId()).isEqualTo(PLAYER_ID);
+            assertThat(completed.occurredAt()).isEqualTo(ACCEPTED_AT);
+            assertThat(completed.attributes())
+                    .containsEntry("acceptanceId", ACCEPTANCE_ID)
+                    .containsEntry("progress", 1)
+                    .containsEntry("target", 1)
+                    .containsEntry("repeatRule", "ONCE")
+                    .containsEntry("completionPolicy", "AUTO")
+                    .containsEntry("goalReachedAt", ACCEPTED_AT)
+                    .containsEntry("completedAt", ACCEPTED_AT)
+                    .containsEntry("questDefinitionVersion", 1)
+                    .containsEntry("questSemanticCategory", "RECORD")
+                    .containsEntry("progressSource", "RECORD_CREATED")
+                    .containsEntry("repeatPolicy", "ONCE")
+                    .containsEntry(
+                            "rewardProfileCode",
+                            "RP_EXP_TINY_10"
+                    )
+                    .doesNotContainKeys(
+                            "rewardExp",
+                            "rewardStats",
+                            "rewardLines",
+                            "rewardProfileId"
+                    );
+            assertThat(completed.correlationId()).isEqualTo(
+                    "quest:193:acceptance:1930:admin-completed"
+            );
         }
     }
 

--- a/src/test/java/online/lifeasgame/quest/application/QuestServiceStateContractTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/QuestServiceStateContractTest.java
@@ -5,6 +5,7 @@ import online.lifeasgame.core.event.DomainEventPublisher;
 import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.quest.application.blueprint.StaticQuestBlueprintCatalog;
 import online.lifeasgame.quest.application.command.QuestCommand;
+import online.lifeasgame.quest.application.event.QuestCompletionEventFactory;
 import online.lifeasgame.quest.application.result.QuestResult;
 import online.lifeasgame.quest.domain.*;
 import online.lifeasgame.quest.domain.error.QuestError;
@@ -72,6 +73,7 @@ class QuestServiceStateContractTest {
                 questWriter,
                 rewardProfileLookupApi,
                 domainEventPublisher,
+                new QuestCompletionEventFactory(),
                 ignored -> PLAYER_ZONE,
                 Clock.fixed(ACCEPTED_AT, ZoneOffset.UTC)
         );

--- a/src/test/java/online/lifeasgame/quest/application/automation/QuestSignalProcessingAttemptTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/automation/QuestSignalProcessingAttemptTest.java
@@ -5,6 +5,7 @@ import online.lifeasgame.core.event.DomainEventPublisher;
 import online.lifeasgame.quest.application.DefaultPlayerTimezoneResolver;
 import online.lifeasgame.quest.application.QuestService;
 import online.lifeasgame.quest.application.blueprint.StaticQuestBlueprintCatalog;
+import online.lifeasgame.quest.application.event.QuestCompletionEventFactory;
 import online.lifeasgame.quest.domain.*;
 import online.lifeasgame.quest.domain.event.QuestEvent;
 import online.lifeasgame.quest.domain.event.QuestEventType;
@@ -72,6 +73,7 @@ class QuestSignalProcessingAttemptTest {
                 questAcceptanceRepository,
                 questProgressStore,
                 domainEventPublisher,
+                new QuestCompletionEventFactory(),
                 new DefaultPlayerTimezoneResolver(),
                 Clock.fixed(OCCURRED_AT, ZoneOffset.UTC)
         );

--- a/src/test/java/online/lifeasgame/quest/application/event/QuestCompletionEventFactoryTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/event/QuestCompletionEventFactoryTest.java
@@ -1,0 +1,192 @@
+package online.lifeasgame.quest.application.event;
+
+import online.lifeasgame.quest.domain.*;
+import online.lifeasgame.quest.domain.event.QuestEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("QuestCompletionEventFactory")
+class QuestCompletionEventFactoryTest {
+
+    private static final Instant ACCEPTED_AT =
+            Instant.parse("2026-07-30T01:00:00Z");
+    private static final Instant GOAL_REACHED_AT =
+            Instant.parse("2026-07-30T02:00:00Z");
+    private static final Instant COMPLETED_AT =
+            Instant.parse("2026-07-30T03:00:00Z");
+    private static final Set<String> CANONICAL_ATTRIBUTES = Set.of(
+            "acceptanceId",
+            "progress",
+            "target",
+            "repeatRule",
+            "completionPolicy",
+            "goalReachedAt",
+            "completedAt",
+            "questDefinitionVersion",
+            "questSemanticCategory",
+            "progressSource",
+            "repeatPolicy",
+            "roleTemplateCode",
+            "rewardProfileCode"
+    );
+
+    private final QuestCompletionEventFactory factory =
+            new QuestCompletionEventFactory();
+    private Quest quest;
+    private QuestAcceptance acceptance;
+
+    @BeforeEach
+    void setUp() {
+        quest = Quest.createDefinition(
+                "quest:test:completion-factory",
+                7,
+                QuestSemanticCategory.GROWTH,
+                QuestTitle.of("Factory"),
+                "Factory test",
+                QuestTarget.of(QuestTargetType.COUNT, 3),
+                QuestProgressSource.COUNT,
+                RewardProfileRef.of("RP_EXP_TINY_10"),
+                QuestRepeatRule.ONCE,
+                QuestRoleTemplateRef.of("ROLE_WARRIOR"),
+                QuestCompletionPolicy.AUTO,
+                null
+        );
+        ReflectionTestUtils.setField(quest, "id", 219L);
+        acceptance = QuestAcceptance.start(
+                219L,
+                2190L,
+                TimePeriod.forever(),
+                ACCEPTED_AT,
+                null
+        );
+        ReflectionTestUtils.setField(acceptance, "id", 21900L);
+        acceptance.setProgress(3, quest, GOAL_REACHED_AT);
+        acceptance.complete(COMPLETED_AT);
+    }
+
+    @Test
+    @DisplayName("source context를 보존하고 canonical 완료 값과 보상 snapshot으로 위조 값을 덮어쓴다")
+    void createsCanonicalPayloadWithoutContextOverride() {
+        QuestEvent event = factory.create(
+                acceptance,
+                quest,
+                "source:219:completed",
+                Map.ofEntries(
+                        Map.entry("lifeLogId", 901L),
+                        Map.entry("acceptanceId", -1L),
+                        Map.entry("progress", 999),
+                        Map.entry("target", 999),
+                        Map.entry("repeatRule", "DAILY"),
+                        Map.entry("completionPolicy", "USER_CONFIRM"),
+                        Map.entry("goalReachedAt", ACCEPTED_AT),
+                        Map.entry("completedAt", ACCEPTED_AT),
+                        Map.entry("questDefinitionVersion", 99),
+                        Map.entry("rewardProfileCode", "RP_NONE"),
+                        Map.entry("rewardExp", 999),
+                        Map.entry("rewardStats", Map.of("luck", 999))
+                )
+        );
+
+        assertThat(event.questId()).isEqualTo(219L);
+        assertThat(event.questCode())
+                .isEqualTo("quest:test:completion-factory");
+        assertThat(event.playerId()).isEqualTo(2190L);
+        assertThat(event.occurredAt()).isEqualTo(COMPLETED_AT);
+        assertThat(event.correlationId()).isEqualTo("source:219:completed");
+        assertThat(event.attributes())
+                .containsEntry("lifeLogId", 901L)
+                .containsEntry("acceptanceId", 21900L)
+                .containsEntry("progress", 3)
+                .containsEntry("target", 3)
+                .containsEntry("repeatRule", "ONCE")
+                .containsEntry("completionPolicy", "AUTO")
+                .containsEntry("goalReachedAt", GOAL_REACHED_AT)
+                .containsEntry("completedAt", COMPLETED_AT)
+                .containsEntry("questDefinitionVersion", 7)
+                .containsEntry("questSemanticCategory", "GROWTH")
+                .containsEntry("progressSource", "COUNT")
+                .containsEntry("repeatPolicy", "ONCE")
+                .containsEntry("roleTemplateCode", "ROLE_WARRIOR")
+                .containsEntry("rewardProfileCode", "RP_EXP_TINY_10")
+                .doesNotContainKeys(
+                        "rewardExp",
+                        "rewardStats",
+                        "rewardLines",
+                        "rewardProfileId"
+                );
+    }
+
+    @Test
+    @DisplayName("USER_CONFIRM과 AUTO 조립은 correlation/source context 외 canonical 값이 같다")
+    void keepsCanonicalParityAcrossCompletionPaths() {
+        QuestEvent userConfirm = factory.create(
+                acceptance,
+                quest,
+                "quest:219:acceptance:21900:completed"
+        );
+        QuestEvent auto = factory.create(
+                acceptance,
+                quest,
+                "lifelog:901:completed",
+                Map.of("lifeLogId", 901L)
+        );
+
+        assertThat(canonical(auto)).isEqualTo(canonical(userConfirm));
+        assertThat(auto.questId()).isEqualTo(userConfirm.questId());
+        assertThat(auto.questCode()).isEqualTo(userConfirm.questCode());
+        assertThat(auto.playerId()).isEqualTo(userConfirm.playerId());
+        assertThat(auto.occurredAt()).isEqualTo(userConfirm.occurredAt());
+        assertThat(userConfirm.attributes()).doesNotContainKey("lifeLogId");
+        assertThat(auto.attributes()).containsEntry("lifeLogId", 901L);
+        assertThat(auto.correlationId())
+                .isNotEqualTo(userConfirm.correlationId());
+    }
+
+    @Test
+    @DisplayName("null, 미영속, 미완료, blank correlation 입력은 raw NPE 없이 거부한다")
+    void validatesCompletionPrerequisites() {
+        assertThatThrownBy(() ->
+                factory.create(null, quest, "correlation")
+        ).isInstanceOf(IllegalArgumentException.class);
+
+        ReflectionTestUtils.setField(acceptance, "id", null);
+        assertThatThrownBy(() ->
+                factory.create(acceptance, quest, "correlation")
+        ).isInstanceOf(IllegalArgumentException.class);
+        ReflectionTestUtils.setField(acceptance, "id", 21900L);
+
+        QuestAcceptance inProgress = QuestAcceptance.start(
+                219L,
+                2190L,
+                TimePeriod.forever(),
+                ACCEPTED_AT,
+                null
+        );
+        ReflectionTestUtils.setField(inProgress, "id", 21901L);
+        assertThatThrownBy(() ->
+                factory.create(inProgress, quest, "correlation")
+        ).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() ->
+                factory.create(acceptance, quest, " ")
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private Map<String, Object> canonical(QuestEvent event) {
+        return event.attributes().entrySet().stream()
+                .filter(entry -> CANONICAL_ATTRIBUTES.contains(entry.getKey()))
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        Map.Entry::getValue
+                ));
+    }
+}

--- a/src/test/java/online/lifeasgame/quest/application/event/QuestCompletionEventFactoryTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/event/QuestCompletionEventFactoryTest.java
@@ -176,6 +176,13 @@ class QuestCompletionEventFactoryTest {
         assertThatThrownBy(() ->
                 factory.create(inProgress, quest, "correlation")
         ).isInstanceOf(IllegalArgumentException.class);
+
+        ReflectionTestUtils.setField(quest, "id", 220L);
+        assertThatThrownBy(() ->
+                factory.create(acceptance, quest, "correlation")
+        ).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("acceptance must belong to quest");
+        ReflectionTestUtils.setField(quest, "id", 219L);
         assertThatThrownBy(() ->
                 factory.create(acceptance, quest, " ")
         ).isInstanceOf(IllegalArgumentException.class);

--- a/src/test/java/online/lifeasgame/quest/application/saga/QuestRewardSagaTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/saga/QuestRewardSagaTest.java
@@ -1,0 +1,87 @@
+package online.lifeasgame.quest.application.saga;
+
+import online.lifeasgame.core.event.DomainEvent;
+import online.lifeasgame.core.event.DomainEventPublisher;
+import online.lifeasgame.quest.domain.event.QuestEvent;
+import online.lifeasgame.quest.domain.event.QuestEventType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@DisplayName("QuestRewardSaga")
+class QuestRewardSagaTest {
+
+    private static final Instant COMPLETED_AT =
+            Instant.parse("2026-07-30T03:00:00Z");
+    private static final Instant READY_AT =
+            Instant.parse("2026-07-30T03:00:01Z");
+
+    @Test
+    @DisplayName("QUEST_COMPLETED를 주입 Clock 시각의 QUEST_REWARD_READY로 변환한다")
+    void schedulesRewardWithPreservedContextAndCorrelation() {
+        DomainEventPublisher publisher = mock(DomainEventPublisher.class);
+        QuestRewardSaga saga = new QuestRewardSaga(
+                publisher,
+                Clock.fixed(READY_AT, ZoneOffset.UTC)
+        );
+        QuestEvent completed = new QuestEvent(
+                QuestEventType.QUEST_COMPLETED,
+                2190L,
+                219L,
+                "Q_FIRST_STEP",
+                Map.of(
+                        "acceptanceId", 21900L,
+                        "rewardProfileCode", "RP_EXP_TINY_10",
+                        "source", "MANUAL_CHECK"
+                ),
+                COMPLETED_AT,
+                "manual-check:219:completed"
+        );
+
+        saga.onQuestEvent(completed);
+
+        ArgumentCaptor<DomainEvent> captor =
+                ArgumentCaptor.forClass(DomainEvent.class);
+        verify(publisher).publish(captor.capture());
+        QuestEvent ready = (QuestEvent) captor.getValue();
+        assertThat(ready.type())
+                .isEqualTo(QuestEventType.QUEST_REWARD_READY);
+        assertThat(ready.questId()).isEqualTo(completed.questId());
+        assertThat(ready.questCode()).isEqualTo(completed.questCode());
+        assertThat(ready.playerId()).isEqualTo(completed.playerId());
+        assertThat(ready.attributes()).isEqualTo(completed.attributes());
+        assertThat(ready.occurredAt()).isEqualTo(READY_AT);
+        assertThat(ready.correlationId())
+                .isEqualTo("manual-check:219:completed:reward");
+    }
+
+    @Test
+    @DisplayName("QUEST_COMPLETED 외 Event는 변환하지 않는다")
+    void ignoresOtherQuestEvents() {
+        DomainEventPublisher publisher = mock(DomainEventPublisher.class);
+        QuestRewardSaga saga = new QuestRewardSaga(
+                publisher,
+                Clock.fixed(READY_AT, ZoneOffset.UTC)
+        );
+
+        saga.onQuestEvent(new QuestEvent(
+                QuestEventType.QUEST_PROGRESS,
+                2190L,
+                219L,
+                "Q_FIRST_STEP",
+                Map.of(),
+                COMPLETED_AT,
+                "quest:219:progress"
+        ));
+
+        verifyNoInteractions(publisher);
+    }
+}

--- a/src/test/java/online/lifeasgame/reward/application/QuestCompletionRewardServiceTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/QuestCompletionRewardServiceTest.java
@@ -4,13 +4,17 @@ import online.lifeasgame.character.domain.error.PlayerError;
 import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.reward.application.event.QuestRewardReadyFact;
 import online.lifeasgame.reward.domain.*;
+import online.lifeasgame.reward.domain.error.RewardError;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.time.Instant;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
@@ -18,87 +22,284 @@ import static org.mockito.Mockito.*;
 class QuestCompletionRewardServiceTest {
 
     private RewardSettlementCreateService createService;
+    private RewardSettlementReader settlementReader;
     private RewardSettlementExpProcessService expProcessService;
     private QuestCompletionRewardService service;
 
     @BeforeEach
     void setUp() {
         createService = mock(RewardSettlementCreateService.class);
+        settlementReader = mock(RewardSettlementReader.class);
         expProcessService =
                 mock(RewardSettlementExpProcessService.class);
         service = new QuestCompletionRewardService(
                 createService,
+                settlementReader,
                 expProcessService
         );
     }
 
-    @Test
-    @DisplayName("acceptanceId와 Event profile로 Settlement를 만들고 EXP만 처리한다")
-    void createsSettlementAndProcessesOnlyExp() {
-        RewardSettlement created = mock(RewardSettlement.class);
-        RewardSettlementLine exp = line(701L, RewardType.EXP);
-        RewardSettlementLine item = line(702L, RewardType.ITEM);
-        when(created.getId()).thenReturn(700L);
-        when(created.getLines()).thenReturn(List.of(exp, item));
-        when(createService.create(
-                2190L,
-                RewardSettlementSourceType.QUEST_COMPLETION,
-                21900L,
-                "RP_EXP_AND_ITEM_FIRST_STEP_20"
-        )).thenReturn(created);
+    @ParameterizedTest
+    @EnumSource(
+            value = RewardSettlementLineStatus.class,
+            names = {"PENDING", "SUCCEEDED"}
+    )
+    @DisplayName("PENDING과 SUCCEEDED EXP는 Processor에서 성공/replay를 검증한다")
+    void processesPendingAndSucceededExp(
+            RewardSettlementLineStatus status
+    ) {
+        RewardSettlementLine exp = line(
+                701L,
+                RewardType.EXP,
+                status,
+                null
+        );
+        RewardSettlementLine item = line(
+                702L,
+                RewardType.ITEM,
+                RewardSettlementLineStatus.PENDING,
+                null
+        );
+        stubCreated(
+                settlement(
+                        700L,
+                        "RP_EXP_AND_ITEM_FIRST_STEP_20",
+                        List.of(exp, item)
+                )
+        );
 
         service.process(fact("RP_EXP_AND_ITEM_FIRST_STEP_20"));
 
         verify(expProcessService).process(700L, 701L);
         verify(expProcessService, never()).process(700L, 702L);
+        verifyNoInteractions(settlementReader);
     }
 
     @Test
     @DisplayName("RP_NONE의 빈 Settlement는 EXP Processor를 호출하지 않는다")
     void leavesNoRewardSettlementCompleted() {
-        RewardSettlement created = mock(RewardSettlement.class);
-        when(created.getId()).thenReturn(710L);
-        when(created.getLines()).thenReturn(List.of());
-        when(createService.create(
-                2190L,
-                RewardSettlementSourceType.QUEST_COMPLETION,
-                21900L,
-                "RP_NONE"
-        )).thenReturn(created);
+        stubCreated(settlement(710L, "RP_NONE", List.of()));
 
         service.process(fact("RP_NONE"));
 
-        verifyNoInteractions(expProcessService);
+        verifyNoInteractions(settlementReader, expProcessService);
     }
 
     @Test
-    @DisplayName("EXP known DomainException은 소비하고 unexpected RuntimeException은 전파한다")
-    void handlesOnlyKnownExpFailure() {
-        RewardSettlement created = mock(RewardSettlement.class);
-        RewardSettlementLine first = line(721L, RewardType.EXP);
-        RewardSettlementLine second = line(722L, RewardType.EXP);
-        when(created.getId()).thenReturn(720L);
-        when(created.getLines()).thenReturn(List.of(first, second));
-        when(createService.create(anyLong(), any(), anyLong(), anyString()))
-                .thenReturn(created);
-        doThrow(new DomainException(PlayerError.PLAYER_NOT_FOUND))
-                .when(expProcessService).process(720L, 721L);
+    @DisplayName("기존 FAILED EXP는 Processor와 RetryPreparation 없이 skip한다")
+    void skipsPreviouslyFailedExp() {
+        RewardSettlementLine failed = line(
+                711L,
+                RewardType.EXP,
+                RewardSettlementLineStatus.FAILED,
+                PlayerError.PLAYER_NOT_FOUND.code()
+        );
+        stubCreated(settlement(
+                710L,
+                "RP_EXP_30",
+                List.of(failed)
+        ));
 
         service.process(fact("RP_EXP_30"));
 
-        verify(expProcessService).process(720L, 722L);
+        verifyNoInteractions(settlementReader, expProcessService);
+    }
 
+    @Test
+    @DisplayName("DomainException 후 fresh FAILED만 소비하고 다음 EXP Line을 처리한다")
+    void consumesOnlyFreshDurableFailureAndContinues() {
+        RewardSettlementLine first = line(
+                721L,
+                RewardType.EXP,
+                RewardSettlementLineStatus.PENDING,
+                null
+        );
+        RewardSettlementLine second = line(
+                722L,
+                RewardType.EXP,
+                RewardSettlementLineStatus.PENDING,
+                null
+        );
+        stubCreated(settlement(
+                720L,
+                "RP_EXP_30",
+                List.of(first, second)
+        ));
+        doThrow(new DomainException(PlayerError.PLAYER_NOT_FOUND))
+                .when(expProcessService).process(720L, 721L);
+        RewardSettlement fresh = mock(RewardSettlement.class);
+        RewardSettlementLine durableFailed = line(
+                721L,
+                RewardType.EXP,
+                RewardSettlementLineStatus.FAILED,
+                PlayerError.PLAYER_NOT_FOUND.code()
+        );
+        when(fresh.getLineByIdOrThrow(721L))
+                .thenReturn(durableFailed);
+        when(settlementReader.getByIdInNewTransactionOrThrow(720L))
+                .thenReturn(fresh);
+
+        service.process(fact("RP_EXP_30"));
+
+        verify(settlementReader)
+                .getByIdInNewTransactionOrThrow(720L);
+        verify(expProcessService).process(720L, 722L);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = RewardSettlementLineStatus.class,
+            names = {"PENDING", "SUCCEEDED"}
+    )
+    @DisplayName("DomainException 후 fresh Line이 FAILED가 아니면 원래 예외를 전파한다")
+    void propagatesWhenFreshLineIsNotFailed(
+            RewardSettlementLineStatus freshStatus
+    ) {
+        RewardSettlementLine line = line(
+                731L,
+                RewardType.EXP,
+                RewardSettlementLineStatus.PENDING,
+                null
+        );
+        stubCreated(settlement(
+                730L,
+                "RP_EXP_30",
+                List.of(line)
+        ));
+        DomainException original =
+                new DomainException(PlayerError.PLAYER_NOT_FOUND);
+        doThrow(original).when(expProcessService).process(730L, 731L);
+        RewardSettlement fresh = mock(RewardSettlement.class);
+        RewardSettlementLine freshLine = line(
+                731L,
+                RewardType.EXP,
+                freshStatus,
+                null
+        );
+        when(fresh.getLineByIdOrThrow(731L)).thenReturn(freshLine);
+        when(settlementReader.getByIdInNewTransactionOrThrow(730L))
+                .thenReturn(fresh);
+
+        assertThatThrownBy(() -> service.process(fact("RP_EXP_30")))
+                .isSameAs(original);
+    }
+
+    @Test
+    @DisplayName("fresh Settlement 또는 Line 조회 실패는 해당 stable 오류를 전파한다")
+    void propagatesFreshLookupFailure() {
+        RewardSettlementLine line = line(
+                741L,
+                RewardType.EXP,
+                RewardSettlementLineStatus.PENDING,
+                null
+        );
+        stubCreated(settlement(
+                740L,
+                "RP_EXP_30",
+                List.of(line)
+        ));
+        doThrow(new DomainException(PlayerError.PLAYER_NOT_FOUND))
+                .when(expProcessService).process(740L, 741L);
+        DomainException settlementMissing = new DomainException(
+                RewardError.REWARD_SETTLEMENT_NOT_FOUND
+        );
+        when(settlementReader.getByIdInNewTransactionOrThrow(740L))
+                .thenThrow(settlementMissing);
+
+        assertThatThrownBy(() -> service.process(fact("RP_EXP_30")))
+                .isSameAs(settlementMissing);
+
+        RewardSettlement fresh = mock(RewardSettlement.class);
+        DomainException lineMissing = new DomainException(
+                RewardError.REWARD_SETTLEMENT_LINE_NOT_FOUND
+        );
+        when(fresh.getLineByIdOrThrow(741L)).thenThrow(lineMissing);
+        doReturn(fresh).when(settlementReader)
+                .getByIdInNewTransactionOrThrow(740L);
+
+        assertThatThrownBy(() -> service.process(fact("RP_EXP_30")))
+                .isSameAs(lineMissing);
+    }
+
+    @Test
+    @DisplayName("unexpected RuntimeException은 fresh 조회 없이 Outbox retry로 전파한다")
+    void propagatesUnexpectedRuntimeException() {
+        RewardSettlementLine line = line(
+                751L,
+                RewardType.EXP,
+                RewardSettlementLineStatus.PENDING,
+                null
+        );
+        stubCreated(settlement(
+                750L,
+                "RP_EXP_30",
+                List.of(line)
+        ));
         doThrow(new IllegalStateException("unexpected"))
-                .when(expProcessService).process(720L, 722L);
+                .when(expProcessService).process(750L, 751L);
+
         assertThatThrownBy(() -> service.process(fact("RP_EXP_30")))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("unexpected");
+        verifyNoInteractions(settlementReader);
     }
 
-    private RewardSettlementLine line(Long id, RewardType type) {
+    @Test
+    @DisplayName("동일 Settlement identity의 다른 Event profile은 stable 409로 거부한다")
+    void rejectsConflictingProfileSnapshot() {
+        when(createService.create(
+                anyLong(),
+                any(RewardSettlementSourceType.class),
+                anyLong(),
+                anyString()
+        )).thenThrow(new DomainException(
+                RewardError.REWARD_SETTLEMENT_SOURCE_PROFILE_CONFLICT
+        ));
+
+        assertThatThrownBy(() -> service.process(fact("RP_NONE")))
+                .isInstanceOfSatisfying(
+                        DomainException.class,
+                        exception -> assertThat(exception.getErrorCode())
+                                .isEqualTo(
+                                        RewardError
+                                                .REWARD_SETTLEMENT_SOURCE_PROFILE_CONFLICT
+                                )
+                );
+        verifyNoInteractions(settlementReader, expProcessService);
+    }
+
+    private void stubCreated(RewardSettlement settlement) {
+        when(createService.create(
+                anyLong(),
+                any(RewardSettlementSourceType.class),
+                anyLong(),
+                anyString()
+        )).thenReturn(settlement);
+    }
+
+    private RewardSettlement settlement(
+            Long id,
+            String profileCode,
+            List<RewardSettlementLine> lines
+    ) {
+        RewardSettlement settlement = mock(RewardSettlement.class);
+        when(settlement.getId()).thenReturn(id);
+        when(settlement.getRewardProfileCode()).thenReturn(profileCode);
+        when(settlement.getLines()).thenReturn(lines);
+        return settlement;
+    }
+
+    private RewardSettlementLine line(
+            Long id,
+            RewardType type,
+            RewardSettlementLineStatus status,
+            String failureCode
+    ) {
         RewardSettlementLine line = mock(RewardSettlementLine.class);
         when(line.getId()).thenReturn(id);
         when(line.getRewardType()).thenReturn(type);
+        when(line.getStatus()).thenReturn(status);
+        when(line.getFailureCode()).thenReturn(failureCode);
         return line;
     }
 

--- a/src/test/java/online/lifeasgame/reward/application/QuestCompletionRewardServiceTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/QuestCompletionRewardServiceTest.java
@@ -1,0 +1,117 @@
+package online.lifeasgame.reward.application;
+
+import online.lifeasgame.character.domain.error.PlayerError;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.reward.application.event.QuestRewardReadyFact;
+import online.lifeasgame.reward.domain.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@DisplayName("QuestCompletionRewardService")
+class QuestCompletionRewardServiceTest {
+
+    private RewardSettlementCreateService createService;
+    private RewardSettlementExpProcessService expProcessService;
+    private QuestCompletionRewardService service;
+
+    @BeforeEach
+    void setUp() {
+        createService = mock(RewardSettlementCreateService.class);
+        expProcessService =
+                mock(RewardSettlementExpProcessService.class);
+        service = new QuestCompletionRewardService(
+                createService,
+                expProcessService
+        );
+    }
+
+    @Test
+    @DisplayName("acceptanceId와 Event profile로 Settlement를 만들고 EXP만 처리한다")
+    void createsSettlementAndProcessesOnlyExp() {
+        RewardSettlement created = mock(RewardSettlement.class);
+        RewardSettlementLine exp = line(701L, RewardType.EXP);
+        RewardSettlementLine item = line(702L, RewardType.ITEM);
+        when(created.getId()).thenReturn(700L);
+        when(created.getLines()).thenReturn(List.of(exp, item));
+        when(createService.create(
+                2190L,
+                RewardSettlementSourceType.QUEST_COMPLETION,
+                21900L,
+                "RP_EXP_AND_ITEM_FIRST_STEP_20"
+        )).thenReturn(created);
+
+        service.process(fact("RP_EXP_AND_ITEM_FIRST_STEP_20"));
+
+        verify(expProcessService).process(700L, 701L);
+        verify(expProcessService, never()).process(700L, 702L);
+    }
+
+    @Test
+    @DisplayName("RP_NONE의 빈 Settlement는 EXP Processor를 호출하지 않는다")
+    void leavesNoRewardSettlementCompleted() {
+        RewardSettlement created = mock(RewardSettlement.class);
+        when(created.getId()).thenReturn(710L);
+        when(created.getLines()).thenReturn(List.of());
+        when(createService.create(
+                2190L,
+                RewardSettlementSourceType.QUEST_COMPLETION,
+                21900L,
+                "RP_NONE"
+        )).thenReturn(created);
+
+        service.process(fact("RP_NONE"));
+
+        verifyNoInteractions(expProcessService);
+    }
+
+    @Test
+    @DisplayName("EXP known DomainException은 소비하고 unexpected RuntimeException은 전파한다")
+    void handlesOnlyKnownExpFailure() {
+        RewardSettlement created = mock(RewardSettlement.class);
+        RewardSettlementLine first = line(721L, RewardType.EXP);
+        RewardSettlementLine second = line(722L, RewardType.EXP);
+        when(created.getId()).thenReturn(720L);
+        when(created.getLines()).thenReturn(List.of(first, second));
+        when(createService.create(anyLong(), any(), anyLong(), anyString()))
+                .thenReturn(created);
+        doThrow(new DomainException(PlayerError.PLAYER_NOT_FOUND))
+                .when(expProcessService).process(720L, 721L);
+
+        service.process(fact("RP_EXP_30"));
+
+        verify(expProcessService).process(720L, 722L);
+
+        doThrow(new IllegalStateException("unexpected"))
+                .when(expProcessService).process(720L, 722L);
+        assertThatThrownBy(() -> service.process(fact("RP_EXP_30")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("unexpected");
+    }
+
+    private RewardSettlementLine line(Long id, RewardType type) {
+        RewardSettlementLine line = mock(RewardSettlementLine.class);
+        when(line.getId()).thenReturn(id);
+        when(line.getRewardType()).thenReturn(type);
+        return line;
+    }
+
+    private QuestRewardReadyFact fact(String profileCode) {
+        return new QuestRewardReadyFact(
+                2190L,
+                21900L,
+                profileCode,
+                219L,
+                "Q_FIRST_STEP",
+                7,
+                Instant.parse("2026-07-30T03:00:01Z"),
+                "quest:219:completed:reward"
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/reward/application/QuestCompletionRewardTransactionalOutboxIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/QuestCompletionRewardTransactionalOutboxIntegrationTest.java
@@ -1,0 +1,372 @@
+package online.lifeasgame.reward.application;
+
+import online.lifeasgame.core.event.DomainEventPublisher;
+import online.lifeasgame.platform.outbox.OutboxProperties;
+import online.lifeasgame.platform.outbox.application.*;
+import online.lifeasgame.quest.domain.event.QuestEvent;
+import online.lifeasgame.quest.domain.event.QuestEventType;
+import online.lifeasgame.reward.application.event.QuestRewardReadyBridge;
+import online.lifeasgame.reward.domain.RewardSettlementLineStatus;
+import online.lifeasgame.reward.domain.RewardSettlementStatus;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles({"test", "migration-test"})
+@DisplayName("Quest completion Reward/Outbox MySQL 통합")
+class QuestCompletionRewardTransactionalOutboxIntegrationTest {
+
+    private static final long PLAYER_ID = 219001L;
+    private static final Instant COMPLETED_AT =
+            Instant.parse("2026-07-30T03:00:00Z");
+
+    @Container
+    private static final MySQLContainer<?> MYSQL =
+            new MySQLContainer<>("mysql:8.0.39")
+                    .withDatabaseName("lifeasgame_quest_completion_reward")
+                    .withUsername("lifeasgame")
+                    .withPassword("lifeasgame");
+
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add(
+                "spring.datasource.password",
+                MYSQL::getPassword
+        );
+        registry.add(
+                "spring.datasource.driver-class-name",
+                MYSQL::getDriverClassName
+        );
+        registry.add("app.outbox.enabled", () -> false);
+    }
+
+    @Autowired
+    private QuestRewardReadyBridge bridge;
+
+    @Autowired
+    private DomainEventPublisher eventPublisher;
+
+    @Autowired
+    private OutboxClaimService claimService;
+
+    @Autowired
+    private OutboxDispatchAttempt dispatchAttempt;
+
+    @Autowired
+    private OutboxCompletionService completionService;
+
+    @Autowired
+    private OutboxProperties outboxProperties;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    private TransactionTemplate transactionTemplate;
+    private ExecutorService executor;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.update("DELETE FROM outbox_events");
+        jdbcTemplate.update("DELETE FROM player_growth_changes");
+        jdbcTemplate.update("DELETE FROM reward_settlement_lines");
+        jdbcTemplate.update("DELETE FROM reward_settlements");
+        jdbcTemplate.update("DELETE FROM player WHERE id = ?", PLAYER_ID);
+        insertPlayer();
+        outboxProperties.setBatchSize(50);
+        transactionTemplate = new TransactionTemplate(transactionManager);
+        executor = Executors.newFixedThreadPool(2);
+    }
+
+    @AfterEach
+    void tearDown() throws InterruptedException {
+        executor.shutdownNow();
+        assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    @DisplayName("RP_NONE은 Line 없이 COMPLETED이고 EXP를 지급하지 않는다")
+    void completesNoRewardProfile() {
+        bridge.onQuestEvent(rewardReady(219101L, "RP_NONE"));
+
+        assertThat(settlementCount()).isEqualTo(1);
+        assertThat(lineCount()).isZero();
+        assertThat(settlementStatus(219101L))
+                .isEqualTo(RewardSettlementStatus.COMPLETED.name());
+        assertThat(playerExp()).isZero();
+        assertThat(growthChangeCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("RP_EXP_TINY_10은 EXP 10을 exact-once 지급하고 Settlement를 완료한다")
+    void processesExpTenExactlyOnceUnderConcurrentRedelivery()
+            throws Exception {
+        QuestEvent event = rewardReady(
+                219102L,
+                "RP_EXP_TINY_10"
+        );
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<?>> futures = List.of(
+                submit(event, ready, start),
+                submit(event, ready, start)
+        );
+
+        assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+        start.countDown();
+        for (Future<?> future : futures) {
+            future.get(Duration.ofSeconds(20).toMillis(), TimeUnit.MILLISECONDS);
+        }
+
+        assertThat(settlementCount()).isEqualTo(1);
+        assertThat(lineCount()).isEqualTo(1);
+        assertThat(lineStatus(219102L, "EXP"))
+                .isEqualTo(RewardSettlementLineStatus.SUCCEEDED.name());
+        assertThat(settlementStatus(219102L))
+                .isEqualTo(RewardSettlementStatus.COMPLETED.name());
+        assertThat(playerExp()).isEqualTo(10L);
+        assertThat(growthChangeCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("RP_EXP_AND_ITEM_FIRST_STEP_20은 EXP만 성공시키고 ITEM과 Settlement를 PENDING으로 둔다")
+    void processesExpAndLeavesItemPending() {
+        bridge.onQuestEvent(rewardReady(
+                219103L,
+                "RP_EXP_AND_ITEM_FIRST_STEP_20"
+        ));
+
+        assertThat(settlementCount()).isEqualTo(1);
+        assertThat(lineCount()).isEqualTo(2);
+        assertThat(lineStatus(219103L, "EXP"))
+                .isEqualTo(RewardSettlementLineStatus.SUCCEEDED.name());
+        assertThat(lineStatus(219103L, "ITEM"))
+                .isEqualTo(RewardSettlementLineStatus.PENDING.name());
+        assertThat(settlementStatus(219103L))
+                .isEqualTo(RewardSettlementStatus.PENDING.name());
+        assertThat(playerExp()).isEqualTo(20L);
+        assertThat(growthChangeCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("새 acceptance attempt는 별도 Settlement identity로 한 번 더 지급한다")
+    void treatsRestartedAcceptanceAsNewSettlementIdentity() {
+        bridge.onQuestEvent(rewardReady(
+                219104L,
+                "RP_EXP_TINY_10"
+        ));
+        bridge.onQuestEvent(rewardReady(
+                219105L,
+                "RP_EXP_TINY_10"
+        ));
+
+        assertThat(settlementCount()).isEqualTo(2);
+        assertThat(playerExp()).isEqualTo(20L);
+        assertThat(growthChangeCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("LifeLog/Manual 완료의 두 단계 Outbox를 재전달해도 acceptance별 EXP는 한 번만 지급한다")
+    void redeliversTwoStageOutboxExactlyOnce() {
+        appendCompleted(
+                219106L,
+                "RP_EXP_TINY_10",
+                Map.of("lifeLogId", 901L)
+        );
+        appendCompleted(
+                219107L,
+                "RP_EXP_TINY_10",
+                Map.of("manualCheck", true)
+        );
+
+        List<OutboxClaim> completionClaims = claimService.claimBatch();
+        assertThat(completionClaims).hasSize(2);
+        completionClaims.forEach(claim -> {
+            dispatchAttempt.dispatch(claim);
+            completionService.complete(claim);
+        });
+
+        List<OutboxClaim> rewardClaims = claimService.claimBatch();
+        assertThat(rewardClaims).hasSize(2);
+        rewardClaims.forEach(claim -> {
+            dispatchAttempt.dispatch(claim);
+            dispatchAttempt.dispatch(claim);
+            completionService.complete(claim);
+        });
+
+        assertThat(settlementCount()).isEqualTo(2);
+        assertThat(playerExp()).isEqualTo(20L);
+        assertThat(growthChangeCount()).isEqualTo(2);
+        assertThat(publishedOutboxCount()).isEqualTo(4);
+    }
+
+    private Future<?> submit(
+            QuestEvent event,
+            CountDownLatch ready,
+            CountDownLatch start
+    ) {
+        return executor.submit(() -> {
+            ready.countDown();
+            start.await();
+            bridge.onQuestEvent(event);
+            return null;
+        });
+    }
+
+    private void appendCompleted(
+            long acceptanceId,
+            String profileCode,
+            Map<String, Object> sourceContext
+    ) {
+        Map<String, Object> attributes =
+                new java.util.LinkedHashMap<>(sourceContext);
+        attributes.put("acceptanceId", acceptanceId);
+        attributes.put("rewardProfileCode", profileCode);
+        attributes.put("questSemanticCategory", "GROWTH");
+        attributes.put("progressSource", "COUNT");
+        attributes.put("repeatPolicy", "ONCE");
+        transactionTemplate.executeWithoutResult(status ->
+                eventPublisher.publish(new QuestEvent(
+                        QuestEventType.QUEST_COMPLETED,
+                        PLAYER_ID,
+                        219L,
+                        "Q_FIRST_STEP",
+                        attributes,
+                        COMPLETED_AT,
+                        "quest:219:acceptance:%d:completed".formatted(
+                                acceptanceId
+                        )
+                ))
+        );
+    }
+
+    private QuestEvent rewardReady(long acceptanceId, String profileCode) {
+        return new QuestEvent(
+                QuestEventType.QUEST_REWARD_READY,
+                PLAYER_ID,
+                219L,
+                "Q_FIRST_STEP",
+                Map.of(
+                        "acceptanceId", acceptanceId,
+                        "rewardProfileCode", profileCode,
+                        "questDefinitionVersion", 1,
+                        "questSemanticCategory", "GROWTH",
+                        "progressSource", "COUNT",
+                        "repeatPolicy", "ONCE"
+                ),
+                COMPLETED_AT.plusSeconds(1),
+                "quest:219:acceptance:%d:completed:reward".formatted(
+                        acceptanceId
+                )
+        );
+    }
+
+    private void insertPlayer() {
+        jdbcTemplate.update("""
+                INSERT INTO player (
+                    id, user_id, name, gender, level, exp,
+                    hp_cur, hp_cap, mp_cur, mp_cap,
+                    str_stat, agi_stat, dex_stat, int_stat, vit_stat, luc_stat,
+                    extra_stats, status_effects, version, created_at, updated_at
+                ) VALUES (
+                    ?, ?, 'Quest Reward Tester', 'male', 1, 0,
+                    100, 100, 50, 50,
+                    1, 1, 1, 1, 1, 1,
+                    JSON_OBJECT(), '[]', 0, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
+                )
+                """, PLAYER_ID, PLAYER_ID + 100000L);
+    }
+
+    private int settlementCount() {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM reward_settlements",
+                Integer.class
+        );
+    }
+
+    private int lineCount() {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM reward_settlement_lines",
+                Integer.class
+        );
+    }
+
+    private String settlementStatus(long acceptanceId) {
+        return jdbcTemplate.queryForObject(
+                """
+                SELECT status
+                FROM reward_settlements
+                WHERE player_id = ?
+                  AND source_type = 'QUEST_COMPLETION'
+                  AND source_id = ?
+                """,
+                String.class,
+                PLAYER_ID,
+                acceptanceId
+        );
+    }
+
+    private String lineStatus(long acceptanceId, String rewardType) {
+        return jdbcTemplate.queryForObject(
+                """
+                SELECT line.status
+                FROM reward_settlement_lines line
+                JOIN reward_settlements settlement
+                  ON settlement.id = line.reward_settlement_id
+                WHERE settlement.player_id = ?
+                  AND settlement.source_type = 'QUEST_COMPLETION'
+                  AND settlement.source_id = ?
+                  AND line.reward_type = ?
+                """,
+                String.class,
+                PLAYER_ID,
+                acceptanceId,
+                rewardType
+        );
+    }
+
+    private long playerExp() {
+        return jdbcTemplate.queryForObject(
+                "SELECT exp FROM player WHERE id = ?",
+                Long.class,
+                PLAYER_ID
+        );
+    }
+
+    private int growthChangeCount() {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM player_growth_changes",
+                Integer.class
+        );
+    }
+
+    private int publishedOutboxCount() {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM outbox_events WHERE status = 'PUBLISHED'",
+                Integer.class
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/reward/application/QuestCompletionRewardTransactionalOutboxIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/QuestCompletionRewardTransactionalOutboxIntegrationTest.java
@@ -1,43 +1,71 @@
 package online.lifeasgame.reward.application;
 
+import online.lifeasgame.character.domain.error.PlayerError;
+import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.core.event.DomainEventPublisher;
+import online.lifeasgame.lifelog.domain.event.LifeLogRecorded;
+import online.lifeasgame.lifelog.domain.record.LifeLogEntryMode;
+import online.lifeasgame.lifelog.domain.record.LifeLogSubtype;
 import online.lifeasgame.platform.outbox.OutboxProperties;
 import online.lifeasgame.platform.outbox.application.*;
+import online.lifeasgame.platform.outbox.application.codec.OutboxEventCodecRegistry;
+import online.lifeasgame.quest.application.QuestManualCheckService;
+import online.lifeasgame.quest.application.QuestService;
+import online.lifeasgame.quest.application.command.QuestCommand;
+import online.lifeasgame.quest.application.result.QuestResult;
+import online.lifeasgame.quest.domain.QuestCode;
+import online.lifeasgame.quest.domain.QuestStatus;
 import online.lifeasgame.quest.domain.event.QuestEvent;
 import online.lifeasgame.quest.domain.event.QuestEventType;
 import online.lifeasgame.reward.application.event.QuestRewardReadyBridge;
 import online.lifeasgame.reward.domain.RewardSettlementLineStatus;
 import online.lifeasgame.reward.domain.RewardSettlementStatus;
+import online.lifeasgame.reward.domain.error.RewardError;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import java.time.Duration;
-import java.time.Instant;
+import java.time.*;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @Testcontainers
 @SpringBootTest
 @ActiveProfiles({"test", "migration-test"})
+@Import(
+        QuestCompletionRewardTransactionalOutboxIntegrationTest
+                .MutableClockConfiguration.class
+)
 @DisplayName("Quest completion Reward/Outbox MySQL 통합")
 class QuestCompletionRewardTransactionalOutboxIntegrationTest {
 
     private static final long PLAYER_ID = 219001L;
+    private static final Instant ACCEPTED_AT =
+            Instant.parse("2026-07-31T01:00:00Z");
     private static final Instant COMPLETED_AT =
-            Instant.parse("2026-07-30T03:00:00Z");
+            Instant.parse("2026-07-31T02:00:00Z");
 
     @Container
     private static final MySQLContainer<?> MYSQL =
@@ -65,7 +93,16 @@ class QuestCompletionRewardTransactionalOutboxIntegrationTest {
     private QuestRewardReadyBridge bridge;
 
     @Autowired
+    private QuestService questService;
+
+    @Autowired
+    private QuestManualCheckService manualCheckService;
+
+    @Autowired
     private DomainEventPublisher eventPublisher;
+
+    @Autowired
+    private OutboxRelayService relayService;
 
     @Autowired
     private OutboxClaimService claimService;
@@ -77,6 +114,9 @@ class QuestCompletionRewardTransactionalOutboxIntegrationTest {
     private OutboxCompletionService completionService;
 
     @Autowired
+    private OutboxEventCodecRegistry codecRegistry;
+
+    @Autowired
     private OutboxProperties outboxProperties;
 
     @Autowired
@@ -85,18 +125,37 @@ class QuestCompletionRewardTransactionalOutboxIntegrationTest {
     @Autowired
     private PlatformTransactionManager transactionManager;
 
+    @Autowired
+    private MutableClock clock;
+
+    @MockitoSpyBean
+    private RewardSettlementExpProcessService expProcessService;
+
     private TransactionTemplate transactionTemplate;
     private ExecutorService executor;
 
     @BeforeEach
     void setUp() {
+        clock.set(ACCEPTED_AT);
         jdbcTemplate.update("DELETE FROM outbox_events");
         jdbcTemplate.update("DELETE FROM player_growth_changes");
         jdbcTemplate.update("DELETE FROM reward_settlement_lines");
         jdbcTemplate.update("DELETE FROM reward_settlements");
+        jdbcTemplate.update(
+                "DELETE FROM quest_signal_receipts WHERE player_id = ?",
+                PLAYER_ID
+        );
+        jdbcTemplate.update(
+                "DELETE FROM quest_acceptances WHERE player_id = ?",
+                PLAYER_ID
+        );
         jdbcTemplate.update("DELETE FROM player WHERE id = ?", PLAYER_ID);
         insertPlayer();
         outboxProperties.setBatchSize(50);
+        outboxProperties.setMaxAttempts(3);
+        outboxProperties.setRetryDelayMs(0);
+        outboxProperties.setInstanceId("quest-reward-integration");
+        clearInvocations(expProcessService);
         transactionTemplate = new TransactionTemplate(transactionManager);
         executor = Executors.newFixedThreadPool(2);
     }
@@ -189,38 +248,255 @@ class QuestCompletionRewardTransactionalOutboxIntegrationTest {
     }
 
     @Test
-    @DisplayName("LifeLog/Manual 완료의 두 단계 Outbox를 재전달해도 acceptance별 EXP는 한 번만 지급한다")
-    void redeliversTwoStageOutboxExactlyOnce() {
-        appendCompleted(
-                219106L,
-                "RP_EXP_TINY_10",
-                Map.of("lifeLogId", 901L)
-        );
-        appendCompleted(
+    @DisplayName("Player가 없으면 FAILED/failureCode를 durable 저장하고 중복 Event에서 Processor를 재호출하지 않는다")
+    void consumesOnlyDurableFailureAndSkipsFailedReplay() {
+        jdbcTemplate.update("DELETE FROM player WHERE id = ?", PLAYER_ID);
+        QuestEvent event = rewardReady(219106L, "RP_EXP_TINY_10");
+
+        append(event);
+        OutboxRelayResult first = relayService.relayBatch();
+        append(event);
+        OutboxRelayResult duplicate = relayService.relayBatch();
+
+        assertThat(first.published()).isEqualTo(1);
+        assertThat(duplicate.published()).isEqualTo(1);
+        assertThat(lineStatus(219106L, "EXP"))
+                .isEqualTo(RewardSettlementLineStatus.FAILED.name());
+        assertThat(lineFailureCode(219106L, "EXP"))
+                .isEqualTo(PlayerError.PLAYER_NOT_FOUND.code());
+        assertThat(settlementStatus(219106L))
+                .isEqualTo(RewardSettlementStatus.FAILED.name());
+        assertThat(growthChangeCount()).isZero();
+        verify(expProcessService, times(1))
+                .process(anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("동일 Settlement identity의 다른 profile은 Snapshot을 바꾸거나 추가 지급하지 않고 stable 409다")
+    void rejectsProfileSnapshotConflict() {
+        bridge.onQuestEvent(rewardReady(
                 219107L,
-                "RP_EXP_TINY_10",
-                Map.of("manualCheck", true)
+                "RP_EXP_TINY_10"
+        ));
+
+        assertThatThrownBy(() -> bridge.onQuestEvent(
+                rewardReady(219107L, "RP_NONE")
+        )).isInstanceOfSatisfying(
+                DomainException.class,
+                exception -> assertThat(exception.getErrorCode())
+                        .isEqualTo(
+                                RewardError
+                                        .REWARD_SETTLEMENT_SOURCE_PROFILE_CONFLICT
+                        )
         );
 
-        List<OutboxClaim> completionClaims = claimService.claimBatch();
-        assertThat(completionClaims).hasSize(2);
-        completionClaims.forEach(claim -> {
+        assertThat(settlementCount()).isEqualTo(1);
+        assertThat(settlementProfile(219107L))
+                .isEqualTo("RP_EXP_TINY_10");
+        assertThat(playerExp()).isEqualTo(10L);
+        assertThat(growthChangeCount()).isEqualTo(1);
+        verify(expProcessService, times(1))
+                .process(anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("서로 다른 profile의 동시 unique 경쟁은 winner Snapshot 하나와 loser conflict로 끝난다")
+    void rejectsConcurrentProfileSnapshotLoser() throws Exception {
+        long acceptanceId = 219108L;
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<?>> futures = List.of(
+                submit(
+                        rewardReady(
+                                acceptanceId,
+                                "RP_EXP_TINY_10"
+                        ),
+                        ready,
+                        start
+                ),
+                submit(
+                        rewardReady(acceptanceId, "RP_NONE"),
+                        ready,
+                        start
+                )
+        );
+        assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+        start.countDown();
+
+        int succeeded = 0;
+        int conflicted = 0;
+        for (Future<?> future : futures) {
+            try {
+                future.get(
+                        Duration.ofSeconds(20).toMillis(),
+                        TimeUnit.MILLISECONDS
+                );
+                succeeded++;
+            } catch (ExecutionException exception) {
+                assertThat(exception.getCause())
+                        .isInstanceOfSatisfying(
+                                DomainException.class,
+                                cause -> assertThat(cause.getErrorCode())
+                                        .isEqualTo(
+                                                RewardError
+                                                        .REWARD_SETTLEMENT_SOURCE_PROFILE_CONFLICT
+                                        )
+                        );
+                conflicted++;
+            }
+        }
+
+        assertThat(succeeded).isEqualTo(1);
+        assertThat(conflicted).isEqualTo(1);
+        assertThat(settlementCount()).isEqualTo(1);
+        String profile = settlementProfile(acceptanceId);
+        assertThat(profile).isIn("RP_EXP_TINY_10", "RP_NONE");
+        assertThat(playerExp()).isEqualTo(
+                profile.equals("RP_EXP_TINY_10") ? 10L : 0L
+        );
+        assertThat(growthChangeCount()).isEqualTo(
+                profile.equals("RP_EXP_TINY_10") ? 1 : 0
+        );
+    }
+
+    @Test
+    @DisplayName("actual LifeLog AUTO closed loop는 Q_RECORD_FIRST_TRACE를 완료하고 EXP 10을 지급한다")
+    void completesActualLifeLogAutoClosedLoop() {
+        QuestResult.Acceptance accepted =
+                accept(QuestCode.Q_RECORD_FIRST_TRACE);
+        append(lifeLog(
+                "219-auto-first",
+                219201L,
+                ACCEPTED_AT.plusSeconds(1)
+        ));
+
+        relayStages(3);
+
+        assertThat(acceptanceStatus(accepted.id()))
+                .isEqualTo(QuestStatus.COMPLETED.name());
+        assertThat(settlementSourceIds())
+                .containsExactly(accepted.id());
+        assertThat(settlementProfile(accepted.id()))
+                .isEqualTo("RP_EXP_TINY_10");
+        assertThat(lineStatus(accepted.id(), "EXP"))
+                .isEqualTo(RewardSettlementLineStatus.SUCCEEDED.name());
+        assertThat(settlementStatus(accepted.id()))
+                .isEqualTo(RewardSettlementStatus.COMPLETED.name());
+        assertThat(playerExp()).isEqualTo(10L);
+        assertThat(growthChangeCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("actual Manual Check USER_CONFIRM closed loop는 Q_GROWTH_ONE_FOCUS와 RP_NONE을 완료한다")
+    void completesActualManualCheckClosedLoop() {
+        QuestResult.Acceptance accepted =
+                accept(QuestCode.Q_GROWTH_ONE_FOCUS);
+        clock.set(ACCEPTED_AT.plusSeconds(60));
+
+        QuestResult.Acceptance completed = manualCheckService.check(
+                PLAYER_ID,
+                new QuestCommand.ManualCheck(
+                        QuestCode.Q_GROWTH_ONE_FOCUS.value()
+                )
+        );
+
+        relayStages(2);
+
+        assertThat(completed.id()).isEqualTo(accepted.id());
+        assertThat(completed.status())
+                .isEqualTo(QuestStatus.COMPLETED.name());
+        assertThat(settlementProfile(accepted.id()))
+                .isEqualTo("RP_NONE");
+        assertThat(lineCount()).isZero();
+        assertThat(settlementStatus(accepted.id()))
+                .isEqualTo(RewardSettlementStatus.COMPLETED.name());
+        assertThat(playerExp()).isZero();
+        assertThat(growthChangeCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("actual 세 LifeLog closed loop는 EXP 20만 성공시키고 ITEM을 PENDING으로 둔다")
+    void completesActualExpAndItemClosedLoop() {
+        QuestResult.Acceptance accepted =
+                accept(QuestCode.Q_RECORD_THREE_TRACES);
+        append(lifeLog(
+                "219-three-a",
+                219211L,
+                ACCEPTED_AT.plusSeconds(1)
+        ));
+        append(lifeLog(
+                "219-three-b",
+                219212L,
+                ACCEPTED_AT.plusSeconds(2)
+        ));
+        append(lifeLog(
+                "219-three-c",
+                219213L,
+                ACCEPTED_AT.plusSeconds(3)
+        ));
+
+        relayStages(3);
+
+        assertThat(acceptanceStatus(accepted.id()))
+                .isEqualTo(QuestStatus.COMPLETED.name());
+        assertThat(settlementProfile(accepted.id()))
+                .isEqualTo("RP_EXP_AND_ITEM_FIRST_STEP_20");
+        assertThat(lineStatus(accepted.id(), "EXP"))
+                .isEqualTo(RewardSettlementLineStatus.SUCCEEDED.name());
+        assertThat(lineStatus(accepted.id(), "ITEM"))
+                .isEqualTo(RewardSettlementLineStatus.PENDING.name());
+        assertThat(settlementStatus(accepted.id()))
+                .isEqualTo(RewardSettlementStatus.PENDING.name());
+        assertThat(playerExp()).isEqualTo(20L);
+        assertThat(growthChangeCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("actual AUTO QUEST_COMPLETED first-stage와 Reward Ready 중복 dispatch도 한 번만 지급한다")
+    void redeliversActualFirstStageExactlyOnce() {
+        QuestResult.Acceptance accepted =
+                accept(QuestCode.Q_RECORD_FIRST_TRACE);
+        append(lifeLog(
+                "219-first-stage",
+                219221L,
+                ACCEPTED_AT.plusSeconds(1)
+        ));
+        assertThat(relayService.relayBatch().published()).isEqualTo(1);
+
+        List<OutboxClaim> questClaims = claimService.claimBatch();
+        assertThat(questClaims).hasSize(3);
+        assertThat(questClaims.stream()
+                .map(this::decodeQuestEvent)
+                .filter(event ->
+                        event.type() == QuestEventType.QUEST_COMPLETED
+                )).hasSize(1);
+        questClaims.forEach(claim -> {
+            QuestEvent event = decodeQuestEvent(claim);
             dispatchAttempt.dispatch(claim);
+            if (event.type() == QuestEventType.QUEST_COMPLETED) {
+                dispatchAttempt.dispatch(claim);
+            }
             completionService.complete(claim);
         });
 
         List<OutboxClaim> rewardClaims = claimService.claimBatch();
         assertThat(rewardClaims).hasSize(2);
         rewardClaims.forEach(claim -> {
+            assertThat(decodeQuestEvent(claim).type())
+                    .isEqualTo(QuestEventType.QUEST_REWARD_READY);
             dispatchAttempt.dispatch(claim);
             dispatchAttempt.dispatch(claim);
             completionService.complete(claim);
         });
 
-        assertThat(settlementCount()).isEqualTo(2);
-        assertThat(playerExp()).isEqualTo(20L);
-        assertThat(growthChangeCount()).isEqualTo(2);
-        assertThat(publishedOutboxCount()).isEqualTo(4);
+        assertThat(settlementCount()).isEqualTo(1);
+        assertThat(settlementSourceIds())
+                .containsExactly(accepted.id());
+        assertThat(settlementProfile(accepted.id()))
+                .isEqualTo("RP_EXP_TINY_10");
+        assertThat(playerExp()).isEqualTo(10L);
+        assertThat(growthChangeCount()).isEqualTo(1);
+        assertThat(publishedOutboxCount()).isEqualTo(6);
     }
 
     private Future<?> submit(
@@ -236,30 +512,57 @@ class QuestCompletionRewardTransactionalOutboxIntegrationTest {
         });
     }
 
-    private void appendCompleted(
-            long acceptanceId,
-            String profileCode,
-            Map<String, Object> sourceContext
-    ) {
-        Map<String, Object> attributes =
-                new java.util.LinkedHashMap<>(sourceContext);
-        attributes.put("acceptanceId", acceptanceId);
-        attributes.put("rewardProfileCode", profileCode);
-        attributes.put("questSemanticCategory", "GROWTH");
-        attributes.put("progressSource", "COUNT");
-        attributes.put("repeatPolicy", "ONCE");
+    private QuestResult.Acceptance accept(QuestCode questCode) {
+        return questService.accept(
+                PLAYER_ID,
+                new QuestCommand.Accept(
+                        questCode.value(),
+                        null,
+                        null
+                )
+        );
+    }
+
+    private void append(online.lifeasgame.core.event.DomainEvent event) {
         transactionTemplate.executeWithoutResult(status ->
-                eventPublisher.publish(new QuestEvent(
-                        QuestEventType.QUEST_COMPLETED,
-                        PLAYER_ID,
-                        219L,
-                        "Q_FIRST_STEP",
-                        attributes,
-                        COMPLETED_AT,
-                        "quest:219:acceptance:%d:completed".formatted(
-                                acceptanceId
-                        )
-                ))
+                eventPublisher.publish(event)
+        );
+    }
+
+    private void relayStages(int count) {
+        for (int stage = 0; stage < count; stage++) {
+            OutboxRelayResult result = relayService.relayBatch();
+            assertThat(result.failed()).isZero();
+            assertThat(result.published()).isPositive();
+        }
+    }
+
+    private LifeLogRecorded lifeLog(
+            String eventId,
+            Long lifeLogId,
+            Instant occurredAt
+    ) {
+        return new LifeLogRecorded(
+                eventId,
+                LifeLogRecorded.EVENT_TYPE,
+                LifeLogRecorded.EVENT_VERSION,
+                occurredAt,
+                PLAYER_ID,
+                lifeLogId,
+                1,
+                LifeLogSubtype.STUDY,
+                LifeLogEntryMode.FULL,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    private QuestEvent decodeQuestEvent(OutboxClaim claim) {
+        return (QuestEvent) codecRegistry.decode(
+                claim.eventType(),
+                claim.payload()
         );
     }
 
@@ -348,6 +651,65 @@ class QuestCompletionRewardTransactionalOutboxIntegrationTest {
         );
     }
 
+    private String lineFailureCode(
+            long acceptanceId,
+            String rewardType
+    ) {
+        return jdbcTemplate.queryForObject(
+                """
+                SELECT line.failure_code
+                FROM reward_settlement_lines line
+                JOIN reward_settlements settlement
+                  ON settlement.id = line.reward_settlement_id
+                WHERE settlement.player_id = ?
+                  AND settlement.source_type = 'QUEST_COMPLETION'
+                  AND settlement.source_id = ?
+                  AND line.reward_type = ?
+                """,
+                String.class,
+                PLAYER_ID,
+                acceptanceId,
+                rewardType
+        );
+    }
+
+    private String settlementProfile(long acceptanceId) {
+        return jdbcTemplate.queryForObject(
+                """
+                SELECT reward_profile_code
+                FROM reward_settlements
+                WHERE player_id = ?
+                  AND source_type = 'QUEST_COMPLETION'
+                  AND source_id = ?
+                """,
+                String.class,
+                PLAYER_ID,
+                acceptanceId
+        );
+    }
+
+    private List<Long> settlementSourceIds() {
+        return jdbcTemplate.queryForList(
+                """
+                SELECT source_id
+                FROM reward_settlements
+                WHERE player_id = ?
+                  AND source_type = 'QUEST_COMPLETION'
+                ORDER BY source_id
+                """,
+                Long.class,
+                PLAYER_ID
+        );
+    }
+
+    private String acceptanceStatus(long acceptanceId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT status FROM quest_acceptances WHERE id = ?",
+                String.class,
+                acceptanceId
+        );
+    }
+
     private long playerExp() {
         return jdbcTemplate.queryForObject(
                 "SELECT exp FROM player WHERE id = ?",
@@ -368,5 +730,39 @@ class QuestCompletionRewardTransactionalOutboxIntegrationTest {
                 "SELECT COUNT(*) FROM outbox_events WHERE status = 'PUBLISHED'",
                 Integer.class
         );
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class MutableClockConfiguration {
+
+        @Bean
+        @Primary
+        MutableClock questRewardClock() {
+            return new MutableClock();
+        }
+    }
+
+    static final class MutableClock extends Clock {
+
+        private volatile Instant current = ACCEPTED_AT;
+
+        void set(Instant instant) {
+            current = instant;
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return Clock.fixed(current, zone);
+        }
+
+        @Override
+        public Instant instant() {
+            return current;
+        }
     }
 }

--- a/src/test/java/online/lifeasgame/reward/application/QuestCompletionRewardTransactionalOutboxIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/QuestCompletionRewardTransactionalOutboxIntegrationTest.java
@@ -6,7 +6,6 @@ import online.lifeasgame.core.event.DomainEventPublisher;
 import online.lifeasgame.lifelog.domain.event.LifeLogRecorded;
 import online.lifeasgame.lifelog.domain.record.LifeLogEntryMode;
 import online.lifeasgame.lifelog.domain.record.LifeLogSubtype;
-import online.lifeasgame.platform.outbox.OutboxProperties;
 import online.lifeasgame.platform.outbox.application.*;
 import online.lifeasgame.platform.outbox.application.codec.OutboxEventCodecRegistry;
 import online.lifeasgame.quest.application.QuestManualCheckService;
@@ -42,7 +41,9 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.time.*;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -87,6 +88,13 @@ class QuestCompletionRewardTransactionalOutboxIntegrationTest {
                 MYSQL::getDriverClassName
         );
         registry.add("app.outbox.enabled", () -> false);
+        registry.add("app.outbox.batch-size", () -> 50);
+        registry.add("app.outbox.max-attempts", () -> 3);
+        registry.add("app.outbox.retry-delay-ms", () -> 0);
+        registry.add(
+                "app.outbox.instance-id",
+                () -> "quest-reward-integration"
+        );
     }
 
     @Autowired
@@ -115,9 +123,6 @@ class QuestCompletionRewardTransactionalOutboxIntegrationTest {
 
     @Autowired
     private OutboxEventCodecRegistry codecRegistry;
-
-    @Autowired
-    private OutboxProperties outboxProperties;
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
@@ -151,10 +156,6 @@ class QuestCompletionRewardTransactionalOutboxIntegrationTest {
         );
         jdbcTemplate.update("DELETE FROM player WHERE id = ?", PLAYER_ID);
         insertPlayer();
-        outboxProperties.setBatchSize(50);
-        outboxProperties.setMaxAttempts(3);
-        outboxProperties.setRetryDelayMs(0);
-        outboxProperties.setInstanceId("quest-reward-integration");
         clearInvocations(expProcessService);
         transactionTemplate = new TransactionTemplate(transactionManager);
         executor = Executors.newFixedThreadPool(2);
@@ -164,6 +165,18 @@ class QuestCompletionRewardTransactionalOutboxIntegrationTest {
     void tearDown() throws InterruptedException {
         executor.shutdownNow();
         assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    @DisplayName("MutableClock zoned view는 변경된 Instant를 공유한다")
+    void sharesMutableInstantWithZonedView() {
+        ZoneId zone = ZoneId.of("Asia/Seoul");
+        Clock zoned = clock.withZone(zone);
+
+        clock.set(COMPLETED_AT);
+
+        assertThat(zoned.getZone()).isEqualTo(zone);
+        assertThat(zoned.instant()).isEqualTo(COMPLETED_AT);
     }
 
     @Test
@@ -744,25 +757,38 @@ class QuestCompletionRewardTransactionalOutboxIntegrationTest {
 
     static final class MutableClock extends Clock {
 
-        private volatile Instant current = ACCEPTED_AT;
+        private final AtomicReference<Instant> current;
+        private final ZoneId zone;
+
+        MutableClock() {
+            this(new AtomicReference<>(ACCEPTED_AT), ZoneOffset.UTC);
+        }
+
+        private MutableClock(
+                AtomicReference<Instant> current,
+                ZoneId zone
+        ) {
+            this.current = current;
+            this.zone = Objects.requireNonNull(zone, "zone");
+        }
 
         void set(Instant instant) {
-            current = instant;
+            current.set(instant);
         }
 
         @Override
         public ZoneId getZone() {
-            return ZoneOffset.UTC;
+            return zone;
         }
 
         @Override
         public Clock withZone(ZoneId zone) {
-            return Clock.fixed(current, zone);
+            return new MutableClock(current, zone);
         }
 
         @Override
         public Instant instant() {
-            return current;
+            return current.get();
         }
     }
 }

--- a/src/test/java/online/lifeasgame/reward/application/RewardSettlementCreateServiceTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardSettlementCreateServiceTest.java
@@ -146,6 +146,26 @@ class RewardSettlementCreateServiceTest {
         }
 
         @Test
+        @DisplayName("기존 Settlement Snapshot과 다른 Profile은 stable 409로 거부한다")
+        void rejectsConflictingExistingProfile() {
+            RewardSettlement existing = settlement(activeEmptyProfile());
+            given(settlementReader.findByIdentity(
+                    PLAYER_ID,
+                    sourceType(),
+                    SOURCE_ID
+            )).willReturn(Optional.of(existing));
+
+            assertRewardError(
+                    RewardSettlementCreateServiceTest.this::create,
+                    RewardError.REWARD_SETTLEMENT_SOURCE_PROFILE_CONFLICT
+            );
+            verify(profileReader, never())
+                    .getActiveByCodeOrThrow(anyString());
+            verify(settlementWriter, never())
+                    .saveAndFlush(any(RewardSettlement.class));
+        }
+
+        @Test
         @DisplayName("동시 생성 Unique 충돌 후 기존 Settlement를 다시 조회해 반환한다")
         void returnsWinnerAfterUniqueConflict() {
             RewardProfile profile = activeProfile();
@@ -163,6 +183,35 @@ class RewardSettlementCreateServiceTest {
             assertThat(result).isSameAs(winner);
             verify(settlementReader)
                     .findByIdentityInNewTransaction(PLAYER_ID, sourceType(), SOURCE_ID);
+        }
+
+        @Test
+        @DisplayName("동시 Unique winner의 Profile이 다르면 stable 409로 거부한다")
+        void rejectsConflictingWinnerAfterUniqueConflict() {
+            RewardProfile requested = activeProfile();
+            RewardSettlement winner = settlement(activeEmptyProfile());
+            given(settlementReader.findByIdentity(
+                    PLAYER_ID,
+                    sourceType(),
+                    SOURCE_ID
+            )).willReturn(Optional.empty());
+            given(settlementReader.findByIdentityInNewTransaction(
+                    PLAYER_ID,
+                    sourceType(),
+                    SOURCE_ID
+            )).willReturn(Optional.of(winner));
+            given(profileReader.getActiveByCodeOrThrow(PROFILE_CODE))
+                    .willReturn(requested);
+            given(settlementWriter.saveAndFlush(
+                    any(RewardSettlement.class)
+            )).willThrow(new DataIntegrityViolationException(
+                    "duplicate settlement identity"
+            ));
+
+            assertRewardError(
+                    RewardSettlementCreateServiceTest.this::create,
+                    RewardError.REWARD_SETTLEMENT_SOURCE_PROFILE_CONFLICT
+            );
         }
 
         @Test

--- a/src/test/java/online/lifeasgame/reward/application/event/QuestRewardReadyBridgeTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/event/QuestRewardReadyBridgeTest.java
@@ -34,7 +34,7 @@ class QuestRewardReadyBridgeTest {
         bridge.onQuestEvent(event(Map.of(
                 "acceptanceId", 21900L,
                 "rewardProfileCode", "  RP_EXP_TINY_10  ",
-                "questDefinitionVersion", 7
+                "questDefinitionVersion", 7L
         )));
 
         var captor = forClass(QuestRewardReadyFact.class);

--- a/src/test/java/online/lifeasgame/reward/application/event/QuestRewardReadyBridgeTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/event/QuestRewardReadyBridgeTest.java
@@ -53,6 +53,70 @@ class QuestRewardReadyBridgeTest {
     }
 
     @Test
+    @DisplayName("questDefinitionVersion은 양의 exact integer 타입만 coercion한다")
+    void coercesOptionalDefinitionVersionExactly() {
+        for (Object[] allowed : new Object[][]{
+                {(byte) 1, 1},
+                {(short) 2, 2},
+                {3, 3},
+                {4L, 4},
+                {BigInteger.valueOf(5L), 5},
+                {(long) Integer.MAX_VALUE, Integer.MAX_VALUE},
+                {BigInteger.valueOf(Integer.MAX_VALUE), Integer.MAX_VALUE}
+        }) {
+            assertThat(QuestRewardReadyFact.from(event(Map.of(
+                    "acceptanceId", 21900L,
+                    "rewardProfileCode", "RP_NONE",
+                    "questDefinitionVersion", allowed[0]
+            ))).orElseThrow().questDefinitionVersion())
+                    .isEqualTo(allowed[1]);
+        }
+
+        for (Object invalid : new Object[]{
+                0,
+                -1,
+                (long) Integer.MAX_VALUE + 1,
+                BigInteger.valueOf(Integer.MAX_VALUE).add(BigInteger.ONE),
+                new BigDecimal("7"),
+                7.0F,
+                7.0D,
+                "7",
+                new Number() {
+                    @Override
+                    public int intValue() {
+                        return 7;
+                    }
+
+                    @Override
+                    public long longValue() {
+                        return 7L;
+                    }
+
+                    @Override
+                    public float floatValue() {
+                        return 7.0F;
+                    }
+
+                    @Override
+                    public double doubleValue() {
+                        return 7.0D;
+                    }
+                }
+        }) {
+            assertThat(QuestRewardReadyFact.from(event(Map.of(
+                    "acceptanceId", 21900L,
+                    "rewardProfileCode", "RP_NONE",
+                    "questDefinitionVersion", invalid
+            ))).orElseThrow().questDefinitionVersion()).isNull();
+        }
+
+        assertThat(QuestRewardReadyFact.from(event(Map.of(
+                "acceptanceId", 21900L,
+                "rewardProfileCode", "RP_NONE"
+        ))).orElseThrow().questDefinitionVersion()).isNull();
+    }
+
+    @Test
     @DisplayName("legacy Event는 no-op이고 final marker가 있는 profile 누락은 stable error다")
     void gatesLegacyAndMalformedFinalEvents() {
         QuestCompletionRewardService service =

--- a/src/test/java/online/lifeasgame/reward/application/event/QuestRewardReadyBridgeTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/event/QuestRewardReadyBridgeTest.java
@@ -1,0 +1,162 @@
+package online.lifeasgame.reward.application.event;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.quest.domain.event.QuestEvent;
+import online.lifeasgame.quest.domain.event.QuestEventType;
+import online.lifeasgame.reward.application.QuestCompletionRewardService;
+import online.lifeasgame.reward.domain.error.RewardError;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.Mockito.*;
+
+@DisplayName("QuestRewardReady Bridge/Fact")
+class QuestRewardReadyBridgeTest {
+
+    private static final Instant OCCURRED_AT =
+            Instant.parse("2026-07-30T03:00:01Z");
+
+    @Test
+    @DisplayName("final contract를 acceptanceId Settlement fact로 전달한다")
+    void translatesFinalContract() {
+        QuestCompletionRewardService service =
+                mock(QuestCompletionRewardService.class);
+        QuestRewardReadyBridge bridge = new QuestRewardReadyBridge(service);
+
+        bridge.onQuestEvent(event(Map.of(
+                "acceptanceId", 21900L,
+                "rewardProfileCode", "RP_EXP_TINY_10",
+                "questDefinitionVersion", 7
+        )));
+
+        var captor = forClass(QuestRewardReadyFact.class);
+        verify(service).process(captor.capture());
+        QuestRewardReadyFact fact = captor.getValue();
+        assertThat(fact.playerId()).isEqualTo(2190L);
+        assertThat(fact.acceptanceId()).isEqualTo(21900L);
+        assertThat(fact.rewardProfileCode())
+                .isEqualTo("RP_EXP_TINY_10");
+        assertThat(fact.questId()).isEqualTo(219L);
+        assertThat(fact.questCode()).isEqualTo("Q_FIRST_STEP");
+        assertThat(fact.questDefinitionVersion()).isEqualTo(7);
+        assertThat(fact.occurredAt()).isEqualTo(OCCURRED_AT);
+        assertThat(fact.correlationId())
+                .isEqualTo("quest:219:completed:reward");
+    }
+
+    @Test
+    @DisplayName("legacy Event는 no-op이고 final marker가 있는 profile 누락은 stable error다")
+    void gatesLegacyAndMalformedFinalEvents() {
+        QuestCompletionRewardService service =
+                mock(QuestCompletionRewardService.class);
+        QuestRewardReadyBridge bridge = new QuestRewardReadyBridge(service);
+
+        bridge.onQuestEvent(event(Map.of("acceptanceId", 21900L)));
+        verifyNoInteractions(service);
+
+        assertRewardError(
+                () -> bridge.onQuestEvent(event(Map.of(
+                        "acceptanceId", 21900L,
+                        "progressSource", "COUNT"
+                ))),
+                RewardError.REWARD_PROFILE_CODE_REQUIRED
+        );
+    }
+
+    @Test
+    @DisplayName("acceptanceId는 integral exact positive long만 허용한다")
+    void validatesAcceptanceIdentityExactly() {
+        assertThat(QuestRewardReadyFact.from(event(Map.of(
+                "acceptanceId", BigInteger.valueOf(21900L),
+                "rewardProfileCode", "RP_NONE"
+        ))).orElseThrow().acceptanceId()).isEqualTo(21900L);
+        assertThat(QuestRewardReadyFact.from(event(Map.of(
+                "acceptanceId", new BigDecimal("21900.0"),
+                "rewardProfileCode", "RP_NONE"
+        ))).orElseThrow().acceptanceId()).isEqualTo(21900L);
+
+        for (Object invalid : new Object[]{
+                "21900",
+                21900.5,
+                BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE),
+                0L
+        }) {
+            assertRewardError(
+                    () -> QuestRewardReadyFact.from(event(Map.of(
+                            "acceptanceId", invalid,
+                            "rewardProfileCode", "RP_NONE"
+                    ))),
+                    RewardError.REWARD_SETTLEMENT_SOURCE_ID_REQUIRED
+            );
+        }
+    }
+
+    @Test
+    @DisplayName("invalid player/profile과 다른 Quest Event는 안전하게 처리한다")
+    void validatesPlayerAndProfileAndIgnoresOtherTypes() {
+        assertRewardError(
+                () -> QuestRewardReadyFact.from(new QuestEvent(
+                        QuestEventType.QUEST_REWARD_READY,
+                        0L,
+                        219L,
+                        "Q_FIRST_STEP",
+                        Map.of(
+                                "acceptanceId", 21900L,
+                                "rewardProfileCode", "RP_NONE"
+                        ),
+                        OCCURRED_AT,
+                        "reward"
+                )),
+                RewardError.REWARD_SETTLEMENT_PLAYER_ID_REQUIRED
+        );
+        assertRewardError(
+                () -> QuestRewardReadyFact.from(event(Map.of(
+                        "acceptanceId", 21900L,
+                        "rewardProfileCode", " "
+                ))),
+                RewardError.REWARD_PROFILE_CODE_REQUIRED
+        );
+
+        QuestCompletionRewardService service =
+                mock(QuestCompletionRewardService.class);
+        new QuestRewardReadyBridge(service).onQuestEvent(new QuestEvent(
+                QuestEventType.QUEST_COMPLETED,
+                2190L,
+                219L,
+                "Q_FIRST_STEP",
+                Map.of(),
+                OCCURRED_AT,
+                "completed"
+        ));
+        verifyNoInteractions(service);
+    }
+
+    private QuestEvent event(Map<String, Object> attributes) {
+        return new QuestEvent(
+                QuestEventType.QUEST_REWARD_READY,
+                2190L,
+                219L,
+                "Q_FIRST_STEP",
+                attributes,
+                OCCURRED_AT,
+                "quest:219:completed:reward"
+        );
+    }
+
+    private void assertRewardError(Runnable action, RewardError error) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(
+                        DomainException.class,
+                        exception -> assertThat(exception.getErrorCode())
+                                .isEqualTo(error)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/reward/application/event/QuestRewardReadyBridgeTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/event/QuestRewardReadyBridgeTest.java
@@ -33,7 +33,7 @@ class QuestRewardReadyBridgeTest {
 
         bridge.onQuestEvent(event(Map.of(
                 "acceptanceId", 21900L,
-                "rewardProfileCode", "RP_EXP_TINY_10",
+                "rewardProfileCode", "  RP_EXP_TINY_10  ",
                 "questDefinitionVersion", 7
         )));
 
@@ -72,22 +72,52 @@ class QuestRewardReadyBridgeTest {
     }
 
     @Test
-    @DisplayName("acceptanceId는 integral exact positive long만 허용한다")
+    @DisplayName("acceptanceId는 정수 wrapper와 범위 내 BigInteger만 허용한다")
     void validatesAcceptanceIdentityExactly() {
-        assertThat(QuestRewardReadyFact.from(event(Map.of(
-                "acceptanceId", BigInteger.valueOf(21900L),
-                "rewardProfileCode", "RP_NONE"
-        ))).orElseThrow().acceptanceId()).isEqualTo(21900L);
-        assertThat(QuestRewardReadyFact.from(event(Map.of(
-                "acceptanceId", new BigDecimal("21900.0"),
-                "rewardProfileCode", "RP_NONE"
-        ))).orElseThrow().acceptanceId()).isEqualTo(21900L);
+        for (Number allowed : new Number[]{
+                (byte) 1,
+                (short) 2,
+                3,
+                4L,
+                BigInteger.valueOf(5L)
+        }) {
+            assertThat(QuestRewardReadyFact.from(event(Map.of(
+                    "acceptanceId", allowed,
+                    "rewardProfileCode", "RP_NONE"
+            ))).orElseThrow().acceptanceId())
+                    .isEqualTo(allowed.longValue());
+        }
 
         for (Object invalid : new Object[]{
                 "21900",
+                new BigDecimal("21900"),
+                21900.0F,
+                21900.0D,
                 21900.5,
                 BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE),
-                0L
+                0L,
+                -1L,
+                new Number() {
+                    @Override
+                    public int intValue() {
+                        return 21900;
+                    }
+
+                    @Override
+                    public long longValue() {
+                        return 21900L;
+                    }
+
+                    @Override
+                    public float floatValue() {
+                        return 21900.0F;
+                    }
+
+                    @Override
+                    public double doubleValue() {
+                        return 21900.0D;
+                    }
+                }
         }) {
             assertRewardError(
                     () -> QuestRewardReadyFact.from(event(Map.of(


### PR DESCRIPTION
## What

Quest 완료 Event 계약을 AUTO와 USER_CONFIRM 경로에서 통일하고,
해당 Event를 기존 Reward Settlement 및 EXP 처리 파이프라인에 연결한다.

```text
Quest complete
→ canonical QUEST_COMPLETED
→ QUEST_REWARD_READY
→ RewardSettlement
→ EXP processing
```

## QuestCompleted Contract

신규 `QuestCompletionEventFactory`가
두 완료 경로의 canonical payload를 조립한다.

적용 경로:

- `QuestAcceptanceCompletionService`
- `QuestSignalProcessingAttempt`

공통 필드:

- `acceptanceId`
- `progress`
- `target`
- `repeatRule`
- `completionPolicy`
- `goalReachedAt`
- `completedAt`
- Quest Definition Snapshot
- Reward Profile Snapshot

AUTO 경로의 LifeLog 및 automation context attribute는 유지한다.

Context attribute를 먼저 병합한 뒤 canonical 값을 적용하여
source context가 완료 계약을 덮어쓸 수 없도록 한다.

## Correlation

기존 의미를 유지한다.

USER_CONFIRM:

```text
quest:{questId}:acceptance:{acceptanceId}:completed
```

AUTO:

```text
{signalCorrelation}:completed
```

Reward exact-once identity는 correlation이 아니라 `acceptanceId`다.

## Explicit Time

`QuestAcceptance`에서 내부 `Instant.now()`를 사용하던
무시간 progress overload를 제거한다.

제거:

- `addProgress(int, Quest)`
- `setProgress(int, Quest)`

모든 호출자는 `Clock`, `QuestSignal.occurredAt`,
Domain Event time 등 정책상 결정된 `Instant`를 명시한다.

## Quest Reward Event

기존 `QuestRewardSaga`와 `QUEST_REWARD_READY` 단계를 유지한다.

Saga는 injected `Clock`으로 Event time을 결정한다.

Domain Event와 Integration Event 타입 분리 및 Saga rename은
이번 범위에 포함하지 않는다.

## Settlement Identity

```text
playerId
+ sourceType = QUEST_COMPLETION
+ sourceId = acceptanceId
```

같은 Acceptance 완료 Event가 여러 번 전달돼도
Settlement는 한 건만 생성된다.

## Reward Snapshot

Event의 `rewardProfileCode`를 Settlement 권위로 사용한다.

Reward Context는 현재 Quest Definition이나 Acceptance를 다시 조회하지 않는다.

Legacy inline reward Event는 신규 Consumer에서 처리하지 않는다.

## EXP Processing

Settlement의 EXP Line은 기존
`RewardSettlementExpProcessService`를 통해 처리한다.

기존 `PlayerGrowthChange.rewardLineId` ledger가 EXP exact-once를 보장한다.

ITEM Line은 이번 작업에서 처리하지 않고 `PENDING`으로 유지한다.

## Profile Results

### `RP_NONE`

- Line 0개
- Settlement `COMPLETED`
- EXP 처리 없음

### `RP_EXP_TINY_10`

- EXP 10 `SUCCEEDED`
- Settlement `COMPLETED`
- Player EXP +10 exact-once

### `RP_EXP_AND_ITEM_FIRST_STEP_20`

- EXP 20 `SUCCEEDED`
- ITEM `PENDING`
- Settlement `PENDING`
- Player EXP +20 exact-once

## Delivery and Failure

```text
QUEST_COMPLETED Outbox
→ QuestRewardSaga
→ QUEST_REWARD_READY Outbox
→ Reward Consumer
```

Settlement 생성 실패와 예상하지 못한 시스템 실패는
Outbox retry를 위해 예외를 전파한다.

알려진 EXP Domain failure는 기존 Processor가
Line `FAILED`와 `failureCode`를 저장하며,
자동 Retry 없이 explicit retry preparation 정책을 유지한다.

## Migration

신규 Migration 없음.

기존 Quest, Reward Settlement, Player Growth 및 Outbox schema를 변경하지 않는다.

## Test

- Completion Event Factory canonical shape
- AUTO / USER_CONFIRM payload parity
- source context preservation
- canonical override protection
- explicit QuestAcceptance transition time
- QuestRewardSaga Clock
- final/legacy Event gate
- acceptanceId Settlement identity
- `RP_NONE`
- EXP 10 exact-once
- EXP 20 + ITEM pending
- concurrent/redelivery/restart replay
- LifeLog auto completion end-to-end
- Manual Check completion end-to-end
- existing Quest/Outbox/Reward regression

## Out of Scope

- Domain Event / Integration Event type separation
- QuestRewardSaga rename
- correlation/causation model redesign
- Progress/Goal Event Factory
- ITEM processor
- Reward Mailbox / Claim / Inventory
- public Reward API
- automatic failed-line retry
- retry scheduler/backoff/DLQ
- Achievement
- Notification
- Frontend

Closes #219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Completed quests can automatically create reward settlements.
  * Experience rewards are processed automatically, while item rewards remain pending.
  * Quest reward events are validated before processing; malformed or unrelated events are safely ignored.

* **Bug Fixes**
  * Improved consistency of quest completion and reward event data.
  * Added protection against conflicting reward profiles.
  * Timestamps are now consistently controlled for reliable processing.

* **Tests**
  * Expanded coverage for reward delivery, duplicate events, partial rewards, validation, concurrency, and transactional outbox behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->