### PR TITLE
[Inventory] Harden mailbox claim concurrency and atomicity

### DIFF
--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -1,5 +1,7 @@
 tasks.named('test') {
     useJUnitPlatform()
+    maxHeapSize = '2g'
+    systemProperty 'spring.test.context.cache.maxSize', '8'
 }
 
 ext['testcontainers.version'] = '1.21.4'

--- a/src/main/java/online/lifeasgame/inventory/api/player/mapper/MailboxWebMapper.java
+++ b/src/main/java/online/lifeasgame/inventory/api/player/mapper/MailboxWebMapper.java
@@ -42,9 +42,9 @@ public final class MailboxWebMapper {
 
     public static MailboxCommand.ClaimAll toClaimAllCommand(MailboxRequest.ClaimAll request) {
         return new MailboxCommand.ClaimAll(
-                request.claims().stream()
+                request.claims() == null ? null : request.claims().stream()
                         .map(
-                                claim -> new MailboxCommand.Claim(
+                                claim -> claim == null ? null : new MailboxCommand.Claim(
                                         claim.slotIndex(),
                                         claim.quantity()
                                 )

--- a/src/main/java/online/lifeasgame/inventory/api/player/request/MailboxRequest.java
+++ b/src/main/java/online/lifeasgame/inventory/api/player/request/MailboxRequest.java
@@ -1,6 +1,11 @@
 package online.lifeasgame.inventory.api.player.request;
 
 import jakarta.validation.constraints.Min;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import online.lifeasgame.inventory.domain.PlayerMailbox;
 
 import java.util.List;
 
@@ -16,7 +21,9 @@ public final class MailboxRequest {
     }
 
     public record ClaimAll(
-            List<Claim> claims
+            @NotEmpty
+            @Size(max = PlayerMailbox.DEFAULT_CAPACITY)
+            List<@NotNull @Valid Claim> claims
     ) {}
 
     public record Delete(

--- a/src/main/java/online/lifeasgame/inventory/application/InventoryContainerProvisioningService.java
+++ b/src/main/java/online/lifeasgame/inventory/application/InventoryContainerProvisioningService.java
@@ -24,13 +24,13 @@ public class InventoryContainerProvisioningService {
             throw new DomainException(InventoryError.PLAYER_ID_INVALID);
         }
 
-        inventoryRepository.insertIfAbsent(
-                playerId,
-                PlayerInventory.DEFAULT_CAPACITY
-        );
         mailboxRepository.insertIfAbsent(
                 playerId,
                 PlayerMailbox.DEFAULT_CAPACITY
+        );
+        inventoryRepository.insertIfAbsent(
+                playerId,
+                PlayerInventory.DEFAULT_CAPACITY
         );
     }
 }

--- a/src/main/java/online/lifeasgame/inventory/application/InventoryReader.java
+++ b/src/main/java/online/lifeasgame/inventory/application/InventoryReader.java
@@ -22,6 +22,7 @@ public class InventoryReader {
                 .orElseThrow(() -> new DomainException(InventoryError.CONTAINER_NOT_FOUND));
     }
 
+    @Transactional(propagation = Propagation.MANDATORY)
     public PlayerInventory getByPlayerIdForUpdateOrThrow(Long playerId) {
         return repository.findByPlayerIdForUpdate(playerId)
                 .orElseThrow(() -> new DomainException(InventoryError.CONTAINER_NOT_FOUND));

--- a/src/main/java/online/lifeasgame/inventory/application/InventoryReader.java
+++ b/src/main/java/online/lifeasgame/inventory/application/InventoryReader.java
@@ -21,4 +21,9 @@ public class InventoryReader {
         return repository.findByPlayerId(playerId)
                 .orElseThrow(() -> new DomainException(InventoryError.CONTAINER_NOT_FOUND));
     }
+
+    public PlayerInventory getByPlayerIdForUpdateOrThrow(Long playerId) {
+        return repository.findByPlayerIdForUpdate(playerId)
+                .orElseThrow(() -> new DomainException(InventoryError.CONTAINER_NOT_FOUND));
+    }
 }

--- a/src/main/java/online/lifeasgame/inventory/application/MailboxReader.java
+++ b/src/main/java/online/lifeasgame/inventory/application/MailboxReader.java
@@ -21,6 +21,7 @@ class MailboxReader {
                 .orElseThrow(() -> new DomainException(InventoryError.CONTAINER_NOT_FOUND));
     }
 
+    @Transactional(propagation = Propagation.MANDATORY)
     public PlayerMailbox getByPlayerIdForUpdateOrThrow(Long playerId) {
         return repository.findByPlayerIdForUpdate(playerId)
                 .orElseThrow(() -> new DomainException(InventoryError.CONTAINER_NOT_FOUND));

--- a/src/main/java/online/lifeasgame/inventory/application/MailboxReader.java
+++ b/src/main/java/online/lifeasgame/inventory/application/MailboxReader.java
@@ -20,4 +20,9 @@ class MailboxReader {
         return repository.findByPlayerId(playerId)
                 .orElseThrow(() -> new DomainException(InventoryError.CONTAINER_NOT_FOUND));
     }
+
+    public PlayerMailbox getByPlayerIdForUpdateOrThrow(Long playerId) {
+        return repository.findByPlayerIdForUpdate(playerId)
+                .orElseThrow(() -> new DomainException(InventoryError.CONTAINER_NOT_FOUND));
+    }
 }

--- a/src/main/java/online/lifeasgame/inventory/application/MailboxService.java
+++ b/src/main/java/online/lifeasgame/inventory/application/MailboxService.java
@@ -1,14 +1,18 @@
 package online.lifeasgame.inventory.application;
 
 import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.inventory.application.command.MailboxCommand;
 import online.lifeasgame.inventory.application.query.MailboxEntryView;
 import online.lifeasgame.inventory.application.result.MailboxResult;
 import online.lifeasgame.inventory.domain.*;
+import online.lifeasgame.inventory.domain.error.InventoryError;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -24,7 +28,8 @@ public class MailboxService {
         Item item = itemReader.getByIdOrThrow(command.itemId());
         ItemCarryPolicy policy = ItemCarryPolicy.from(item);
 
-        PlayerMailbox playerMailbox = mailboxReader.getByPlayerIdOrThrow(playerId);
+        PlayerMailbox playerMailbox = mailboxReader
+                .getByPlayerIdForUpdateOrThrow(playerId);
         SlotIndex slotIndex = playerMailbox.deliver(
                 policy,
                 command.quantity(),
@@ -37,47 +42,104 @@ public class MailboxService {
 
     @Transactional
     public void claim(Long playerId, MailboxCommand.Claim command) {
-        PlayerMailbox mailbox = mailboxReader.getByPlayerIdOrThrow(playerId);
-        PlayerInventory inventory = inventoryReader.getByPlayerIdOrThrow(playerId);
+        validateClaim(command);
+        PlayerMailbox mailbox = mailboxReader
+                .getByPlayerIdForUpdateOrThrow(playerId);
+        PlayerInventory inventory = inventoryReader
+                .getByPlayerIdForUpdateOrThrow(playerId);
 
-        claimSingle(mailbox, inventory, command);
+        claim(mailbox, inventory, List.of(command));
     }
 
     @Transactional
     public void claimAll(Long playerId, MailboxCommand.ClaimAll command) {
-        PlayerMailbox mailbox = mailboxReader.getByPlayerIdOrThrow(playerId);
-        PlayerInventory inventory = inventoryReader.getByPlayerIdOrThrow(playerId);
+        List<MailboxCommand.Claim> claims = validateClaimAll(command);
+        PlayerMailbox mailbox = mailboxReader
+                .getByPlayerIdForUpdateOrThrow(playerId);
+        PlayerInventory inventory = inventoryReader
+                .getByPlayerIdForUpdateOrThrow(playerId);
 
+        claim(mailbox, inventory, claims);
+    }
+
+    private void claim(
+            PlayerMailbox mailbox,
+            PlayerInventory inventory,
+            List<MailboxCommand.Claim> claims
+    ) {
+        List<PlayerMailbox.ClaimPlan> plans = claims.stream()
+                .map(command -> planClaim(mailbox, command))
+                .toList();
+        List<PlayerInventory.Addition> additions = plans.stream()
+                .map(plan -> new PlayerInventory.Addition(
+                        plan.policy(),
+                        plan.quantity(),
+                        plan.attrs(),
+                        plan.bound()
+                ))
+                .toList();
+
+        inventory.assertCanAddAll(additions);
+        plans.forEach(mailbox::applyClaim);
+        additions.forEach(addition -> inventory.add(
+                addition.policy(),
+                addition.quantity(),
+                addition.attrs(),
+                addition.bound()
+        ));
+    }
+
+    private PlayerMailbox.ClaimPlan planClaim(
+            PlayerMailbox mailbox,
+            MailboxCommand.Claim command
+    ) {
+        SlotIndex slot = SlotIndex.of(command.slotIndex());
+        MailboxEntry entry = mailbox.getEntryOrThrow(slot);
+        Item item = itemReader.getByIdOrThrow(entry.getItemId());
+        return mailbox.planClaim(
+                slot,
+                command.quantity(),
+                ItemCarryPolicy.from(item)
+        );
+    }
+
+    private List<MailboxCommand.Claim> validateClaimAll(
+            MailboxCommand.ClaimAll command
+    ) {
+        if (command == null
+                || command.claims() == null
+                || command.claims().isEmpty()
+                || command.claims().stream().anyMatch(java.util.Objects::isNull)) {
+            throw new DomainException(InventoryError.MAILBOX_CLAIM_EMPTY);
+        }
+        if (command.claims().size() > PlayerMailbox.DEFAULT_CAPACITY) {
+            throw new DomainException(InventoryError.MAILBOX_CLAIM_TOO_LARGE);
+        }
+
+        Set<Integer> slots = new HashSet<>();
         for (MailboxCommand.Claim claim : command.claims()) {
-            claimSingle(mailbox, inventory, claim);
+            validateClaim(claim);
+            if (!slots.add(claim.slotIndex())) {
+                throw new DomainException(
+                        InventoryError.MAILBOX_CLAIM_DUPLICATE_SLOT
+                );
+            }
+        }
+        return command.claims();
+    }
+
+    private void validateClaim(MailboxCommand.Claim command) {
+        if (command == null) {
+            throw new DomainException(InventoryError.MAILBOX_CLAIM_EMPTY);
+        }
+        if (command.slotIndex() < 0) {
+            throw new DomainException(InventoryError.INVALID_SLOT);
+        }
+        if (command.quantity() < 1) {
+            throw new DomainException(InventoryError.INVALID_QUANTITY);
         }
     }
 
-    private void claimSingle(
-            PlayerMailbox mailbox,
-            PlayerInventory inventory,
-            MailboxCommand.Claim command
-    ) {
-        SlotIndex slotIndex = SlotIndex.of(command.slotIndex());
-
-        MailboxEntry entry = mailbox.getEntry(slotIndex);
-
-        Item item = itemReader.getByIdOrThrow(entry.getItemId());
-        ItemCarryPolicy policy = ItemCarryPolicy.from(item);
-
-        PlayerMailbox.ClaimedSlice slice = mailbox.claim(
-                slotIndex,
-                command.quantity(),
-                policy
-        );
-
-        inventory.add(
-                policy,
-                slice.quantity(),
-                slice.attrs(),
-                slice.bound()
-        );
-    }
     @Transactional(readOnly = true)
     public MailboxResult.Entries list(Long playerId) {
         List<MailboxEntryView> entryViews = mailBoxQueryReader.list(playerId);
@@ -86,7 +148,8 @@ public class MailboxService {
 
     @Transactional
     public void delete(Long playerId, MailboxCommand.Delete command) {
-        PlayerMailbox mailbox = mailboxReader.getByPlayerIdOrThrow(playerId);
+        PlayerMailbox mailbox = mailboxReader
+                .getByPlayerIdForUpdateOrThrow(playerId);
         mailbox.deleteEntry(SlotIndex.of(command.slotIndex()));
     }
 }

--- a/src/main/java/online/lifeasgame/inventory/domain/PlayerInventory.java
+++ b/src/main/java/online/lifeasgame/inventory/domain/PlayerInventory.java
@@ -74,24 +74,11 @@ public class PlayerInventory extends AbstractTime {
         }
     }
 
-    private int freeSlots() {
-        return capacitySlots - entries.size();
-    }
-
     public List<SlotIndex> add(ItemCarryPolicy itemCarryPolicy, int quantity, InstanceAttrs attrs, boolean bound) {
-        Guard.minValue(quantity, 1, "qty");
         InstanceAttrs instanceAttrs = (attrs == null) ? InstanceAttrs.empty() : attrs;
+        assertCanAdd(itemCarryPolicy, quantity, instanceAttrs, bound);
 
         List<InventoryEntry> stacks = stacksOf(itemCarryPolicy, bound, instanceAttrs);
-
-        int capacityInExisting = stacks.stream()
-                .mapToInt(s -> itemCarryPolicy.spaceInStack(s.getQuantity().value()))
-                .sum();
-        int remainingAfterExisting = Math.max(0, quantity - capacityInExisting);
-        int neededNew = itemCarryPolicy.estimateNewStacksNeeded(remainingAfterExisting);
-        if (neededNew > freeSlots()) {
-            throw new DomainException(InventoryError.INVENTORY_FULL);
-        }
 
         int remaining = quantity;
         for (InventoryEntry s : stacks) {
@@ -139,6 +126,100 @@ public class PlayerInventory extends AbstractTime {
         );
 
         return placed;
+    }
+
+    public record Addition(
+            ItemCarryPolicy policy,
+            int quantity,
+            InstanceAttrs attrs,
+            boolean bound
+    ) {
+    }
+
+    public void assertCanAdd(
+            ItemCarryPolicy policy,
+            int quantity,
+            InstanceAttrs attrs,
+            boolean bound
+    ) {
+        assertCanAddAll(List.of(new Addition(policy, quantity, attrs, bound)));
+    }
+
+    public void assertCanAddAll(List<Addition> additions) {
+        Objects.requireNonNull(additions, "additions must not be null");
+        List<SimulatedStack> simulated = entries.stream()
+                .map(entry -> new SimulatedStack(
+                        entry.getItemId(),
+                        entry.isBound(),
+                        safeAttrs(entry.getInstAttrs()),
+                        entry.getQuantity().value()
+                ))
+                .collect(java.util.stream.Collectors.toCollection(ArrayList::new));
+
+        for (Addition addition : additions) {
+            Objects.requireNonNull(addition, "addition must not be null");
+            if (addition.quantity() < 1) {
+                throw new DomainException(InventoryError.INVALID_QUANTITY);
+            }
+
+            ItemCarryPolicy policy = Objects.requireNonNull(
+                    addition.policy(),
+                    "policy must not be null"
+            );
+            Map<String, Object> attrs = safeAttrs(addition.attrs());
+            int remaining = addition.quantity();
+
+            for (int index = 0; index < simulated.size() && remaining > 0; index++) {
+                SimulatedStack stack = simulated.get(index);
+                if (!Objects.equals(stack.itemId(), policy.itemId())
+                        || !policy.sameStackKey(
+                        stack.bound(),
+                        stack.attrs(),
+                        addition.bound(),
+                        attrs
+                )) {
+                    continue;
+                }
+
+                int added = policy.clampAddToLimit(
+                        stack.quantity(),
+                        remaining
+                );
+                if (added > 0) {
+                    simulated.set(index, stack.withQuantity(
+                            stack.quantity() + added
+                    ));
+                    remaining -= added;
+                }
+            }
+
+            while (remaining > 0) {
+                if (simulated.size() >= capacitySlots) {
+                    throw new DomainException(InventoryError.INVENTORY_FULL);
+                }
+                int put = policy.stackable()
+                        ? Math.min(policy.maxStack(), remaining)
+                        : 1;
+                simulated.add(new SimulatedStack(
+                        policy.itemId(),
+                        addition.bound(),
+                        attrs,
+                        put
+                ));
+                remaining -= put;
+            }
+        }
+    }
+
+    private record SimulatedStack(
+            Long itemId,
+            boolean bound,
+            Map<String, Object> attrs,
+            int quantity
+    ) {
+        private SimulatedStack withQuantity(int nextQuantity) {
+            return new SimulatedStack(itemId, bound, attrs, nextQuantity);
+        }
     }
 
     /**

--- a/src/main/java/online/lifeasgame/inventory/domain/PlayerMailbox.java
+++ b/src/main/java/online/lifeasgame/inventory/domain/PlayerMailbox.java
@@ -13,6 +13,7 @@ import online.lifeasgame.platform.persistence.jpa.AbstractTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Getter
@@ -139,8 +140,10 @@ public class PlayerMailbox extends AbstractTime {
         throw new IllegalStateException("deliver() must return a slot when quantity > 0");
     }
 
-    public MailboxEntry getEntry(SlotIndex of) {
-        return entries.stream().filter(e -> e.slotIndex.equals(of)).findFirst().orElse(null);
+    public MailboxEntry getEntryOrThrow(SlotIndex slot) {
+        ensureValidSlot(slot);
+        return findBySlot(slot)
+                .orElseThrow(() -> new DomainException(InventoryError.SLOT_EMPTY));
     }
 
     public void deleteEntry(SlotIndex slot) {
@@ -152,31 +155,56 @@ public class PlayerMailbox extends AbstractTime {
         entries.remove(entry);
     }
 
-    /**
-     * 수령 슬라이스 VO (인벤토리에 넣을 정보)
-     */
-    public record ClaimedSlice(int quantity, InstanceAttrs attrs, boolean bound) {
+    public record ClaimPlan(
+            SlotIndex slotIndex,
+            Long itemId,
+            int quantity,
+            InstanceAttrs attrs,
+            boolean bound,
+            ItemCarryPolicy policy
+    ) {
     }
 
-    /**
-     * 우편 수령: 메일함에서 차감만 하고, 인벤토리에 넣을 데이터를 반환
-     */
-    public ClaimedSlice claim(SlotIndex from, int qty, ItemCarryPolicy p) {
-        ensureValidSlot(from);
-        MailboxEntry src = findBySlot(from).orElseThrow(() -> new DomainException(InventoryError.SLOT_EMPTY));
+    public ClaimPlan planClaim(
+            SlotIndex slot,
+            int quantity,
+            ItemCarryPolicy policy
+    ) {
+        MailboxEntry entry = getEntryOrThrow(slot);
+        if (quantity < 1) {
+            throw new DomainException(InventoryError.INVALID_QUANTITY);
+        }
+        if (quantity > entry.getQuantity().value()) {
+            throw new DomainException(InventoryError.NOT_ENOUGH_QUANTITY);
+        }
+        if (!policy.itemId().equals(entry.getItemId())) {
+            throw new DomainException(InventoryError.ITEM_NOT_FOUND);
+        }
+        return new ClaimPlan(
+                slot,
+                entry.getItemId(),
+                quantity,
+                entry.getInstAttrs(),
+                entry.isBound(),
+                policy
+        );
+    }
 
-        Guard.minValue(qty, 1, "qty");
-        if (qty > src.getQuantity().value()) throw new DomainException(InventoryError.NOT_ENOUGH_QUANTITY);
+    public void applyClaim(ClaimPlan plan) {
+        MailboxEntry entry = getEntryOrThrow(plan.slotIndex());
+        if (!Objects.equals(entry.getItemId(), plan.itemId())
+                || entry.getQuantity().value() < plan.quantity()
+                || !Objects.equals(entry.getInstAttrs(), plan.attrs())
+                || entry.isBound() != plan.bound()) {
+            throw new IllegalStateException(
+                    "Mailbox claim state changed after preflight"
+            );
+        }
 
-        // (정책 일관성 체크: 스택 규칙이 깨진 상태 방지용. 보통은 저장 당시 보장됨)
-        if (!p.itemId().equals(src.getItemId())) throw new DomainException(InventoryError.ITEM_NOT_FOUND);
-
-        // 먼저 메일함에서 차감
-        src.decreaseQuantity(qty);
-        if (src.getQuantity().value() == 0) entries.remove(src);
-
-        // 인벤토리에 넣을 페이로드 반환
-        return new ClaimedSlice(qty, src.getInstAttrs(), src.isBound());
+        entry.decreaseQuantity(plan.quantity());
+        if (entry.getQuantity().value() == 0) {
+            entries.remove(entry);
+        }
     }
 
     public List<MailboxEntry> getEntries() {

--- a/src/main/java/online/lifeasgame/inventory/domain/error/InventoryError.java
+++ b/src/main/java/online/lifeasgame/inventory/domain/error/InventoryError.java
@@ -21,7 +21,10 @@ public enum InventoryError implements ErrorCode {
     PLAYER_ID_INVALID("INV-PLAYER-ID-INVALID","Player ID must be positive",400),
     REWARD_ITEM_CODE_INVALID("INV-REWARD-ITEM-CODE-INVALID","Reward item code is invalid",400),
     REWARD_QUANTITY_INVALID("INV-REWARD-QUANTITY-INVALID","Reward quantity is invalid",400),
-    REWARD_DELIVERY_CONFLICT("INV-REWARD-DELIVERY-CONFLICT","Reward delivery payload conflict",409),;
+    REWARD_DELIVERY_CONFLICT("INV-REWARD-DELIVERY-CONFLICT","Reward delivery payload conflict",409),
+    MAILBOX_CLAIM_EMPTY("INV-MAILBOX-CLAIM-EMPTY","Mailbox claims must not be empty",400),
+    MAILBOX_CLAIM_DUPLICATE_SLOT("INV-MAILBOX-CLAIM-DUPLICATE-SLOT","Mailbox claim slots must be unique",400),
+    MAILBOX_CLAIM_TOO_LARGE("INV-MAILBOX-CLAIM-TOO-LARGE","Too many mailbox claims",400),;
 
 
     private final String code;

--- a/src/main/java/online/lifeasgame/inventory/domain/repository/PlayerInventoryRepository.java
+++ b/src/main/java/online/lifeasgame/inventory/domain/repository/PlayerInventoryRepository.java
@@ -5,6 +5,7 @@ import online.lifeasgame.inventory.domain.PlayerInventory;
 
 public interface PlayerInventoryRepository {
     Optional<PlayerInventory> findByPlayerId(Long playerId);
+    Optional<PlayerInventory> findByPlayerIdForUpdate(Long playerId);
     PlayerInventory save(PlayerInventory inv);
     void insertIfAbsent(Long playerId, int capacitySlots);
 }

--- a/src/main/java/online/lifeasgame/inventory/infra/JpaInventoryRepository.java
+++ b/src/main/java/online/lifeasgame/inventory/infra/JpaInventoryRepository.java
@@ -1,7 +1,9 @@
 package online.lifeasgame.inventory.infra;
 
+import jakarta.persistence.LockModeType;
 import online.lifeasgame.inventory.domain.PlayerInventory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,6 +12,10 @@ import java.util.Optional;
 
 public interface JpaInventoryRepository extends JpaRepository<PlayerInventory, Long> {
     Optional<PlayerInventory> findByPlayerId(Long playerId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT inventory FROM PlayerInventory inventory WHERE inventory.playerId = :playerId")
+    Optional<PlayerInventory> findByPlayerIdForUpdate(@Param("playerId") Long playerId);
 
     @Modifying
     @Query(value = """

--- a/src/main/java/online/lifeasgame/inventory/infra/PlayerInventoryAdapter.java
+++ b/src/main/java/online/lifeasgame/inventory/infra/PlayerInventoryAdapter.java
@@ -20,6 +20,11 @@ public class PlayerInventoryAdapter implements PlayerInventoryRepository, Invent
     }
 
     @Override
+    public Optional<PlayerInventory> findByPlayerIdForUpdate(Long playerId) {
+        return jpaRepository.findByPlayerIdForUpdate(playerId);
+    }
+
+    @Override
     public PlayerInventory save(PlayerInventory inv) {
         return jpaRepository.save(inv);
     }

--- a/src/test/java/online/lifeasgame/inventory/application/MailboxClaimBoundaryTest.java
+++ b/src/test/java/online/lifeasgame/inventory/application/MailboxClaimBoundaryTest.java
@@ -1,0 +1,215 @@
+package online.lifeasgame.inventory.application;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.inventory.api.player.request.MailboxRequest;
+import online.lifeasgame.inventory.application.command.MailboxCommand;
+import online.lifeasgame.inventory.domain.*;
+import online.lifeasgame.inventory.domain.error.InventoryError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Mailbox claim boundary")
+class MailboxClaimBoundaryTest {
+
+    private static final Long PLAYER_ID = 2280L;
+    private static final Long ITEM_ID = 228L;
+
+    @Mock
+    private MailboxReader mailboxReader;
+
+    @Mock
+    private InventoryReader inventoryReader;
+
+    @Mock
+    private ItemReader itemReader;
+
+    @Mock
+    private MailBoxQueryReader mailBoxQueryReader;
+
+    private MailboxService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new MailboxService(
+                mailboxReader,
+                inventoryReader,
+                itemReader,
+                mailBoxQueryReader
+        );
+    }
+
+    @Test
+    @DisplayName("null, empty, null element, size 초과를 lock 전에 거부한다")
+    void rejectsEmptyAndOversizedBatch() {
+        assertError(
+                () -> service.claimAll(PLAYER_ID, null),
+                InventoryError.MAILBOX_CLAIM_EMPTY
+        );
+        assertError(
+                () -> service.claimAll(
+                        PLAYER_ID,
+                        new MailboxCommand.ClaimAll(null)
+                ),
+                InventoryError.MAILBOX_CLAIM_EMPTY
+        );
+        assertError(
+                () -> service.claimAll(
+                        PLAYER_ID,
+                        new MailboxCommand.ClaimAll(List.of())
+                ),
+                InventoryError.MAILBOX_CLAIM_EMPTY
+        );
+        assertError(
+                () -> service.claimAll(
+                        PLAYER_ID,
+                        new MailboxCommand.ClaimAll(
+                                Collections.singletonList(null)
+                        )
+                ),
+                InventoryError.MAILBOX_CLAIM_EMPTY
+        );
+        assertError(
+                () -> service.claimAll(
+                        PLAYER_ID,
+                        new MailboxCommand.ClaimAll(
+                                new ArrayList<>(Collections.nCopies(
+                                        PlayerMailbox.DEFAULT_CAPACITY + 1,
+                                        new MailboxCommand.Claim(0, 1)
+                                ))
+                        )
+                ),
+                InventoryError.MAILBOX_CLAIM_TOO_LARGE
+        );
+
+        verifyNoInteractions(mailboxReader, inventoryReader, itemReader);
+    }
+
+    @Test
+    @DisplayName("duplicate slot과 invalid slot/quantity를 stable error로 거부한다")
+    void rejectsInvalidClaims() {
+        assertError(
+                () -> service.claimAll(
+                        PLAYER_ID,
+                        new MailboxCommand.ClaimAll(List.of(
+                                new MailboxCommand.Claim(0, 1),
+                                new MailboxCommand.Claim(0, 1)
+                        ))
+                ),
+                InventoryError.MAILBOX_CLAIM_DUPLICATE_SLOT
+        );
+        assertError(
+                () -> service.claim(
+                        PLAYER_ID,
+                        new MailboxCommand.Claim(-1, 1)
+                ),
+                InventoryError.INVALID_SLOT
+        );
+        assertError(
+                () -> service.claim(
+                        PLAYER_ID,
+                        new MailboxCommand.Claim(0, 0)
+                ),
+                InventoryError.INVALID_QUANTITY
+        );
+
+        verifyNoInteractions(mailboxReader, inventoryReader, itemReader);
+    }
+
+    @Test
+    @DisplayName("claim은 Mailbox 후 Inventory를 잠그고 snapshot을 그대로 옮긴다")
+    void locksInCanonicalOrderAndClaims() {
+        Item item = item();
+        ItemCarryPolicy policy = ItemCarryPolicy.from(item);
+        PlayerMailbox mailbox = PlayerMailbox.of(PLAYER_ID, 2);
+        mailbox.deliver(policy, 1, InstanceAttrs.empty(), true);
+        PlayerInventory inventory = PlayerInventory.of(PLAYER_ID, 2);
+        given(mailboxReader.getByPlayerIdForUpdateOrThrow(PLAYER_ID))
+                .willReturn(mailbox);
+        given(inventoryReader.getByPlayerIdForUpdateOrThrow(PLAYER_ID))
+                .willReturn(inventory);
+        given(itemReader.getByIdOrThrow(ITEM_ID)).willReturn(item);
+
+        service.claim(PLAYER_ID, new MailboxCommand.Claim(0, 1));
+
+        InOrder locks = inOrder(mailboxReader, inventoryReader);
+        locks.verify(mailboxReader).getByPlayerIdForUpdateOrThrow(PLAYER_ID);
+        locks.verify(inventoryReader).getByPlayerIdForUpdateOrThrow(PLAYER_ID);
+        verify(mailboxReader, never()).getByPlayerIdOrThrow(anyLong());
+        verify(inventoryReader, never()).getByPlayerIdOrThrow(anyLong());
+        assertThat(mailbox.getEntries()).isEmpty();
+        assertThat(inventory.getEntries()).hasSize(1);
+        assertThat(inventory.getEntries().getFirst().isBound()).isTrue();
+    }
+
+    @Test
+    @DisplayName("deliver와 delete도 Mailbox for-update 조회를 사용한다")
+    void locksDeliverAndDelete() {
+        Item item = item();
+        PlayerMailbox mailbox = PlayerMailbox.of(PLAYER_ID, 2);
+        given(itemReader.getByIdOrThrow(ITEM_ID)).willReturn(item);
+        given(mailboxReader.getByPlayerIdForUpdateOrThrow(PLAYER_ID))
+                .willReturn(mailbox);
+
+        service.deliver(
+                PLAYER_ID,
+                new MailboxCommand.Deliver(ITEM_ID, 1, null, false)
+        );
+        service.delete(PLAYER_ID, new MailboxCommand.Delete(0));
+
+        verify(mailboxReader, times(2))
+                .getByPlayerIdForUpdateOrThrow(PLAYER_ID);
+        verify(mailboxReader, never()).getByPlayerIdOrThrow(anyLong());
+        assertThat(mailbox.getEntries()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("ClaimAll API는 collection과 element validation을 선언한다")
+    void validatesApiRequest() {
+        Validator validator = Validation.buildDefaultValidatorFactory()
+                .getValidator();
+
+        assertThat(validator.validate(new MailboxRequest.ClaimAll(null)))
+                .isNotEmpty();
+        assertThat(validator.validate(new MailboxRequest.ClaimAll(List.of())))
+                .isNotEmpty();
+        assertThat(validator.validate(new MailboxRequest.ClaimAll(
+                Collections.singletonList(null)
+        ))).isNotEmpty();
+        assertThat(validator.validate(new MailboxRequest.ClaimAll(List.of(
+                new MailboxRequest.Claim(0, 0)
+        )))).isNotEmpty();
+    }
+
+    private Item item() {
+        Item item = mock(Item.class);
+        given(item.getId()).willReturn(ITEM_ID);
+        given(item.getRarity()).willReturn(Rarity.COMMON);
+        given(item.isStackable()).willReturn(true);
+        given(item.maxStack()).willReturn(10);
+        return item;
+    }
+
+    private void assertError(Runnable call, InventoryError error) {
+        assertThatThrownBy(call::run)
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(error)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/inventory/application/MailboxClaimConcurrencyIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/inventory/application/MailboxClaimConcurrencyIntegrationTest.java
@@ -1,0 +1,355 @@
+package online.lifeasgame.inventory.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.inventory.application.command.MailboxCommand;
+import online.lifeasgame.inventory.application.internal.InventoryRewardDeliveryApi;
+import online.lifeasgame.inventory.domain.error.InventoryError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Mailbox claim concurrency MySQL integration")
+class MailboxClaimConcurrencyIntegrationTest
+        extends MailboxClaimMySqlIntegrationTestSupport {
+
+    private static final Long PLAYER_ID = 228201L;
+    private static final String ITEM_A = "IT_228_CONCURRENT_A";
+    private static final String ITEM_B = "IT_228_CONCURRENT_B";
+
+    @Autowired
+    private MailboxService mailboxService;
+
+    @Autowired
+    private InventoryRewardDeliveryApi rewardDeliveryApi;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        resetState();
+    }
+
+    @Test
+    @DisplayName("same slot quantity 1은 정확히 하나만 claim하고 timeout 없이 보존한다")
+    void serializesSameSlotClaim() throws Exception {
+        deliver(ITEM_A, 1, Map.of(), true);
+
+        List<Throwable> outcomes = race(
+                () -> claim(0, 1),
+                () -> claim(0, 1)
+        );
+
+        assertOneFailure(outcomes, InventoryError.SLOT_EMPTY);
+        assertThat(mailboxTotal()).isZero();
+        assertThat(inventoryTotal()).isEqualTo(1);
+        assertConserved(1, 0);
+    }
+
+    @Test
+    @DisplayName("same slot quantity 10의 두 claim 7은 하나만 성공한다")
+    void serializesInsufficientSameSlotClaim() throws Exception {
+        deliver(ITEM_A, 10, Map.of(), true);
+
+        List<Throwable> outcomes = race(
+                () -> claim(0, 7),
+                () -> claim(0, 7)
+        );
+
+        assertOneFailure(outcomes, InventoryError.NOT_ENOUGH_QUANTITY);
+        assertThat(mailboxTotal()).isEqualTo(3);
+        assertThat(inventoryTotal()).isEqualTo(7);
+        assertConserved(10, 0);
+    }
+
+    @Test
+    @DisplayName("overlapping claimAll은 후행 batch 전체를 latest state에서 거부한다")
+    void serializesOverlappingBatches() throws Exception {
+        deliver(ITEM_A, 5, Map.of("grade", "A"), true);
+        deliver(ITEM_A, 5, Map.of("grade", "B"), true);
+        deliver(ITEM_B, 1, Map.of(), true);
+
+        List<Throwable> outcomes = race(
+                () -> claimAll(
+                        new MailboxCommand.Claim(0, 3),
+                        new MailboxCommand.Claim(1, 3)
+                ),
+                () -> claimAll(
+                        new MailboxCommand.Claim(1, 4),
+                        new MailboxCommand.Claim(2, 1)
+                )
+        );
+
+        assertOneFailure(outcomes, InventoryError.NOT_ENOUGH_QUANTITY);
+        assertThat(mailboxTotal() + inventoryTotal()).isEqualTo(11);
+        if (inventoryTotal() == 6) {
+            assertThat(mailboxSlotQuantity(0)).isEqualTo(2);
+            assertThat(mailboxSlotQuantity(2)).isEqualTo(1);
+        } else {
+            assertThat(inventoryTotal()).isEqualTo(5);
+            assertThat(mailboxSlotQuantity(0)).isEqualTo(5);
+            assertThat(mailboxSlotQuantity(2)).isZero();
+        }
+    }
+
+    @Test
+    @DisplayName("claim과 overlapping claimAll도 partial batch 없이 직렬화한다")
+    void serializesClaimAgainstBatch() throws Exception {
+        deliver(ITEM_A, 2, Map.of("grade", "A"), true);
+        deliver(ITEM_A, 1, Map.of("grade", "B"), true);
+
+        List<Throwable> outcomes = race(
+                () -> claim(0, 1),
+                () -> claimAll(
+                        new MailboxCommand.Claim(0, 2),
+                        new MailboxCommand.Claim(1, 1)
+                )
+        );
+
+        assertThat(successCount(outcomes)).isEqualTo(1);
+        assertThat(failure(outcomes)).isInstanceOfSatisfying(
+                DomainException.class,
+                exception -> assertThat(exception.getErrorCode()).isIn(
+                        InventoryError.SLOT_EMPTY,
+                        InventoryError.NOT_ENOUGH_QUANTITY
+                )
+        );
+        assertThat(mailboxTotal() + inventoryTotal()).isEqualTo(3);
+        if (inventoryTotal() == 1) {
+            assertThat(mailboxSlotQuantity(1)).isEqualTo(1);
+        } else {
+            assertThat(inventoryTotal()).isEqualTo(3);
+            assertThat(mailboxTotal()).isZero();
+        }
+    }
+
+    @RepeatedTest(10)
+    @DisplayName("claim과 Reward delivery는 lost update 없이 receipt와 총량을 보존한다")
+    void serializesClaimAgainstRewardDelivery() throws Exception {
+        deliver(ITEM_A, 1, Map.of(), true);
+
+        List<Throwable> outcomes = race(
+                () -> claim(0, 1),
+                () -> rewardDeliveryApi.deliverReward(
+                        2282001L,
+                        PLAYER_ID,
+                        ITEM_A,
+                        2L
+                )
+        );
+
+        assertThat(outcomes).containsOnlyNulls();
+        assertThat(receiptCount(2282001L)).isEqualTo(1);
+        assertThat(mailboxTotal()).isEqualTo(2);
+        assertThat(inventoryTotal()).isEqualTo(1);
+        assertConserved(3, 0);
+    }
+
+    @Test
+    @DisplayName("claim과 delete는 정확히 하나만 적용하고 총량을 보존한다")
+    void serializesClaimAgainstDelete() throws Exception {
+        deliver(ITEM_A, 1, Map.of(), true);
+
+        List<Throwable> outcomes = race(
+                () -> claim(0, 1),
+                () -> mailboxService.delete(
+                        PLAYER_ID,
+                        new MailboxCommand.Delete(0)
+                )
+        );
+
+        assertOneFailure(outcomes, InventoryError.SLOT_EMPTY);
+        long deleted = inventoryTotal() == 0 ? 1 : 0;
+        assertThat(mailboxTotal()).isZero();
+        assertConserved(1, deleted);
+    }
+
+    private void claim(int slot, int quantity) {
+        mailboxService.claim(
+                PLAYER_ID,
+                new MailboxCommand.Claim(slot, quantity)
+        );
+    }
+
+    private void claimAll(MailboxCommand.Claim... claims) {
+        mailboxService.claimAll(
+                PLAYER_ID,
+                new MailboxCommand.ClaimAll(List.of(claims))
+        );
+    }
+
+    private void deliver(
+            String itemCode,
+            int quantity,
+            Map<String, Object> attrs,
+            boolean bound
+    ) {
+        mailboxService.deliver(
+                PLAYER_ID,
+                new MailboxCommand.Deliver(
+                        itemId(itemCode),
+                        quantity,
+                        attrs,
+                        bound
+                )
+        );
+    }
+
+    private List<Throwable> race(
+            ThrowingAction first,
+            ThrowingAction second
+    ) throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<Throwable>> futures = new ArrayList<>();
+
+        try {
+            for (ThrowingAction action : List.of(first, second)) {
+                futures.add(executor.submit(() -> {
+                    ready.countDown();
+                    start.await();
+                    try {
+                        action.run();
+                        return null;
+                    } catch (Throwable failure) {
+                        return failure;
+                    }
+                }));
+            }
+
+            assertThat(ready.await(10, TimeUnit.SECONDS)).isTrue();
+            start.countDown();
+            List<Throwable> outcomes = new ArrayList<>();
+            for (Future<Throwable> future : futures) {
+                outcomes.add(future.get(30, TimeUnit.SECONDS));
+            }
+            return outcomes;
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private void assertOneFailure(
+            List<Throwable> outcomes,
+            InventoryError error
+    ) {
+        assertThat(successCount(outcomes)).isEqualTo(1);
+        assertThat(failure(outcomes)).isInstanceOfSatisfying(
+                DomainException.class,
+                exception -> assertThat(exception.getErrorCode())
+                        .isEqualTo(error)
+        );
+    }
+
+    private long successCount(List<Throwable> outcomes) {
+        return outcomes.stream().filter(Objects::isNull).count();
+    }
+
+    private Throwable failure(List<Throwable> outcomes) {
+        return outcomes.stream().filter(Objects::nonNull).findFirst()
+                .orElseThrow();
+    }
+
+    private void assertConserved(long initialAndDelivered, long deleted) {
+        assertThat(mailboxTotal() + inventoryTotal() + deleted)
+                .isEqualTo(initialAndDelivered);
+    }
+
+    private void resetState() {
+        jdbcTemplate.update("DELETE FROM inventory_reward_deliveries");
+        jdbcTemplate.update("DELETE FROM inventory_entries");
+        jdbcTemplate.update("DELETE FROM mailbox_entries");
+        jdbcTemplate.update("DELETE FROM player_inventory");
+        jdbcTemplate.update("DELETE FROM player_mailbox");
+        insertItem(ITEM_A, "Issue 228 concurrent A");
+        insertItem(ITEM_B, "Issue 228 concurrent B");
+        jdbcTemplate.update("""
+                INSERT INTO player_inventory (
+                    player_id, capacity_slots, version, created_at, updated_at
+                ) VALUES (?, 10, 0, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6))
+                """, PLAYER_ID);
+        jdbcTemplate.update("""
+                INSERT INTO player_mailbox (
+                    player_id, capacity_slots, version, created_at, updated_at
+                ) VALUES (?, 10, 0, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6))
+                """, PLAYER_ID);
+    }
+
+    private void insertItem(String code, String name) {
+        jdbcTemplate.update("""
+                INSERT IGNORE INTO items (
+                    code, name, category, type, rarity, base_attrs,
+                    stackable, max_stack, max_durability,
+                    created_at, updated_at
+                ) VALUES (
+                    ?, ?, 'QUEST', 'ETC', 'COMMON', JSON_OBJECT(),
+                    TRUE, 10, NULL,
+                    CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
+                )
+                """, code, name);
+    }
+
+    private Long itemId(String code) {
+        return jdbcTemplate.queryForObject(
+                "SELECT id FROM items WHERE code = ?",
+                Long.class,
+                code
+        );
+    }
+
+    private long mailboxTotal() {
+        return jdbcTemplate.queryForObject("""
+                SELECT COALESCE(SUM(quantity), 0)
+                FROM mailbox_entries
+                WHERE player_id = ?
+                """, Long.class, PLAYER_ID);
+    }
+
+    private int mailboxSlotQuantity(int slot) {
+        return jdbcTemplate.queryForList("""
+                SELECT quantity
+                FROM mailbox_entries
+                WHERE player_id = ? AND slot_index = ?
+                """, Integer.class, PLAYER_ID, slot)
+                .stream()
+                .findFirst()
+                .orElse(0);
+    }
+
+    private long inventoryTotal() {
+        return jdbcTemplate.queryForObject("""
+                SELECT COALESCE(SUM(quantity), 0)
+                FROM inventory_entries
+                WHERE player_id = ?
+                """, Long.class, PLAYER_ID);
+    }
+
+    private int receiptCount(Long rewardLineId) {
+        return jdbcTemplate.queryForObject("""
+                SELECT COUNT(*)
+                FROM inventory_reward_deliveries
+                WHERE reward_line_id = ?
+                """, Integer.class, rewardLineId);
+    }
+
+    @FunctionalInterface
+    private interface ThrowingAction {
+        void run() throws Exception;
+    }
+}

--- a/src/test/java/online/lifeasgame/inventory/application/MailboxClaimIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/inventory/application/MailboxClaimIntegrationTest.java
@@ -1,0 +1,417 @@
+package online.lifeasgame.inventory.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.error.ErrorCode;
+import online.lifeasgame.inventory.application.command.MailboxCommand;
+import online.lifeasgame.inventory.domain.error.InventoryError;
+import online.lifeasgame.inventory.domain.error.ItemError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Mailbox claim MySQL integration")
+class MailboxClaimIntegrationTest
+        extends MailboxClaimMySqlIntegrationTestSupport {
+
+    private static final Long PLAYER_ID = 228101L;
+    private static final String ITEM_A = "IT_228_STACK_A";
+    private static final String ITEM_B = "IT_228_STACK_B";
+
+    @Autowired
+    private MailboxService mailboxService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        cleanState();
+        ensureItems();
+        insertContainers(3, 10);
+    }
+
+    @Test
+    @DisplayName("single claim은 attrs/bound를 보존하며 stack merge와 신규 stack을 적용한다")
+    void claimsSingleAfterCompletePreflight() {
+        insertInventoryEntry(0, itemId(ITEM_A), 9, true, "A");
+        mailboxService.deliver(
+                PLAYER_ID,
+                new MailboxCommand.Deliver(
+                        itemId(ITEM_A),
+                        5,
+                        Map.of("grade", "A"),
+                        true
+                )
+        );
+
+        mailboxService.claim(
+                PLAYER_ID,
+                new MailboxCommand.Claim(0, 5)
+        );
+
+        assertThat(mailboxTotal()).isZero();
+        assertThat(inventoryQuantities()).containsExactly(4, 10);
+        assertThat(inventoryBoundCount()).isEqualTo(2);
+        assertThat(inventoryGradeCount("A")).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("claimAll은 서로 다른 stack key를 한 batch로 옮긴다")
+    void claimsAllAfterBatchPreflight() {
+        mailboxService.deliver(
+                PLAYER_ID,
+                new MailboxCommand.Deliver(
+                        itemId(ITEM_A),
+                        5,
+                        Map.of("grade", "A"),
+                        true
+                )
+        );
+        mailboxService.deliver(
+                PLAYER_ID,
+                new MailboxCommand.Deliver(
+                        itemId(ITEM_A),
+                        4,
+                        Map.of("grade", "B"),
+                        false
+                )
+        );
+
+        mailboxService.claimAll(
+                PLAYER_ID,
+                new MailboxCommand.ClaimAll(List.of(
+                        new MailboxCommand.Claim(0, 2),
+                        new MailboxCommand.Claim(1, 3)
+                ))
+        );
+
+        assertThat(mailboxQuantities()).containsExactly(3, 1);
+        assertThat(inventoryTotal()).isEqualTo(5);
+        assertThat(inventoryEntryCount()).isEqualTo(2);
+        assertThat(inventoryGradeCount("A")).isEqualTo(1);
+        assertThat(inventoryGradeCount("B")).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("single Inventory full은 Mailbox와 Inventory를 모두 유지한다")
+    void keepsBothAggregatesOnSingleFailure() {
+        cleanState();
+        ensureItems();
+        insertContainers(1, 10);
+        insertInventoryEntry(0, itemId(ITEM_A), 1, false, null);
+        mailboxService.deliver(
+                PLAYER_ID,
+                new MailboxCommand.Deliver(
+                        itemId(ITEM_A),
+                        1,
+                        Map.of(),
+                        true
+                )
+        );
+        State before = state();
+
+        assertError(
+                () -> mailboxService.claim(
+                        PLAYER_ID,
+                        new MailboxCommand.Claim(0, 1)
+                ),
+                InventoryError.INVENTORY_FULL
+        );
+
+        assertThat(state()).isEqualTo(before);
+    }
+
+    @Test
+    @DisplayName("batch 마지막 quantity 실패도 앞선 Mailbox를 차감하지 않는다")
+    void keepsBothAggregatesOnLateQuantityFailure() {
+        deliverTwoEntries();
+        State before = state();
+
+        assertError(
+                () -> mailboxService.claimAll(
+                        PLAYER_ID,
+                        new MailboxCommand.ClaimAll(List.of(
+                                new MailboxCommand.Claim(0, 1),
+                                new MailboxCommand.Claim(1, 2)
+                        ))
+                ),
+                InventoryError.NOT_ENOUGH_QUANTITY
+        );
+
+        assertThat(state()).isEqualTo(before);
+    }
+
+    @Test
+    @DisplayName("batch 중간 empty와 마지막 missing Item도 두 aggregate를 유지한다")
+    void keepsBothAggregatesOnEmptyOrMissingItem() {
+        insertMailboxEntry(0, itemId(ITEM_A), 1, true);
+        State beforeEmpty = state();
+
+        assertError(
+                () -> mailboxService.claimAll(
+                        PLAYER_ID,
+                        new MailboxCommand.ClaimAll(List.of(
+                                new MailboxCommand.Claim(0, 1),
+                                new MailboxCommand.Claim(1, 1)
+                        ))
+                ),
+                InventoryError.SLOT_EMPTY
+        );
+        assertThat(state()).isEqualTo(beforeEmpty);
+
+        insertMailboxEntry(1, 9_999_999L, 1, true);
+        State beforeMissing = state();
+        assertError(
+                () -> mailboxService.claimAll(
+                        PLAYER_ID,
+                        new MailboxCommand.ClaimAll(List.of(
+                                new MailboxCommand.Claim(0, 1),
+                                new MailboxCommand.Claim(1, 1)
+                        ))
+                ),
+                ItemError.ITEM_NOT_FOUND
+        );
+        assertThat(state()).isEqualTo(beforeMissing);
+    }
+
+    @Test
+    @DisplayName("누적 capacity 실패는 batch의 Mailbox와 Inventory를 모두 유지한다")
+    void keepsBothAggregatesOnAccumulatedCapacityFailure() {
+        cleanState();
+        ensureItems();
+        insertContainers(2, 10);
+        insertInventoryEntry(0, itemId(ITEM_A), 9, true, null);
+        insertMailboxEntry(0, itemId(ITEM_A), 10, true);
+        insertMailboxEntry(1, itemId(ITEM_B), 1, true);
+        State before = state();
+
+        assertError(
+                () -> mailboxService.claimAll(
+                        PLAYER_ID,
+                        new MailboxCommand.ClaimAll(List.of(
+                                new MailboxCommand.Claim(0, 10),
+                                new MailboxCommand.Claim(1, 1)
+                        ))
+                ),
+                InventoryError.INVENTORY_FULL
+        );
+
+        assertThat(state()).isEqualTo(before);
+    }
+
+    private void deliverTwoEntries() {
+        mailboxService.deliver(
+                PLAYER_ID,
+                new MailboxCommand.Deliver(
+                        itemId(ITEM_A),
+                        1,
+                        Map.of("grade", "A"),
+                        true
+                )
+        );
+        mailboxService.deliver(
+                PLAYER_ID,
+                new MailboxCommand.Deliver(
+                        itemId(ITEM_A),
+                        1,
+                        Map.of("grade", "B"),
+                        true
+                )
+        );
+    }
+
+    private void ensureItems() {
+        insertItem(ITEM_A, "Issue 228 stack A");
+        insertItem(ITEM_B, "Issue 228 stack B");
+    }
+
+    private void insertItem(String code, String name) {
+        jdbcTemplate.update("""
+                INSERT IGNORE INTO items (
+                    code, name, category, type, rarity, base_attrs,
+                    stackable, max_stack, max_durability,
+                    created_at, updated_at
+                ) VALUES (
+                    ?, ?, 'QUEST', 'ETC', 'COMMON', JSON_OBJECT(),
+                    TRUE, 10, NULL,
+                    CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
+                )
+                """, code, name);
+    }
+
+    private void insertContainers(int inventoryCapacity, int mailboxCapacity) {
+        jdbcTemplate.update("""
+                INSERT INTO player_inventory (
+                    player_id, capacity_slots, version, created_at, updated_at
+                ) VALUES (?, ?, 0, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6))
+                """, PLAYER_ID, inventoryCapacity);
+        jdbcTemplate.update("""
+                INSERT INTO player_mailbox (
+                    player_id, capacity_slots, version, created_at, updated_at
+                ) VALUES (?, ?, 0, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6))
+                """, PLAYER_ID, mailboxCapacity);
+    }
+
+    private void insertMailboxEntry(
+            int slot,
+            Long itemId,
+            int quantity,
+            boolean bound
+    ) {
+        jdbcTemplate.update("""
+                INSERT INTO mailbox_entries (
+                    player_id, slot_index, item_id, rarity, quantity,
+                    durability, bound, inst_attrs, created_at, updated_at
+                ) VALUES (
+                    ?, ?, ?, 'COMMON', ?, NULL, ?, JSON_OBJECT(),
+                    CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
+                )
+                """, PLAYER_ID, slot, itemId, quantity, bound);
+    }
+
+    private void insertInventoryEntry(
+            int slot,
+            Long itemId,
+            int quantity,
+            boolean bound,
+            String grade
+    ) {
+        jdbcTemplate.update("""
+                INSERT INTO inventory_entries (
+                    player_id, slot_index, item_id, rarity, quantity,
+                    durability, bound, inst_attrs, created_at, updated_at
+                ) VALUES (
+                    ?, ?, ?, 'COMMON', ?, NULL, ?,
+                    IF(? IS NULL, JSON_OBJECT(), JSON_OBJECT('grade', ?)),
+                    CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
+                )
+                """, PLAYER_ID, slot, itemId, quantity, bound, grade, grade);
+    }
+
+    private void cleanState() {
+        jdbcTemplate.update("DELETE FROM inventory_reward_deliveries");
+        jdbcTemplate.update("DELETE FROM inventory_entries");
+        jdbcTemplate.update("DELETE FROM mailbox_entries");
+        jdbcTemplate.update("DELETE FROM player_inventory");
+        jdbcTemplate.update("DELETE FROM player_mailbox");
+    }
+
+    private Long itemId(String code) {
+        return jdbcTemplate.queryForObject(
+                "SELECT id FROM items WHERE code = ?",
+                Long.class,
+                code
+        );
+    }
+
+    private State state() {
+        return new State(
+                mailboxEntryCount(),
+                mailboxTotal(),
+                containerVersion("player_mailbox"),
+                inventoryEntryCount(),
+                inventoryTotal(),
+                containerVersion("player_inventory")
+        );
+    }
+
+    private long containerVersion(String table) {
+        return jdbcTemplate.queryForObject(
+                "SELECT version FROM " + table + " WHERE player_id = ?",
+                Long.class,
+                PLAYER_ID
+        );
+    }
+
+    private int mailboxEntryCount() {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM mailbox_entries WHERE player_id = ?",
+                Integer.class,
+                PLAYER_ID
+        );
+    }
+
+    private long mailboxTotal() {
+        return jdbcTemplate.queryForObject("""
+                SELECT COALESCE(SUM(quantity), 0)
+                FROM mailbox_entries
+                WHERE player_id = ?
+                """, Long.class, PLAYER_ID);
+    }
+
+    private List<Integer> mailboxQuantities() {
+        return jdbcTemplate.queryForList("""
+                SELECT quantity
+                FROM mailbox_entries
+                WHERE player_id = ?
+                ORDER BY slot_index
+                """, Integer.class, PLAYER_ID);
+    }
+
+    private int inventoryEntryCount() {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM inventory_entries WHERE player_id = ?",
+                Integer.class,
+                PLAYER_ID
+        );
+    }
+
+    private long inventoryTotal() {
+        return jdbcTemplate.queryForObject("""
+                SELECT COALESCE(SUM(quantity), 0)
+                FROM inventory_entries
+                WHERE player_id = ?
+                """, Long.class, PLAYER_ID);
+    }
+
+    private List<Integer> inventoryQuantities() {
+        return jdbcTemplate.queryForList("""
+                SELECT quantity
+                FROM inventory_entries
+                WHERE player_id = ?
+                ORDER BY quantity
+                """, Integer.class, PLAYER_ID);
+    }
+
+    private int inventoryBoundCount() {
+        return jdbcTemplate.queryForObject("""
+                SELECT COUNT(*)
+                FROM inventory_entries
+                WHERE player_id = ? AND bound = TRUE
+                """, Integer.class, PLAYER_ID);
+    }
+
+    private int inventoryGradeCount(String grade) {
+        return jdbcTemplate.queryForObject("""
+                SELECT COUNT(*)
+                FROM inventory_entries
+                WHERE player_id = ?
+                  AND JSON_UNQUOTE(JSON_EXTRACT(inst_attrs, '$.grade')) = ?
+                """, Integer.class, PLAYER_ID, grade);
+    }
+
+    private void assertError(Runnable call, ErrorCode error) {
+        assertThatThrownBy(call::run)
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(error)
+                );
+    }
+
+    private record State(
+            int mailboxEntries,
+            long mailboxQuantity,
+            long mailboxVersion,
+            int inventoryEntries,
+            long inventoryQuantity,
+            long inventoryVersion
+    ) {
+    }
+}

--- a/src/test/java/online/lifeasgame/inventory/application/MailboxClaimMySqlIntegrationTestSupport.java
+++ b/src/test/java/online/lifeasgame/inventory/application/MailboxClaimMySqlIntegrationTestSupport.java
@@ -1,0 +1,33 @@
+package online.lifeasgame.inventory.application;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+
+@SpringBootTest
+@ActiveProfiles({"test", "migration-test"})
+abstract class MailboxClaimMySqlIntegrationTestSupport {
+
+    protected static final MySQLContainer<?> MYSQL = new MySQLContainer<>(
+            "mysql:8.0.39"
+    ).withDatabaseName("lifeasgame_mailbox_claim_228")
+            .withUsername("lifeasgame")
+            .withPassword("lifeasgame");
+
+    static {
+        MYSQL.start();
+    }
+
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add(
+                "spring.datasource.driver-class-name",
+                MYSQL::getDriverClassName
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/inventory/application/ReaderLockingTransactionContractTest.java
+++ b/src/test/java/online/lifeasgame/inventory/application/ReaderLockingTransactionContractTest.java
@@ -1,0 +1,121 @@
+package online.lifeasgame.inventory.application;
+
+import online.lifeasgame.inventory.domain.PlayerInventory;
+import online.lifeasgame.inventory.domain.PlayerMailbox;
+import online.lifeasgame.inventory.domain.repository.PlayerInventoryRepository;
+import online.lifeasgame.inventory.domain.repository.PlayerMailboxRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.transaction.IllegalTransactionStateException;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@SpringJUnitConfig(ReaderLockingTransactionContractTest.Config.class)
+class ReaderLockingTransactionContractTest {
+
+    private static final Long PLAYER_ID = 229L;
+
+    @Autowired
+    private InventoryReader inventoryReader;
+
+    @Autowired
+    private MailboxReader mailboxReader;
+
+    @Autowired
+    private PlayerInventoryRepository inventoryRepository;
+
+    @Autowired
+    private PlayerMailboxRepository mailboxRepository;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @Test
+    void rejectsLockingReadersWithoutTransaction() {
+        assertThatThrownBy(() ->
+                inventoryReader.getByPlayerIdForUpdateOrThrow(PLAYER_ID)
+        ).isInstanceOf(IllegalTransactionStateException.class);
+        assertThatThrownBy(() ->
+                mailboxReader.getByPlayerIdForUpdateOrThrow(PLAYER_ID)
+        ).isInstanceOf(IllegalTransactionStateException.class);
+    }
+
+    @Test
+    void allowsLockingReadersInsideTransaction() {
+        PlayerInventory inventory = mock(PlayerInventory.class);
+        PlayerMailbox mailbox = mock(PlayerMailbox.class);
+        given(inventoryRepository.findByPlayerIdForUpdate(PLAYER_ID))
+                .willReturn(Optional.of(inventory));
+        given(mailboxRepository.findByPlayerIdForUpdate(PLAYER_ID))
+                .willReturn(Optional.of(mailbox));
+
+        new TransactionTemplate(transactionManager).executeWithoutResult(status -> {
+            assertThat(inventoryReader.getByPlayerIdForUpdateOrThrow(PLAYER_ID))
+                    .isSameAs(inventory);
+            assertThat(mailboxReader.getByPlayerIdForUpdateOrThrow(PLAYER_ID))
+                    .isSameAs(mailbox);
+        });
+    }
+
+    @Test
+    void keepsRegularReadersUsableWithoutTransaction() {
+        PlayerInventory inventory = mock(PlayerInventory.class);
+        PlayerMailbox mailbox = mock(PlayerMailbox.class);
+        given(inventoryRepository.findByPlayerId(PLAYER_ID))
+                .willReturn(Optional.of(inventory));
+        given(mailboxRepository.findByPlayerId(PLAYER_ID))
+                .willReturn(Optional.of(mailbox));
+
+        assertThat(inventoryReader.getByPlayerIdOrThrow(PLAYER_ID))
+                .isSameAs(inventory);
+        assertThat(mailboxReader.getByPlayerIdOrThrow(PLAYER_ID))
+                .isSameAs(mailbox);
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableTransactionManagement
+    @Import({InventoryReader.class, MailboxReader.class})
+    static class Config {
+
+        @Bean
+        PlayerInventoryRepository inventoryRepository() {
+            return mock(PlayerInventoryRepository.class);
+        }
+
+        @Bean
+        PlayerMailboxRepository mailboxRepository() {
+            return mock(PlayerMailboxRepository.class);
+        }
+
+        @Bean
+        EmbeddedDatabase dataSource() {
+            return new EmbeddedDatabaseBuilder()
+                    .generateUniqueName(true)
+                    .setType(EmbeddedDatabaseType.H2)
+                    .build();
+        }
+
+        @Bean
+        PlatformTransactionManager transactionManager(
+                EmbeddedDatabase dataSource
+        ) {
+            return new DataSourceTransactionManager(dataSource);
+        }
+    }
+}

--- a/src/test/java/online/lifeasgame/inventory/domain/PlayerInventoryClaimCapacityPreflightTest.java
+++ b/src/test/java/online/lifeasgame/inventory/domain/PlayerInventoryClaimCapacityPreflightTest.java
@@ -1,0 +1,131 @@
+package online.lifeasgame.inventory.domain;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.inventory.domain.error.InventoryError;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("PlayerInventory claim capacity preflight")
+class PlayerInventoryClaimCapacityPreflightTest {
+
+    private static final ItemCarryPolicy STACKABLE = new ItemCarryPolicy(
+            10L,
+            Rarity.COMMON,
+            true,
+            10,
+            null
+    );
+    private static final ItemCarryPolicy OTHER = new ItemCarryPolicy(
+            11L,
+            Rarity.COMMON,
+            true,
+            10,
+            null
+    );
+
+    @Test
+    @DisplayName("앞선 claim의 stack과 slot 사용을 누적해 batch 전체를 거부한다")
+    void rejectsAccumulatedCapacityWithoutMutation() {
+        PlayerInventory inventory = PlayerInventory.of(1L, 2);
+        inventory.add(STACKABLE, 9, InstanceAttrs.empty(), true);
+        InventoryEntry existing = inventory.getEntries().getFirst();
+
+        List<PlayerInventory.Addition> additions = List.of(
+                addition(STACKABLE, 11, InstanceAttrs.empty(), true),
+                addition(OTHER, 1, InstanceAttrs.empty(), true)
+        );
+
+        assertThatThrownBy(() -> inventory.assertCanAddAll(additions))
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode())
+                                .isEqualTo(InventoryError.INVENTORY_FULL)
+                );
+
+        assertThat(inventory.getEntries()).containsExactly(existing);
+        assertThat(existing.getQuantity().value()).isEqualTo(9);
+    }
+
+    @Test
+    @DisplayName("성공 simulation도 실제 stack과 slot을 변경하지 않는다")
+    void simulatesStackAndNewSlotWithoutMutation() {
+        PlayerInventory inventory = PlayerInventory.of(1L, 2);
+        inventory.add(STACKABLE, 9, InstanceAttrs.empty(), true);
+
+        inventory.assertCanAddAll(List.of(
+                addition(STACKABLE, 1, InstanceAttrs.empty(), true),
+                addition(STACKABLE, 10, InstanceAttrs.empty(), true)
+        ));
+
+        assertThat(inventory.getEntries()).hasSize(1);
+        assertThat(inventory.getEntries().getFirst().getQuantity().value())
+                .isEqualTo(9);
+    }
+
+    @Test
+    @DisplayName("bound와 attrs가 다른 동일 Item은 서로 다른 slot으로 계산한다")
+    void distinguishesStackKeys() {
+        PlayerInventory inventory = PlayerInventory.of(1L, 2);
+        InstanceAttrs first = InstanceAttrs.of(Map.of("grade", "A"));
+        InstanceAttrs second = InstanceAttrs.of(Map.of("grade", "B"));
+
+        inventory.assertCanAddAll(List.of(
+                addition(STACKABLE, 1, first, true),
+                addition(STACKABLE, 1, second, false)
+        ));
+
+        assertThatThrownBy(() -> inventory.assertCanAddAll(List.of(
+                addition(STACKABLE, 1, first, true),
+                addition(STACKABLE, 1, second, false),
+                addition(OTHER, 1, InstanceAttrs.empty(), true)
+        ))).isInstanceOfSatisfying(DomainException.class, exception ->
+                assertThat(exception.getErrorCode())
+                        .isEqualTo(InventoryError.INVENTORY_FULL)
+        );
+        assertThat(inventory.getEntries()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("non-stackable Item은 quantity만큼 free slot을 사용한다")
+    void simulatesNonStackableItems() {
+        PlayerInventory inventory = PlayerInventory.of(1L, 2);
+        ItemCarryPolicy nonStackable = new ItemCarryPolicy(
+                12L,
+                Rarity.COMMON,
+                false,
+                1,
+                null
+        );
+
+        inventory.assertCanAdd(
+                nonStackable,
+                2,
+                InstanceAttrs.empty(),
+                false
+        );
+        assertThatThrownBy(() -> inventory.assertCanAdd(
+                nonStackable,
+                3,
+                InstanceAttrs.empty(),
+                false
+        )).isInstanceOfSatisfying(DomainException.class, exception ->
+                assertThat(exception.getErrorCode())
+                        .isEqualTo(InventoryError.INVENTORY_FULL)
+        );
+        assertThat(inventory.getEntries()).isEmpty();
+    }
+
+    private PlayerInventory.Addition addition(
+            ItemCarryPolicy policy,
+            int quantity,
+            InstanceAttrs attrs,
+            boolean bound
+    ) {
+        return new PlayerInventory.Addition(policy, quantity, attrs, bound);
+    }
+}

--- a/src/test/java/online/lifeasgame/inventory/domain/PlayerMailboxClaimPlanTest.java
+++ b/src/test/java/online/lifeasgame/inventory/domain/PlayerMailboxClaimPlanTest.java
@@ -1,0 +1,102 @@
+package online.lifeasgame.inventory.domain;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.inventory.domain.error.InventoryError;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("PlayerMailbox claim plan")
+class PlayerMailboxClaimPlanTest {
+
+    private static final ItemCarryPolicy POLICY = new ItemCarryPolicy(
+            10L,
+            Rarity.RARE,
+            true,
+            10,
+            null
+    );
+
+    @Test
+    @DisplayName("plan은 attrs와 bound를 snapshot하고 apply 전에는 변경하지 않는다")
+    void plansThenAppliesClaim() {
+        PlayerMailbox mailbox = PlayerMailbox.of(1L, 2);
+        InstanceAttrs attrs = InstanceAttrs.of(Map.of("grade", "A"));
+        SlotIndex slot = mailbox.deliver(POLICY, 3, attrs, true);
+
+        PlayerMailbox.ClaimPlan plan = mailbox.planClaim(slot, 2, POLICY);
+
+        assertThat(plan.itemId()).isEqualTo(POLICY.itemId());
+        assertThat(plan.quantity()).isEqualTo(2);
+        assertThat(plan.attrs()).isEqualTo(attrs);
+        assertThat(plan.bound()).isTrue();
+        assertThat(mailbox.getEntryOrThrow(slot).getQuantity().value())
+                .isEqualTo(3);
+
+        mailbox.applyClaim(plan);
+
+        assertThat(mailbox.getEntryOrThrow(slot).getQuantity().value())
+                .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("빈 slot은 nullable 대신 stable SLOT_EMPTY다")
+    void rejectsEmptySlot() {
+        PlayerMailbox mailbox = PlayerMailbox.of(1L, 2);
+
+        assertError(
+                () -> mailbox.getEntryOrThrow(SlotIndex.of(0)),
+                InventoryError.SLOT_EMPTY
+        );
+        assertError(
+                () -> mailbox.planClaim(SlotIndex.of(0), 1, POLICY),
+                InventoryError.SLOT_EMPTY
+        );
+    }
+
+    @Test
+    @DisplayName("invalid quantity와 policy mismatch는 Mailbox를 변경하지 않는다")
+    void rejectsInvalidPlanWithoutMutation() {
+        PlayerMailbox mailbox = PlayerMailbox.of(1L, 2);
+        SlotIndex slot = mailbox.deliver(
+                POLICY,
+                2,
+                InstanceAttrs.empty(),
+                false
+        );
+        ItemCarryPolicy otherPolicy = new ItemCarryPolicy(
+                11L,
+                Rarity.COMMON,
+                true,
+                10,
+                null
+        );
+
+        assertError(
+                () -> mailbox.planClaim(slot, 0, POLICY),
+                InventoryError.INVALID_QUANTITY
+        );
+        assertError(
+                () -> mailbox.planClaim(slot, 3, POLICY),
+                InventoryError.NOT_ENOUGH_QUANTITY
+        );
+        assertError(
+                () -> mailbox.planClaim(slot, 1, otherPolicy),
+                InventoryError.ITEM_NOT_FOUND
+        );
+
+        assertThat(mailbox.getEntryOrThrow(slot).getQuantity().value())
+                .isEqualTo(2);
+    }
+
+    private void assertError(Runnable call, InventoryError error) {
+        assertThatThrownBy(call::run)
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(error)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/system/bootstrap/security/AdminAuthorizationContractTest.java
+++ b/src/test/java/online/lifeasgame/system/bootstrap/security/AdminAuthorizationContractTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +20,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = AdminAuthorizationContractTest.ContractController.class)
+@ActiveProfiles("test")
 @Import({
         AdminAuthorizationContractTest.ContractController.class,
         SecurityConfig.class,

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,19 @@
+<configuration>
+    <property name="LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%ex{full}"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="WARN">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+    <logger name="online.lifeasgame" level="INFO"/>
+    <logger name="com.zaxxer.hikari" level="WARN"/>
+    <logger name="org.hibernate.SQL" level="WARN"/>
+    <logger name="org.hibernate.orm.jdbc.bind" level="OFF"/>
+</configuration>


### PR DESCRIPTION
## What

Mailbox → Inventory claim 흐름을
고정된 lock order와 전체 preflight 기반으로 보강한다.

## Lock Order

모든 Mailbox mutation은 `PlayerMailbox`를
`PESSIMISTIC_WRITE`로 조회한다.

claim과 claimAll:

```text
PlayerMailbox
→ PlayerInventory
```

## Claim Preflight

단건 claim:

- slot/quantity
- Item policy
- Inventory capacity

일괄 claim:

- null/empty request
- duplicate slot
- 모든 entry와 quantity
- 모든 Item policy
- batch 누적 Inventory capacity

전체 검증이 성공한 뒤에만 aggregate를 변경한다.

## Failure Safety

예상 가능한 실패에서 다음 상태를 보존한다.

- Mailbox entry/quantity
- Inventory entry/quantity
- 신규 slot 없음

빈 slot은 nullable 접근 대신 stable Domain error로 처리한다.

## Concurrency

MySQL 통합 테스트:

- same-slot claim
- overlapping claimAll
- claim vs claimAll
- claim vs reward delivery
- claim vs delete

Item 총량 보존과 deadlock timeout을 확인한다.

## API

기존 경로와 응답 유지:

```text
POST /api/v1/mailbox/claim
POST /api/v1/mailbox/claim/all
ApiResponse<Void>
```

## Migration

신규 Migration 없음.

## Out of Scope

- claim idempotency receipt
- claim history
- Reward/Settlement 변경
- Item delete/deactivate policy
- 전체 Inventory mutation lock 전환
- Frontend

Closes #228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mailbox claim validation for empty, duplicate, invalid, oversized, and null requests.
  * Prevented partial updates when capacity or validation checks fail.
  * Preserved item attributes, quantities, and binding status during claims.
  * Improved reliability during simultaneous deliveries, claims, and deletions.
* **Tests**
  * Added coverage for mailbox claims, capacity checks, rollback behavior, and concurrent operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->