### PR TITLE
[Character] Harden write transactions and title consistency

### DIFF
--- a/src/main/java/online/lifeasgame/character/api/admin/AdminPlayerTitleController.java
+++ b/src/main/java/online/lifeasgame/character/api/admin/AdminPlayerTitleController.java
@@ -29,7 +29,7 @@ public class AdminPlayerTitleController implements AdminPlayerTitleApiSpecV1 {
     }
 
     @Override
-    @GetMapping("/{playerId}/titles/{titleId}")
+    @DeleteMapping("/{playerId}/titles/{titleId}")
     public ResponseEntity<ApiResponse<AdminPlayerTitleResponse.Revoked>> revokeTitle(
             @PathVariable Long playerId,
             @PathVariable Long titleId

--- a/src/main/java/online/lifeasgame/character/application/PlayerAchievementService.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerAchievementService.java
@@ -54,6 +54,6 @@ public class PlayerAchievementService {
         achievementReader.assertExistsById(achievementId);
 
         playerAchievementWriter.revoke(playerId, achievementId);
-        return new PlayerAchievementResult.Revoked(achievementId, achievementId);
+        return new PlayerAchievementResult.Revoked(playerId, achievementId);
     }
 }

--- a/src/main/java/online/lifeasgame/character/application/PlayerService.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerService.java
@@ -47,9 +47,8 @@ public class PlayerService {
 
     @Transactional
     public PlayerResult.UpdatedTitle changeRepresentativeTitle(Long playerId, Long titleId) {
+        Player player = playerReader.getByIdForUpdateOrThrow(playerId);
         playerTitleReader.assertHasTitle(playerId, titleId);
-
-        Player player = playerReader.getByIdOrThrow(playerId);
         player.changeRepresentativeTitle(titleId);
 
         return new PlayerResult.UpdatedTitle(player.getTitleId());
@@ -124,6 +123,7 @@ public class PlayerService {
         return PlayerResult.PlayerSummary.from(player);
     }
 
+    @Transactional
     public PlayerResult.Renamed rename(Long playerId, PlayerCommand.Renamed command) {
         Name name = Name.of(command.name());
         Player player = playerReader.getByIdOrThrow(playerId);

--- a/src/main/java/online/lifeasgame/character/application/PlayerTitleReader.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerTitleReader.java
@@ -25,7 +25,7 @@ class PlayerTitleReader {
     }
 
     public void assertHasTitle(Long playerId, Long titleId) {
-        if (repository.existsByPlayerIdAndTitleId(playerId, titleId)) {
+        if (!repository.existsByPlayerIdAndTitleId(playerId, titleId)) {
             throw new DomainException(PlayerTitleError.PLAYER_TITLE_NOT_FOUND);
         }
     }

--- a/src/main/java/online/lifeasgame/character/application/PlayerTitleService.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerTitleService.java
@@ -19,6 +19,7 @@ public class PlayerTitleService {
     private final PlayerTitleReader playerTitleReader;
     private final PlayerTitleWriter playerTitleWriter;
     private final TitleReader titleReader;
+    private final PlayerReader playerReader;
 
     public List<PlayerTitleResult.Info> getPlayerTitleInfos(Long playerId) {
         List<PlayerTitleView> playerTitleViews = playerTitleReader.getViewsByPlayerId(playerId);
@@ -38,7 +39,11 @@ public class PlayerTitleService {
         return PlayerTitleResult.Created.from(playerTitle, title);
     }
 
+    @Transactional
     public PlayerTitleResult.Revoked revokeTitle(Long playerId, Long titleId) {
+        var player = playerReader.getByIdForUpdateOrThrow(playerId);
+        playerTitleReader.assertHasTitle(playerId, titleId);
+        player.clearRepresentativeTitleIfMatches(titleId);
         playerTitleWriter.revoke(playerId, titleId);
         return new PlayerTitleResult.Revoked(playerId, titleId);
     }

--- a/src/main/java/online/lifeasgame/character/domain/Player.java
+++ b/src/main/java/online/lifeasgame/character/domain/Player.java
@@ -19,6 +19,7 @@ import online.lifeasgame.platform.persistence.jpa.AbstractTime;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 @Entity
@@ -235,6 +236,12 @@ public class Player extends AbstractTime {
 
     public void changeRepresentativeTitle(Long titleId) {
         this.titleId = titleId;
+    }
+
+    public void clearRepresentativeTitleIfMatches(Long revokedTitleId) {
+        if (Objects.equals(this.titleId, revokedTitleId)) {
+            this.titleId = null;
+        }
     }
 
     public List<DomainEvent> pullEvents() {

--- a/src/test/java/online/lifeasgame/character/api/admin/AdminPlayerTitleMappingContractTest.java
+++ b/src/test/java/online/lifeasgame/character/api/admin/AdminPlayerTitleMappingContractTest.java
@@ -1,0 +1,47 @@
+package online.lifeasgame.character.api.admin;
+
+import online.lifeasgame.character.application.PlayerTitleService;
+import online.lifeasgame.platform.web.error.docs.ErrorDocLinker;
+import online.lifeasgame.support.ControllerSliceTest;
+import online.lifeasgame.system.bootstrap.error.handler.AppErrorProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ControllerSliceTest(controllers = AdminPlayerTitleController.class)
+class AdminPlayerTitleMappingContractTest {
+
+    private static final String PATH =
+            "/admin/v1/players/{playerId}/titles/{titleId}";
+
+    @Autowired
+    private RequestMappingHandlerMapping handlerMapping;
+
+    @MockitoBean
+    private PlayerTitleService playerTitleService;
+
+    @MockitoBean
+    private AppErrorProperties appErrorProperties;
+
+    @MockitoBean
+    private ErrorDocLinker errorDocLinker;
+
+    @Test
+    void exposesDeleteOnlyForRevokeAndKeepsPostGrant() {
+        assertThat(hasMapping(RequestMethod.DELETE, PATH)).isTrue();
+        assertThat(hasMapping(RequestMethod.GET, PATH)).isFalse();
+        assertThat(hasMapping(RequestMethod.POST, PATH)).isTrue();
+    }
+
+    private boolean hasMapping(RequestMethod method, String path) {
+        return handlerMapping.getHandlerMethods().keySet().stream()
+                .anyMatch(mapping ->
+                        mapping.getMethodsCondition().getMethods().contains(method)
+                                && mapping.getPatternValues().contains(path)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/character/application/CharacterApplicationBoundaryTest.java
+++ b/src/test/java/online/lifeasgame/character/application/CharacterApplicationBoundaryTest.java
@@ -1,0 +1,173 @@
+package online.lifeasgame.character.application;
+
+import online.lifeasgame.character.application.query.PlayerTitleQuery;
+import online.lifeasgame.character.domain.GenderType;
+import online.lifeasgame.character.domain.Name;
+import online.lifeasgame.character.domain.Player;
+import online.lifeasgame.character.domain.error.PlayerTitleError;
+import online.lifeasgame.character.domain.repository.PlayerTitleRepository;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.event.DomainEventPublisher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+
+@ExtendWith(MockitoExtension.class)
+class CharacterApplicationBoundaryTest {
+
+    private static final Long PLAYER_ID = 230L;
+    private static final Long TITLE_ID = 231L;
+
+    @Mock
+    private PlayerTitleQuery playerTitleQuery;
+
+    @Mock
+    private PlayerTitleRepository playerTitleRepository;
+
+    @Mock
+    private PlayerReader playerReader;
+
+    @Mock
+    private PlayerTitleReader playerTitleReader;
+
+    @Mock
+    private PlayerTitleWriter playerTitleWriter;
+
+    @Mock
+    private TitleReader titleReader;
+
+    @Mock
+    private PlayerWriter playerWriter;
+
+    @Mock
+    private PlayerExpGrantService playerExpGrantService;
+
+    @Mock
+    private DomainEventPublisher domainEventPublisher;
+
+    @Mock
+    private PlayerAchievementReader playerAchievementReader;
+
+    @Mock
+    private PlayerAchievementWriter playerAchievementWriter;
+
+    @Mock
+    private AchievementReader achievementReader;
+
+    private PlayerTitleReader actualPlayerTitleReader;
+
+    @BeforeEach
+    void setUp() {
+        actualPlayerTitleReader = new PlayerTitleReader(
+                playerTitleQuery,
+                playerTitleRepository
+        );
+    }
+
+    @Test
+    void acceptsOwnedTitle() {
+        given(playerTitleRepository.existsByPlayerIdAndTitleId(
+                PLAYER_ID,
+                TITLE_ID
+        )).willReturn(true);
+
+        assertThatCode(() -> actualPlayerTitleReader.assertHasTitle(
+                PLAYER_ID,
+                TITLE_ID
+        )).doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsMissingTitle() {
+        given(playerTitleRepository.existsByPlayerIdAndTitleId(
+                PLAYER_ID,
+                TITLE_ID
+        )).willReturn(false);
+
+        assertThatThrownBy(() -> actualPlayerTitleReader.assertHasTitle(
+                PLAYER_ID,
+                TITLE_ID
+        )).isInstanceOfSatisfying(DomainException.class, exception ->
+                assertThat(exception.getErrorCode())
+                        .isEqualTo(PlayerTitleError.PLAYER_TITLE_NOT_FOUND)
+        );
+    }
+
+    @Test
+    void locksPlayerBeforeChangingRepresentativeTitle() {
+        Player player = player();
+        given(playerReader.getByIdForUpdateOrThrow(PLAYER_ID))
+                .willReturn(player);
+        PlayerService service = new PlayerService(
+                playerWriter,
+                playerReader,
+                playerTitleReader,
+                playerExpGrantService,
+                domainEventPublisher
+        );
+
+        var result = service.changeRepresentativeTitle(PLAYER_ID, TITLE_ID);
+
+        InOrder locks = inOrder(playerReader, playerTitleReader);
+        locks.verify(playerReader).getByIdForUpdateOrThrow(PLAYER_ID);
+        locks.verify(playerTitleReader).assertHasTitle(PLAYER_ID, TITLE_ID);
+        assertThat(result.titleId()).isEqualTo(TITLE_ID);
+        assertThat(player.getTitleId()).isEqualTo(TITLE_ID);
+    }
+
+    @Test
+    void locksPlayerAndClearsRepresentativeTitleBeforeRevoke() {
+        Player player = player();
+        player.changeRepresentativeTitle(TITLE_ID);
+        given(playerReader.getByIdForUpdateOrThrow(PLAYER_ID))
+                .willReturn(player);
+        PlayerTitleService service = new PlayerTitleService(
+                playerTitleReader,
+                playerTitleWriter,
+                titleReader,
+                playerReader
+        );
+
+        var result = service.revokeTitle(PLAYER_ID, TITLE_ID);
+
+        InOrder order = inOrder(
+                playerReader,
+                playerTitleReader,
+                playerTitleWriter
+        );
+        order.verify(playerReader).getByIdForUpdateOrThrow(PLAYER_ID);
+        order.verify(playerTitleReader).assertHasTitle(PLAYER_ID, TITLE_ID);
+        order.verify(playerTitleWriter).revoke(PLAYER_ID, TITLE_ID);
+        assertThat(player.getTitleId()).isNull();
+        assertThat(result.playerId()).isEqualTo(PLAYER_ID);
+        assertThat(result.titleId()).isEqualTo(TITLE_ID);
+    }
+
+    @Test
+    void returnsPlayerAndAchievementIdsOnRevoke() {
+        PlayerAchievementService service = new PlayerAchievementService(
+                playerAchievementReader,
+                playerAchievementWriter,
+                achievementReader,
+                playerReader
+        );
+
+        var result = service.revokeAchievement(PLAYER_ID, 232L);
+
+        assertThat(result.playerId()).isEqualTo(PLAYER_ID);
+        assertThat(result.achievementId()).isEqualTo(232L);
+    }
+
+    private Player player() {
+        return Player.linkStart(1L, Name.of("player"), GenderType.MALE);
+    }
+}

--- a/src/test/java/online/lifeasgame/character/application/CharacterTransactionBoundaryIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/character/application/CharacterTransactionBoundaryIntegrationTest.java
@@ -1,0 +1,294 @@
+package online.lifeasgame.character.application;
+
+import online.lifeasgame.character.application.command.PlayerCommand;
+import online.lifeasgame.character.application.command.TitleCommand;
+import online.lifeasgame.character.domain.error.PlayerTitleError;
+import online.lifeasgame.character.domain.repository.PlayerTitleRepository;
+import online.lifeasgame.core.error.DomainException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+
+@SpringBootTest
+@ActiveProfiles({"test", "migration-test"})
+@Testcontainers
+class CharacterTransactionBoundaryIntegrationTest {
+
+    private static final AtomicLong SEQUENCE = new AtomicLong(230_000L);
+
+    @Container
+    private static final MySQLContainer<?> MYSQL = new MySQLContainer<>(
+            "mysql:8.0.39"
+    ).withDatabaseName("lifeasgame_character_230")
+            .withUsername("lifeasgame")
+            .withPassword("lifeasgame");
+
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add(
+                "spring.datasource.driver-class-name",
+                MYSQL::getDriverClassName
+        );
+    }
+
+    @Autowired
+    private PlayerService playerService;
+
+    @Autowired
+    private PlayerTitleService playerTitleService;
+
+    @Autowired
+    private TitleService titleService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @MockitoSpyBean
+    private PlayerTitleRepository playerTitleRepository;
+
+    @Test
+    void persistsRenameAndKeepsNameOnValidationFailure() {
+        Long playerId = createPlayer();
+
+        playerService.rename(
+                playerId,
+                new PlayerCommand.Renamed("renamed-player")
+        );
+
+        assertThat(playerName(playerId)).isEqualTo("renamed-player");
+        assertThatThrownBy(() -> playerService.rename(
+                playerId,
+                new PlayerCommand.Renamed(" ")
+        )).isInstanceOf(IllegalArgumentException.class);
+        assertThat(playerName(playerId)).isEqualTo("renamed-player");
+    }
+
+    @Test
+    void revokesCurrentRepresentativeTitleAtomically() {
+        Fixture fixture = fixture(false);
+
+        playerTitleService.revokeTitle(fixture.playerId(), fixture.titleA());
+
+        assertThat(playerTitleId(fixture.playerId())).isNull();
+        assertThat(hasTitle(fixture.playerId(), fixture.titleA())).isFalse();
+    }
+
+    @Test
+    void keepsDifferentRepresentativeTitleOnRevoke() {
+        Fixture fixture = fixture(true);
+        playerService.changeRepresentativeTitle(
+                fixture.playerId(),
+                fixture.titleB()
+        );
+
+        playerTitleService.revokeTitle(fixture.playerId(), fixture.titleA());
+
+        assertThat(playerTitleId(fixture.playerId()))
+                .isEqualTo(fixture.titleB());
+        assertThat(hasTitle(fixture.playerId(), fixture.titleA())).isFalse();
+        assertThat(hasTitle(fixture.playerId(), fixture.titleB())).isTrue();
+    }
+
+    @Test
+    void keepsBothRowsWhenRevokeDeleteFails() {
+        Fixture fixture = fixture(false);
+        doThrow(new RuntimeException("delete failed"))
+                .when(playerTitleRepository)
+                .deleteByPlayerIdAndTitleId(
+                        fixture.playerId(),
+                        fixture.titleA()
+                );
+
+        assertThatThrownBy(() -> playerTitleService.revokeTitle(
+                fixture.playerId(),
+                fixture.titleA()
+        )).isInstanceOf(RuntimeException.class)
+                .hasMessage("delete failed");
+
+        assertThat(playerTitleId(fixture.playerId()))
+                .isEqualTo(fixture.titleA());
+        assertThat(hasTitle(fixture.playerId(), fixture.titleA())).isTrue();
+    }
+
+    @Test
+    void keepsStateWhenOwnershipCheckFails() {
+        Fixture fixture = fixture(false);
+
+        assertThatThrownBy(() -> playerTitleService.revokeTitle(
+                fixture.playerId(),
+                Long.MAX_VALUE
+        )).isInstanceOfSatisfying(DomainException.class, exception ->
+                assertThat(exception.getErrorCode())
+                        .isEqualTo(PlayerTitleError.PLAYER_TITLE_NOT_FOUND)
+        );
+
+        assertThat(playerTitleId(fixture.playerId()))
+                .isEqualTo(fixture.titleA());
+        assertThat(hasTitle(fixture.playerId(), fixture.titleA())).isTrue();
+    }
+
+    @Test
+    void serializesConcurrentChangeAndRevokeWithoutStaleTitle() throws Exception {
+        Fixture fixture = fixture(false);
+
+        List<Throwable> outcomes = race(
+                () -> playerService.changeRepresentativeTitle(
+                        fixture.playerId(),
+                        fixture.titleA()
+                ),
+                () -> playerTitleService.revokeTitle(
+                        fixture.playerId(),
+                        fixture.titleA()
+                )
+        );
+
+        assertThat(outcomes.get(1)).isNull();
+        if (outcomes.get(0) != null) {
+            assertThat(outcomes.get(0)).isInstanceOfSatisfying(
+                    DomainException.class,
+                    exception -> assertThat(exception.getErrorCode())
+                            .isEqualTo(PlayerTitleError.PLAYER_TITLE_NOT_FOUND)
+            );
+        }
+        Long representativeTitleId = playerTitleId(fixture.playerId());
+        boolean associationExists = hasTitle(
+                fixture.playerId(),
+                fixture.titleA()
+        );
+        assertThat(representativeTitleId).isNull();
+        assertThat(associationExists).isFalse();
+        assertThat(representativeTitleId == null || associationExists).isTrue();
+    }
+
+    private List<Throwable> race(
+            ThrowingAction first,
+            ThrowingAction second
+    ) throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<Throwable>> futures = new ArrayList<>();
+
+        try {
+            for (ThrowingAction action : List.of(first, second)) {
+                futures.add(executor.submit(() -> {
+                    ready.countDown();
+                    start.await();
+                    try {
+                        action.run();
+                        return null;
+                    } catch (Throwable failure) {
+                        return failure;
+                    }
+                }));
+            }
+            assertThat(ready.await(10, TimeUnit.SECONDS)).isTrue();
+            start.countDown();
+
+            List<Throwable> outcomes = new ArrayList<>();
+            for (Future<Throwable> future : futures) {
+                outcomes.add(future.get(30, TimeUnit.SECONDS));
+            }
+            return outcomes;
+        } finally {
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+        }
+    }
+
+    private Fixture fixture(boolean includeTitleB) {
+        Long playerId = createPlayer();
+        Long titleA = createTitle("A");
+        playerTitleService.createTitle(playerId, titleA);
+        Long titleB = null;
+        if (includeTitleB) {
+            titleB = createTitle("B");
+            playerTitleService.createTitle(playerId, titleB);
+        }
+        playerService.changeRepresentativeTitle(playerId, titleA);
+        return new Fixture(playerId, titleA, titleB);
+    }
+
+    private Long createPlayer() {
+        long sequence = SEQUENCE.incrementAndGet();
+        return playerService.linkStart(
+                sequence,
+                new PlayerCommand.Register(
+                        "player-" + sequence,
+                        "MALE"
+                )
+        ).id();
+    }
+
+    private Long createTitle(String suffix) {
+        long sequence = SEQUENCE.incrementAndGet();
+        return titleService.create(new TitleCommand.Create(
+                "TITLE_230_" + suffix + "_" + sequence,
+                "Title " + suffix + " " + sequence,
+                "OTHER",
+                "Issue 230"
+        )).titleId();
+    }
+
+    private String playerName(Long playerId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT name FROM player WHERE id = ?",
+                String.class,
+                playerId
+        );
+    }
+
+    private Long playerTitleId(Long playerId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT title_id FROM player WHERE id = ?",
+                Long.class,
+                playerId
+        );
+    }
+
+    private boolean hasTitle(Long playerId, Long titleId) {
+        return Objects.equals(1, jdbcTemplate.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM player_titles
+                WHERE player_id = ? AND title_id = ?
+                """,
+                Integer.class,
+                playerId,
+                titleId
+        ));
+    }
+
+    private record Fixture(Long playerId, Long titleA, Long titleB) {
+    }
+
+    @FunctionalInterface
+    private interface ThrowingAction {
+        void run();
+    }
+}

--- a/src/test/java/online/lifeasgame/character/domain/PlayerRepresentativeTitleTest.java
+++ b/src/test/java/online/lifeasgame/character/domain/PlayerRepresentativeTitleTest.java
@@ -1,0 +1,32 @@
+package online.lifeasgame.character.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlayerRepresentativeTitleTest {
+
+    @Test
+    void clearsMatchingRepresentativeTitle() {
+        Player player = player();
+        player.changeRepresentativeTitle(10L);
+
+        player.clearRepresentativeTitleIfMatches(10L);
+
+        assertThat(player.getTitleId()).isNull();
+    }
+
+    @Test
+    void keepsDifferentRepresentativeTitle() {
+        Player player = player();
+        player.changeRepresentativeTitle(20L);
+
+        player.clearRepresentativeTitleIfMatches(10L);
+
+        assertThat(player.getTitleId()).isEqualTo(20L);
+    }
+
+    private Player player() {
+        return Player.linkStart(1L, Name.of("player"), GenderType.MALE);
+    }
+}


### PR DESCRIPTION
## What

Character write path의 Transaction 경계와 Title consistency를 보강한다.

대상:

- Player rename 영속화
- Player Title ownership 검증
- 대표 Title 변경/revoke lock order
- 대표 Title revoke 원자성
- Admin revoke HTTP method
- Achievement revoke 응답 ID

## Player Rename

`PlayerService.rename`을 Write Transaction으로 실행한다.

```text
load Player
→ rename
→ dirty checking
→ commit
```

기존 Player API path와 response shape는 유지한다.

## Title Ownership

`PlayerTitleReader.assertHasTitle`의 반대 조건을 수정한다.

```text
owned
→ pass

not owned
→ PLAYER_TITLE_NOT_FOUND
```

## Lock Order

대표 Title 변경과 revoke는 모두 Player row를 먼저 잠근다.

```text
Player PESSIMISTIC_WRITE
→ PlayerTitle ownership check
→ mutation
```

대표 Title 변경:

```text
lock Player
→ assert ownership
→ set representative title
```

Title revoke:

```text
lock Player
→ assert ownership
→ clear representative title if matched
→ delete PlayerTitle
```

Player와 PlayerTitle 변경은 같은 Transaction에서 commit/rollback된다.

## HTTP Contract

Title revoke method를 변경한다.

```http
DELETE /admin/v1/players/{playerId}/titles/{titleId}
```

기존 GET mutation mapping은 제거한다.

## Achievement Response

Achievement revoke 결과가 실제 identity를 반환한다.

```text
Revoked(playerId, achievementId)
```

## Concurrency

대표 Title 변경과 revoke가 동시에 실행돼도 다음 invariant를 유지한다.

```text
Player.titleId = X
→ PlayerTitle(playerId, X) exists
```

stale representative title을 허용하지 않는다.

## Migration

신규 Migration 없음.

## Test

- rename persistence/validation rollback
- owned/missing Title predicate
- representative title change
- current/non-current revoke
- revoke rollback
- change vs revoke concurrency
- DELETE mapping 존재 / GET mapping 부재
- Achievement response identity
- Character regression
- full clean test/build

## Out of Scope

- Player Aggregate split
- Role/Person/User ownership redesign
- job/guildId cleanup
- PlayerGrowthApi/EXP/Level changes
- Title Catalog redesign
- Character clock hardening
- Equipment/Certification/Hobby refactor
- Migration
- Frontend

Closes #230