### PR TITLE
[Inventory] Add exact-once reward delivery foundation

### DIFF
--- a/src/main/java/online/lifeasgame/inventory/application/InventoryContainerProvisioningService.java
+++ b/src/main/java/online/lifeasgame/inventory/application/InventoryContainerProvisioningService.java
@@ -1,0 +1,36 @@
+package online.lifeasgame.inventory.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.inventory.domain.PlayerInventory;
+import online.lifeasgame.inventory.domain.PlayerMailbox;
+import online.lifeasgame.inventory.domain.error.InventoryError;
+import online.lifeasgame.inventory.domain.repository.PlayerInventoryRepository;
+import online.lifeasgame.inventory.domain.repository.PlayerMailboxRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class InventoryContainerProvisioningService {
+
+    private final PlayerInventoryRepository inventoryRepository;
+    private final PlayerMailboxRepository mailboxRepository;
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void ensureContainers(Long playerId) {
+        if (playerId == null || playerId <= 0) {
+            throw new DomainException(InventoryError.PLAYER_ID_INVALID);
+        }
+
+        inventoryRepository.insertIfAbsent(
+                playerId,
+                PlayerInventory.DEFAULT_CAPACITY
+        );
+        mailboxRepository.insertIfAbsent(
+                playerId,
+                PlayerMailbox.DEFAULT_CAPACITY
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryService.java
+++ b/src/main/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryService.java
@@ -1,0 +1,134 @@
+package online.lifeasgame.inventory.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.inventory.application.internal.InventoryRewardDeliveryApi;
+import online.lifeasgame.inventory.domain.InstanceAttrs;
+import online.lifeasgame.inventory.domain.InventoryRewardDelivery;
+import online.lifeasgame.inventory.domain.Item;
+import online.lifeasgame.inventory.domain.ItemCarryPolicy;
+import online.lifeasgame.inventory.domain.ItemCode;
+import online.lifeasgame.inventory.domain.PlayerMailbox;
+import online.lifeasgame.inventory.domain.error.InventoryError;
+import online.lifeasgame.inventory.domain.repository.InventoryRewardDeliveryRepository;
+import online.lifeasgame.inventory.domain.repository.PlayerMailboxRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+public class InventoryRewardDeliveryService implements InventoryRewardDeliveryApi {
+
+    private final InventoryContainerProvisioningService provisioningService;
+    private final PlayerMailboxRepository mailboxRepository;
+    private final InventoryRewardDeliveryRepository deliveryRepository;
+    private final ItemReader itemReader;
+    private final Clock clock;
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRED)
+    public RewardDeliveryResult deliverReward(
+            Long rewardLineId,
+            Long playerId,
+            String itemCode,
+            long quantity
+    ) {
+        validateRewardLineId(rewardLineId);
+        validatePlayerId(playerId);
+        ItemCode normalizedItemCode = normalizeItemCode(itemCode);
+        int mailboxQuantity = validateQuantity(quantity);
+
+        provisioningService.ensureContainers(playerId);
+        PlayerMailbox mailbox = mailboxRepository
+                .findByPlayerIdForUpdate(playerId)
+                .orElseThrow(() -> new DomainException(
+                        InventoryError.CONTAINER_NOT_FOUND
+                ));
+
+        var existing = deliveryRepository.findByRewardLineId(rewardLineId);
+        if (existing.isPresent()) {
+            InventoryRewardDelivery delivery = existing.get();
+            delivery.assertMatches(
+                    rewardLineId,
+                    playerId,
+                    normalizedItemCode,
+                    quantity
+            );
+            return result(delivery, true);
+        }
+
+        Item item = itemReader.getByCodeOrThrow(normalizedItemCode);
+        if (item.getCode() == null
+                || !item.getCode().value().equals(normalizedItemCode.value())) {
+            throw new DomainException(InventoryError.REWARD_ITEM_CODE_INVALID);
+        }
+
+        mailbox.deliver(
+                ItemCarryPolicy.from(item),
+                mailboxQuantity,
+                InstanceAttrs.empty(),
+                true
+        );
+
+        InventoryRewardDelivery saved = deliveryRepository.save(
+                InventoryRewardDelivery.create(
+                        rewardLineId,
+                        playerId,
+                        normalizedItemCode,
+                        item.getId(),
+                        quantity,
+                        Instant.now(clock)
+                )
+        );
+        return result(saved, false);
+    }
+
+    private static RewardDeliveryResult result(
+            InventoryRewardDelivery delivery,
+            boolean replayed
+    ) {
+        return new RewardDeliveryResult(
+                delivery.getId(),
+                delivery.getRewardLineId(),
+                delivery.getPlayerId(),
+                delivery.getItemId(),
+                delivery.getItemCode(),
+                delivery.getQuantity(),
+                replayed
+        );
+    }
+
+    private static void validateRewardLineId(Long rewardLineId) {
+        if (rewardLineId == null || rewardLineId <= 0) {
+            throw new DomainException(InventoryError.REWARD_LINE_ID_INVALID);
+        }
+    }
+
+    private static void validatePlayerId(Long playerId) {
+        if (playerId == null || playerId <= 0) {
+            throw new DomainException(InventoryError.PLAYER_ID_INVALID);
+        }
+    }
+
+    private static ItemCode normalizeItemCode(String itemCode) {
+        if (itemCode == null) {
+            throw new DomainException(InventoryError.REWARD_ITEM_CODE_INVALID);
+        }
+        String normalized = itemCode.strip();
+        if (normalized.isEmpty() || normalized.length() > ItemCode.MAX_LENGTH) {
+            throw new DomainException(InventoryError.REWARD_ITEM_CODE_INVALID);
+        }
+        return ItemCode.of(normalized);
+    }
+
+    private static int validateQuantity(long quantity) {
+        if (quantity <= 0 || quantity > Integer.MAX_VALUE) {
+            throw new DomainException(InventoryError.REWARD_QUANTITY_INVALID);
+        }
+        return (int) quantity;
+    }
+}

--- a/src/main/java/online/lifeasgame/inventory/application/internal/InventoryRewardDeliveryApi.java
+++ b/src/main/java/online/lifeasgame/inventory/application/internal/InventoryRewardDeliveryApi.java
@@ -1,0 +1,22 @@
+package online.lifeasgame.inventory.application.internal;
+
+public interface InventoryRewardDeliveryApi {
+
+    RewardDeliveryResult deliverReward(
+            Long rewardLineId,
+            Long playerId,
+            String itemCode,
+            long quantity
+    );
+
+    record RewardDeliveryResult(
+            Long deliveryId,
+            Long rewardLineId,
+            Long playerId,
+            Long itemId,
+            String itemCode,
+            long quantity,
+            boolean replayed
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/inventory/domain/InventoryRewardDelivery.java
+++ b/src/main/java/online/lifeasgame/inventory/domain/InventoryRewardDelivery.java
@@ -1,0 +1,134 @@
+package online.lifeasgame.inventory.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.inventory.domain.error.InventoryError;
+import online.lifeasgame.platform.persistence.jpa.AbstractTime;
+
+import java.time.Instant;
+
+@Getter
+@Entity
+@Table(
+        name = "inventory_reward_deliveries",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_inventory_reward_delivery_line",
+                columnNames = "reward_line_id"
+        ),
+        indexes = @Index(
+                name = "idx_inventory_reward_delivery_player",
+                columnList = "player_id, delivered_at"
+        )
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InventoryRewardDelivery extends AbstractTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "reward_line_id", nullable = false)
+    private Long rewardLineId;
+
+    @Column(name = "player_id", nullable = false)
+    private Long playerId;
+
+    @Column(name = "item_code", length = ItemCode.MAX_LENGTH, nullable = false)
+    private String itemCode;
+
+    @Column(name = "item_id", nullable = false)
+    private Long itemId;
+
+    @Column(nullable = false)
+    private long quantity;
+
+    @Column(name = "delivered_at", nullable = false)
+    private Instant deliveredAt;
+
+    private InventoryRewardDelivery(
+            Long rewardLineId,
+            Long playerId,
+            ItemCode itemCode,
+            Long itemId,
+            long quantity,
+            Instant deliveredAt
+    ) {
+        validate(rewardLineId, playerId, itemCode, itemId, quantity, deliveredAt);
+        this.rewardLineId = rewardLineId;
+        this.playerId = playerId;
+        this.itemCode = itemCode.value();
+        this.itemId = itemId;
+        this.quantity = quantity;
+        this.deliveredAt = deliveredAt;
+    }
+
+    public static InventoryRewardDelivery create(
+            Long rewardLineId,
+            Long playerId,
+            ItemCode itemCode,
+            Long itemId,
+            long quantity,
+            Instant deliveredAt
+    ) {
+        return new InventoryRewardDelivery(
+                rewardLineId,
+                playerId,
+                itemCode,
+                itemId,
+                quantity,
+                deliveredAt
+        );
+    }
+
+    public void assertMatches(
+            Long rewardLineId,
+            Long playerId,
+            ItemCode itemCode,
+            long quantity
+    ) {
+        if (!this.rewardLineId.equals(rewardLineId)
+                || !this.playerId.equals(playerId)
+                || !this.itemCode.equals(itemCode.value())
+                || this.quantity != quantity) {
+            throw new DomainException(InventoryError.REWARD_DELIVERY_CONFLICT);
+        }
+    }
+
+    private static void validate(
+            Long rewardLineId,
+            Long playerId,
+            ItemCode itemCode,
+            Long itemId,
+            long quantity,
+            Instant deliveredAt
+    ) {
+        if (rewardLineId == null || rewardLineId <= 0) {
+            throw new DomainException(InventoryError.REWARD_LINE_ID_INVALID);
+        }
+        if (playerId == null || playerId <= 0) {
+            throw new DomainException(InventoryError.PLAYER_ID_INVALID);
+        }
+        if (itemCode == null) {
+            throw new DomainException(InventoryError.REWARD_ITEM_CODE_INVALID);
+        }
+        if (itemId == null || itemId <= 0) {
+            throw new DomainException(InventoryError.ITEM_NOT_FOUND);
+        }
+        if (quantity <= 0) {
+            throw new DomainException(InventoryError.REWARD_QUANTITY_INVALID);
+        }
+        if (deliveredAt == null) {
+            throw new DomainException(InventoryError.REWARD_DELIVERY_CONFLICT);
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/inventory/domain/PlayerInventory.java
+++ b/src/main/java/online/lifeasgame/inventory/domain/PlayerInventory.java
@@ -21,6 +21,8 @@ import java.util.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PlayerInventory extends AbstractTime {
 
+    public static final int DEFAULT_CAPACITY = 60;
+
     @Id
     @Column(name = "player_id")
     private Long playerId;
@@ -49,7 +51,7 @@ public class PlayerInventory extends AbstractTime {
     }
 
     public static PlayerInventory create(Long playerId) {
-        return new PlayerInventory(playerId, 60);
+        return new PlayerInventory(playerId, DEFAULT_CAPACITY);
     }
 
     public static PlayerInventory of(Long playerId, int capacitySlots) {

--- a/src/main/java/online/lifeasgame/inventory/domain/PlayerMailbox.java
+++ b/src/main/java/online/lifeasgame/inventory/domain/PlayerMailbox.java
@@ -22,12 +22,14 @@ import java.util.Optional;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PlayerMailbox extends AbstractTime {
 
+    public static final int DEFAULT_CAPACITY = 100;
+
     @Id
     @Column(name = "player_id")
     private Long playerId;
 
     @Column(name = "capacity_slots", nullable = false)
-    private int capacitySlots = 100;
+    private int capacitySlots = DEFAULT_CAPACITY;
 
     @Version
     private Long version;
@@ -76,14 +78,20 @@ public class PlayerMailbox extends AbstractTime {
     public SlotIndex deliver(ItemCarryPolicy itemCarryPolicy, int quantity, InstanceAttrs attrs, boolean bound) {
         Guard.minValue(quantity, 1, "qty");
         InstanceAttrs safeAttrs = (attrs == null) ? InstanceAttrs.empty() : attrs;
-
-        int remaining = quantity;
-
-        // 1) 기존 스택 채우기
         List<MailboxEntry> stacks = entries.stream()
                 .filter(e -> e.isSameStackKey(itemCarryPolicy, bound, safeAttrs))
                 .toList();
 
+        int capacityInExisting = stacks.stream()
+                .mapToInt(stack -> itemCarryPolicy.spaceInStack(stack.getQuantity().value()))
+                .sum();
+        int remainingAfterExisting = Math.max(0, quantity - capacityInExisting);
+        int neededNew = itemCarryPolicy.estimateNewStacksNeeded(remainingAfterExisting);
+        if (neededNew > freeSlots()) {
+            throw new DomainException(InventoryError.MAILBOX_FULL);
+        }
+
+        int remaining = quantity;
         SlotIndex firstExisting = null; // 기존 스택 중 처음으로 건드린 슬롯
         for (MailboxEntry stack : stacks) {
             if (remaining == 0) {
@@ -100,18 +108,6 @@ public class PlayerMailbox extends AbstractTime {
             }
         }
 
-        // 2) Pre-flight: 새 스택 필요 개수 계산
-        int capacityInExisting = stacks.stream()
-                .mapToInt(s -> itemCarryPolicy.spaceInStack(s.getQuantity().value()))
-                .sum();
-        int remainAfterExisting = Math.max(0, remaining - capacityInExisting);
-        int needNew = itemCarryPolicy.estimateNewStacksNeeded(remainAfterExisting);
-
-        if (needNew > freeSlots()) {
-            throw new DomainException(InventoryError.MAILBOX_FULL);
-        }
-
-        // 3) 신규 스택 생성
         SlotIndex firstNew = null;
         while (remaining > 0) {
             int put = itemCarryPolicy.stackable() ? Math.min(itemCarryPolicy.maxStack(), remaining) : 1;

--- a/src/main/java/online/lifeasgame/inventory/domain/error/InventoryError.java
+++ b/src/main/java/online/lifeasgame/inventory/domain/error/InventoryError.java
@@ -16,7 +16,12 @@ public enum InventoryError implements ErrorCode {
     DURABILITY_POLICY("INV-DURABILITY-POLICY","Durability policy violation",400),
     ITEM_NOT_FOUND("INV-ITEM-NOT-FOUND","Item not found",404),
     CONTAINER_NOT_FOUND("INV-CONTAINER-NOT-FOUND","Container not found",404),
-    INVENTORY_ENTRY_NOT_FOUND("INV-ENTRY-NOT-FOUND","Inventory entry not found",404),;
+    INVENTORY_ENTRY_NOT_FOUND("INV-ENTRY-NOT-FOUND","Inventory entry not found",404),
+    REWARD_LINE_ID_INVALID("INV-REWARD-LINE-ID-INVALID","Reward line ID must be positive",400),
+    PLAYER_ID_INVALID("INV-PLAYER-ID-INVALID","Player ID must be positive",400),
+    REWARD_ITEM_CODE_INVALID("INV-REWARD-ITEM-CODE-INVALID","Reward item code is invalid",400),
+    REWARD_QUANTITY_INVALID("INV-REWARD-QUANTITY-INVALID","Reward quantity is invalid",400),
+    REWARD_DELIVERY_CONFLICT("INV-REWARD-DELIVERY-CONFLICT","Reward delivery payload conflict",409),;
 
 
     private final String code;

--- a/src/main/java/online/lifeasgame/inventory/domain/repository/InventoryRewardDeliveryRepository.java
+++ b/src/main/java/online/lifeasgame/inventory/domain/repository/InventoryRewardDeliveryRepository.java
@@ -1,0 +1,12 @@
+package online.lifeasgame.inventory.domain.repository;
+
+import online.lifeasgame.inventory.domain.InventoryRewardDelivery;
+
+import java.util.Optional;
+
+public interface InventoryRewardDeliveryRepository {
+
+    Optional<InventoryRewardDelivery> findByRewardLineId(Long rewardLineId);
+
+    InventoryRewardDelivery save(InventoryRewardDelivery delivery);
+}

--- a/src/main/java/online/lifeasgame/inventory/domain/repository/PlayerInventoryRepository.java
+++ b/src/main/java/online/lifeasgame/inventory/domain/repository/PlayerInventoryRepository.java
@@ -6,4 +6,5 @@ import online.lifeasgame.inventory.domain.PlayerInventory;
 public interface PlayerInventoryRepository {
     Optional<PlayerInventory> findByPlayerId(Long playerId);
     PlayerInventory save(PlayerInventory inv);
+    void insertIfAbsent(Long playerId, int capacitySlots);
 }

--- a/src/main/java/online/lifeasgame/inventory/domain/repository/PlayerMailboxRepository.java
+++ b/src/main/java/online/lifeasgame/inventory/domain/repository/PlayerMailboxRepository.java
@@ -5,5 +5,7 @@ import online.lifeasgame.inventory.domain.PlayerMailbox;
 
 public interface PlayerMailboxRepository {
     Optional<PlayerMailbox> findByPlayerId(Long playerId);
+    Optional<PlayerMailbox> findByPlayerIdForUpdate(Long playerId);
     PlayerMailbox save(PlayerMailbox box);
+    void insertIfAbsent(Long playerId, int capacitySlots);
 }

--- a/src/main/java/online/lifeasgame/inventory/infra/InventoryRewardDeliveryRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/inventory/infra/InventoryRewardDeliveryRepositoryAdapter.java
@@ -1,0 +1,26 @@
+package online.lifeasgame.inventory.infra;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.inventory.domain.InventoryRewardDelivery;
+import online.lifeasgame.inventory.domain.repository.InventoryRewardDeliveryRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class InventoryRewardDeliveryRepositoryAdapter
+        implements InventoryRewardDeliveryRepository {
+
+    private final JpaInventoryRewardDeliveryRepository jpaRepository;
+
+    @Override
+    public Optional<InventoryRewardDelivery> findByRewardLineId(Long rewardLineId) {
+        return jpaRepository.findByRewardLineId(rewardLineId);
+    }
+
+    @Override
+    public InventoryRewardDelivery save(InventoryRewardDelivery delivery) {
+        return jpaRepository.saveAndFlush(delivery);
+    }
+}

--- a/src/main/java/online/lifeasgame/inventory/infra/JpaInventoryRepository.java
+++ b/src/main/java/online/lifeasgame/inventory/infra/JpaInventoryRepository.java
@@ -2,6 +2,7 @@ package online.lifeasgame.inventory.infra;
 
 import online.lifeasgame.inventory.domain.PlayerInventory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -9,6 +10,27 @@ import java.util.Optional;
 
 public interface JpaInventoryRepository extends JpaRepository<PlayerInventory, Long> {
     Optional<PlayerInventory> findByPlayerId(Long playerId);
+
+    @Modifying
+    @Query(value = """
+            INSERT IGNORE INTO player_inventory (
+                player_id,
+                capacity_slots,
+                version,
+                created_at,
+                updated_at
+            ) VALUES (
+                :playerId,
+                :capacitySlots,
+                0,
+                CURRENT_TIMESTAMP(6),
+                CURRENT_TIMESTAMP(6)
+            )
+            """, nativeQuery = true)
+    int insertIfAbsent(
+            @Param("playerId") Long playerId,
+            @Param("capacitySlots") int capacitySlots
+    );
 
     @Query(
             """

--- a/src/main/java/online/lifeasgame/inventory/infra/JpaInventoryRewardDeliveryRepository.java
+++ b/src/main/java/online/lifeasgame/inventory/infra/JpaInventoryRewardDeliveryRepository.java
@@ -1,0 +1,12 @@
+package online.lifeasgame.inventory.infra;
+
+import online.lifeasgame.inventory.domain.InventoryRewardDelivery;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface JpaInventoryRewardDeliveryRepository
+        extends JpaRepository<InventoryRewardDelivery, Long> {
+
+    Optional<InventoryRewardDelivery> findByRewardLineId(Long rewardLineId);
+}

--- a/src/main/java/online/lifeasgame/inventory/infra/JpaMailboxRepository.java
+++ b/src/main/java/online/lifeasgame/inventory/infra/JpaMailboxRepository.java
@@ -1,7 +1,10 @@
 package online.lifeasgame.inventory.infra;
 
+import jakarta.persistence.LockModeType;
 import online.lifeasgame.inventory.domain.PlayerMailbox;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -9,6 +12,31 @@ import java.util.Optional;
 
 public interface JpaMailboxRepository extends JpaRepository<PlayerMailbox, Long> {
     Optional<PlayerMailbox> findByPlayerId(Long playerId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT mailbox FROM PlayerMailbox mailbox WHERE mailbox.playerId = :playerId")
+    Optional<PlayerMailbox> findByPlayerIdForUpdate(@Param("playerId") Long playerId);
+
+    @Modifying
+    @Query(value = """
+            INSERT IGNORE INTO player_mailbox (
+                player_id,
+                capacity_slots,
+                version,
+                created_at,
+                updated_at
+            ) VALUES (
+                :playerId,
+                :capacitySlots,
+                0,
+                CURRENT_TIMESTAMP(6),
+                CURRENT_TIMESTAMP(6)
+            )
+            """, nativeQuery = true)
+    int insertIfAbsent(
+            @Param("playerId") Long playerId,
+            @Param("capacitySlots") int capacitySlots
+    );
 
     @Query(
             """

--- a/src/main/java/online/lifeasgame/inventory/infra/PlayerInventoryAdapter.java
+++ b/src/main/java/online/lifeasgame/inventory/infra/PlayerInventoryAdapter.java
@@ -25,6 +25,11 @@ public class PlayerInventoryAdapter implements PlayerInventoryRepository, Invent
     }
 
     @Override
+    public void insertIfAbsent(Long playerId, int capacitySlots) {
+        jpaRepository.insertIfAbsent(playerId, capacitySlots);
+    }
+
+    @Override
     public long countStacksExceeding(Long itemId, int limit) {
         return jpaRepository.countStacksExceeding(itemId, limit);
     }

--- a/src/main/java/online/lifeasgame/inventory/infra/PlayerMailboxRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/inventory/infra/PlayerMailboxRepositoryAdapter.java
@@ -20,8 +20,18 @@ public class PlayerMailboxRepositoryAdapter implements PlayerMailboxRepository, 
     }
 
     @Override
+    public Optional<PlayerMailbox> findByPlayerIdForUpdate(Long playerId) {
+        return jpaRepository.findByPlayerIdForUpdate(playerId);
+    }
+
+    @Override
     public PlayerMailbox save(PlayerMailbox box) {
         return jpaRepository.save(box);
+    }
+
+    @Override
+    public void insertIfAbsent(Long playerId, int capacitySlots) {
+        jpaRepository.insertIfAbsent(playerId, capacitySlots);
     }
 
     @Override

--- a/src/main/resources/db/migration/V17__inventory_reward_delivery_foundation.sql
+++ b/src/main/resources/db/migration/V17__inventory_reward_delivery_foundation.sql
@@ -1,0 +1,25 @@
+CREATE TABLE inventory_reward_deliveries (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    reward_line_id BIGINT NOT NULL,
+    player_id BIGINT NOT NULL,
+    item_code VARCHAR(80) NOT NULL,
+    item_id BIGINT NOT NULL,
+    quantity BIGINT NOT NULL,
+    delivered_at DATETIME(6) NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_inventory_reward_delivery_line UNIQUE (reward_line_id),
+    CONSTRAINT ck_inventory_reward_delivery_line CHECK (reward_line_id > 0),
+    CONSTRAINT ck_inventory_reward_delivery_player CHECK (player_id > 0),
+    CONSTRAINT ck_inventory_reward_delivery_item CHECK (item_id > 0),
+    CONSTRAINT ck_inventory_reward_delivery_quantity CHECK (quantity > 0),
+    CONSTRAINT ck_inventory_reward_delivery_item_code CHECK (
+        CHAR_LENGTH(TRIM(item_code)) BETWEEN 1 AND 80
+    )
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE INDEX idx_inventory_reward_delivery_player
+    ON inventory_reward_deliveries (player_id, delivered_at);

--- a/src/test/java/online/lifeasgame/inventory/application/InventoryContainerProvisioningIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/inventory/application/InventoryContainerProvisioningIntegrationTest.java
@@ -1,0 +1,234 @@
+package online.lifeasgame.inventory.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.inventory.domain.PlayerInventory;
+import online.lifeasgame.inventory.domain.PlayerMailbox;
+import online.lifeasgame.inventory.domain.error.InventoryError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles({"test", "migration-test"})
+@DisplayName("Inventory container provisioning integration")
+class InventoryContainerProvisioningIntegrationTest {
+
+    private static final Long PLAYER_ID = 224001L;
+
+    @Container
+    private static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0.39")
+            .withDatabaseName("lifeasgame_inventory_provisioning")
+            .withUsername("lifeasgame")
+            .withPassword("lifeasgame");
+
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", MYSQL::getDriverClassName);
+    }
+
+    @Autowired
+    private InventoryContainerProvisioningService provisioningService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanContainers() {
+        jdbcTemplate.update("DELETE FROM inventory_entries");
+        jdbcTemplate.update("DELETE FROM mailbox_entries");
+        jdbcTemplate.update("DELETE FROM player_inventory");
+        jdbcTemplate.update("DELETE FROM player_mailbox");
+    }
+
+    @Test
+    @DisplayName("둘 다 없으면 기본 capacity로 만들고 순차 replay는 no-op이다")
+    void ensuresMissingContainersIdempotently() {
+        provisioningService.ensureContainers(PLAYER_ID);
+        provisioningService.ensureContainers(PLAYER_ID);
+
+        assertContainerCounts(PLAYER_ID, 1, 1);
+        assertThat(inventoryCapacity(PLAYER_ID))
+                .isEqualTo(PlayerInventory.DEFAULT_CAPACITY);
+        assertThat(mailboxCapacity(PLAYER_ID))
+                .isEqualTo(PlayerMailbox.DEFAULT_CAPACITY);
+    }
+
+    @Test
+    @DisplayName("Inventory만 있으면 기존 capacity와 version을 보존한다")
+    void preservesExistingInventory() {
+        insertInventory(PLAYER_ID, 77, 8L);
+
+        provisioningService.ensureContainers(PLAYER_ID);
+
+        assertContainerCounts(PLAYER_ID, 1, 1);
+        assertThat(inventoryCapacity(PLAYER_ID)).isEqualTo(77);
+        assertThat(inventoryVersion(PLAYER_ID)).isEqualTo(8L);
+        assertThat(mailboxCapacity(PLAYER_ID))
+                .isEqualTo(PlayerMailbox.DEFAULT_CAPACITY);
+    }
+
+    @Test
+    @DisplayName("Mailbox만 있으면 기존 capacity와 version을 보존한다")
+    void preservesExistingMailbox() {
+        insertMailbox(PLAYER_ID, 133, 9L);
+
+        provisioningService.ensureContainers(PLAYER_ID);
+
+        assertContainerCounts(PLAYER_ID, 1, 1);
+        assertThat(mailboxCapacity(PLAYER_ID)).isEqualTo(133);
+        assertThat(mailboxVersion(PLAYER_ID)).isEqualTo(9L);
+        assertThat(inventoryCapacity(PLAYER_ID))
+                .isEqualTo(PlayerInventory.DEFAULT_CAPACITY);
+    }
+
+    @Test
+    @DisplayName("둘 다 있으면 custom capacity와 version을 모두 보존한다")
+    void preservesBothExistingContainers() {
+        insertInventory(PLAYER_ID, 71, 4L);
+        insertMailbox(PLAYER_ID, 121, 5L);
+
+        provisioningService.ensureContainers(PLAYER_ID);
+
+        assertContainerCounts(PLAYER_ID, 1, 1);
+        assertThat(inventoryCapacity(PLAYER_ID)).isEqualTo(71);
+        assertThat(inventoryVersion(PLAYER_ID)).isEqualTo(4L);
+        assertThat(mailboxCapacity(PLAYER_ID)).isEqualTo(121);
+        assertThat(mailboxVersion(PLAYER_ID)).isEqualTo(5L);
+    }
+
+    @Test
+    @DisplayName("동시 ensure에도 각 container는 한 건이다")
+    void ensuresConcurrently() throws Exception {
+        int workers = 8;
+        ExecutorService executor = Executors.newFixedThreadPool(workers);
+        CountDownLatch ready = new CountDownLatch(workers);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<Void>> futures = new ArrayList<>();
+
+        try {
+            for (int i = 0; i < workers; i++) {
+                futures.add(executor.submit(() -> {
+                    ready.countDown();
+                    start.await();
+                    provisioningService.ensureContainers(PLAYER_ID);
+                    return null;
+                }));
+            }
+
+            assertThat(ready.await(10, TimeUnit.SECONDS)).isTrue();
+            start.countDown();
+            for (Future<Void> future : futures) {
+                future.get(30, TimeUnit.SECONDS);
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertContainerCounts(PLAYER_ID, 1, 1);
+        assertThat(inventoryCapacity(PLAYER_ID))
+                .isEqualTo(PlayerInventory.DEFAULT_CAPACITY);
+        assertThat(mailboxCapacity(PLAYER_ID))
+                .isEqualTo(PlayerMailbox.DEFAULT_CAPACITY);
+    }
+
+    @Test
+    @DisplayName("playerId는 양수여야 한다")
+    void rejectsInvalidPlayerId() {
+        assertThatThrownBy(() -> provisioningService.ensureContainers(0L))
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode())
+                                .isEqualTo(InventoryError.PLAYER_ID_INVALID)
+                );
+
+        assertContainerCounts(0L, 0, 0);
+    }
+
+    private void insertInventory(Long playerId, int capacity, Long version) {
+        jdbcTemplate.update("""
+                INSERT INTO player_inventory (
+                    player_id, capacity_slots, version, created_at, updated_at
+                ) VALUES (?, ?, ?, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6))
+                """, playerId, capacity, version);
+    }
+
+    private void insertMailbox(Long playerId, int capacity, Long version) {
+        jdbcTemplate.update("""
+                INSERT INTO player_mailbox (
+                    player_id, capacity_slots, version, created_at, updated_at
+                ) VALUES (?, ?, ?, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6))
+                """, playerId, capacity, version);
+    }
+
+    private void assertContainerCounts(
+            Long playerId,
+            int inventoryCount,
+            int mailboxCount
+    ) {
+        assertThat(count("player_inventory", playerId)).isEqualTo(inventoryCount);
+        assertThat(count("player_mailbox", playerId)).isEqualTo(mailboxCount);
+    }
+
+    private int count(String table, Long playerId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM " + table + " WHERE player_id = ?",
+                Integer.class,
+                playerId
+        );
+    }
+
+    private int inventoryCapacity(Long playerId) {
+        return capacity("player_inventory", playerId);
+    }
+
+    private int mailboxCapacity(Long playerId) {
+        return capacity("player_mailbox", playerId);
+    }
+
+    private int capacity(String table, Long playerId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT capacity_slots FROM " + table + " WHERE player_id = ?",
+                Integer.class,
+                playerId
+        );
+    }
+
+    private Long inventoryVersion(Long playerId) {
+        return version("player_inventory", playerId);
+    }
+
+    private Long mailboxVersion(Long playerId) {
+        return version("player_mailbox", playerId);
+    }
+
+    private Long version(String table, Long playerId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT version FROM " + table + " WHERE player_id = ?",
+                Long.class,
+                playerId
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryIntegrationTest.java
@@ -1,0 +1,476 @@
+package online.lifeasgame.inventory.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.inventory.application.internal.InventoryRewardDeliveryApi;
+import online.lifeasgame.inventory.domain.PlayerInventory;
+import online.lifeasgame.inventory.domain.error.InventoryError;
+import online.lifeasgame.inventory.domain.error.ItemError;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles({"test", "migration-test"})
+@DisplayName("Inventory reward delivery integration")
+class InventoryRewardDeliveryIntegrationTest {
+
+    private static final Long PLAYER_ID = 224101L;
+    private static final Long OTHER_PLAYER_ID = 224102L;
+    private static final String ITEM_CODE = "IT_FIRST_STEP_FRAGMENT";
+    private static final String OTHER_ITEM_CODE = "IT_REWARD_SECOND";
+
+    @Container
+    private static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0.39")
+            .withDatabaseName("lifeasgame_inventory_reward_delivery")
+            .withUsername("lifeasgame")
+            .withPassword("lifeasgame");
+
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", MYSQL::getDriverClassName);
+    }
+
+    @Autowired
+    private InventoryRewardDeliveryApi deliveryApi;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private Flyway flyway;
+
+    @Autowired
+    private Environment environment;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @BeforeEach
+    void cleanDeliveryState() {
+        jdbcTemplate.update("DELETE FROM inventory_reward_deliveries");
+        jdbcTemplate.update("DELETE FROM inventory_entries");
+        jdbcTemplate.update("DELETE FROM mailbox_entries");
+        jdbcTemplate.update("DELETE FROM player_inventory");
+        jdbcTemplate.update("DELETE FROM player_mailbox");
+        jdbcTemplate.update("""
+                INSERT IGNORE INTO items (
+                    code, name, category, type, rarity, base_attrs,
+                    stackable, max_stack, max_durability,
+                    created_at, updated_at
+                ) VALUES (
+                    ?, 'Reward test item', 'QUEST', 'ETC', 'COMMON',
+                    JSON_OBJECT(), TRUE, 10, NULL,
+                    CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
+                )
+                """, OTHER_ITEM_CODE);
+    }
+
+    @Test
+    @DisplayName("V17 receipt table은 JPA validate와 unique/check/index 계약을 만족한다")
+    void validatesMigrationContract() {
+        assertThat(flyway.info().current().getVersion().getVersion())
+                .isEqualTo("17");
+        assertThat(environment.getProperty("spring.jpa.hibernate.ddl-auto"))
+                .isEqualTo("validate");
+
+        Set<String> constraints = Set.copyOf(jdbcTemplate.queryForList("""
+                SELECT constraint_name
+                FROM information_schema.table_constraints
+                WHERE table_schema = DATABASE()
+                  AND table_name = 'inventory_reward_deliveries'
+                """, String.class));
+        assertThat(constraints).contains(
+                "uq_inventory_reward_delivery_line",
+                "ck_inventory_reward_delivery_line",
+                "ck_inventory_reward_delivery_player",
+                "ck_inventory_reward_delivery_item",
+                "ck_inventory_reward_delivery_quantity",
+                "ck_inventory_reward_delivery_item_code"
+        );
+
+        Set<String> indexes = Set.copyOf(jdbcTemplate.queryForList("""
+                SELECT DISTINCT index_name
+                FROM information_schema.statistics
+                WHERE table_schema = DATABASE()
+                  AND table_name = 'inventory_reward_deliveries'
+                """, String.class));
+        assertThat(indexes).contains(
+                "uq_inventory_reward_delivery_line",
+                "idx_inventory_reward_delivery_player"
+        );
+    }
+
+    @Test
+    @DisplayName("stable ItemCode로 bound=true, empty attrs 지급과 receipt를 원자 저장한다")
+    void deliversNewReward() {
+        InventoryRewardDeliveryApi.RewardDeliveryResult result =
+                deliveryApi.deliverReward(
+                        2241001L,
+                        PLAYER_ID,
+                        "  " + ITEM_CODE + "  ",
+                        2L
+                );
+
+        assertThat(result.deliveryId()).isPositive();
+        assertThat(result.rewardLineId()).isEqualTo(2241001L);
+        assertThat(result.playerId()).isEqualTo(PLAYER_ID);
+        assertThat(result.itemId()).isEqualTo(itemId(ITEM_CODE));
+        assertThat(result.itemCode()).isEqualTo(ITEM_CODE);
+        assertThat(result.quantity()).isEqualTo(2L);
+        assertThat(result.replayed()).isFalse();
+        assertThat(receiptCount(2241001L)).isEqualTo(1);
+        assertThat(mailboxTotalQuantity(PLAYER_ID)).isEqualTo(2L);
+        assertThat(mailboxEntryBound(PLAYER_ID)).isTrue();
+        assertThat(mailboxEntryAttrs(PLAYER_ID)).isEqualTo("{}");
+    }
+
+    @Test
+    @DisplayName("기존 stack, 신규 stack, 다중 stack에 지급하고 receipt는 전체 수량을 저장한다")
+    void stacksAcrossMailboxEntries() {
+        deliveryApi.deliverReward(2241101L, PLAYER_ID, ITEM_CODE, 90L);
+        deliveryApi.deliverReward(2241102L, PLAYER_ID, ITEM_CODE, 30L);
+
+        assertThat(mailboxQuantities(PLAYER_ID)).containsExactly(21, 99);
+        assertThat(receiptQuantity(2241102L)).isEqualTo(30L);
+
+        deliveryApi.deliverReward(2241103L, PLAYER_ID, ITEM_CODE, 150L);
+
+        assertThat(mailboxQuantities(PLAYER_ID)).containsExactly(72, 99, 99);
+        assertThat(mailboxTotalQuantity(PLAYER_ID)).isEqualTo(270L);
+        assertThat(receiptQuantity(2241103L)).isEqualTo(150L);
+    }
+
+    @Test
+    @DisplayName("순차 동일 payload replay는 Mailbox를 다시 변경하지 않는다")
+    void replaysSequentially() {
+        InventoryRewardDeliveryApi.RewardDeliveryResult first =
+                deliveryApi.deliverReward(2241201L, PLAYER_ID, ITEM_CODE, 5L);
+        InventoryRewardDeliveryApi.RewardDeliveryResult replay =
+                deliveryApi.deliverReward(
+                        2241201L,
+                        PLAYER_ID,
+                        "  " + ITEM_CODE + " ",
+                        5L
+                );
+
+        assertThat(first.replayed()).isFalse();
+        assertThat(replay.replayed()).isTrue();
+        assertThat(replay.deliveryId()).isEqualTo(first.deliveryId());
+        assertThat(mailboxTotalQuantity(PLAYER_ID)).isEqualTo(5L);
+        assertThat(receiptCount(2241201L)).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("동시 동일 payload는 Mailbox lock으로 한 번만 지급한다")
+    void replaysConcurrently() throws Exception {
+        int workers = 2;
+        ExecutorService executor = Executors.newFixedThreadPool(workers);
+        CountDownLatch ready = new CountDownLatch(workers);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<InventoryRewardDeliveryApi.RewardDeliveryResult>> futures =
+                new ArrayList<>();
+
+        try {
+            for (int i = 0; i < workers; i++) {
+                futures.add(executor.submit(() -> {
+                    ready.countDown();
+                    start.await();
+                    return deliveryApi.deliverReward(
+                            2241301L,
+                            PLAYER_ID,
+                            ITEM_CODE,
+                            7L
+                    );
+                }));
+            }
+
+            assertThat(ready.await(10, TimeUnit.SECONDS)).isTrue();
+            start.countDown();
+            List<InventoryRewardDeliveryApi.RewardDeliveryResult> results =
+                    new ArrayList<>();
+            for (Future<InventoryRewardDeliveryApi.RewardDeliveryResult> future : futures) {
+                results.add(future.get(30, TimeUnit.SECONDS));
+            }
+
+            assertThat(results)
+                    .extracting(InventoryRewardDeliveryApi.RewardDeliveryResult::replayed)
+                    .containsExactlyInAnyOrder(false, true);
+            assertThat(results)
+                    .extracting(InventoryRewardDeliveryApi.RewardDeliveryResult::deliveryId)
+                    .containsOnly(results.getFirst().deliveryId());
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(mailboxTotalQuantity(PLAYER_ID)).isEqualTo(7L);
+        assertThat(receiptCount(2241301L)).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("같은 rewardLineId의 다른 player, itemCode, quantity는 stable conflict다")
+    void rejectsReplayPayloadMismatch() {
+        deliveryApi.deliverReward(2241401L, PLAYER_ID, ITEM_CODE, 3L);
+
+        assertConflict(() -> deliveryApi.deliverReward(
+                2241401L,
+                OTHER_PLAYER_ID,
+                ITEM_CODE,
+                3L
+        ));
+        assertConflict(() -> deliveryApi.deliverReward(
+                2241401L,
+                PLAYER_ID,
+                OTHER_ITEM_CODE,
+                3L
+        ));
+        assertConflict(() -> deliveryApi.deliverReward(
+                2241401L,
+                PLAYER_ID,
+                ITEM_CODE,
+                4L
+        ));
+
+        assertThat(mailboxTotalQuantity(PLAYER_ID)).isEqualTo(3L);
+        assertThat(mailboxTotalQuantity(OTHER_PLAYER_ID)).isZero();
+        assertThat(receiptCount(2241401L)).isEqualTo(1);
+        assertThat(receiptQuantity(2241401L)).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("invalid input과 missing Item은 receipt와 Mailbox를 변경하지 않는다")
+    void rejectsInvalidOrMissingPayload() {
+        assertError(
+                () -> deliveryApi.deliverReward(0L, PLAYER_ID, ITEM_CODE, 1L),
+                InventoryError.REWARD_LINE_ID_INVALID
+        );
+        assertError(
+                () -> deliveryApi.deliverReward(2241501L, 0L, ITEM_CODE, 1L),
+                InventoryError.PLAYER_ID_INVALID
+        );
+        assertError(
+                () -> deliveryApi.deliverReward(2241502L, PLAYER_ID, " ", 1L),
+                InventoryError.REWARD_ITEM_CODE_INVALID
+        );
+        assertError(
+                () -> deliveryApi.deliverReward(
+                        2241503L,
+                        PLAYER_ID,
+                        "I".repeat(81),
+                        1L
+                ),
+                InventoryError.REWARD_ITEM_CODE_INVALID
+        );
+        assertError(
+                () -> deliveryApi.deliverReward(2241504L, PLAYER_ID, ITEM_CODE, 0L),
+                InventoryError.REWARD_QUANTITY_INVALID
+        );
+        assertError(
+                () -> deliveryApi.deliverReward(
+                        2241505L,
+                        PLAYER_ID,
+                        ITEM_CODE,
+                        (long) Integer.MAX_VALUE + 1
+                ),
+                InventoryError.REWARD_QUANTITY_INVALID
+        );
+        assertItemError(() -> deliveryApi.deliverReward(
+                2241506L,
+                PLAYER_ID,
+                "IT_MISSING",
+                1L
+        ));
+
+        assertThat(receiptCountAll()).isZero();
+        assertThat(mailboxTotalQuantity(PLAYER_ID)).isZero();
+    }
+
+    @Test
+    @DisplayName("Mailbox full은 entry mutation과 receipt를 모두 rollback한다")
+    void rollsBackWhenMailboxIsFull() {
+        insertInventory(PLAYER_ID, PlayerInventory.DEFAULT_CAPACITY);
+        insertMailbox(PLAYER_ID, 1);
+
+        assertError(
+                () -> deliveryApi.deliverReward(
+                        2241601L,
+                        PLAYER_ID,
+                        ITEM_CODE,
+                        100L
+                ),
+                InventoryError.MAILBOX_FULL
+        );
+
+        assertThat(mailboxTotalQuantity(PLAYER_ID)).isZero();
+        assertThat(mailboxEntryCount(PLAYER_ID)).isZero();
+        assertThat(receiptCount(2241601L)).isZero();
+        assertThat(mailboxCapacity(PLAYER_ID)).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("provider는 caller REQUIRED transaction rollback에 참여한다")
+    void joinsCallerTransaction() {
+        TransactionTemplate transaction = new TransactionTemplate(transactionManager);
+
+        transaction.executeWithoutResult(status -> {
+            deliveryApi.deliverReward(2241701L, PLAYER_ID, ITEM_CODE, 1L);
+            status.setRollbackOnly();
+        });
+
+        assertThat(receiptCount(2241701L)).isZero();
+        assertThat(mailboxEntryCount(PLAYER_ID)).isZero();
+        assertThat(containerCount("player_inventory", PLAYER_ID)).isZero();
+        assertThat(containerCount("player_mailbox", PLAYER_ID)).isZero();
+    }
+
+    private void assertConflict(Runnable call) {
+        assertError(call, InventoryError.REWARD_DELIVERY_CONFLICT);
+    }
+
+    private void assertItemError(Runnable call) {
+        assertThatThrownBy(call::run)
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode())
+                                .isEqualTo(ItemError.ITEM_CODE_NOT_FOUND)
+                );
+    }
+
+    private void assertError(Runnable call, InventoryError error) {
+        assertThatThrownBy(call::run)
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(error)
+                );
+    }
+
+    private void insertInventory(Long playerId, int capacity) {
+        jdbcTemplate.update("""
+                INSERT INTO player_inventory (
+                    player_id, capacity_slots, version, created_at, updated_at
+                ) VALUES (?, ?, 0, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6))
+                """, playerId, capacity);
+    }
+
+    private void insertMailbox(Long playerId, int capacity) {
+        jdbcTemplate.update("""
+                INSERT INTO player_mailbox (
+                    player_id, capacity_slots, version, created_at, updated_at
+                ) VALUES (?, ?, 0, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6))
+                """, playerId, capacity);
+    }
+
+    private Long itemId(String code) {
+        return jdbcTemplate.queryForObject(
+                "SELECT id FROM items WHERE code = ?",
+                Long.class,
+                code
+        );
+    }
+
+    private int receiptCount(Long rewardLineId) {
+        return jdbcTemplate.queryForObject("""
+                SELECT COUNT(*)
+                FROM inventory_reward_deliveries
+                WHERE reward_line_id = ?
+                """, Integer.class, rewardLineId);
+    }
+
+    private int receiptCountAll() {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM inventory_reward_deliveries",
+                Integer.class
+        );
+    }
+
+    private long receiptQuantity(Long rewardLineId) {
+        return jdbcTemplate.queryForObject("""
+                SELECT quantity
+                FROM inventory_reward_deliveries
+                WHERE reward_line_id = ?
+                """, Long.class, rewardLineId);
+    }
+
+    private int mailboxEntryCount(Long playerId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM mailbox_entries WHERE player_id = ?",
+                Integer.class,
+                playerId
+        );
+    }
+
+    private long mailboxTotalQuantity(Long playerId) {
+        return jdbcTemplate.queryForObject("""
+                SELECT COALESCE(SUM(quantity), 0)
+                FROM mailbox_entries
+                WHERE player_id = ?
+                """, Long.class, playerId);
+    }
+
+    private List<Integer> mailboxQuantities(Long playerId) {
+        return jdbcTemplate.queryForList("""
+                SELECT quantity
+                FROM mailbox_entries
+                WHERE player_id = ?
+                ORDER BY quantity, slot_index
+                """, Integer.class, playerId);
+    }
+
+    private boolean mailboxEntryBound(Long playerId) {
+        return Boolean.TRUE.equals(jdbcTemplate.queryForObject("""
+                SELECT bound
+                FROM mailbox_entries
+                WHERE player_id = ?
+                """, Boolean.class, playerId));
+    }
+
+    private String mailboxEntryAttrs(Long playerId) {
+        return jdbcTemplate.queryForObject("""
+                SELECT CAST(inst_attrs AS CHAR)
+                FROM mailbox_entries
+                WHERE player_id = ?
+                """, String.class, playerId);
+    }
+
+    private int mailboxCapacity(Long playerId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT capacity_slots FROM player_mailbox WHERE player_id = ?",
+                Integer.class,
+                playerId
+        );
+    }
+
+    private int containerCount(String table, Long playerId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM " + table + " WHERE player_id = ?",
+                Integer.class,
+                playerId
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/inventory/domain/InventoryRewardDeliveryTest.java
+++ b/src/test/java/online/lifeasgame/inventory/domain/InventoryRewardDeliveryTest.java
@@ -1,0 +1,128 @@
+package online.lifeasgame.inventory.domain;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.inventory.domain.error.InventoryError;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("InventoryRewardDelivery")
+class InventoryRewardDeliveryTest {
+
+    private static final Instant DELIVERED_AT =
+            Instant.parse("2026-08-03T08:00:00Z");
+
+    @Test
+    @DisplayName("양수 identity와 정규화 ItemCode로 append-only receipt를 생성한다")
+    void createsReceipt() {
+        InventoryRewardDelivery delivery = delivery();
+
+        assertThat(delivery.getRewardLineId()).isEqualTo(101L);
+        assertThat(delivery.getPlayerId()).isEqualTo(201L);
+        assertThat(delivery.getItemCode()).isEqualTo("IT_FIRST_STEP_FRAGMENT");
+        assertThat(delivery.getItemId()).isEqualTo(301L);
+        assertThat(delivery.getQuantity()).isEqualTo(2L);
+        assertThat(delivery.getDeliveredAt()).isEqualTo(DELIVERED_AT);
+    }
+
+    @Test
+    @DisplayName("동일 payload replay는 일치한다")
+    void acceptsMatchingPayload() {
+        assertThatCode(() -> delivery().assertMatches(
+                101L,
+                201L,
+                ItemCode.of("IT_FIRST_STEP_FRAGMENT"),
+                2L
+        )).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("같은 rewardLineId의 다른 payload는 stable 409 conflict다")
+    void rejectsMismatchedPayload() {
+        InventoryRewardDelivery delivery = delivery();
+
+        assertConflict(() -> delivery.assertMatches(
+                101L,
+                202L,
+                ItemCode.of("IT_FIRST_STEP_FRAGMENT"),
+                2L
+        ));
+        assertConflict(() -> delivery.assertMatches(
+                101L,
+                201L,
+                ItemCode.of("IT_OTHER"),
+                2L
+        ));
+        assertConflict(() -> delivery.assertMatches(
+                101L,
+                201L,
+                ItemCode.of("IT_FIRST_STEP_FRAGMENT"),
+                3L
+        ));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 receipt identity와 quantity를 거부한다")
+    void rejectsInvalidReceipt() {
+        assertError(
+                () -> InventoryRewardDelivery.create(
+                        0L,
+                        201L,
+                        ItemCode.of("IT_FIRST_STEP_FRAGMENT"),
+                        301L,
+                        2L,
+                        DELIVERED_AT
+                ),
+                InventoryError.REWARD_LINE_ID_INVALID
+        );
+        assertError(
+                () -> InventoryRewardDelivery.create(
+                        101L,
+                        0L,
+                        ItemCode.of("IT_FIRST_STEP_FRAGMENT"),
+                        301L,
+                        2L,
+                        DELIVERED_AT
+                ),
+                InventoryError.PLAYER_ID_INVALID
+        );
+        assertError(
+                () -> InventoryRewardDelivery.create(
+                        101L,
+                        201L,
+                        ItemCode.of("IT_FIRST_STEP_FRAGMENT"),
+                        301L,
+                        0L,
+                        DELIVERED_AT
+                ),
+                InventoryError.REWARD_QUANTITY_INVALID
+        );
+    }
+
+    private InventoryRewardDelivery delivery() {
+        return InventoryRewardDelivery.create(
+                101L,
+                201L,
+                ItemCode.of("  IT_FIRST_STEP_FRAGMENT  "),
+                301L,
+                2L,
+                DELIVERED_AT
+        );
+    }
+
+    private void assertConflict(Runnable assertion) {
+        assertError(assertion, InventoryError.REWARD_DELIVERY_CONFLICT);
+    }
+
+    private void assertError(Runnable assertion, InventoryError error) {
+        assertThatThrownBy(assertion::run)
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(error)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/inventory/domain/PlayerMailboxDeliveryPreflightTest.java
+++ b/src/test/java/online/lifeasgame/inventory/domain/PlayerMailboxDeliveryPreflightTest.java
@@ -1,0 +1,39 @@
+package online.lifeasgame.inventory.domain;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.inventory.domain.error.InventoryError;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("PlayerMailbox delivery capacity preflight")
+class PlayerMailboxDeliveryPreflightTest {
+
+    @Test
+    @DisplayName("신규 stack 공간이 부족하면 기존 stack도 변경하지 않는다")
+    void rejectsBeforeMutatingExistingStack() {
+        PlayerMailbox mailbox = PlayerMailbox.of(1L, 1);
+        ItemCarryPolicy policy = new ItemCarryPolicy(
+                10L,
+                Rarity.COMMON,
+                true,
+                10,
+                null
+        );
+        mailbox.deliver(policy, 9, InstanceAttrs.empty(), true);
+
+        MailboxEntry existing = mailbox.getEntries().getFirst();
+
+        assertThatThrownBy(() ->
+                mailbox.deliver(policy, 2, InstanceAttrs.empty(), true)
+        ).isInstanceOfSatisfying(DomainException.class, exception ->
+                assertThat(exception.getErrorCode())
+                        .isEqualTo(InventoryError.MAILBOX_FULL)
+        );
+
+        assertThat(mailbox.getEntries()).containsExactly(existing);
+        assertThat(existing.getQuantity().value()).isEqualTo(9);
+    }
+}

--- a/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
@@ -63,7 +63,7 @@ class FlywayExplicitBaselineTest {
     class ApplyExplicitBaseline {
 
         @Test
-        @DisplayName("V1을 재실행하지 않고 V2부터 V16까지 적용한 뒤 JPA validate를 통과한다")
+        @DisplayName("V1을 재실행하지 않고 V2부터 V17까지 적용한 뒤 JPA validate를 통과한다")
         void migratesFromVersionTwoAndValidatesJpa() throws Exception {
             String jdbcUrl = createV1EquivalentDatabase();
             Flyway flyway = migrationFlyway(jdbcUrl);
@@ -72,12 +72,12 @@ class FlywayExplicitBaselineTest {
             MigrateResult migrateResult = flyway.migrate();
             List<HistoryRow> history = successfulHistory(jdbcUrl);
 
-            assertThat(migrateResult.migrationsExecuted).isEqualTo(15);
+            assertThat(migrateResult.migrationsExecuted).isEqualTo(16);
             assertThat(history).extracting(HistoryRow::version)
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
-                            "14", "15", "16"
+                            "14", "15", "16", "17"
                     );
             assertThat(history.getFirst().type()).isEqualTo("BASELINE");
             assertThat(history.getFirst().script())
@@ -103,7 +103,8 @@ class FlywayExplicitBaselineTest {
                             "V13__first_step_reward_profile_seed.sql",
                             "V14__final_quest_legacy_category_nullable.sql",
                             "V15__canonical_lifelog_record_metadata.sql",
-                            "V16__quest_acceptance_fact_context.sql"
+                            "V16__quest_acceptance_fact_context.sql",
+                            "V17__inventory_reward_delivery_foundation.sql"
                     );
             assertThat(history.subList(1, history.size()))
                     .allSatisfy(row -> assertThat(row.checksum()).isNotNull());
@@ -123,7 +124,7 @@ class FlywayExplicitBaselineTest {
                         "spring.jpa.hibernate.ddl-auto"
                 )).isEqualTo("validate");
                 assertThat(context.getBean(Flyway.class).info().current().getVersion().getVersion())
-                        .isEqualTo("16");
+                        .isEqualTo("17");
             }
         }
     }

--- a/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
@@ -33,10 +33,10 @@ class FlywayHistoryChecksumTest {
     class MigrateAgain {
 
         @Test
-        @DisplayName("V1~V15 checksum을 보존하고 V16 이후 두 번째 실행은 no-op이다")
+        @DisplayName("V1~V16 checksum을 보존하고 V17 이후 두 번째 실행은 no-op이다")
         void keepsMigrationHistory() throws Exception {
-            Flyway throughV15 = flyway(MigrationVersion.fromVersion("15"));
-            MigrateResult legacy = throughV15.migrate();
+            Flyway throughV16 = flyway(MigrationVersion.fromVersion("16"));
+            MigrateResult legacy = throughV16.migrate();
             List<HistoryRow> legacyHistory = successfulHistory();
             Flyway flyway = flyway(null);
 
@@ -46,7 +46,7 @@ class FlywayHistoryChecksumTest {
             MigrateResult second = flyway.migrate();
             List<HistoryRow> secondHistory = successfulHistory();
 
-            assertThat(legacy.migrationsExecuted).isEqualTo(15);
+            assertThat(legacy.migrationsExecuted).isEqualTo(16);
             assertThat(first.migrationsExecuted).isEqualTo(1);
             assertThat(second.migrationsExecuted).isZero();
             assertThat(secondHistory).isEqualTo(firstHistory);
@@ -56,7 +56,7 @@ class FlywayHistoryChecksumTest {
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
-                            "14", "15", "16"
+                            "14", "15", "16", "17"
                     );
             assertThat(secondHistory).allSatisfy(history -> {
                 assertThat(history.checksum()).isNotNull();

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -39,7 +39,7 @@ class FlywayMigrationTest {
     class MigrateCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V16까지 적용되고 Quest Fact context를 추가한다")
+        @DisplayName("V1부터 V17까지 적용되고 Inventory reward delivery 기반을 추가한다")
         void migratesSchemaAndSeedsRewardProfiles() throws Exception {
             Flyway throughV10 = flyway(MigrationVersion.fromVersion("10"));
             MigrateResult legacyResult = throughV10.migrate();
@@ -58,12 +58,12 @@ class FlywayMigrationTest {
             assertThat(legacyResult.migrationsExecuted).isEqualTo(10);
             assertThat(semanticResult.migrationsExecuted).isEqualTo(1);
             assertThat(itemResult.migrationsExecuted).isEqualTo(1);
-            assertThat(result.migrationsExecuted).isEqualTo(4);
+            assertThat(result.migrationsExecuted).isEqualTo(5);
             assertThat(appliedVersions())
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
-                            "14", "15", "16"
+                            "14", "15", "16", "17"
                     );
             assertThat(existingTables(
                     "users",
@@ -80,7 +80,8 @@ class FlywayMigrationTest {
                     "quest_signal_receipts",
                     "outbox_events",
                     "quick_record_request_receipts",
-                    "life_log_records"
+                    "life_log_records",
+                    "inventory_reward_deliveries"
             )).containsExactlyInAnyOrder(
                     "users",
                     "player",
@@ -96,7 +97,8 @@ class FlywayMigrationTest {
                     "quest_signal_receipts",
                     "outbox_events",
                     "quick_record_request_receipts",
-                    "life_log_records"
+                    "life_log_records",
+                    "inventory_reward_deliveries"
             );
             assertThat(existingTables(
                     "quick_lifelog_entries",

--- a/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
@@ -149,7 +149,7 @@ class FlywayProfileCutoverTest {
     class StartLocalWithCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V16까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
+        @DisplayName("V1부터 V17까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
         void migratesThenValidates() {
             ConfigurableEnvironment environment =
                     (ConfigurableEnvironment) applicationContext.getEnvironment();
@@ -161,8 +161,8 @@ class FlywayProfileCutoverTest {
             assertThat(environment.getProperty(
                     "spring.flyway.baseline-on-migrate", Boolean.class
             )).isFalse();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("16");
-            assertThat(appliedMigrationCount()).isEqualTo(16);
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("17");
+            assertThat(appliedMigrationCount()).isEqualTo(17);
         }
     }
 

--- a/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 @SpringBootTest
 @ActiveProfiles({"test", "migration-test"})
-@DisplayName("V16 migration 이후 JPA schema validation")
+@DisplayName("V17 migration 이후 JPA schema validation")
 class JpaValidateAfterMigrationTest {
 
     @Container
@@ -79,14 +79,14 @@ class JpaValidateAfterMigrationTest {
     private QuestDefinitionBootstrapper questDefinitionBootstrapper;
 
     @Nested
-    @DisplayName("V1부터 V16까지 적용된 schema로 ApplicationContext를 기동할 때")
+    @DisplayName("V1부터 V17까지 적용된 schema로 ApplicationContext를 기동할 때")
     class LoadApplicationContext {
 
         @Test
         @DisplayName("ddl-auto validate 상태로 정상 기동한다")
         void loadsWithJpaValidation() {
             assertThat(applicationContext).isNotNull();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("16");
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("17");
             assertThat(applicationContext.getEnvironment().getProperty("spring.jpa.hibernate.ddl-auto"))
                     .isEqualTo("validate");
             assertThat(applicationContext.getEnvironment()


### PR DESCRIPTION
## What

Reward ITEM Line Processor가 안전하게 사용할
Inventory-owned delivery foundation을 추가한다.

## Container Provisioning

`PlayerInventory`와 `PlayerMailbox`를
동시 호출에서도 안전하게 ensure한다.

- 신규 Inventory capacity: 60
- 신규 Mailbox capacity: 100
- 기존 container와 capacity는 변경하지 않음

## Reward Delivery Receipt

다음 identity로 append-only receipt를 저장한다.

```text
rewardLineId
```

Receipt snapshot:

- playerId
- itemCode
- itemId
- quantity
- deliveredAt

같은 `rewardLineId`의 동일 payload는 replay로 처리하고,
다른 payload는 conflict로 거부한다.

## Inventory InternalApi

```text
deliverReward(
  rewardLineId,
  playerId,
  itemCode,
  quantity
)
```

- Inventory-owned provider
- public HTTP 노출 없음
- `REQUIRED` Transaction
- stable itemCode resolution
- reward default: bound=true, attrs empty

## Concurrency

Reward delivery는 `PlayerMailbox`를
`PESSIMISTIC_WRITE`로 잠근다.

같은 Player의 동시 replay는 직렬화되며
Mailbox와 receipt는 한 번만 변경된다.

## Mailbox Full

필요한 slot을 mutation 전에 계산한다.

Mailbox가 가득 차면:

- 기존 stack 변경 없음
- 신규 entry 없음
- receipt 없음

## Migration

```text
V17__inventory_reward_delivery_foundation.sql
```

신규 Table:

```text
inventory_reward_deliveries
```

## Test

- Migration/Hibernate validate
- 신규/기존/concurrent container ensure
- 단일 delivery와 stacking
- sequential/concurrent replay
- mismatched replay conflict
- Mailbox full rollback
- invalid input와 missing itemCode
- Inventory regression
- full clean test/build

## Out of Scope

- Reward ITEM Line Processor
- Reward itemCode snapshot
- Mailbox claim hardening
- Item delete/deactivate policy
- retry scheduler
- public/admin delivery API

Closes #224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reward delivery to player mailboxes with duplicate-safe replay handling.
  * Automatically creates missing inventory and mailbox containers using default capacities.
  * Added delivery records for tracking reward, player, item, quantity, and delivery time.

* **Bug Fixes**
  * Prevented mailbox contents from being modified when capacity is insufficient.
  * Added validation for invalid players, reward lines, items, quantities, and conflicting deliveries.

* **Tests**
  * Added coverage for concurrent delivery, retries, capacity limits, rollback behavior, and database migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->