### PR TITLE
[Reward] Process ITEM settlement lines through inventory delivery

### DIFF
--- a/src/main/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryService.java
+++ b/src/main/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryService.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -85,6 +86,21 @@ public class InventoryRewardDeliveryService implements InventoryRewardDeliveryAp
                 )
         );
         return result(saved, false);
+    }
+
+    @Override
+    @Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+    public Optional<RewardDeliveryReceipt> findRewardDelivery(Long rewardLineId) {
+        validateRewardLineId(rewardLineId);
+        return deliveryRepository.findByRewardLineId(rewardLineId)
+                .map(delivery -> new RewardDeliveryReceipt(
+                        delivery.getId(),
+                        delivery.getRewardLineId(),
+                        delivery.getPlayerId(),
+                        delivery.getItemId(),
+                        delivery.getItemCode(),
+                        delivery.getQuantity()
+                ));
     }
 
     private static RewardDeliveryResult result(

--- a/src/main/java/online/lifeasgame/inventory/application/ItemLookupService.java
+++ b/src/main/java/online/lifeasgame/inventory/application/ItemLookupService.java
@@ -1,9 +1,11 @@
 package online.lifeasgame.inventory.application;
 
 import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.inventory.application.internal.ItemLookupApi;
 import online.lifeasgame.inventory.domain.Item;
 import online.lifeasgame.inventory.domain.ItemCode;
+import online.lifeasgame.inventory.domain.error.ItemError;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +20,23 @@ public class ItemLookupService implements ItemLookupApi {
     @Override
     public ItemReference getByCode(String code) {
         Item item = itemReader.getByCodeOrThrow(ItemCode.of(code));
-        return new ItemReference(item.getId(), item.getCode().value());
+        return reference(item);
+    }
+
+    @Override
+    public ItemReference getById(Long itemId) {
+        if (itemId == null || itemId <= 0) {
+            throw new DomainException(ItemError.ITEM_ID_INVALID);
+        }
+        return reference(itemReader.getByIdOrThrow(itemId));
+    }
+
+    private static ItemReference reference(Item item) {
+        if (item.getCode() == null
+                || item.getCode().value() == null
+                || item.getCode().value().isBlank()) {
+            throw new DomainException(ItemError.ITEM_CODE_NOT_FOUND);
+        }
+        return new ItemReference(item.getId(), item.getCode().value().strip());
     }
 }

--- a/src/main/java/online/lifeasgame/inventory/application/internal/InventoryRewardDeliveryApi.java
+++ b/src/main/java/online/lifeasgame/inventory/application/internal/InventoryRewardDeliveryApi.java
@@ -1,5 +1,7 @@
 package online.lifeasgame.inventory.application.internal;
 
+import java.util.Optional;
+
 public interface InventoryRewardDeliveryApi {
 
     RewardDeliveryResult deliverReward(
@@ -9,6 +11,8 @@ public interface InventoryRewardDeliveryApi {
             long quantity
     );
 
+    Optional<RewardDeliveryReceipt> findRewardDelivery(Long rewardLineId);
+
     record RewardDeliveryResult(
             Long deliveryId,
             Long rewardLineId,
@@ -17,6 +21,16 @@ public interface InventoryRewardDeliveryApi {
             String itemCode,
             long quantity,
             boolean replayed
+    ) {
+    }
+
+    record RewardDeliveryReceipt(
+            Long deliveryId,
+            Long rewardLineId,
+            Long playerId,
+            Long itemId,
+            String itemCode,
+            long quantity
     ) {
     }
 }

--- a/src/main/java/online/lifeasgame/inventory/application/internal/ItemLookupApi.java
+++ b/src/main/java/online/lifeasgame/inventory/application/internal/ItemLookupApi.java
@@ -4,6 +4,8 @@ public interface ItemLookupApi {
 
     ItemReference getByCode(String code);
 
+    ItemReference getById(Long itemId);
+
     record ItemReference(Long id, String code) {
     }
 }

--- a/src/main/java/online/lifeasgame/inventory/domain/error/ItemError.java
+++ b/src/main/java/online/lifeasgame/inventory/domain/error/ItemError.java
@@ -5,6 +5,7 @@ import online.lifeasgame.core.error.ErrorCode;
 public enum ItemError implements ErrorCode {
 
     ITEM_NOT_FOUND("ITM-404-NOT-FOUND", "Item not found", 404),
+    ITEM_ID_INVALID("ITM-400-ID-INVALID", "Item id must be positive", 400),
     ITEM_CODE_NOT_FOUND("ITM-404-CODE-NOT-FOUND", "Item code not found", 404),
     ITEM_NAME_DUP("ITM-409-NAME-DUP", "Duplicate item name", 409),
     INVALID_ITEM_CATEGORY("ITM-400-INVALID-ITEM-CATEGORY", "Invalid item category", 400),

--- a/src/main/java/online/lifeasgame/reward/application/QuestCompletionRewardService.java
+++ b/src/main/java/online/lifeasgame/reward/application/QuestCompletionRewardService.java
@@ -18,6 +18,7 @@ public class QuestCompletionRewardService {
     private final RewardSettlementCreateService settlementCreateService;
     private final RewardSettlementReader settlementReader;
     private final RewardSettlementExpProcessService expProcessService;
+    private final RewardSettlementItemProcessService itemProcessService;
 
     public void process(QuestRewardReadyFact fact) {
         RewardSettlement settlement = settlementCreateService.create(
@@ -37,9 +38,27 @@ public class QuestCompletionRewardService {
                     }
                 }
                 case ITEM -> {
-                    // ITEM settlement lines intentionally remain PENDING.
+                    if (line.getStatus() == RewardSettlementLineStatus.FAILED) {
+                        logFailed(settlement.getId(), line);
+                    } else {
+                        processItem(settlement.getId(), line.getId());
+                    }
                 }
             }
+        }
+    }
+
+    private void processItem(Long settlementId, Long lineId) {
+        try {
+            itemProcessService.process(settlementId, lineId);
+        } catch (DomainException exception) {
+            RewardSettlement fresh = settlementReader
+                    .getByIdInNewTransactionOrThrow(settlementId);
+            RewardSettlementLine freshLine = fresh.getLineByIdOrThrow(lineId);
+            if (freshLine.getStatus() != RewardSettlementLineStatus.FAILED) {
+                throw exception;
+            }
+            logFailed(settlementId, freshLine);
         }
     }
 
@@ -66,7 +85,8 @@ public class QuestCompletionRewardService {
             RewardSettlementLine line
     ) {
         log.warn(
-                "Quest reward EXP failed: settlementId={}, lineId={}, failureCode={}",
+                "Quest reward {} failed: settlementId={}, lineId={}, failureCode={}",
+                line.getRewardType(),
                 settlementId,
                 line.getId(),
                 line.getFailureCode()

--- a/src/main/java/online/lifeasgame/reward/application/RewardDefinitionReader.java
+++ b/src/main/java/online/lifeasgame/reward/application/RewardDefinitionReader.java
@@ -16,6 +16,13 @@ public class RewardDefinitionReader {
 
     private final RewardDefinitionRepository repository;
 
+    public RewardDefinition getByIdOrThrow(Long id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new DomainException(
+                        RewardError.REWARD_DEFINITION_NOT_FOUND
+                ));
+    }
+
     public RewardDefinition getByCodeOrThrow(String code) {
         return repository.findByCode(code)
                 .orElseThrow(() -> new DomainException(RewardError.REWARD_DEFINITION_NOT_FOUND));

--- a/src/main/java/online/lifeasgame/reward/application/RewardDefinitionService.java
+++ b/src/main/java/online/lifeasgame/reward/application/RewardDefinitionService.java
@@ -1,0 +1,98 @@
+package online.lifeasgame.reward.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.inventory.application.internal.ItemLookupApi;
+import online.lifeasgame.reward.application.command.RewardDefinitionCommand;
+import online.lifeasgame.reward.application.result.RewardDefinitionResult;
+import online.lifeasgame.reward.domain.RewardDefinition;
+import online.lifeasgame.reward.domain.RewardType;
+import online.lifeasgame.reward.domain.error.RewardError;
+import online.lifeasgame.reward.domain.repository.RewardDefinitionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class RewardDefinitionService {
+
+    private final RewardDefinitionReader definitionReader;
+    private final RewardDefinitionRepository definitionRepository;
+    private final ItemLookupApi itemLookupApi;
+
+    @Transactional
+    public RewardDefinitionResult.Detail create(
+            RewardDefinitionCommand.Create command
+    ) {
+        String itemCode = resolveItemCode(
+                command.rewardType(), command.itemId()
+        );
+        RewardDefinition definition = RewardDefinition.create(
+                command.code(),
+                command.name(),
+                command.rewardType(),
+                command.amount(),
+                command.itemId(),
+                itemCode,
+                command.active()
+        );
+        return RewardDefinitionResult.Detail.from(
+                definitionRepository.save(definition)
+        );
+    }
+
+    @Transactional
+    public RewardDefinitionResult.Detail update(
+            Long definitionId,
+            RewardDefinitionCommand.Update command
+    ) {
+        RewardDefinition definition = definitionReader.getByIdOrThrow(
+                definitionId
+        );
+        String itemCode = resolveItemCode(
+                command.rewardType(), command.itemId()
+        );
+        definition.update(
+                command.code(),
+                command.name(),
+                command.rewardType(),
+                command.amount(),
+                command.itemId(),
+                itemCode,
+                command.active()
+        );
+        return RewardDefinitionResult.Detail.from(
+                definitionRepository.save(definition)
+        );
+    }
+
+    private String resolveItemCode(RewardType rewardType, Long itemId) {
+        if (rewardType != RewardType.ITEM) {
+            return null;
+        }
+        if (itemId == null) {
+            throw new DomainException(RewardError.REWARD_ITEM_ID_REQUIRED);
+        }
+        if (itemId <= 0) {
+            throw new DomainException(
+                    RewardError.REWARD_ITEM_ID_MUST_BE_POSITIVE
+            );
+        }
+        ItemLookupApi.ItemReference reference = itemLookupApi.getById(itemId);
+        if (!Objects.equals(itemId, reference.id())) {
+            throw new DomainException(
+                    RewardError.REWARD_ITEM_REFERENCE_INCONSISTENT
+            );
+        }
+        if (reference.code() == null || reference.code().isBlank()) {
+            throw new DomainException(RewardError.REWARD_ITEM_CODE_REQUIRED);
+        }
+        String itemCode = reference.code().strip();
+        if (itemCode.length() > 80) {
+            throw new DomainException(RewardError.REWARD_ITEM_CODE_TOO_LONG);
+        }
+        return itemCode;
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/application/RewardSettlementItemProcessAttempt.java
+++ b/src/main/java/online/lifeasgame/reward/application/RewardSettlementItemProcessAttempt.java
@@ -1,0 +1,124 @@
+package online.lifeasgame.reward.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.inventory.application.internal.InventoryRewardDeliveryApi;
+import online.lifeasgame.reward.application.result.RewardSettlementItemProcessResult;
+import online.lifeasgame.reward.domain.RewardSettlement;
+import online.lifeasgame.reward.domain.RewardSettlementLine;
+import online.lifeasgame.reward.domain.error.RewardError;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class RewardSettlementItemProcessAttempt {
+
+    private final RewardSettlementReader settlementReader;
+    private final RewardSettlementWriter settlementWriter;
+    private final InventoryRewardDeliveryApi inventoryDeliveryApi;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public RewardSettlementItemProcessResult process(
+            Long settlementId,
+            Long lineId
+    ) {
+        RewardSettlement settlement = settlementReader
+                .getByIdForUpdateOrThrow(settlementId);
+        RewardSettlementLine line = settlement.getLineByIdOrThrow(lineId);
+
+        if (line.isItemSucceeded()) {
+            InventoryRewardDeliveryApi.RewardDeliveryReceipt receipt =
+                    inventoryDeliveryApi.findRewardDelivery(lineId)
+                            .orElseThrow(this::inconsistent);
+            assertMatches(
+                    settlement,
+                    line,
+                    receipt.rewardLineId(),
+                    receipt.playerId(),
+                    receipt.itemId(),
+                    receipt.itemCode(),
+                    receipt.quantity()
+            );
+            return result(
+                    settlement,
+                    line,
+                    receipt.deliveryId(),
+                    true
+            );
+        }
+
+        line.isItemProcessingRequired();
+        InventoryRewardDeliveryApi.RewardDeliveryResult delivery =
+                inventoryDeliveryApi.deliverReward(
+                        lineId,
+                        settlement.getPlayerId(),
+                        line.getItemCode(),
+                        line.getAmount()
+                );
+        assertMatches(
+                settlement,
+                line,
+                delivery.rewardLineId(),
+                delivery.playerId(),
+                delivery.itemId(),
+                delivery.itemCode(),
+                delivery.quantity()
+        );
+
+        settlement.markItemLineSucceeded(lineId);
+        settlementWriter.saveAndFlush(settlement);
+        return result(
+                settlement,
+                line,
+                delivery.deliveryId(),
+                delivery.replayed()
+        );
+    }
+
+    private void assertMatches(
+            RewardSettlement settlement,
+            RewardSettlementLine line,
+            Long rewardLineId,
+            Long playerId,
+            Long itemId,
+            String itemCode,
+            long quantity
+    ) {
+        if (!line.getId().equals(rewardLineId)
+                || !settlement.getPlayerId().equals(playerId)
+                || !line.getItemId().equals(itemId)
+                || itemCode == null
+                || !line.getItemCode().equals(itemCode.strip())
+                || line.getAmount() != quantity) {
+            throw inconsistent();
+        }
+    }
+
+    private DomainException inconsistent() {
+        return new DomainException(
+                RewardError.REWARD_SETTLEMENT_ITEM_DELIVERY_INCONSISTENT
+        );
+    }
+
+    private RewardSettlementItemProcessResult result(
+            RewardSettlement settlement,
+            RewardSettlementLine line,
+            Long deliveryId,
+            boolean replayed
+    ) {
+        return new RewardSettlementItemProcessResult(
+                settlement.getId(),
+                line.getId(),
+                settlement.getPlayerId(),
+                line.getStatus(),
+                settlement.getStatus(),
+                line.getItemId(),
+                line.getItemCode(),
+                line.getAmount(),
+                replayed,
+                deliveryId
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/application/RewardSettlementItemProcessService.java
+++ b/src/main/java/online/lifeasgame/reward/application/RewardSettlementItemProcessService.java
@@ -1,0 +1,30 @@
+package online.lifeasgame.reward.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.reward.application.result.RewardSettlementItemProcessResult;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RewardSettlementItemProcessService {
+
+    private final RewardSettlementItemProcessAttempt processAttempt;
+    private final RewardSettlementLineFailureRecorder failureRecorder;
+
+    public RewardSettlementItemProcessResult process(
+            Long settlementId,
+            Long lineId
+    ) {
+        try {
+            return processAttempt.process(settlementId, lineId);
+        } catch (DomainException exception) {
+            failureRecorder.record(
+                    settlementId,
+                    lineId,
+                    exception.getErrorCode()
+            );
+            throw exception;
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/application/command/RewardDefinitionCommand.java
+++ b/src/main/java/online/lifeasgame/reward/application/command/RewardDefinitionCommand.java
@@ -1,0 +1,29 @@
+package online.lifeasgame.reward.application.command;
+
+import online.lifeasgame.reward.domain.RewardType;
+
+public final class RewardDefinitionCommand {
+
+    private RewardDefinitionCommand() {
+    }
+
+    public record Create(
+            String code,
+            String name,
+            RewardType rewardType,
+            Long amount,
+            Long itemId,
+            boolean active
+    ) {
+    }
+
+    public record Update(
+            String code,
+            String name,
+            RewardType rewardType,
+            Long amount,
+            Long itemId,
+            boolean active
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/application/result/RewardDefinitionResult.java
+++ b/src/main/java/online/lifeasgame/reward/application/result/RewardDefinitionResult.java
@@ -14,6 +14,7 @@ public final class RewardDefinitionResult {
             String rewardType,
             Long amount,
             Long itemId,
+            String itemCode,
             boolean active
     ) {
         public static Detail from(RewardDefinition definition) {
@@ -24,6 +25,7 @@ public final class RewardDefinitionResult {
                     definition.getRewardType().name(),
                     definition.getAmount(),
                     definition.getItemId(),
+                    definition.getItemCode(),
                     definition.isActive()
             );
         }

--- a/src/main/java/online/lifeasgame/reward/application/result/RewardSettlementItemProcessResult.java
+++ b/src/main/java/online/lifeasgame/reward/application/result/RewardSettlementItemProcessResult.java
@@ -1,0 +1,18 @@
+package online.lifeasgame.reward.application.result;
+
+import online.lifeasgame.reward.domain.RewardSettlementLineStatus;
+import online.lifeasgame.reward.domain.RewardSettlementStatus;
+
+public record RewardSettlementItemProcessResult(
+        Long settlementId,
+        Long lineId,
+        Long playerId,
+        RewardSettlementLineStatus lineStatus,
+        RewardSettlementStatus settlementStatus,
+        Long itemId,
+        String itemCode,
+        long quantity,
+        boolean replayed,
+        Long deliveryId
+) {
+}

--- a/src/main/java/online/lifeasgame/reward/domain/RewardDefinition.java
+++ b/src/main/java/online/lifeasgame/reward/domain/RewardDefinition.java
@@ -43,6 +43,9 @@ public class RewardDefinition extends AbstractTime {
     @Column(name = "item_id")
     private Long itemId;
 
+    @Column(name = "item_code", length = 80)
+    private String itemCode;
+
     @Column(nullable = false)
     private boolean active;
 
@@ -52,28 +55,10 @@ public class RewardDefinition extends AbstractTime {
             RewardType rewardType,
             Long amount,
             Long itemId,
+            String itemCode,
             boolean active
     ) {
-        this.code = normalizeRequired(
-                code,
-                80,
-                RewardError.REWARD_DEFINITION_CODE_REQUIRED,
-                RewardError.REWARD_DEFINITION_CODE_TOO_LONG
-        );
-        this.name = normalizeRequired(
-                name,
-                120,
-                RewardError.REWARD_DEFINITION_NAME_REQUIRED,
-                RewardError.REWARD_DEFINITION_NAME_TOO_LONG
-        );
-        if (rewardType == null) {
-            throw new DomainException(RewardError.REWARD_LINE_TYPE_REQUIRED);
-        }
-        this.rewardType = rewardType;
-        validatePayload(rewardType, amount, itemId);
-        this.amount = amount;
-        this.itemId = itemId;
-        this.active = active;
+        apply(code, name, rewardType, amount, itemId, itemCode, active);
     }
 
     public static RewardDefinition create(
@@ -82,9 +67,60 @@ public class RewardDefinition extends AbstractTime {
             RewardType rewardType,
             Long amount,
             Long itemId,
+            String itemCode,
             boolean active
     ) {
-        return new RewardDefinition(code, name, rewardType, amount, itemId, active);
+        return new RewardDefinition(
+                code, name, rewardType, amount, itemId, itemCode, active
+        );
+    }
+
+    public void update(
+            String code,
+            String name,
+            RewardType rewardType,
+            Long amount,
+            Long itemId,
+            String itemCode,
+            boolean active
+    ) {
+        apply(code, name, rewardType, amount, itemId, itemCode, active);
+    }
+
+    private void apply(
+            String code,
+            String name,
+            RewardType rewardType,
+            Long amount,
+            Long itemId,
+            String itemCode,
+            boolean active
+    ) {
+        String normalizedCode = normalizeRequired(
+                code,
+                80,
+                RewardError.REWARD_DEFINITION_CODE_REQUIRED,
+                RewardError.REWARD_DEFINITION_CODE_TOO_LONG
+        );
+        String normalizedName = normalizeRequired(
+                name,
+                120,
+                RewardError.REWARD_DEFINITION_NAME_REQUIRED,
+                RewardError.REWARD_DEFINITION_NAME_TOO_LONG
+        );
+        if (rewardType == null) {
+            throw new DomainException(RewardError.REWARD_LINE_TYPE_REQUIRED);
+        }
+        String normalizedItemCode = validatePayload(
+                rewardType, amount, itemId, itemCode
+        );
+        this.code = normalizedCode;
+        this.name = normalizedName;
+        this.rewardType = rewardType;
+        this.amount = amount;
+        this.itemId = itemId;
+        this.itemCode = normalizedItemCode;
+        this.active = active;
     }
 
     public void activate() {
@@ -111,7 +147,12 @@ public class RewardDefinition extends AbstractTime {
         return normalized;
     }
 
-    private static void validatePayload(RewardType rewardType, Long amount, Long itemId) {
+    private static String validatePayload(
+            RewardType rewardType,
+            Long amount,
+            Long itemId,
+            String itemCode
+    ) {
         if (rewardType == RewardType.EXP) {
             if (amount == null || amount <= 0) {
                 throw new DomainException(RewardError.REWARD_AMOUNT_MUST_BE_POSITIVE);
@@ -119,7 +160,10 @@ public class RewardDefinition extends AbstractTime {
             if (itemId != null) {
                 throw new DomainException(RewardError.REWARD_EXP_ITEM_ID_NOT_ALLOWED);
             }
-            return;
+            if (itemCode != null) {
+                throw new DomainException(RewardError.REWARD_EXP_ITEM_CODE_NOT_ALLOWED);
+            }
+            return null;
         }
         if (amount == null || amount <= 0) {
             throw new DomainException(RewardError.REWARD_ITEM_QUANTITY_MUST_BE_POSITIVE);
@@ -130,5 +174,11 @@ public class RewardDefinition extends AbstractTime {
         if (itemId <= 0) {
             throw new DomainException(RewardError.REWARD_ITEM_ID_MUST_BE_POSITIVE);
         }
+        return normalizeRequired(
+                itemCode,
+                80,
+                RewardError.REWARD_ITEM_CODE_REQUIRED,
+                RewardError.REWARD_ITEM_CODE_TOO_LONG
+        );
     }
 }

--- a/src/main/java/online/lifeasgame/reward/domain/RewardSettlement.java
+++ b/src/main/java/online/lifeasgame/reward/domain/RewardSettlement.java
@@ -107,6 +107,11 @@ public class RewardSettlement extends AbstractTime {
         recalculateStatus();
     }
 
+    public void markItemLineSucceeded(Long lineId) {
+        findLineById(lineId).succeedItem();
+        recalculateStatus();
+    }
+
     public void markLineFailed(int sortOrder, ErrorCode errorCode) {
         findLine(sortOrder).fail(errorCode);
         recalculateStatus();

--- a/src/main/java/online/lifeasgame/reward/domain/RewardSettlementLine.java
+++ b/src/main/java/online/lifeasgame/reward/domain/RewardSettlementLine.java
@@ -56,6 +56,9 @@ public class RewardSettlementLine extends AbstractTime {
     @Column(name = "item_id")
     private Long itemId;
 
+    @Column(name = "item_code", length = 80)
+    private String itemCode;
+
     @Column(name = "sort_order", nullable = false)
     private int sortOrder;
 
@@ -81,6 +84,7 @@ public class RewardSettlementLine extends AbstractTime {
         this.rewardType = definition.getRewardType();
         this.amount = amount;
         this.itemId = definition.getItemId();
+        this.itemCode = definition.getItemCode();
         this.sortOrder = sortOrder;
         this.status = RewardSettlementLineStatus.PENDING;
     }
@@ -113,12 +117,30 @@ public class RewardSettlementLine extends AbstractTime {
         succeed();
     }
 
+    void succeedItem() {
+        assertItemSnapshot();
+        succeed();
+    }
+
     public boolean isExpProcessingRequired() {
         assertExp();
         if (status == RewardSettlementLineStatus.FAILED) {
             throw new DomainException(RewardError.REWARD_SETTLEMENT_LINE_ALREADY_FAILED);
         }
         return status == RewardSettlementLineStatus.PENDING;
+    }
+
+    public boolean isItemProcessingRequired() {
+        assertItemSnapshot();
+        if (status == RewardSettlementLineStatus.FAILED) {
+            throw new DomainException(RewardError.REWARD_SETTLEMENT_LINE_ALREADY_FAILED);
+        }
+        return status == RewardSettlementLineStatus.PENDING;
+    }
+
+    public boolean isItemSucceeded() {
+        assertItemSnapshot();
+        return status == RewardSettlementLineStatus.SUCCEEDED;
     }
 
     boolean isPending() {
@@ -156,6 +178,21 @@ public class RewardSettlementLine extends AbstractTime {
     private void assertExp() {
         if (rewardType != RewardType.EXP) {
             throw new DomainException(RewardError.REWARD_SETTLEMENT_LINE_NOT_EXP);
+        }
+    }
+
+    private void assertItemSnapshot() {
+        if (rewardType != RewardType.ITEM) {
+            throw new DomainException(RewardError.REWARD_SETTLEMENT_LINE_NOT_ITEM);
+        }
+        if (itemId == null || itemId <= 0) {
+            throw new DomainException(RewardError.REWARD_ITEM_ID_REQUIRED);
+        }
+        if (itemCode == null || itemCode.isBlank()) {
+            throw new DomainException(RewardError.REWARD_ITEM_CODE_REQUIRED);
+        }
+        if (itemCode.length() > 80) {
+            throw new DomainException(RewardError.REWARD_ITEM_CODE_TOO_LONG);
         }
     }
 

--- a/src/main/java/online/lifeasgame/reward/domain/error/RewardError.java
+++ b/src/main/java/online/lifeasgame/reward/domain/error/RewardError.java
@@ -46,11 +46,23 @@ public enum RewardError implements ErrorCode {
     REWARD_EXP_ITEM_ID_NOT_ALLOWED(
             "RWD-400-EXP-ITEM-ID-NOT-ALLOWED", "EXP reward must not have an item id", 400
     ),
+    REWARD_EXP_ITEM_CODE_NOT_ALLOWED(
+            "RWD-400-EXP-ITEM-CODE-NOT-ALLOWED", "EXP reward must not have an item code", 400
+    ),
     REWARD_ITEM_ID_REQUIRED(
             "RWD-400-ITEM-ID-REQUIRED", "Item reward requires an item id", 400
     ),
     REWARD_ITEM_ID_MUST_BE_POSITIVE(
             "RWD-400-ITEM-ID-NOT-POSITIVE", "Reward item id must be positive", 400
+    ),
+    REWARD_ITEM_CODE_REQUIRED(
+            "RWD-400-ITEM-CODE-REQUIRED", "Item reward requires an item code", 400
+    ),
+    REWARD_ITEM_CODE_TOO_LONG(
+            "RWD-400-ITEM-CODE-TOO-LONG", "Reward item code is too long", 400
+    ),
+    REWARD_ITEM_REFERENCE_INCONSISTENT(
+            "RWD-409-ITEM-REFERENCE-INCONSISTENT", "Resolved item reference is inconsistent", 409
     ),
     REWARD_ITEM_QUANTITY_MUST_BE_POSITIVE(
             "RWD-400-ITEM-QUANTITY-NOT-POSITIVE", "Item reward quantity must be positive", 400
@@ -102,6 +114,9 @@ public enum RewardError implements ErrorCode {
     REWARD_SETTLEMENT_LINE_NOT_EXP(
             "RWD-409-SETTLEMENT-LINE-NOT-EXP", "Reward settlement line is not an EXP reward", 409
     ),
+    REWARD_SETTLEMENT_LINE_NOT_ITEM(
+            "RWD-409-SETTLEMENT-LINE-NOT-ITEM", "Reward settlement line is not an ITEM reward", 409
+    ),
     REWARD_SETTLEMENT_LINE_ALREADY_FAILED(
             "RWD-409-SETTLEMENT-LINE-ALREADY-FAILED", "Failed reward settlement line cannot succeed", 409
     ),
@@ -116,6 +131,11 @@ public enum RewardError implements ErrorCode {
     ),
     REWARD_SETTLEMENT_EXP_GROWTH_INCONSISTENT(
             "RWD-409-SETTLEMENT-EXP-GROWTH-INCONSISTENT", "EXP line and player growth change are inconsistent", 409
+    ),
+    REWARD_SETTLEMENT_ITEM_DELIVERY_INCONSISTENT(
+            "RWD-409-SETTLEMENT-ITEM-DELIVERY-INCONSISTENT",
+            "ITEM line and inventory delivery receipt are inconsistent",
+            409
     );
 
     private final String code;

--- a/src/main/java/online/lifeasgame/reward/domain/repository/RewardDefinitionRepository.java
+++ b/src/main/java/online/lifeasgame/reward/domain/repository/RewardDefinitionRepository.java
@@ -8,5 +8,7 @@ public interface RewardDefinitionRepository {
 
     RewardDefinition save(RewardDefinition rewardDefinition);
 
+    Optional<RewardDefinition> findById(Long id);
+
     Optional<RewardDefinition> findByCode(String code);
 }

--- a/src/main/java/online/lifeasgame/reward/infra/RewardDefinitionRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/reward/infra/RewardDefinitionRepositoryAdapter.java
@@ -19,6 +19,11 @@ public class RewardDefinitionRepositoryAdapter implements RewardDefinitionReposi
     }
 
     @Override
+    public Optional<RewardDefinition> findById(Long id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
     public Optional<RewardDefinition> findByCode(String code) {
         return jpaRepository.findByCode(code);
     }

--- a/src/main/resources/db/migration/V18__reward_item_code_snapshot.sql
+++ b/src/main/resources/db/migration/V18__reward_item_code_snapshot.sql
@@ -1,0 +1,50 @@
+ALTER TABLE reward_definitions
+    ADD COLUMN item_code VARCHAR(80) NULL AFTER item_id;
+
+UPDATE reward_definitions definition
+JOIN items item ON item.id = definition.item_id
+SET definition.item_code = item.code
+WHERE definition.reward_type = 'ITEM';
+
+ALTER TABLE reward_definitions
+    DROP CHECK ck_reward_definition_payload,
+    ADD CONSTRAINT ck_reward_definition_payload CHECK (
+        (
+            reward_type = 'EXP'
+            AND amount IS NOT NULL
+            AND amount > 0
+            AND item_id IS NULL
+            AND item_code IS NULL
+        )
+        OR (
+            reward_type = 'ITEM'
+            AND amount IS NOT NULL
+            AND amount > 0
+            AND item_id IS NOT NULL
+            AND item_id > 0
+            AND item_code IS NOT NULL
+            AND CHAR_LENGTH(TRIM(item_code)) BETWEEN 1 AND 80
+        )
+    );
+
+ALTER TABLE reward_settlement_lines
+    ADD COLUMN item_code VARCHAR(80) NULL AFTER item_id;
+
+UPDATE reward_settlement_lines line
+JOIN reward_definitions definition
+    ON definition.id = line.reward_definition_id
+SET line.item_code = definition.item_code
+WHERE line.reward_type = 'ITEM';
+
+ALTER TABLE reward_settlement_lines
+    DROP CHECK ck_reward_settlement_line_payload,
+    ADD CONSTRAINT ck_reward_settlement_line_payload CHECK (
+        (reward_type = 'EXP' AND item_id IS NULL AND item_code IS NULL)
+        OR (
+            reward_type = 'ITEM'
+            AND item_id IS NOT NULL
+            AND item_id > 0
+            AND item_code IS NOT NULL
+            AND CHAR_LENGTH(TRIM(item_code)) BETWEEN 1 AND 80
+        )
+    );

--- a/src/test/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryIntegrationTest.java
@@ -98,7 +98,7 @@ class InventoryRewardDeliveryIntegrationTest {
     @DisplayName("V17 receipt table은 JPA validate와 unique/check/index 계약을 만족한다")
     void validatesMigrationContract() {
         assertThat(flyway.info().current().getVersion().getVersion())
-                .isEqualTo("17");
+                .isEqualTo("18");
         assertThat(environment.getProperty("spring.jpa.hibernate.ddl-auto"))
                 .isEqualTo("validate");
 
@@ -151,6 +151,35 @@ class InventoryRewardDeliveryIntegrationTest {
         assertThat(mailboxTotalQuantity(PLAYER_ID)).isEqualTo(2L);
         assertThat(mailboxEntryBound(PLAYER_ID)).isTrue();
         assertThat(mailboxEntryAttrs(PLAYER_ID)).isEqualTo("{}");
+
+        InventoryRewardDeliveryApi.RewardDeliveryReceipt receipt =
+                deliveryApi.findRewardDelivery(2241001L).orElseThrow();
+        assertThat(receipt.deliveryId()).isEqualTo(result.deliveryId());
+        assertThat(receipt.rewardLineId()).isEqualTo(2241001L);
+        assertThat(receipt.playerId()).isEqualTo(PLAYER_ID);
+        assertThat(receipt.itemId()).isEqualTo(result.itemId());
+        assertThat(receipt.itemCode()).isEqualTo(ITEM_CODE);
+        assertThat(receipt.quantity()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("receipt 조회 miss는 container, Mailbox, Catalog를 변경하지 않는다")
+    void findsMissingReceiptWithoutMutation() {
+        assertThat(deliveryApi.findRewardDelivery(2241099L)).isEmpty();
+
+        assertThat(receiptCountAll()).isZero();
+        assertThat(containerCount("player_inventory", PLAYER_ID)).isZero();
+        assertThat(containerCount("player_mailbox", PLAYER_ID)).isZero();
+        assertThat(mailboxEntryCount(PLAYER_ID)).isZero();
+    }
+
+    @Test
+    @DisplayName("receipt 조회도 rewardLineId 양수 경계를 검증한다")
+    void validatesReceiptLookupRewardLineId() {
+        assertError(
+                () -> deliveryApi.findRewardDelivery(0L),
+                InventoryError.REWARD_LINE_ID_INVALID
+        );
     }
 
     @Test

--- a/src/test/java/online/lifeasgame/inventory/application/ItemLookupIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/inventory/application/ItemLookupIntegrationTest.java
@@ -48,6 +48,9 @@ class ItemLookupIntegrationTest {
 
         assertThat(reference.id()).isPositive();
         assertThat(reference.code()).isEqualTo("IT_FIRST_STEP_FRAGMENT");
+
+        ItemLookupApi.ItemReference byId = itemLookupApi.getById(reference.id());
+        assertThat(byId).isEqualTo(reference);
     }
 
     @Test

--- a/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
@@ -63,7 +63,7 @@ class FlywayExplicitBaselineTest {
     class ApplyExplicitBaseline {
 
         @Test
-        @DisplayName("V1을 재실행하지 않고 V2부터 V17까지 적용한 뒤 JPA validate를 통과한다")
+        @DisplayName("V1을 재실행하지 않고 V2부터 V18까지 적용한 뒤 JPA validate를 통과한다")
         void migratesFromVersionTwoAndValidatesJpa() throws Exception {
             String jdbcUrl = createV1EquivalentDatabase();
             Flyway flyway = migrationFlyway(jdbcUrl);
@@ -72,12 +72,12 @@ class FlywayExplicitBaselineTest {
             MigrateResult migrateResult = flyway.migrate();
             List<HistoryRow> history = successfulHistory(jdbcUrl);
 
-            assertThat(migrateResult.migrationsExecuted).isEqualTo(16);
+            assertThat(migrateResult.migrationsExecuted).isEqualTo(17);
             assertThat(history).extracting(HistoryRow::version)
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
-                            "14", "15", "16", "17"
+                            "14", "15", "16", "17", "18"
                     );
             assertThat(history.getFirst().type()).isEqualTo("BASELINE");
             assertThat(history.getFirst().script())
@@ -104,7 +104,8 @@ class FlywayExplicitBaselineTest {
                             "V14__final_quest_legacy_category_nullable.sql",
                             "V15__canonical_lifelog_record_metadata.sql",
                             "V16__quest_acceptance_fact_context.sql",
-                            "V17__inventory_reward_delivery_foundation.sql"
+                            "V17__inventory_reward_delivery_foundation.sql",
+                            "V18__reward_item_code_snapshot.sql"
                     );
             assertThat(history.subList(1, history.size()))
                     .allSatisfy(row -> assertThat(row.checksum()).isNotNull());
@@ -124,7 +125,7 @@ class FlywayExplicitBaselineTest {
                         "spring.jpa.hibernate.ddl-auto"
                 )).isEqualTo("validate");
                 assertThat(context.getBean(Flyway.class).info().current().getVersion().getVersion())
-                        .isEqualTo("17");
+                        .isEqualTo("18");
             }
         }
     }

--- a/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
@@ -33,10 +33,10 @@ class FlywayHistoryChecksumTest {
     class MigrateAgain {
 
         @Test
-        @DisplayName("V1~V16 checksum을 보존하고 V17 이후 두 번째 실행은 no-op이다")
+        @DisplayName("V1~V17 checksum을 보존하고 V18 이후 두 번째 실행은 no-op이다")
         void keepsMigrationHistory() throws Exception {
-            Flyway throughV16 = flyway(MigrationVersion.fromVersion("16"));
-            MigrateResult legacy = throughV16.migrate();
+            Flyway throughV17 = flyway(MigrationVersion.fromVersion("17"));
+            MigrateResult legacy = throughV17.migrate();
             List<HistoryRow> legacyHistory = successfulHistory();
             Flyway flyway = flyway(null);
 
@@ -46,7 +46,7 @@ class FlywayHistoryChecksumTest {
             MigrateResult second = flyway.migrate();
             List<HistoryRow> secondHistory = successfulHistory();
 
-            assertThat(legacy.migrationsExecuted).isEqualTo(16);
+            assertThat(legacy.migrationsExecuted).isEqualTo(17);
             assertThat(first.migrationsExecuted).isEqualTo(1);
             assertThat(second.migrationsExecuted).isZero();
             assertThat(secondHistory).isEqualTo(firstHistory);
@@ -56,7 +56,7 @@ class FlywayHistoryChecksumTest {
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
-                            "14", "15", "16", "17"
+                            "14", "15", "16", "17", "18"
                     );
             assertThat(secondHistory).allSatisfy(history -> {
                 assertThat(history.checksum()).isNotNull();

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -39,7 +39,7 @@ class FlywayMigrationTest {
     class MigrateCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V17까지 적용되고 Inventory reward delivery 기반을 추가한다")
+        @DisplayName("V1부터 V18까지 적용되고 Reward ITEM code snapshot을 추가한다")
         void migratesSchemaAndSeedsRewardProfiles() throws Exception {
             Flyway throughV10 = flyway(MigrationVersion.fromVersion("10"));
             MigrateResult legacyResult = throughV10.migrate();
@@ -58,12 +58,12 @@ class FlywayMigrationTest {
             assertThat(legacyResult.migrationsExecuted).isEqualTo(10);
             assertThat(semanticResult.migrationsExecuted).isEqualTo(1);
             assertThat(itemResult.migrationsExecuted).isEqualTo(1);
-            assertThat(result.migrationsExecuted).isEqualTo(5);
+            assertThat(result.migrationsExecuted).isEqualTo(6);
             assertThat(appliedVersions())
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
-                            "14", "15", "16", "17"
+                            "14", "15", "16", "17", "18"
                     );
             assertThat(existingTables(
                     "users",

--- a/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
@@ -149,7 +149,7 @@ class FlywayProfileCutoverTest {
     class StartLocalWithCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V17까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
+        @DisplayName("V1부터 V18까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
         void migratesThenValidates() {
             ConfigurableEnvironment environment =
                     (ConfigurableEnvironment) applicationContext.getEnvironment();
@@ -161,8 +161,8 @@ class FlywayProfileCutoverTest {
             assertThat(environment.getProperty(
                     "spring.flyway.baseline-on-migrate", Boolean.class
             )).isFalse();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("17");
-            assertThat(appliedMigrationCount()).isEqualTo(17);
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("18");
+            assertThat(appliedMigrationCount()).isEqualTo(18);
         }
     }
 

--- a/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 @SpringBootTest
 @ActiveProfiles({"test", "migration-test"})
-@DisplayName("V17 migration 이후 JPA schema validation")
+@DisplayName("V18 migration 이후 JPA schema validation")
 class JpaValidateAfterMigrationTest {
 
     @Container
@@ -79,14 +79,14 @@ class JpaValidateAfterMigrationTest {
     private QuestDefinitionBootstrapper questDefinitionBootstrapper;
 
     @Nested
-    @DisplayName("V1부터 V17까지 적용된 schema로 ApplicationContext를 기동할 때")
+    @DisplayName("V1부터 V18까지 적용된 schema로 ApplicationContext를 기동할 때")
     class LoadApplicationContext {
 
         @Test
         @DisplayName("ddl-auto validate 상태로 정상 기동한다")
         void loadsWithJpaValidation() {
             assertThat(applicationContext).isNotNull();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("17");
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("18");
             assertThat(applicationContext.getEnvironment().getProperty("spring.jpa.hibernate.ddl-auto"))
                     .isEqualTo("validate");
             assertThat(applicationContext.getEnvironment()

--- a/src/test/java/online/lifeasgame/migration/RewardItemCodeSnapshotFlywayTest.java
+++ b/src/test/java/online/lifeasgame/migration/RewardItemCodeSnapshotFlywayTest.java
@@ -1,0 +1,166 @@
+package online.lifeasgame.migration;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+@DisplayName("V18 Reward ITEM code snapshot migration")
+class RewardItemCodeSnapshotFlywayTest {
+
+    @Container
+    private static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0.39")
+            .withDatabaseName("lifeasgame_reward_item_snapshot")
+            .withUsername("lifeasgame")
+            .withPassword("lifeasgame");
+
+    @Test
+    @DisplayName("V17 ITEM rows를 Catalog code로 backfill하고 EXP/ITEM payload CHECK를 적용한다")
+    void backfillsExistingItemRowsAndAddsChecks() {
+        Flyway throughV17 = flyway(MigrationVersion.fromVersion("17"));
+        throughV17.migrate();
+        JdbcTemplate jdbc = jdbc();
+        insertLegacySettlement(jdbc);
+
+        Flyway flyway = flyway(null);
+        flyway.migrate();
+
+        assertThat(flyway.info().current().getVersion().getVersion())
+                .isEqualTo("18");
+        assertThat(jdbc.queryForObject("""
+                SELECT item_code
+                FROM reward_definitions
+                WHERE code = 'RD_ITEM_FIRST_STEP_FRAGMENT_1'
+                """, String.class)).isEqualTo("IT_FIRST_STEP_FRAGMENT");
+        assertThat(jdbc.queryForObject("""
+                SELECT item_code
+                FROM reward_settlement_lines
+                WHERE reward_type = 'ITEM'
+                """, String.class)).isEqualTo("IT_FIRST_STEP_FRAGMENT");
+        assertThat(jdbc.queryForObject("""
+                SELECT COUNT(*)
+                FROM reward_definitions
+                WHERE reward_type = 'EXP' AND item_code IS NOT NULL
+                """, Integer.class)).isZero();
+        assertThat(jdbc.queryForObject("""
+                SELECT COUNT(*)
+                FROM reward_settlement_lines
+                WHERE reward_type = 'EXP' AND item_code IS NOT NULL
+                """, Integer.class)).isZero();
+
+        Set<String> checks = Set.copyOf(jdbc.queryForList("""
+                SELECT constraint_name
+                FROM information_schema.table_constraints
+                WHERE table_schema = DATABASE()
+                  AND constraint_type = 'CHECK'
+                  AND table_name IN (
+                      'reward_definitions', 'reward_settlement_lines'
+                  )
+                """, String.class));
+        assertThat(checks).contains(
+                "ck_reward_definition_payload",
+                "ck_reward_settlement_line_payload"
+        );
+
+        assertThatThrownBy(() -> jdbc.update("""
+                UPDATE reward_definitions
+                SET item_code = NULL
+                WHERE code = 'RD_ITEM_FIRST_STEP_FRAGMENT_1'
+                """)).isInstanceOf(RuntimeException.class);
+        assertThatThrownBy(() -> jdbc.update("""
+                UPDATE reward_settlement_lines
+                SET item_code = ' '
+                WHERE reward_type = 'ITEM'
+                """)).isInstanceOf(RuntimeException.class);
+    }
+
+    private void insertLegacySettlement(JdbcTemplate jdbc) {
+        jdbc.update("""
+                INSERT INTO reward_settlements (
+                    player_id, source_type, source_id,
+                    reward_profile_id, reward_profile_code, status,
+                    created_at, updated_at
+                )
+                SELECT
+                    226001, 'QUEST_COMPLETION', 226101,
+                    profile.id, profile.code, 'PENDING',
+                    CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
+                FROM reward_profiles profile
+                WHERE profile.code = 'RP_EXP_AND_ITEM_FIRST_STEP_20'
+                """);
+        insertLegacyLine(jdbc, "RD_EXP_20", 0);
+        insertLegacyLine(jdbc, "RD_ITEM_FIRST_STEP_FRAGMENT_1", 1);
+    }
+
+    private void insertLegacyLine(
+            JdbcTemplate jdbc,
+            String definitionCode,
+            int sortOrder
+    ) {
+        jdbc.update("""
+                INSERT INTO reward_settlement_lines (
+                    reward_settlement_id,
+                    reward_definition_id,
+                    reward_definition_code,
+                    reward_type,
+                    amount,
+                    item_id,
+                    sort_order,
+                    status,
+                    failure_code,
+                    created_at,
+                    updated_at
+                )
+                SELECT
+                    settlement.id,
+                    definition.id,
+                    definition.code,
+                    definition.reward_type,
+                    definition.amount,
+                    definition.item_id,
+                    ?,
+                    'PENDING',
+                    NULL,
+                    CURRENT_TIMESTAMP(6),
+                    CURRENT_TIMESTAMP(6)
+                FROM reward_settlements settlement
+                JOIN reward_definitions definition
+                  ON definition.code = ?
+                WHERE settlement.source_id = 226101
+                """, sortOrder, definitionCode);
+    }
+
+    private Flyway flyway(MigrationVersion target) {
+        var configuration = Flyway.configure()
+                .dataSource(
+                        MYSQL.getJdbcUrl(),
+                        MYSQL.getUsername(),
+                        MYSQL.getPassword()
+                )
+                .locations("classpath:db/migration")
+                .baselineOnMigrate(false);
+        if (target != null) {
+            configuration.target(target);
+        }
+        return configuration.load();
+    }
+
+    private JdbcTemplate jdbc() {
+        return new JdbcTemplate(new DriverManagerDataSource(
+                MYSQL.getJdbcUrl(),
+                MYSQL.getUsername(),
+                MYSQL.getPassword()
+        ));
+    }
+}

--- a/src/test/java/online/lifeasgame/quest/application/automation/QuestSignalProcessingAttemptTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/automation/QuestSignalProcessingAttemptTest.java
@@ -26,7 +26,6 @@ import java.time.Duration;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
@@ -562,8 +561,10 @@ class QuestSignalProcessingAttemptTest {
         @Test
         @DisplayName("새 기간 Acceptance를 만들고 AUTO 완료 흐름을 유지한다")
         void createsNextAcceptance() {
-            Instant now = Instant.now();
-            LocalDate eventDate = now.atZone(ZoneId.systemDefault())
+            Instant now = Instant.parse("2026-08-03T16:07:00Z");
+            LocalDate eventDate = now.atZone(
+                            DefaultPlayerTimezoneResolver.FALLBACK
+                    )
                     .toLocalDate();
             Quest quest = quest(
                     QuestCompletionPolicy.AUTO,

--- a/src/test/java/online/lifeasgame/reward/application/QuestCompletionItemRewardIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/QuestCompletionItemRewardIntegrationTest.java
@@ -1,0 +1,245 @@
+package online.lifeasgame.reward.application;
+
+import online.lifeasgame.inventory.application.internal.InventoryRewardDeliveryApi;
+import online.lifeasgame.quest.domain.event.QuestEvent;
+import online.lifeasgame.quest.domain.event.QuestEventType;
+import online.lifeasgame.reward.application.event.QuestRewardReadyBridge;
+import online.lifeasgame.reward.domain.RewardSettlementLineStatus;
+import online.lifeasgame.reward.domain.RewardSettlementStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles({"test", "migration-test"})
+@DisplayName("QuestCompletion ITEM Reward closed loop MySQL 통합")
+class QuestCompletionItemRewardIntegrationTest {
+
+    private static final long PLAYER_ID = 226201L;
+
+    @Container
+    private static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0.39")
+            .withDatabaseName("lifeasgame_quest_item_reward")
+            .withUsername("lifeasgame")
+            .withPassword("lifeasgame");
+
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", MYSQL::getDriverClassName);
+    }
+
+    @Autowired
+    private QuestRewardReadyBridge bridge;
+
+    @MockitoSpyBean
+    private InventoryRewardDeliveryApi inventoryDeliveryApi;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private ExecutorService executor;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.update("DELETE FROM outbox_events");
+        jdbcTemplate.update("DELETE FROM player_growth_changes");
+        jdbcTemplate.update("DELETE FROM inventory_reward_deliveries");
+        jdbcTemplate.update("DELETE FROM inventory_entries");
+        jdbcTemplate.update("DELETE FROM mailbox_entries");
+        jdbcTemplate.update("DELETE FROM player_inventory");
+        jdbcTemplate.update("DELETE FROM player_mailbox");
+        jdbcTemplate.update("DELETE FROM reward_settlement_lines");
+        jdbcTemplate.update("DELETE FROM reward_settlements");
+        jdbcTemplate.update("DELETE FROM player WHERE id = ?", PLAYER_ID);
+        insertPlayer();
+        clearInvocations(inventoryDeliveryApi);
+        executor = Executors.newFixedThreadPool(2);
+    }
+
+    @AfterEach
+    void tearDown() throws InterruptedException {
+        executor.shutdownNow();
+        assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    @DisplayName("동시·순차·restart redelivery에도 EXP/ITEM/receipt를 각각 한 번만 반영한다")
+    void completesMixedProfileExactlyOnceAcrossReplays() throws Exception {
+        QuestEvent event = rewardReady();
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<?>> futures = List.of(
+                submit(event, ready, start),
+                submit(event, ready, start)
+        );
+        assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+        start.countDown();
+        for (Future<?> future : futures) {
+            future.get(
+                    Duration.ofSeconds(30).toMillis(),
+                    TimeUnit.MILLISECONDS
+            );
+        }
+
+        clearInvocations(inventoryDeliveryApi);
+        bridge.onQuestEvent(event);
+
+        assertThat(settlementCount()).isEqualTo(1);
+        assertThat(lineCount()).isEqualTo(2);
+        assertThat(lineStatus("EXP"))
+                .isEqualTo(RewardSettlementLineStatus.SUCCEEDED.name());
+        assertThat(lineStatus("ITEM"))
+                .isEqualTo(RewardSettlementLineStatus.SUCCEEDED.name());
+        assertThat(settlementStatus())
+                .isEqualTo(RewardSettlementStatus.COMPLETED.name());
+        assertThat(playerExp()).isEqualTo(20L);
+        assertThat(growthChangeCount()).isEqualTo(1);
+        assertThat(mailboxQuantity()).isEqualTo(1L);
+        assertThat(receiptCount()).isEqualTo(1);
+        verify(inventoryDeliveryApi, never()).deliverReward(
+                anyLong(), anyLong(),
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyLong()
+        );
+        verify(inventoryDeliveryApi).findRewardDelivery(anyLong());
+    }
+
+    private Future<?> submit(
+            QuestEvent event,
+            CountDownLatch ready,
+            CountDownLatch start
+    ) {
+        return executor.submit(() -> {
+            ready.countDown();
+            start.await();
+            bridge.onQuestEvent(event);
+            return null;
+        });
+    }
+
+    private QuestEvent rewardReady() {
+        return new QuestEvent(
+                QuestEventType.QUEST_REWARD_READY,
+                PLAYER_ID,
+                2262L,
+                "Q_RECORD_THREE_TRACES",
+                Map.of(
+                        "acceptanceId", 226301L,
+                        "rewardProfileCode",
+                        "RP_EXP_AND_ITEM_FIRST_STEP_20",
+                        "questDefinitionVersion", 1,
+                        "questSemanticCategory", "GROWTH",
+                        "progressSource", "COUNT",
+                        "repeatPolicy", "ONCE"
+                ),
+                Instant.parse("2026-08-03T12:00:00Z"),
+                "quest:2262:acceptance:226301:completed:reward"
+        );
+    }
+
+    private void insertPlayer() {
+        jdbcTemplate.update("""
+                INSERT INTO player (
+                    id, user_id, name, gender, level, exp,
+                    hp_cur, hp_cap, mp_cur, mp_cap,
+                    str_stat, agi_stat, dex_stat, int_stat, vit_stat, luc_stat,
+                    extra_stats, status_effects, version, created_at, updated_at
+                ) VALUES (
+                    ?, ?, 'ITEM Reward Tester', 'male', 1, 0,
+                    100, 100, 50, 50,
+                    1, 1, 1, 1, 1, 1,
+                    JSON_OBJECT(), '[]', 0,
+                    CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
+                )
+                """, PLAYER_ID, PLAYER_ID + 100000L);
+    }
+
+    private int settlementCount() {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM reward_settlements",
+                Integer.class
+        );
+    }
+
+    private int lineCount() {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM reward_settlement_lines",
+                Integer.class
+        );
+    }
+
+    private String lineStatus(String rewardType) {
+        return jdbcTemplate.queryForObject("""
+                SELECT status
+                FROM reward_settlement_lines
+                WHERE reward_type = ?
+                """, String.class, rewardType);
+    }
+
+    private String settlementStatus() {
+        return jdbcTemplate.queryForObject(
+                "SELECT status FROM reward_settlements",
+                String.class
+        );
+    }
+
+    private long playerExp() {
+        return jdbcTemplate.queryForObject(
+                "SELECT exp FROM player WHERE id = ?",
+                Long.class,
+                PLAYER_ID
+        );
+    }
+
+    private int growthChangeCount() {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM player_growth_changes",
+                Integer.class
+        );
+    }
+
+    private long mailboxQuantity() {
+        return jdbcTemplate.queryForObject(
+                "SELECT COALESCE(SUM(quantity), 0) FROM mailbox_entries",
+                Long.class
+        );
+    }
+
+    private int receiptCount() {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM inventory_reward_deliveries",
+                Integer.class
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/reward/application/QuestCompletionRewardServiceTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/QuestCompletionRewardServiceTest.java
@@ -2,6 +2,7 @@ package online.lifeasgame.reward.application;
 
 import online.lifeasgame.character.domain.error.PlayerError;
 import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.inventory.domain.error.InventoryError;
 import online.lifeasgame.reward.application.event.QuestRewardReadyFact;
 import online.lifeasgame.reward.domain.*;
 import online.lifeasgame.reward.domain.error.RewardError;
@@ -24,6 +25,7 @@ class QuestCompletionRewardServiceTest {
     private RewardSettlementCreateService createService;
     private RewardSettlementReader settlementReader;
     private RewardSettlementExpProcessService expProcessService;
+    private RewardSettlementItemProcessService itemProcessService;
     private QuestCompletionRewardService service;
 
     @BeforeEach
@@ -32,10 +34,12 @@ class QuestCompletionRewardServiceTest {
         settlementReader = mock(RewardSettlementReader.class);
         expProcessService =
                 mock(RewardSettlementExpProcessService.class);
+        itemProcessService = mock(RewardSettlementItemProcessService.class);
         service = new QuestCompletionRewardService(
                 createService,
                 settlementReader,
-                expProcessService
+                expProcessService,
+                itemProcessService
         );
     }
 
@@ -72,6 +76,7 @@ class QuestCompletionRewardServiceTest {
 
         verify(expProcessService).process(700L, 701L);
         verify(expProcessService, never()).process(700L, 702L);
+        verify(itemProcessService).process(700L, 702L);
         verifyNoInteractions(settlementReader);
     }
 
@@ -82,7 +87,9 @@ class QuestCompletionRewardServiceTest {
 
         service.process(fact("RP_NONE"));
 
-        verifyNoInteractions(settlementReader, expProcessService);
+        verifyNoInteractions(
+                settlementReader, expProcessService, itemProcessService
+        );
     }
 
     @Test
@@ -102,7 +109,9 @@ class QuestCompletionRewardServiceTest {
 
         service.process(fact("RP_EXP_30"));
 
-        verifyNoInteractions(settlementReader, expProcessService);
+        verifyNoInteractions(
+                settlementReader, expProcessService, itemProcessService
+        );
     }
 
     @Test
@@ -144,6 +153,64 @@ class QuestCompletionRewardServiceTest {
         verify(settlementReader)
                 .getByIdInNewTransactionOrThrow(720L);
         verify(expProcessService).process(720L, 722L);
+    }
+
+    @Test
+    @DisplayName("ITEM DomainException 후 fresh FAILED를 확인하면 Event 처리를 완료한다")
+    void consumesDurableItemFailure() {
+        RewardSettlementLine item = line(
+                726L,
+                RewardType.ITEM,
+                RewardSettlementLineStatus.PENDING,
+                null
+        );
+        stubCreated(settlement(
+                725L,
+                "RP_EXP_AND_ITEM_FIRST_STEP_20",
+                List.of(item)
+        ));
+        doThrow(new DomainException(InventoryError.MAILBOX_FULL))
+                .when(itemProcessService).process(725L, 726L);
+        RewardSettlement fresh = mock(RewardSettlement.class);
+        RewardSettlementLine failed = line(
+                726L,
+                RewardType.ITEM,
+                RewardSettlementLineStatus.FAILED,
+                InventoryError.MAILBOX_FULL.code()
+        );
+        when(fresh.getLineByIdOrThrow(726L)).thenReturn(failed);
+        when(settlementReader.getByIdInNewTransactionOrThrow(725L))
+                .thenReturn(fresh);
+
+        service.process(fact("RP_EXP_AND_ITEM_FIRST_STEP_20"));
+
+        verify(settlementReader)
+                .getByIdInNewTransactionOrThrow(725L);
+        verify(itemProcessService).process(725L, 726L);
+    }
+
+    @Test
+    @DisplayName("ITEM system failure는 fresh 조회 없이 Outbox retry로 전파한다")
+    void propagatesUnexpectedItemFailure() {
+        RewardSettlementLine item = line(
+                756L,
+                RewardType.ITEM,
+                RewardSettlementLineStatus.PENDING,
+                null
+        );
+        stubCreated(settlement(
+                755L,
+                "RP_EXP_AND_ITEM_FIRST_STEP_20",
+                List.of(item)
+        ));
+        doThrow(new IllegalStateException("item system"))
+                .when(itemProcessService).process(755L, 756L);
+
+        assertThatThrownBy(() -> service.process(fact(
+                "RP_EXP_AND_ITEM_FIRST_STEP_20"
+        ))).isInstanceOf(IllegalStateException.class)
+                .hasMessage("item system");
+        verifyNoInteractions(settlementReader);
     }
 
     @ParameterizedTest
@@ -265,7 +332,9 @@ class QuestCompletionRewardServiceTest {
                                                 .REWARD_SETTLEMENT_SOURCE_PROFILE_CONFLICT
                                 )
                 );
-        verifyNoInteractions(settlementReader, expProcessService);
+        verifyNoInteractions(
+                settlementReader, expProcessService, itemProcessService
+        );
     }
 
     private void stubCreated(RewardSettlement settlement) {

--- a/src/test/java/online/lifeasgame/reward/application/QuestCompletionRewardTransactionalOutboxIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/QuestCompletionRewardTransactionalOutboxIntegrationTest.java
@@ -136,6 +136,9 @@ class QuestCompletionRewardTransactionalOutboxIntegrationTest {
     @MockitoSpyBean
     private RewardSettlementExpProcessService expProcessService;
 
+    @MockitoSpyBean
+    private RewardSettlementItemProcessService itemProcessService;
+
     private TransactionTemplate transactionTemplate;
     private ExecutorService executor;
 
@@ -144,6 +147,11 @@ class QuestCompletionRewardTransactionalOutboxIntegrationTest {
         clock.set(ACCEPTED_AT);
         jdbcTemplate.update("DELETE FROM outbox_events");
         jdbcTemplate.update("DELETE FROM player_growth_changes");
+        jdbcTemplate.update("DELETE FROM inventory_reward_deliveries");
+        jdbcTemplate.update("DELETE FROM inventory_entries");
+        jdbcTemplate.update("DELETE FROM mailbox_entries");
+        jdbcTemplate.update("DELETE FROM player_inventory");
+        jdbcTemplate.update("DELETE FROM player_mailbox");
         jdbcTemplate.update("DELETE FROM reward_settlement_lines");
         jdbcTemplate.update("DELETE FROM reward_settlements");
         jdbcTemplate.update(
@@ -156,7 +164,7 @@ class QuestCompletionRewardTransactionalOutboxIntegrationTest {
         );
         jdbcTemplate.update("DELETE FROM player WHERE id = ?", PLAYER_ID);
         insertPlayer();
-        clearInvocations(expProcessService);
+        clearInvocations(expProcessService, itemProcessService);
         transactionTemplate = new TransactionTemplate(transactionManager);
         executor = Executors.newFixedThreadPool(2);
     }
@@ -224,8 +232,8 @@ class QuestCompletionRewardTransactionalOutboxIntegrationTest {
     }
 
     @Test
-    @DisplayName("RP_EXP_AND_ITEM_FIRST_STEP_20은 EXP만 성공시키고 ITEM과 Settlement를 PENDING으로 둔다")
-    void processesExpAndLeavesItemPending() {
+    @DisplayName("RP_EXP_AND_ITEM_FIRST_STEP_20은 EXP와 ITEM을 exact-once 지급하고 완료한다")
+    void processesExpAndItemToCompletion() {
         bridge.onQuestEvent(rewardReady(
                 219103L,
                 "RP_EXP_AND_ITEM_FIRST_STEP_20"
@@ -236,11 +244,13 @@ class QuestCompletionRewardTransactionalOutboxIntegrationTest {
         assertThat(lineStatus(219103L, "EXP"))
                 .isEqualTo(RewardSettlementLineStatus.SUCCEEDED.name());
         assertThat(lineStatus(219103L, "ITEM"))
-                .isEqualTo(RewardSettlementLineStatus.PENDING.name());
+                .isEqualTo(RewardSettlementLineStatus.SUCCEEDED.name());
         assertThat(settlementStatus(219103L))
-                .isEqualTo(RewardSettlementStatus.PENDING.name());
+                .isEqualTo(RewardSettlementStatus.COMPLETED.name());
         assertThat(playerExp()).isEqualTo(20L);
         assertThat(growthChangeCount()).isEqualTo(1);
+        assertThat(mailboxItemQuantity()).isEqualTo(1L);
+        assertThat(itemReceiptCount()).isEqualTo(1);
     }
 
     @Test
@@ -428,7 +438,7 @@ class QuestCompletionRewardTransactionalOutboxIntegrationTest {
     }
 
     @Test
-    @DisplayName("actual 세 LifeLog closed loop는 EXP 20만 성공시키고 ITEM을 PENDING으로 둔다")
+    @DisplayName("actual 세 LifeLog closed loop는 EXP 20과 ITEM을 지급하고 완료한다")
     void completesActualExpAndItemClosedLoop() {
         QuestResult.Acceptance accepted =
                 accept(QuestCode.Q_RECORD_THREE_TRACES);
@@ -457,11 +467,13 @@ class QuestCompletionRewardTransactionalOutboxIntegrationTest {
         assertThat(lineStatus(accepted.id(), "EXP"))
                 .isEqualTo(RewardSettlementLineStatus.SUCCEEDED.name());
         assertThat(lineStatus(accepted.id(), "ITEM"))
-                .isEqualTo(RewardSettlementLineStatus.PENDING.name());
+                .isEqualTo(RewardSettlementLineStatus.SUCCEEDED.name());
         assertThat(settlementStatus(accepted.id()))
-                .isEqualTo(RewardSettlementStatus.PENDING.name());
+                .isEqualTo(RewardSettlementStatus.COMPLETED.name());
         assertThat(playerExp()).isEqualTo(20L);
         assertThat(growthChangeCount()).isEqualTo(1);
+        assertThat(mailboxItemQuantity()).isEqualTo(1L);
+        assertThat(itemReceiptCount()).isEqualTo(1);
     }
 
     @Test
@@ -734,6 +746,23 @@ class QuestCompletionRewardTransactionalOutboxIntegrationTest {
     private int growthChangeCount() {
         return jdbcTemplate.queryForObject(
                 "SELECT COUNT(*) FROM player_growth_changes",
+                Integer.class
+        );
+    }
+
+    private long mailboxItemQuantity() {
+        return jdbcTemplate.queryForObject("""
+                SELECT COALESCE(SUM(entry.quantity), 0)
+                FROM mailbox_entries entry
+                JOIN items item ON item.id = entry.item_id
+                WHERE entry.player_id = ?
+                  AND item.code = 'IT_FIRST_STEP_FRAGMENT'
+                """, Long.class, PLAYER_ID);
+    }
+
+    private int itemReceiptCount() {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM inventory_reward_deliveries",
                 Integer.class
         );
     }

--- a/src/test/java/online/lifeasgame/reward/application/RewardDefinitionReaderTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardDefinitionReaderTest.java
@@ -41,7 +41,7 @@ class RewardDefinitionReaderTest {
         @DisplayName("존재하는 정의를 반환한다")
         void returnsDefinition() {
             RewardDefinition definition = RewardDefinition.create(
-                    "RD_EXP_10", "EXP 10", RewardType.EXP, 10L, null, true
+                    "RD_EXP_10", "EXP 10", RewardType.EXP, 10L, null, null, true
             );
             given(repository.findByCode("RD_EXP_10")).willReturn(Optional.of(definition));
 

--- a/src/test/java/online/lifeasgame/reward/application/RewardDefinitionServiceTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardDefinitionServiceTest.java
@@ -1,0 +1,145 @@
+package online.lifeasgame.reward.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.inventory.application.internal.ItemLookupApi;
+import online.lifeasgame.reward.application.command.RewardDefinitionCommand;
+import online.lifeasgame.reward.domain.RewardDefinition;
+import online.lifeasgame.reward.domain.RewardType;
+import online.lifeasgame.reward.domain.error.RewardError;
+import online.lifeasgame.reward.domain.repository.RewardDefinitionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RewardDefinitionService")
+class RewardDefinitionServiceTest {
+
+    @Mock
+    private RewardDefinitionReader definitionReader;
+
+    @Mock
+    private RewardDefinitionRepository definitionRepository;
+
+    @Mock
+    private ItemLookupApi itemLookupApi;
+
+    private RewardDefinitionService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new RewardDefinitionService(
+                definitionReader,
+                definitionRepository,
+                itemLookupApi
+        );
+        org.mockito.Mockito.lenient()
+                .when(definitionRepository.save(
+                        org.mockito.ArgumentMatchers.any()
+                ))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Test
+    @DisplayName("ITEM 생성은 getById로 itemId와 stable code를 함께 확정한다")
+    void createsItemWithResolvedSnapshot() {
+        given(itemLookupApi.getById(77L)).willReturn(
+                new ItemLookupApi.ItemReference(77L, "  IT_STABLE  ")
+        );
+
+        var result = service.create(new RewardDefinitionCommand.Create(
+                "RD_ITEM", "Item", RewardType.ITEM, 2L, 77L, true
+        ));
+
+        assertThat(result.itemId()).isEqualTo(77L);
+        assertThat(result.itemCode()).isEqualTo("IT_STABLE");
+        verify(itemLookupApi).getById(77L);
+    }
+
+    @Test
+    @DisplayName("EXP 생성은 Item provider를 호출하지 않고 null payload를 저장한다")
+    void createsExpWithoutItemLookup() {
+        var result = service.create(new RewardDefinitionCommand.Create(
+                "RD_EXP", "EXP", RewardType.EXP, 10L, null, true
+        ));
+
+        assertThat(result.itemId()).isNull();
+        assertThat(result.itemCode()).isNull();
+        verify(itemLookupApi, never()).getById(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("ITEM 수정도 provider code를 다시 snapshot한다")
+    void updatesItemSnapshot() {
+        RewardDefinition definition = RewardDefinition.create(
+                "RD_ITEM", "Item", RewardType.ITEM, 1L, 70L, "IT_OLD", true
+        );
+        given(definitionReader.getByIdOrThrow(1L)).willReturn(definition);
+        given(itemLookupApi.getById(77L)).willReturn(
+                new ItemLookupApi.ItemReference(77L, "IT_NEW")
+        );
+
+        var result = service.update(1L, new RewardDefinitionCommand.Update(
+                "RD_ITEM", "Item", RewardType.ITEM, 3L, 77L, true
+        ));
+
+        assertThat(result.amount()).isEqualTo(3L);
+        assertThat(result.itemId()).isEqualTo(77L);
+        assertThat(result.itemCode()).isEqualTo("IT_NEW");
+    }
+
+    @Test
+    @DisplayName("provider가 다른 id를 반환하면 stable mismatch로 거부한다")
+    void rejectsResolvedIdMismatch() {
+        given(itemLookupApi.getById(77L)).willReturn(
+                new ItemLookupApi.ItemReference(78L, "IT_STABLE")
+        );
+
+        assertError(
+                () -> service.create(new RewardDefinitionCommand.Create(
+                        "RD_ITEM", "Item", RewardType.ITEM, 1L, 77L, true
+                )),
+                RewardError.REWARD_ITEM_REFERENCE_INCONSISTENT
+        );
+    }
+
+    @Test
+    @DisplayName("provider의 blank/too-long code를 Reward stable error로 거부한다")
+    void rejectsInvalidResolvedCode() {
+        given(itemLookupApi.getById(77L)).willReturn(
+                new ItemLookupApi.ItemReference(77L, " "),
+                new ItemLookupApi.ItemReference(77L, "I".repeat(81))
+        );
+
+        assertError(
+                () -> service.create(itemCommand()),
+                RewardError.REWARD_ITEM_CODE_REQUIRED
+        );
+        assertError(
+                () -> service.create(itemCommand()),
+                RewardError.REWARD_ITEM_CODE_TOO_LONG
+        );
+    }
+
+    private RewardDefinitionCommand.Create itemCommand() {
+        return new RewardDefinitionCommand.Create(
+                "RD_ITEM", "Item", RewardType.ITEM, 1L, 77L, true
+        );
+    }
+
+    private void assertError(Runnable action, RewardError error) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(error)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/reward/application/RewardProfileQueryServiceTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardProfileQueryServiceTest.java
@@ -85,6 +85,6 @@ class RewardProfileQueryServiceTest {
     }
 
     private RewardDefinition expDefinition(String code, Long amount) {
-        return RewardDefinition.create(code, code, RewardType.EXP, amount, null, true);
+        return RewardDefinition.create(code, code, RewardType.EXP, amount, null, null, true);
     }
 }

--- a/src/test/java/online/lifeasgame/reward/application/RewardProfileReaderTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardProfileReaderTest.java
@@ -87,7 +87,7 @@ class RewardProfileReaderTest {
 
     private RewardDefinition expDefinition() {
         return RewardDefinition.create(
-                "RD_EXP_10", "EXP 10", RewardType.EXP, 10L, null, true
+                "RD_EXP_10", "EXP 10", RewardType.EXP, 10L, null, null, true
         );
     }
 

--- a/src/test/java/online/lifeasgame/reward/application/RewardSettlementCreateServiceTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardSettlementCreateServiceTest.java
@@ -250,7 +250,7 @@ class RewardSettlementCreateServiceTest {
         );
         ReflectionTestUtils.setField(profile, "id", 10L);
         RewardDefinition definition = RewardDefinition.create(
-                "RD_EXP_10", "EXP 10", RewardType.EXP, 10L, null, true
+                "RD_EXP_10", "EXP 10", RewardType.EXP, 10L, null, null, true
         );
         ReflectionTestUtils.setField(definition, "id", 20L);
         profile.addLine(definition, 0, null);

--- a/src/test/java/online/lifeasgame/reward/application/RewardSettlementExpProcessAttemptTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardSettlementExpProcessAttemptTest.java
@@ -196,7 +196,7 @@ class RewardSettlementExpProcessAttemptTest {
         RewardProfile profile = profile();
         profile.addLine(expDefinition(), 0, null);
         RewardDefinition item = RewardDefinition.create(
-                "RD_ITEM", "Item", RewardType.ITEM, 2L, 77L, true
+                "RD_ITEM", "Item", RewardType.ITEM, 2L, 77L, "IT_ITEM", true
         );
         ReflectionTestUtils.setField(item, "id", 3L);
         profile.addLine(item, 1, null);
@@ -211,7 +211,7 @@ class RewardSettlementExpProcessAttemptTest {
 
     private RewardDefinition expDefinition() {
         RewardDefinition definition = RewardDefinition.create(
-                "RD_EXP", "EXP", RewardType.EXP, 10L, null, true
+                "RD_EXP", "EXP", RewardType.EXP, 10L, null, null, true
         );
         ReflectionTestUtils.setField(definition, "id", 1L);
         return definition;

--- a/src/test/java/online/lifeasgame/reward/application/RewardSettlementExpProcessConcurrencyTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardSettlementExpProcessConcurrencyTest.java
@@ -256,7 +256,9 @@ class RewardSettlementExpProcessConcurrencyTest {
             Long lineId = settlement.getLines().getFirst().getId();
             jdbcTemplate.update("""
                     UPDATE reward_settlement_lines
-                    SET reward_type = 'ITEM', item_id = 77
+                    SET reward_type = 'ITEM',
+                        item_id = 77,
+                        item_code = 'IT_FIRST_STEP_FRAGMENT'
                     WHERE id = ?
                     """, lineId);
 

--- a/src/test/java/online/lifeasgame/reward/application/RewardSettlementItemProcessAttemptTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardSettlementItemProcessAttemptTest.java
@@ -1,0 +1,255 @@
+package online.lifeasgame.reward.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.inventory.application.internal.InventoryRewardDeliveryApi;
+import online.lifeasgame.reward.domain.RewardDefinition;
+import online.lifeasgame.reward.domain.RewardProfile;
+import online.lifeasgame.reward.domain.RewardProfileStatus;
+import online.lifeasgame.reward.domain.RewardSettlement;
+import online.lifeasgame.reward.domain.RewardSettlementLineStatus;
+import online.lifeasgame.reward.domain.RewardSettlementSourceType;
+import online.lifeasgame.reward.domain.RewardSettlementStatus;
+import online.lifeasgame.reward.domain.RewardType;
+import online.lifeasgame.reward.domain.error.RewardError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RewardSettlementItemProcessAttempt")
+class RewardSettlementItemProcessAttemptTest {
+
+    @Mock
+    private RewardSettlementReader settlementReader;
+
+    @Mock
+    private RewardSettlementWriter settlementWriter;
+
+    @Mock
+    private InventoryRewardDeliveryApi inventoryDeliveryApi;
+
+    private RewardSettlementItemProcessAttempt attempt;
+
+    @BeforeEach
+    void setUp() {
+        attempt = new RewardSettlementItemProcessAttempt(
+                settlementReader,
+                settlementWriter,
+                inventoryDeliveryApi
+        );
+    }
+
+    @Test
+    @DisplayName("PENDING ITEM을 신규 지급하고 Line과 Settlement를 성공시킨다")
+    void deliversPendingItem() {
+        RewardSettlement settlement = itemSettlement();
+        given(settlementReader.getByIdForUpdateOrThrow(100L))
+                .willReturn(settlement);
+        given(inventoryDeliveryApi.deliverReward(
+                1000L, 1L, "IT_ITEM", 2L
+        )).willReturn(delivery(false));
+
+        var result = attempt.process(100L, 1000L);
+
+        assertThat(result.lineStatus())
+                .isEqualTo(RewardSettlementLineStatus.SUCCEEDED);
+        assertThat(result.settlementStatus())
+                .isEqualTo(RewardSettlementStatus.COMPLETED);
+        assertThat(result.replayed()).isFalse();
+        assertThat(result.deliveryId()).isEqualTo(500L);
+        verify(settlementWriter).saveAndFlush(settlement);
+    }
+
+    @Test
+    @DisplayName("PENDING ITEM의 matching receipt replay로 Line 성공을 복구한다")
+    void recoversPendingLineFromDeliveryReplay() {
+        RewardSettlement settlement = itemSettlement();
+        given(settlementReader.getByIdForUpdateOrThrow(100L))
+                .willReturn(settlement);
+        given(inventoryDeliveryApi.deliverReward(
+                1000L, 1L, "IT_ITEM", 2L
+        )).willReturn(delivery(true));
+
+        var result = attempt.process(100L, 1000L);
+
+        assertThat(result.replayed()).isTrue();
+        assertThat(result.lineStatus())
+                .isEqualTo(RewardSettlementLineStatus.SUCCEEDED);
+        verify(settlementWriter).saveAndFlush(settlement);
+    }
+
+    @Test
+    @DisplayName("SUCCEEDED ITEM은 receipt만 검증하고 신규 지급과 저장을 하지 않는다")
+    void verifiesSucceededLineReceiptOnly() {
+        RewardSettlement settlement = itemSettlement();
+        settlement.markItemLineSucceeded(1000L);
+        given(settlementReader.getByIdForUpdateOrThrow(100L))
+                .willReturn(settlement);
+        given(inventoryDeliveryApi.findRewardDelivery(1000L))
+                .willReturn(Optional.of(receipt()));
+
+        var result = attempt.process(100L, 1000L);
+
+        assertThat(result.replayed()).isTrue();
+        verify(inventoryDeliveryApi, never()).deliverReward(
+                1000L, 1L, "IT_ITEM", 2L
+        );
+        verify(settlementWriter, never()).saveAndFlush(settlement);
+    }
+
+    @Test
+    @DisplayName("SUCCEEDED ITEM receipt가 없으면 신규 지급 없이 invariant error다")
+    void rejectsSucceededLineWithoutReceipt() {
+        RewardSettlement settlement = itemSettlement();
+        settlement.markItemLineSucceeded(1000L);
+        given(settlementReader.getByIdForUpdateOrThrow(100L))
+                .willReturn(settlement);
+        given(inventoryDeliveryApi.findRewardDelivery(1000L))
+                .willReturn(Optional.empty());
+
+        assertInconsistent(() -> attempt.process(100L, 1000L));
+
+        verify(inventoryDeliveryApi, never()).deliverReward(
+                1000L, 1L, "IT_ITEM", 2L
+        );
+        assertThat(settlement.getLineByIdOrThrow(1000L).getStatus())
+                .isEqualTo(RewardSettlementLineStatus.SUCCEEDED);
+    }
+
+    @ParameterizedTest
+    @MethodSource("mismatchedDeliveries")
+    @DisplayName("delivery의 line/player/item/code/quantity mismatch를 모두 거부한다")
+    void rejectsDeliverySnapshotMismatch(
+            InventoryRewardDeliveryApi.RewardDeliveryResult mismatch
+    ) {
+        RewardSettlement settlement = itemSettlement();
+        given(settlementReader.getByIdForUpdateOrThrow(100L))
+                .willReturn(settlement);
+        given(inventoryDeliveryApi.deliverReward(
+                1000L, 1L, "IT_ITEM", 2L
+        )).willReturn(mismatch);
+
+        assertInconsistent(() -> attempt.process(100L, 1000L));
+
+        assertThat(settlement.getLineByIdOrThrow(1000L).getStatus())
+                .isEqualTo(RewardSettlementLineStatus.PENDING);
+        verify(settlementWriter, never()).saveAndFlush(settlement);
+    }
+
+    @Test
+    @DisplayName("EXP Line을 ITEM processor로 호출하면 stable type error다")
+    void rejectsExpLine() {
+        RewardSettlement settlement = expSettlement();
+        given(settlementReader.getByIdForUpdateOrThrow(100L))
+                .willReturn(settlement);
+
+        assertError(
+                () -> attempt.process(100L, 1000L),
+                RewardError.REWARD_SETTLEMENT_LINE_NOT_ITEM
+        );
+        verify(inventoryDeliveryApi, never()).deliverReward(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.anyLong()
+        );
+    }
+
+    private static Stream<InventoryRewardDeliveryApi.RewardDeliveryResult>
+    mismatchedDeliveries() {
+        return Stream.of(
+                new InventoryRewardDeliveryApi.RewardDeliveryResult(
+                        500L, 999L, 1L, 77L, "IT_ITEM", 2L, false
+                ),
+                new InventoryRewardDeliveryApi.RewardDeliveryResult(
+                        500L, 1000L, 2L, 77L, "IT_ITEM", 2L, false
+                ),
+                new InventoryRewardDeliveryApi.RewardDeliveryResult(
+                        500L, 1000L, 1L, 78L, "IT_ITEM", 2L, false
+                ),
+                new InventoryRewardDeliveryApi.RewardDeliveryResult(
+                        500L, 1000L, 1L, 77L, "IT_OTHER", 2L, false
+                ),
+                new InventoryRewardDeliveryApi.RewardDeliveryResult(
+                        500L, 1000L, 1L, 77L, "IT_ITEM", 3L, false
+                )
+        );
+    }
+
+    private InventoryRewardDeliveryApi.RewardDeliveryResult delivery(
+            boolean replayed
+    ) {
+        return new InventoryRewardDeliveryApi.RewardDeliveryResult(
+                500L, 1000L, 1L, 77L, "IT_ITEM", 2L, replayed
+        );
+    }
+
+    private InventoryRewardDeliveryApi.RewardDeliveryReceipt receipt() {
+        return new InventoryRewardDeliveryApi.RewardDeliveryReceipt(
+                500L, 1000L, 1L, 77L, "IT_ITEM", 2L
+        );
+    }
+
+    private RewardSettlement itemSettlement() {
+        return settlement(RewardDefinition.create(
+                "RD_ITEM", "Item", RewardType.ITEM,
+                2L, 77L, "IT_ITEM", true
+        ));
+    }
+
+    private RewardSettlement expSettlement() {
+        return settlement(RewardDefinition.create(
+                "RD_EXP", "EXP", RewardType.EXP,
+                10L, null, null, true
+        ));
+    }
+
+    private RewardSettlement settlement(RewardDefinition definition) {
+        ReflectionTestUtils.setField(definition, "id", 10L);
+        RewardProfile profile = RewardProfile.create(
+                "RP", "Profile", RewardProfileStatus.ACTIVE
+        );
+        ReflectionTestUtils.setField(profile, "id", 20L);
+        profile.addLine(definition, 0, null);
+        RewardSettlement settlement = RewardSettlement.create(
+                1L,
+                RewardSettlementSourceType.QUEST_COMPLETION,
+                30L,
+                profile
+        );
+        ReflectionTestUtils.setField(settlement, "id", 100L);
+        ReflectionTestUtils.setField(
+                settlement.getLines().getFirst(), "id", 1000L
+        );
+        return settlement;
+    }
+
+    private void assertInconsistent(Runnable action) {
+        assertError(
+                action,
+                RewardError.REWARD_SETTLEMENT_ITEM_DELIVERY_INCONSISTENT
+        );
+    }
+
+    private void assertError(Runnable action, RewardError error) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(error)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/reward/application/RewardSettlementItemProcessIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardSettlementItemProcessIntegrationTest.java
@@ -1,0 +1,388 @@
+package online.lifeasgame.reward.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.inventory.application.internal.InventoryRewardDeliveryApi;
+import online.lifeasgame.inventory.domain.error.InventoryError;
+import online.lifeasgame.reward.application.result.RewardSettlementItemProcessResult;
+import online.lifeasgame.reward.domain.RewardSettlement;
+import online.lifeasgame.reward.domain.RewardSettlementLine;
+import online.lifeasgame.reward.domain.RewardSettlementLineStatus;
+import online.lifeasgame.reward.domain.RewardSettlementSourceType;
+import online.lifeasgame.reward.domain.RewardSettlementStatus;
+import online.lifeasgame.reward.domain.RewardType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles({"test", "migration-test"})
+@DisplayName("RewardSettlement ITEM 처리 MySQL 통합")
+class RewardSettlementItemProcessIntegrationTest {
+
+    private static final long PLAYER_ID = 226001L;
+
+    @Container
+    private static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0.39")
+            .withDatabaseName("lifeasgame_item_reward_process")
+            .withUsername("lifeasgame")
+            .withPassword("lifeasgame");
+
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", MYSQL::getDriverClassName);
+    }
+
+    @Autowired
+    private RewardSettlementCreateService createService;
+
+    @Autowired
+    private RewardSettlementItemProcessService processService;
+
+    @Autowired
+    private RewardSettlementExpProcessService expProcessService;
+
+    @MockitoSpyBean
+    private InventoryRewardDeliveryApi inventoryDeliveryApi;
+
+    @MockitoSpyBean
+    private RewardSettlementWriter settlementWriter;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private ExecutorService executor;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.update("DELETE FROM player_growth_changes");
+        jdbcTemplate.update("DELETE FROM inventory_reward_deliveries");
+        jdbcTemplate.update("DELETE FROM inventory_entries");
+        jdbcTemplate.update("DELETE FROM mailbox_entries");
+        jdbcTemplate.update("DELETE FROM player_inventory");
+        jdbcTemplate.update("DELETE FROM player_mailbox");
+        jdbcTemplate.update("DELETE FROM reward_settlement_lines");
+        jdbcTemplate.update("DELETE FROM reward_settlements");
+        jdbcTemplate.update("DELETE FROM player WHERE id = ?", PLAYER_ID);
+        insertPlayer();
+        clearInvocations(inventoryDeliveryApi, settlementWriter);
+        executor = Executors.newFixedThreadPool(2);
+    }
+
+    @AfterEach
+    void tearDown() throws InterruptedException {
+        executor.shutdownNow();
+        assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    @DisplayName("동시 같은 ITEM Line은 한 번 지급하고 success/replay로 끝난다")
+    void deliversSameLineExactlyOnceConcurrently() throws Exception {
+        RewardSettlement settlement = createMixedSettlement(226101L);
+        RewardSettlementLine itemLine = itemLine(settlement);
+
+        List<RewardSettlementItemProcessResult> results = runConcurrently(
+                () -> processService.process(settlement.getId(), itemLine.getId()),
+                () -> processService.process(settlement.getId(), itemLine.getId())
+        );
+
+        assertThat(results)
+                .extracting(RewardSettlementItemProcessResult::replayed)
+                .containsExactlyInAnyOrder(false, true);
+        assertThat(mailboxQuantity()).isEqualTo(1L);
+        assertThat(receiptCount(itemLine.getId())).isEqualTo(1);
+        assertThat(lineStatus(itemLine.getId()))
+                .isEqualTo(RewardSettlementLineStatus.SUCCEEDED.name());
+        assertThat(settlementStatus(settlement.getId()))
+                .isEqualTo(RewardSettlementStatus.PENDING.name());
+    }
+
+    @Test
+    @DisplayName("PENDING Line의 matching receipt는 중복 지급 없이 성공 복구한다")
+    void recoversPendingLineFromMatchingReceipt() {
+        RewardSettlement settlement = createMixedSettlement(226102L);
+        RewardSettlementLine itemLine = itemLine(settlement);
+        inventoryDeliveryApi.deliverReward(
+                itemLine.getId(), PLAYER_ID,
+                itemLine.getItemCode(), itemLine.getAmount()
+        );
+
+        RewardSettlementItemProcessResult result = processService.process(
+                settlement.getId(), itemLine.getId()
+        );
+
+        assertThat(result.replayed()).isTrue();
+        assertThat(mailboxQuantity()).isEqualTo(1L);
+        assertThat(receiptCount(itemLine.getId())).isEqualTo(1);
+        assertThat(lineStatus(itemLine.getId()))
+                .isEqualTo(RewardSettlementLineStatus.SUCCEEDED.name());
+    }
+
+    @Test
+    @DisplayName("SUCCEEDED Line은 receipt-only replay하며 receipt 유실 시 신규 지급하지 않는다")
+    void protectsSucceededLineWhenReceiptIsMissing() {
+        RewardSettlement settlement = createMixedSettlement(226103L);
+        RewardSettlementLine itemLine = itemLine(settlement);
+        processService.process(settlement.getId(), itemLine.getId());
+        jdbcTemplate.update(
+                "DELETE FROM inventory_reward_deliveries WHERE reward_line_id = ?",
+                itemLine.getId()
+        );
+        clearInvocations(inventoryDeliveryApi);
+
+        assertThatThrownBy(() -> processService.process(
+                settlement.getId(), itemLine.getId()
+        )).isInstanceOfSatisfying(DomainException.class, exception ->
+                assertThat(exception.getErrorCode()).isEqualTo(
+                        online.lifeasgame.reward.domain.error.RewardError
+                                .REWARD_SETTLEMENT_ITEM_DELIVERY_INCONSISTENT
+                )
+        );
+
+        verify(inventoryDeliveryApi, never()).deliverReward(
+                itemLine.getId(), PLAYER_ID,
+                itemLine.getItemCode(), itemLine.getAmount()
+        );
+        assertThat(mailboxQuantity()).isEqualTo(1L);
+        assertThat(lineStatus(itemLine.getId()))
+                .isEqualTo(RewardSettlementLineStatus.SUCCEEDED.name());
+    }
+
+    @Test
+    @DisplayName("Mailbox full Domain failure는 delivery를 rollback하고 Line FAILED를 저장한다")
+    void recordsMailboxFullWithoutPartialDelivery() {
+        RewardSettlement settlement = createMixedSettlement(226104L);
+        RewardSettlementLine itemLine = itemLine(settlement);
+        RewardSettlementLine expLine = expLine(settlement);
+        expProcessService.process(settlement.getId(), expLine.getId());
+        insertFullMailbox();
+
+        assertThatThrownBy(() -> processService.process(
+                settlement.getId(), itemLine.getId()
+        )).isInstanceOfSatisfying(DomainException.class, exception ->
+                assertThat(exception.getErrorCode())
+                        .isEqualTo(InventoryError.MAILBOX_FULL)
+        );
+
+        assertThat(receiptCount(itemLine.getId())).isZero();
+        assertThat(mailboxQuantity()).isEqualTo(99L);
+        assertThat(lineStatus(itemLine.getId()))
+                .isEqualTo(RewardSettlementLineStatus.FAILED.name());
+        assertThat(lineFailureCode(itemLine.getId()))
+                .isEqualTo(InventoryError.MAILBOX_FULL.code());
+        assertThat(settlementStatus(settlement.getId()))
+                .isEqualTo(RewardSettlementStatus.PARTIAL_FAILED.name());
+    }
+
+    @Test
+    @DisplayName("Inventory system failure는 Line PENDING을 유지하고 전파한다")
+    void propagatesInventorySystemFailure() {
+        RewardSettlement settlement = createMixedSettlement(226105L);
+        RewardSettlementLine itemLine = itemLine(settlement);
+        doThrow(new RuntimeException("inventory system"))
+                .when(inventoryDeliveryApi)
+                .deliverReward(
+                        itemLine.getId(), PLAYER_ID,
+                        itemLine.getItemCode(), itemLine.getAmount()
+                );
+
+        assertThatThrownBy(() -> processService.process(
+                settlement.getId(), itemLine.getId()
+        )).isInstanceOf(RuntimeException.class)
+                .hasMessage("inventory system");
+
+        assertThat(receiptCount(itemLine.getId())).isZero();
+        assertThat(mailboxQuantity()).isZero();
+        assertThat(lineStatus(itemLine.getId()))
+                .isEqualTo(RewardSettlementLineStatus.PENDING.name());
+    }
+
+    @Test
+    @DisplayName("Line save system failure는 Mailbox와 receipt까지 같은 Transaction에서 rollback한다")
+    void rollsBackDeliveryWhenLineSaveFails() {
+        RewardSettlement settlement = createMixedSettlement(226106L);
+        RewardSettlementLine itemLine = itemLine(settlement);
+        doThrow(new RuntimeException("line save system"))
+                .when(settlementWriter)
+                .saveAndFlush(argThat(candidate ->
+                        settlement.getId().equals(candidate.getId())
+                ));
+
+        assertThatThrownBy(() -> processService.process(
+                settlement.getId(), itemLine.getId()
+        )).isInstanceOf(RuntimeException.class)
+                .hasMessage("line save system");
+
+        assertThat(receiptCount(itemLine.getId())).isZero();
+        assertThat(mailboxQuantity()).isZero();
+        assertThat(lineStatus(itemLine.getId()))
+                .isEqualTo(RewardSettlementLineStatus.PENDING.name());
+        assertThat(settlementStatus(settlement.getId()))
+                .isEqualTo(RewardSettlementStatus.PENDING.name());
+    }
+
+    private RewardSettlement createMixedSettlement(long sourceId) {
+        return createService.create(
+                PLAYER_ID,
+                RewardSettlementSourceType.QUEST_COMPLETION,
+                sourceId,
+                "RP_EXP_AND_ITEM_FIRST_STEP_20"
+        );
+    }
+
+    private RewardSettlementLine itemLine(RewardSettlement settlement) {
+        return settlement.getLines().stream()
+                .filter(line -> line.getRewardType() == RewardType.ITEM)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private RewardSettlementLine expLine(RewardSettlement settlement) {
+        return settlement.getLines().stream()
+                .filter(line -> line.getRewardType() == RewardType.EXP)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private void insertPlayer() {
+        jdbcTemplate.update("""
+                INSERT INTO player (
+                    id, user_id, name, gender, level, exp,
+                    hp_cur, hp_cap, mp_cur, mp_cap,
+                    str_stat, agi_stat, dex_stat, int_stat, vit_stat, luc_stat,
+                    extra_stats, status_effects, version, created_at, updated_at
+                ) VALUES (
+                    ?, ?, 'ITEM Process Tester', 'male', 1, 0,
+                    100, 100, 50, 50,
+                    1, 1, 1, 1, 1, 1,
+                    JSON_OBJECT(), '[]', 0,
+                    CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
+                )
+                """, PLAYER_ID, PLAYER_ID + 100000L);
+    }
+
+    private void insertFullMailbox() {
+        Long itemId = jdbcTemplate.queryForObject(
+                "SELECT id FROM items WHERE code = 'IT_FIRST_STEP_FRAGMENT'",
+                Long.class
+        );
+        jdbcTemplate.update("""
+                INSERT INTO player_mailbox (
+                    player_id, capacity_slots, version, created_at, updated_at
+                ) VALUES (?, 1, 0, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6))
+                """, PLAYER_ID);
+        jdbcTemplate.update("""
+                INSERT INTO mailbox_entries (
+                    player_id, slot_index, item_id, rarity, quantity,
+                    durability, bound, inst_attrs, created_at, updated_at
+                ) VALUES (
+                    ?, 0, ?, 'COMMON', 99,
+                    NULL, TRUE, JSON_OBJECT(),
+                    CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
+                )
+                """, PLAYER_ID, itemId);
+    }
+
+    private <T> List<T> runConcurrently(
+            CheckedSupplier<T> first,
+            CheckedSupplier<T> second
+    ) throws Exception {
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        Future<T> firstFuture = executor.submit(() -> {
+            ready.countDown();
+            start.await();
+            return first.get();
+        });
+        Future<T> secondFuture = executor.submit(() -> {
+            ready.countDown();
+            start.await();
+            return second.get();
+        });
+        assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+        start.countDown();
+        return List.of(
+                firstFuture.get(
+                        Duration.ofSeconds(30).toMillis(), TimeUnit.MILLISECONDS
+                ),
+                secondFuture.get(
+                        Duration.ofSeconds(30).toMillis(), TimeUnit.MILLISECONDS
+                )
+        );
+    }
+
+    private long mailboxQuantity() {
+        return jdbcTemplate.queryForObject("""
+                SELECT COALESCE(SUM(quantity), 0)
+                FROM mailbox_entries
+                WHERE player_id = ?
+                """, Long.class, PLAYER_ID);
+    }
+
+    private int receiptCount(Long lineId) {
+        return jdbcTemplate.queryForObject("""
+                SELECT COUNT(*)
+                FROM inventory_reward_deliveries
+                WHERE reward_line_id = ?
+                """, Integer.class, lineId);
+    }
+
+    private String lineStatus(Long lineId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT status FROM reward_settlement_lines WHERE id = ?",
+                String.class,
+                lineId
+        );
+    }
+
+    private String lineFailureCode(Long lineId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT failure_code FROM reward_settlement_lines WHERE id = ?",
+                String.class,
+                lineId
+        );
+    }
+
+    private String settlementStatus(Long settlementId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT status FROM reward_settlements WHERE id = ?",
+                String.class,
+                settlementId
+        );
+    }
+
+    @FunctionalInterface
+    private interface CheckedSupplier<T> {
+        T get();
+    }
+}

--- a/src/test/java/online/lifeasgame/reward/application/RewardSettlementItemProcessServiceTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardSettlementItemProcessServiceTest.java
@@ -1,0 +1,63 @@
+package online.lifeasgame.reward.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.inventory.domain.error.InventoryError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RewardSettlementItemProcessService")
+class RewardSettlementItemProcessServiceTest {
+
+    @Mock
+    private RewardSettlementItemProcessAttempt processAttempt;
+
+    @Mock
+    private RewardSettlementLineFailureRecorder failureRecorder;
+
+    private RewardSettlementItemProcessService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new RewardSettlementItemProcessService(
+                processAttempt, failureRecorder
+        );
+    }
+
+    @Test
+    @DisplayName("예상 가능한 Domain failure는 별도 Transaction으로 기록하고 재전파한다")
+    void recordsDomainFailure() {
+        DomainException failure = new DomainException(
+                InventoryError.MAILBOX_FULL
+        );
+        given(processAttempt.process(1L, 2L)).willThrow(failure);
+
+        assertThatThrownBy(() -> service.process(1L, 2L))
+                .isSameAs(failure);
+        verify(failureRecorder).record(
+                1L, 2L, InventoryError.MAILBOX_FULL
+        );
+    }
+
+    @Test
+    @DisplayName("system failure는 Line을 확정 실패시키지 않고 그대로 전파한다")
+    void propagatesSystemFailure() {
+        RuntimeException failure = new RuntimeException("system");
+        given(processAttempt.process(1L, 2L)).willThrow(failure);
+
+        assertThatThrownBy(() -> service.process(1L, 2L))
+                .isSameAs(failure);
+        verify(failureRecorder, never()).record(
+                1L, 2L, InventoryError.MAILBOX_FULL
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/reward/application/RewardSettlementLineRetryPreparationServiceTest.java
+++ b/src/test/java/online/lifeasgame/reward/application/RewardSettlementLineRetryPreparationServiceTest.java
@@ -148,7 +148,7 @@ class RewardSettlementLineRetryPreparationServiceTest {
         );
         ReflectionTestUtils.setField(profile, "id", 10L);
         RewardDefinition definition = RewardDefinition.create(
-                "RD_EXP_10", "EXP 10", RewardType.EXP, 10L, null, true
+                "RD_EXP_10", "EXP 10", RewardType.EXP, 10L, null, null, true
         );
         ReflectionTestUtils.setField(definition, "id", 20L);
         profile.addLine(definition, 0, null);

--- a/src/test/java/online/lifeasgame/reward/domain/RewardDefinitionTest.java
+++ b/src/test/java/online/lifeasgame/reward/domain/RewardDefinitionTest.java
@@ -20,12 +20,13 @@ class RewardDefinitionTest {
         @DisplayName("양수 amount와 itemId 없이 생성된다")
         void createsWithAmountAndWithoutItemId() {
             RewardDefinition definition = RewardDefinition.create(
-                    "RD_EXP_10", "EXP 10", RewardType.EXP, 10L, null, true
+                    "RD_EXP_10", "EXP 10", RewardType.EXP, 10L, null, null, true
             );
 
             assertThat(definition.getRewardType()).isEqualTo(RewardType.EXP);
             assertThat(definition.getAmount()).isEqualTo(10L);
             assertThat(definition.getItemId()).isNull();
+            assertThat(definition.getItemCode()).isNull();
             assertThat(definition.isActive()).isTrue();
         }
 
@@ -34,7 +35,7 @@ class RewardDefinitionTest {
         void throwsWhenAmountIsMissing() {
             assertRewardError(
                     () -> RewardDefinition.create(
-                            "RD_EXP", "EXP", RewardType.EXP, null, null, true
+                            "RD_EXP", "EXP", RewardType.EXP, null, null, null, true
                     ),
                     RewardError.REWARD_AMOUNT_MUST_BE_POSITIVE
             );
@@ -45,7 +46,7 @@ class RewardDefinitionTest {
         void throwsWhenItemIdExists() {
             assertRewardError(
                     () -> RewardDefinition.create(
-                            "RD_EXP", "EXP", RewardType.EXP, 10L, 1L, true
+                            "RD_EXP", "EXP", RewardType.EXP, 10L, 1L, null, true
                     ),
                     RewardError.REWARD_EXP_ITEM_ID_NOT_ALLOWED
             );
@@ -60,12 +61,13 @@ class RewardDefinitionTest {
         @DisplayName("itemId와 수량을 의미하는 amount로 생성된다")
         void createsWithItemIdAndAmount() {
             RewardDefinition definition = RewardDefinition.create(
-                    "RD_ITEM_1", "Item 1", RewardType.ITEM, 2L, 1L, true
+                    "RD_ITEM_1", "Item 1", RewardType.ITEM, 2L, 1L, "  IT_ITEM_1  ", true
             );
 
             assertThat(definition.getRewardType()).isEqualTo(RewardType.ITEM);
             assertThat(definition.getAmount()).isEqualTo(2L);
             assertThat(definition.getItemId()).isEqualTo(1L);
+            assertThat(definition.getItemCode()).isEqualTo("IT_ITEM_1");
         }
 
         @Test
@@ -73,7 +75,7 @@ class RewardDefinitionTest {
         void throwsWhenItemIdIsMissing() {
             assertRewardError(
                     () -> RewardDefinition.create(
-                            "RD_ITEM", "Item", RewardType.ITEM, 1L, null, true
+                            "RD_ITEM", "Item", RewardType.ITEM, 1L, null, "IT_ITEM", true
                     ),
                     RewardError.REWARD_ITEM_ID_REQUIRED
             );
@@ -84,7 +86,7 @@ class RewardDefinitionTest {
         void throwsWhenAmountIsNotPositive() {
             assertRewardError(
                     () -> RewardDefinition.create(
-                            "RD_ITEM", "Item", RewardType.ITEM, 0L, 1L, true
+                            "RD_ITEM", "Item", RewardType.ITEM, 0L, 1L, "IT_ITEM", true
                     ),
                     RewardError.REWARD_ITEM_QUANTITY_MUST_BE_POSITIVE
             );
@@ -95,9 +97,32 @@ class RewardDefinitionTest {
         void throwsWhenItemIdIsNotPositive() {
             assertRewardError(
                     () -> RewardDefinition.create(
-                            "RD_ITEM", "Item", RewardType.ITEM, 1L, 0L, true
+                            "RD_ITEM", "Item", RewardType.ITEM, 1L, 0L, "IT_ITEM", true
                     ),
                     RewardError.REWARD_ITEM_ID_MUST_BE_POSITIVE
+            );
+        }
+
+        @Test
+        @DisplayName("itemCode가 공백이면 REWARD_ITEM_CODE_REQUIRED 예외가 발생한다")
+        void throwsWhenItemCodeIsBlank() {
+            assertRewardError(
+                    () -> RewardDefinition.create(
+                            "RD_ITEM", "Item", RewardType.ITEM, 1L, 1L, " ", true
+                    ),
+                    RewardError.REWARD_ITEM_CODE_REQUIRED
+            );
+        }
+
+        @Test
+        @DisplayName("itemCode가 80자를 넘으면 REWARD_ITEM_CODE_TOO_LONG 예외가 발생한다")
+        void throwsWhenItemCodeIsTooLong() {
+            assertRewardError(
+                    () -> RewardDefinition.create(
+                            "RD_ITEM", "Item", RewardType.ITEM, 1L, 1L,
+                            "I".repeat(81), true
+                    ),
+                    RewardError.REWARD_ITEM_CODE_TOO_LONG
             );
         }
     }
@@ -110,7 +135,7 @@ class RewardDefinitionTest {
         @DisplayName("code와 name의 앞뒤 공백을 제거해 저장한다")
         void trimsCodeAndName() {
             RewardDefinition definition = RewardDefinition.create(
-                    "  RD_EXP  ", "  EXP  ", RewardType.EXP, 1L, null, true
+                    "  RD_EXP  ", "  EXP  ", RewardType.EXP, 1L, null, null, true
             );
 
             assertThat(definition.getCode()).isEqualTo("RD_EXP");
@@ -122,7 +147,7 @@ class RewardDefinitionTest {
         void throwsWhenCodeIsBlank() {
             assertRewardError(
                     () -> RewardDefinition.create(
-                            " ", "EXP", RewardType.EXP, 1L, null, true
+                            " ", "EXP", RewardType.EXP, 1L, null, null, true
                     ),
                     RewardError.REWARD_DEFINITION_CODE_REQUIRED
             );
@@ -133,7 +158,7 @@ class RewardDefinitionTest {
         void throwsWhenNameIsBlank() {
             assertRewardError(
                     () -> RewardDefinition.create(
-                            "RD_EXP", " ", RewardType.EXP, 1L, null, true
+                            "RD_EXP", " ", RewardType.EXP, 1L, null, null, true
                     ),
                     RewardError.REWARD_DEFINITION_NAME_REQUIRED
             );
@@ -144,7 +169,7 @@ class RewardDefinitionTest {
         void throwsWhenRewardTypeIsMissing() {
             assertRewardError(
                     () -> RewardDefinition.create(
-                            "RD_EXP", "EXP", null, 1L, null, true
+                            "RD_EXP", "EXP", null, 1L, null, null, true
                     ),
                     RewardError.REWARD_LINE_TYPE_REQUIRED
             );

--- a/src/test/java/online/lifeasgame/reward/domain/RewardProfileTest.java
+++ b/src/test/java/online/lifeasgame/reward/domain/RewardProfileTest.java
@@ -35,7 +35,7 @@ class RewardProfileTest {
         void includesItemLine() {
             RewardProfile profile = activeProfile();
             RewardDefinition definition = RewardDefinition.create(
-                    "RD_ITEM_1", "Item 1", RewardType.ITEM, 1L, 1L, true
+                    "RD_ITEM_1", "Item 1", RewardType.ITEM, 1L, 1L, "IT_ITEM_1", true
             );
 
             RewardProfileLine line = profile.addLine(definition, 0, 3L);
@@ -166,7 +166,7 @@ class RewardProfileTest {
     }
 
     private RewardDefinition expDefinition(String code, Long amount) {
-        return RewardDefinition.create(code, code, RewardType.EXP, amount, null, true);
+        return RewardDefinition.create(code, code, RewardType.EXP, amount, null, null, true);
     }
 
     private void assertRewardError(Runnable action, RewardError error) {

--- a/src/test/java/online/lifeasgame/reward/domain/RewardSettlementTest.java
+++ b/src/test/java/online/lifeasgame/reward/domain/RewardSettlementTest.java
@@ -32,11 +32,12 @@ class RewardSettlementTest {
                             RewardSettlementLine::getRewardType,
                             RewardSettlementLine::getAmount,
                             RewardSettlementLine::getItemId,
+                            RewardSettlementLine::getItemCode,
                             RewardSettlementLine::getSortOrder
                     )
                     .containsExactly(
-                            org.assertj.core.groups.Tuple.tuple("RD_EXP", RewardType.EXP, 10L, null, 0),
-                            org.assertj.core.groups.Tuple.tuple("RD_ITEM", RewardType.ITEM, 2L, 77L, 1)
+                            org.assertj.core.groups.Tuple.tuple("RD_EXP", RewardType.EXP, 10L, null, null, 0),
+                            org.assertj.core.groups.Tuple.tuple("RD_ITEM", RewardType.ITEM, 2L, 77L, "IT_RD_ITEM", 1)
                     );
             assertThat(settlement.getLines())
                     .extracting(RewardSettlementLine::getStatus)
@@ -59,18 +60,24 @@ class RewardSettlementTest {
         @DisplayName("원본 Profile과 Definition이 변경돼도 스냅샷 값은 유지된다")
         void keepsSnapshotAfterSourceChanges() {
             RewardProfile profile = persistedProfile("RP_SNAPSHOT");
-            RewardDefinition definition = persistedExpDefinition(1L, "RD_EXP_10", 10L);
+            RewardDefinition definition = persistedItemDefinition(
+                    1L, "RD_ITEM", 77L, 2L
+            );
             profile.addLine(definition, 0, null);
             RewardSettlement settlement = settlement(profile);
 
             ReflectionTestUtils.setField(profile, "code", "RP_CHANGED");
             ReflectionTestUtils.setField(definition, "code", "RD_CHANGED");
             ReflectionTestUtils.setField(definition, "amount", 999L);
+            ReflectionTestUtils.setField(definition, "itemId", 88L);
+            ReflectionTestUtils.setField(definition, "itemCode", "IT_CHANGED");
 
             RewardSettlementLine line = settlement.getLines().getFirst();
             assertThat(settlement.getRewardProfileCode()).isEqualTo("RP_SNAPSHOT");
-            assertThat(line.getRewardDefinitionCode()).isEqualTo("RD_EXP_10");
-            assertThat(line.getAmount()).isEqualTo(10L);
+            assertThat(line.getRewardDefinitionCode()).isEqualTo("RD_ITEM");
+            assertThat(line.getAmount()).isEqualTo(2L);
+            assertThat(line.getItemId()).isEqualTo(77L);
+            assertThat(line.getItemCode()).isEqualTo("IT_RD_ITEM");
         }
 
         @Test
@@ -84,6 +91,53 @@ class RewardSettlementTest {
             assertThat(settlement.getRewardProfileCode()).isEqualTo("RP_NONE");
             assertThat(settlement.getLines()).isEmpty();
             assertThat(settlement.getStatus()).isEqualTo(RewardSettlementStatus.COMPLETED);
+        }
+    }
+
+    @Nested
+    @DisplayName("ITEM Line 처리 가능 여부를 확인할 때")
+    class ValidateItemLineProcessing {
+
+        @Test
+        @DisplayName("PENDING ITEM은 처리 필요, SUCCEEDED ITEM은 receipt 검증 대상이다")
+        void distinguishesPendingAndSucceededItem() {
+            RewardSettlement settlement = settlement(profileWithExpAndItem());
+            RewardSettlementLine item = settlement.getLineOrThrow(1);
+
+            assertThat(item.isItemProcessingRequired()).isTrue();
+            assertThat(item.isItemSucceeded()).isFalse();
+
+            settlement.markItemLineSucceeded(1001L);
+
+            assertThat(item.isItemProcessingRequired()).isFalse();
+            assertThat(item.isItemSucceeded()).isTrue();
+        }
+
+        @Test
+        @DisplayName("EXP Line을 ITEM 계약으로 처리할 수 없다")
+        void rejectsExpLine() {
+            RewardSettlement settlement = settlement(profileWithExpAndItem());
+
+            assertRewardError(
+                    () -> settlement.getLineOrThrow(0)
+                            .isItemProcessingRequired(),
+                    RewardError.REWARD_SETTLEMENT_LINE_NOT_ITEM
+            );
+        }
+
+        @Test
+        @DisplayName("FAILED ITEM은 explicit retry 준비 전 자동 처리할 수 없다")
+        void rejectsFailedItemLine() {
+            RewardSettlement settlement = settlement(profileWithExpAndItem());
+            settlement.markLineFailed(
+                    1, RewardError.REWARD_DEFINITION_NOT_FOUND
+            );
+
+            assertRewardError(
+                    () -> settlement.getLineOrThrow(1)
+                            .isItemProcessingRequired(),
+                    RewardError.REWARD_SETTLEMENT_LINE_ALREADY_FAILED
+            );
         }
     }
 
@@ -367,7 +421,7 @@ class RewardSettlementTest {
 
     private RewardDefinition persistedExpDefinition(Long id, String code, Long amount) {
         RewardDefinition definition = RewardDefinition.create(
-                code, code, RewardType.EXP, amount, null, true
+                code, code, RewardType.EXP, amount, null, null, true
         );
         ReflectionTestUtils.setField(definition, "id", id);
         return definition;
@@ -380,7 +434,7 @@ class RewardSettlementTest {
             Long quantity
     ) {
         RewardDefinition definition = RewardDefinition.create(
-                code, code, RewardType.ITEM, quantity, itemId, true
+                code, code, RewardType.ITEM, quantity, itemId, "IT_" + code, true
         );
         ReflectionTestUtils.setField(definition, "id", id);
         return definition;


### PR DESCRIPTION
## What

Reward Settlement의 ITEM Line을
Inventory exact-once delivery foundation에 연결한다.

```text
Reward ITEM Line
→ InventoryRewardDeliveryApi
→ Mailbox + delivery receipt
→ ITEM Line SUCCEEDED
→ Settlement status recalculation
```

## Stable Item Snapshot

ITEM Reward Definition과 Settlement Line에
`itemCode`를 저장한다.

- Definition create/update 시 Inventory ItemLookupApi로 결정
- Settlement 생성 시 itemId/itemCode snapshot
- 기존 ITEM 데이터 Migration backfill
- EXP payload는 itemId/itemCode null 유지

## ITEM Processor

ITEM Attempt는 별도 `REQUIRES_NEW` Transaction에서
Settlement를 먼저 잠근다.

```text
RewardSettlement PESSIMISTIC_WRITE
→ PlayerMailbox PESSIMISTIC_WRITE
```

Inventory delivery와 Line success는 같은 Transaction에 참여한다.

## Replay

PENDING Line에 matching receipt가 존재하면
중복 지급 없이 성공 상태를 복구한다.

이미 SUCCEEDED인 Line은 신규 delivery를 호출하지 않고
기존 receipt만 검증한다.

Receipt가 없거나 snapshot과 다르면
중복 지급 없이 invariant failure를 전파한다.

## Failure Policy

예상 가능한 Domain failure:

- Line FAILED
- failureCode 저장
- 자동 retry 없음

예상하지 못한 system failure:

- Line PENDING 유지
- 예외 전파
- Outbox retry

## Mixed Reward

`RP_EXP_AND_ITEM_FIRST_STEP_20`:

- EXP 20 SUCCEEDED
- ITEM SUCCEEDED
- Settlement COMPLETED
- Event replay exact-once

## Migration

```text
V18__reward_item_code_snapshot.sql
```

## Test

- itemCode schema/backfill/snapshot
- 신규 ITEM delivery
- pending receipt recovery
- succeeded receipt-only replay
- snapshot mismatch
- Mailbox full 및 Domain failure
- system failure rollback
- mixed Profile
- sequential/concurrent/restart replay
- full clean test/build

## Out of Scope

- Mailbox claim hardening
- Item delete/deactivate policy
- automatic retry scheduler
- Reward claim API
- Frontend

Closes #226

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create and update item-based reward definitions with validated item references and codes.
  * Process item rewards with delivery, replay recovery, failure handling, and exactly-once behavior.
  * Look up reward delivery receipts and items by ID.
  * Preserve item-code snapshots in reward definitions and settlement records.

* **Bug Fixes**
  * Improved validation and consistency checks for item rewards and deliveries.
  * Prevented invalid or incomplete item reward data from being processed.
  * Backfilled existing item codes while enforcing valid reward data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->