### PR TITLE
[Role] Add Role and Person persistence foundation

### DIFF
--- a/src/main/resources/db/migration/V19__role_person_persistence_foundation.sql
+++ b/src/main/resources/db/migration/V19__role_person_persistence_foundation.sql
@@ -1,0 +1,88 @@
+CREATE TABLE roles (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    player_id BIGINT NOT NULL,
+    role_type VARCHAR(40) NOT NULL,
+    name VARCHAR(60) NOT NULL,
+    description VARCHAR(500) NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    version BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_role_id_player UNIQUE (id, player_id),
+    CONSTRAINT ck_role_player CHECK (player_id > 0),
+    CONSTRAINT ck_role_type CHECK (
+        CHAR_LENGTH(TRIM(role_type)) BETWEEN 1 AND 40
+    ),
+    CONSTRAINT ck_role_name CHECK (
+        CHAR_LENGTH(TRIM(name)) BETWEEN 1 AND 60
+    ),
+    CONSTRAINT ck_role_status CHECK (status IN ('ACTIVE', 'ARCHIVED')),
+    INDEX idx_role_player_status (player_id, status, id)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE persons (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    owner_player_id BIGINT NOT NULL,
+    linked_user_id BIGINT NULL,
+    display_name VARCHAR(80) NOT NULL,
+    notes TEXT NULL,
+    birthday DATE NULL,
+    contact VARCHAR(120) NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    version BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_person_id_owner UNIQUE (id, owner_player_id),
+    CONSTRAINT uq_person_owner_linked_user UNIQUE (owner_player_id, linked_user_id),
+    CONSTRAINT ck_person_owner CHECK (owner_player_id > 0),
+    CONSTRAINT ck_person_linked_user CHECK (
+        linked_user_id IS NULL OR linked_user_id > 0
+    ),
+    CONSTRAINT ck_person_display_name CHECK (
+        CHAR_LENGTH(TRIM(display_name)) BETWEEN 1 AND 80
+    ),
+    CONSTRAINT ck_person_status CHECK (status IN ('ACTIVE', 'ARCHIVED')),
+    INDEX idx_person_owner_status (owner_player_id, status, id)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE role_relations (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    player_id BIGINT NOT NULL,
+    role_id BIGINT NOT NULL,
+    person_id BIGINT NOT NULL,
+    relation_type VARCHAR(40) NOT NULL,
+    role_notes TEXT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    version BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_role_relation_role_person UNIQUE (role_id, person_id),
+    CONSTRAINT ck_role_relation_player CHECK (player_id > 0),
+    CONSTRAINT ck_role_relation_role CHECK (role_id > 0),
+    CONSTRAINT ck_role_relation_person CHECK (person_id > 0),
+    CONSTRAINT ck_role_relation_type CHECK (
+        CHAR_LENGTH(TRIM(relation_type)) BETWEEN 1 AND 40
+    ),
+    CONSTRAINT ck_role_relation_status CHECK (status IN ('ACTIVE', 'ARCHIVED')),
+    INDEX idx_role_relation_player_role_status (player_id, role_id, status, id),
+    INDEX idx_role_relation_player_person_status (player_id, person_id, status, id),
+    CONSTRAINT fk_role_relation_role_owner
+        FOREIGN KEY (role_id, player_id)
+        REFERENCES roles (id, player_id)
+        ON DELETE RESTRICT
+        ON UPDATE RESTRICT,
+    CONSTRAINT fk_role_relation_person_owner
+        FOREIGN KEY (person_id, player_id)
+        REFERENCES persons (id, owner_player_id)
+        ON DELETE RESTRICT
+        ON UPDATE RESTRICT
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_0900_ai_ci;

--- a/src/test/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryIntegrationTest.java
@@ -98,7 +98,7 @@ class InventoryRewardDeliveryIntegrationTest {
     @DisplayName("V17 receipt table은 JPA validate와 unique/check/index 계약을 만족한다")
     void validatesMigrationContract() {
         assertThat(flyway.info().current().getVersion().getVersion())
-                .isEqualTo("18");
+                .isEqualTo("19");
         assertThat(environment.getProperty("spring.jpa.hibernate.ddl-auto"))
                 .isEqualTo("validate");
 

--- a/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
@@ -63,7 +63,7 @@ class FlywayExplicitBaselineTest {
     class ApplyExplicitBaseline {
 
         @Test
-        @DisplayName("V1을 재실행하지 않고 V2부터 V18까지 적용한 뒤 JPA validate를 통과한다")
+        @DisplayName("V1을 재실행하지 않고 V2부터 V19까지 적용한 뒤 JPA validate를 통과한다")
         void migratesFromVersionTwoAndValidatesJpa() throws Exception {
             String jdbcUrl = createV1EquivalentDatabase();
             Flyway flyway = migrationFlyway(jdbcUrl);
@@ -72,12 +72,12 @@ class FlywayExplicitBaselineTest {
             MigrateResult migrateResult = flyway.migrate();
             List<HistoryRow> history = successfulHistory(jdbcUrl);
 
-            assertThat(migrateResult.migrationsExecuted).isEqualTo(17);
+            assertThat(migrateResult.migrationsExecuted).isEqualTo(18);
             assertThat(history).extracting(HistoryRow::version)
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
-                            "14", "15", "16", "17", "18"
+                            "14", "15", "16", "17", "18", "19"
                     );
             assertThat(history.getFirst().type()).isEqualTo("BASELINE");
             assertThat(history.getFirst().script())
@@ -105,7 +105,8 @@ class FlywayExplicitBaselineTest {
                             "V15__canonical_lifelog_record_metadata.sql",
                             "V16__quest_acceptance_fact_context.sql",
                             "V17__inventory_reward_delivery_foundation.sql",
-                            "V18__reward_item_code_snapshot.sql"
+                            "V18__reward_item_code_snapshot.sql",
+                            "V19__role_person_persistence_foundation.sql"
                     );
             assertThat(history.subList(1, history.size()))
                     .allSatisfy(row -> assertThat(row.checksum()).isNotNull());
@@ -125,7 +126,7 @@ class FlywayExplicitBaselineTest {
                         "spring.jpa.hibernate.ddl-auto"
                 )).isEqualTo("validate");
                 assertThat(context.getBean(Flyway.class).info().current().getVersion().getVersion())
-                        .isEqualTo("18");
+                        .isEqualTo("19");
             }
         }
     }

--- a/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
@@ -33,10 +33,10 @@ class FlywayHistoryChecksumTest {
     class MigrateAgain {
 
         @Test
-        @DisplayName("V1~V17 checksum을 보존하고 V18 이후 두 번째 실행은 no-op이다")
+        @DisplayName("V1~V18 checksum을 보존하고 V19 이후 두 번째 실행은 no-op이다")
         void keepsMigrationHistory() throws Exception {
-            Flyway throughV17 = flyway(MigrationVersion.fromVersion("17"));
-            MigrateResult legacy = throughV17.migrate();
+            Flyway throughV18 = flyway(MigrationVersion.fromVersion("18"));
+            MigrateResult legacy = throughV18.migrate();
             List<HistoryRow> legacyHistory = successfulHistory();
             Flyway flyway = flyway(null);
 
@@ -46,7 +46,7 @@ class FlywayHistoryChecksumTest {
             MigrateResult second = flyway.migrate();
             List<HistoryRow> secondHistory = successfulHistory();
 
-            assertThat(legacy.migrationsExecuted).isEqualTo(17);
+            assertThat(legacy.migrationsExecuted).isEqualTo(18);
             assertThat(first.migrationsExecuted).isEqualTo(1);
             assertThat(second.migrationsExecuted).isZero();
             assertThat(secondHistory).isEqualTo(firstHistory);
@@ -56,7 +56,7 @@ class FlywayHistoryChecksumTest {
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
-                            "14", "15", "16", "17", "18"
+                            "14", "15", "16", "17", "18", "19"
                     );
             assertThat(secondHistory).allSatisfy(history -> {
                 assertThat(history.checksum()).isNotNull();

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -39,7 +39,7 @@ class FlywayMigrationTest {
     class MigrateCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V18까지 적용되고 Reward ITEM code snapshot을 추가한다")
+        @DisplayName("V1부터 V19까지 적용되고 persistence foundation을 추가한다")
         void migratesSchemaAndSeedsRewardProfiles() throws Exception {
             Flyway throughV10 = flyway(MigrationVersion.fromVersion("10"));
             MigrateResult legacyResult = throughV10.migrate();
@@ -58,12 +58,12 @@ class FlywayMigrationTest {
             assertThat(legacyResult.migrationsExecuted).isEqualTo(10);
             assertThat(semanticResult.migrationsExecuted).isEqualTo(1);
             assertThat(itemResult.migrationsExecuted).isEqualTo(1);
-            assertThat(result.migrationsExecuted).isEqualTo(6);
+            assertThat(result.migrationsExecuted).isEqualTo(7);
             assertThat(appliedVersions())
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
-                            "14", "15", "16", "17", "18"
+                            "14", "15", "16", "17", "18", "19"
                     );
             assertThat(existingTables(
                     "users",
@@ -81,7 +81,10 @@ class FlywayMigrationTest {
                     "outbox_events",
                     "quick_record_request_receipts",
                     "life_log_records",
-                    "inventory_reward_deliveries"
+                    "inventory_reward_deliveries",
+                    "roles",
+                    "persons",
+                    "role_relations"
             )).containsExactlyInAnyOrder(
                     "users",
                     "player",
@@ -98,7 +101,10 @@ class FlywayMigrationTest {
                     "outbox_events",
                     "quick_record_request_receipts",
                     "life_log_records",
-                    "inventory_reward_deliveries"
+                    "inventory_reward_deliveries",
+                    "roles",
+                    "persons",
+                    "role_relations"
             );
             assertThat(existingTables(
                     "quick_lifelog_entries",

--- a/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
@@ -149,7 +149,7 @@ class FlywayProfileCutoverTest {
     class StartLocalWithCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V18까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
+        @DisplayName("V1부터 V19까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
         void migratesThenValidates() {
             ConfigurableEnvironment environment =
                     (ConfigurableEnvironment) applicationContext.getEnvironment();
@@ -161,8 +161,8 @@ class FlywayProfileCutoverTest {
             assertThat(environment.getProperty(
                     "spring.flyway.baseline-on-migrate", Boolean.class
             )).isFalse();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("18");
-            assertThat(appliedMigrationCount()).isEqualTo(18);
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("19");
+            assertThat(appliedMigrationCount()).isEqualTo(19);
         }
     }
 

--- a/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 @SpringBootTest
 @ActiveProfiles({"test", "migration-test"})
-@DisplayName("V18 migration 이후 JPA schema validation")
+@DisplayName("V19 migration 이후 JPA schema validation")
 class JpaValidateAfterMigrationTest {
 
     @Container
@@ -79,14 +79,14 @@ class JpaValidateAfterMigrationTest {
     private QuestDefinitionBootstrapper questDefinitionBootstrapper;
 
     @Nested
-    @DisplayName("V1부터 V18까지 적용된 schema로 ApplicationContext를 기동할 때")
+    @DisplayName("V1부터 V19까지 적용된 schema로 ApplicationContext를 기동할 때")
     class LoadApplicationContext {
 
         @Test
         @DisplayName("ddl-auto validate 상태로 정상 기동한다")
         void loadsWithJpaValidation() {
             assertThat(applicationContext).isNotNull();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("18");
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("19");
             assertThat(applicationContext.getEnvironment().getProperty("spring.jpa.hibernate.ddl-auto"))
                     .isEqualTo("validate");
             assertThat(applicationContext.getEnvironment()

--- a/src/test/java/online/lifeasgame/migration/RewardItemCodeSnapshotFlywayTest.java
+++ b/src/test/java/online/lifeasgame/migration/RewardItemCodeSnapshotFlywayTest.java
@@ -33,7 +33,7 @@ class RewardItemCodeSnapshotFlywayTest {
         JdbcTemplate jdbc = jdbc();
         insertLegacySettlement(jdbc);
 
-        Flyway flyway = flyway(null);
+        Flyway flyway = flyway(MigrationVersion.fromVersion("18"));
         flyway.migrate();
 
         assertThat(flyway.info().current().getVersion().getVersion())

--- a/src/test/java/online/lifeasgame/migration/RolePersonPersistenceFoundationFlywayTest.java
+++ b/src/test/java/online/lifeasgame/migration/RolePersonPersistenceFoundationFlywayTest.java
@@ -1,0 +1,348 @@
+package online.lifeasgame.migration;
+
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+@DisplayName("V19 Role/Person persistence foundation migration")
+class RolePersonPersistenceFoundationFlywayTest {
+
+    @Container
+    private static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0.39")
+            .withDatabaseName("lifeasgame_role_person")
+            .withUsername("lifeasgame")
+            .withPassword("lifeasgame");
+
+    private Flyway flyway;
+    private JdbcTemplate jdbc;
+
+    @BeforeEach
+    void migrateCleanDatabase() {
+        flyway = Flyway.configure()
+                .dataSource(MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword())
+                .locations("classpath:db/migration")
+                .baselineOnMigrate(false)
+                .cleanDisabled(false)
+                .load();
+        flyway.clean();
+        flyway.migrate();
+        jdbc = new JdbcTemplate(new DriverManagerDataSource(
+                MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword()
+        ));
+    }
+
+    @Test
+    @DisplayName("V1~V19가 clean MySQL에 적용되고 table/column/index/check/FK 계약을 고정한다")
+    void createsSchemaContract() {
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("19");
+        assertThat(tableContracts()).containsExactly(
+                new TableContract("roles", "InnoDB", "utf8mb4_0900_ai_ci"),
+                new TableContract("persons", "InnoDB", "utf8mb4_0900_ai_ci"),
+                new TableContract("role_relations", "InnoDB", "utf8mb4_0900_ai_ci")
+        );
+        assertThat(columnContracts()).containsExactly(
+                column("roles", "id", "bigint", "NO", null, "auto_increment"),
+                column("roles", "player_id", "bigint", "NO", null, ""),
+                column("roles", "role_type", "varchar(40)", "NO", null, ""),
+                column("roles", "name", "varchar(60)", "NO", null, ""),
+                column("roles", "description", "varchar(500)", "YES", null, ""),
+                column("roles", "status", "varchar(20)", "NO", "ACTIVE", ""),
+                column("roles", "created_at", "datetime(6)", "NO", null, ""),
+                column("roles", "updated_at", "datetime(6)", "NO", null, ""),
+                column("roles", "version", "bigint", "NO", "0", ""),
+                column("persons", "id", "bigint", "NO", null, "auto_increment"),
+                column("persons", "owner_player_id", "bigint", "NO", null, ""),
+                column("persons", "linked_user_id", "bigint", "YES", null, ""),
+                column("persons", "display_name", "varchar(80)", "NO", null, ""),
+                column("persons", "notes", "text", "YES", null, ""),
+                column("persons", "birthday", "date", "YES", null, ""),
+                column("persons", "contact", "varchar(120)", "YES", null, ""),
+                column("persons", "status", "varchar(20)", "NO", "ACTIVE", ""),
+                column("persons", "created_at", "datetime(6)", "NO", null, ""),
+                column("persons", "updated_at", "datetime(6)", "NO", null, ""),
+                column("persons", "version", "bigint", "NO", "0", ""),
+                column("role_relations", "id", "bigint", "NO", null, "auto_increment"),
+                column("role_relations", "player_id", "bigint", "NO", null, ""),
+                column("role_relations", "role_id", "bigint", "NO", null, ""),
+                column("role_relations", "person_id", "bigint", "NO", null, ""),
+                column("role_relations", "relation_type", "varchar(40)", "NO", null, ""),
+                column("role_relations", "role_notes", "text", "YES", null, ""),
+                column("role_relations", "status", "varchar(20)", "NO", "ACTIVE", ""),
+                column("role_relations", "created_at", "datetime(6)", "NO", null, ""),
+                column("role_relations", "updated_at", "datetime(6)", "NO", null, ""),
+                column("role_relations", "version", "bigint", "NO", "0", "")
+        );
+
+        assertIndex("roles", "PRIMARY", false, "id");
+        assertIndex("roles", "uq_role_id_player", false, "id", "player_id");
+        assertIndex("roles", "idx_role_player_status", true, "player_id", "status", "id");
+        assertIndex("persons", "PRIMARY", false, "id");
+        assertIndex("persons", "uq_person_id_owner", false, "id", "owner_player_id");
+        assertIndex("persons", "uq_person_owner_linked_user", false,
+                "owner_player_id", "linked_user_id");
+        assertIndex("persons", "idx_person_owner_status", true,
+                "owner_player_id", "status", "id");
+        assertIndex("role_relations", "PRIMARY", false, "id");
+        assertIndex("role_relations", "uq_role_relation_role_person", false,
+                "role_id", "person_id");
+        assertIndex("role_relations", "idx_role_relation_player_role_status", true,
+                "player_id", "role_id", "status", "id");
+        assertIndex("role_relations", "idx_role_relation_player_person_status", true,
+                "player_id", "person_id", "status", "id");
+
+        assertThat(checkConstraints()).containsExactlyInAnyOrder(
+                "ck_role_player", "ck_role_type", "ck_role_name", "ck_role_status",
+                "ck_person_owner", "ck_person_linked_user", "ck_person_display_name",
+                "ck_person_status", "ck_role_relation_player", "ck_role_relation_role",
+                "ck_role_relation_person", "ck_role_relation_type", "ck_role_relation_status"
+        );
+        assertThat(foreignKeys()).containsExactlyInAnyOrder(
+                new ForeignKeyContract(
+                        "fk_role_relation_role_owner",
+                        "role_id,player_id",
+                        "roles",
+                        "id,player_id",
+                        "RESTRICT",
+                        "RESTRICT"
+                ),
+                new ForeignKeyContract(
+                        "fk_role_relation_person_owner",
+                        "person_id,player_id",
+                        "persons",
+                        "id,owner_player_id",
+                        "RESTRICT",
+                        "RESTRICT"
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("Player ownership과 Person-linked User 분리 invariant를 DB constraint로 보장한다")
+    void enforcesOwnershipAndOptionalLinkedUser() {
+        insertRole(1001, 101, "Self");
+        insertRole(1002, 202, "Other");
+        insertPerson(2001, 101, 9001L, "Linked self");
+        insertPerson(2002, 202, 9001L, "Linked other");
+        insertPerson(2003, 101, null, "Unlinked one");
+        insertPerson(2004, 101, null, "Unlinked two");
+
+        assertThatThrownBy(() -> insertPerson(2005, 101, 9001L, "Duplicate link"))
+                .isInstanceOf(DataIntegrityViolationException.class);
+
+        insertRelation(3001, 101, 1001, 2001);
+        assertThatThrownBy(() -> insertRelation(3002, 101, 1001, 2001))
+                .isInstanceOf(DataIntegrityViolationException.class);
+        assertThatThrownBy(() -> insertRelation(3003, 101, 1002, 2001))
+                .isInstanceOf(DataIntegrityViolationException.class);
+        assertThatThrownBy(() -> insertRelation(3004, 101, 1001, 2002))
+                .isInstanceOf(DataIntegrityViolationException.class);
+        assertThatThrownBy(() -> jdbc.update("DELETE FROM roles WHERE id = 1001"))
+                .isInstanceOf(DataIntegrityViolationException.class);
+        assertThatThrownBy(() -> jdbc.update("DELETE FROM persons WHERE id = 2001"))
+                .isInstanceOf(DataIntegrityViolationException.class);
+
+        assertThat(jdbc.queryForObject(
+                "SELECT COUNT(*) FROM persons WHERE linked_user_id IS NULL",
+                Integer.class
+        )).isEqualTo(2);
+        assertThat(jdbc.queryForObject(
+                "SELECT COUNT(*) FROM persons WHERE linked_user_id = 9001",
+                Integer.class
+        )).isEqualTo(2);
+        assertThat(jdbc.queryForObject(
+                "SELECT COUNT(*) FROM role_relations",
+                Integer.class
+        )).isEqualTo(1);
+    }
+
+    private List<TableContract> tableContracts() {
+        return jdbc.query("""
+                SELECT table_name, engine, table_collation
+                FROM information_schema.tables
+                WHERE table_schema = DATABASE()
+                  AND table_name IN ('roles', 'persons', 'role_relations')
+                ORDER BY FIELD(table_name, 'roles', 'persons', 'role_relations')
+                """, (resultSet, rowNumber) -> new TableContract(
+                resultSet.getString("table_name"),
+                resultSet.getString("engine"),
+                resultSet.getString("table_collation")
+        ));
+    }
+
+    private List<ColumnContract> columnContracts() {
+        return jdbc.query("""
+                SELECT table_name, column_name, column_type, is_nullable,
+                       column_default, extra
+                FROM information_schema.columns
+                WHERE table_schema = DATABASE()
+                  AND table_name IN ('roles', 'persons', 'role_relations')
+                ORDER BY FIELD(table_name, 'roles', 'persons', 'role_relations'),
+                         ordinal_position
+                """, (resultSet, rowNumber) -> new ColumnContract(
+                resultSet.getString("table_name"),
+                resultSet.getString("column_name"),
+                resultSet.getString("column_type"),
+                resultSet.getString("is_nullable"),
+                resultSet.getString("column_default"),
+                resultSet.getString("extra")
+        ));
+    }
+
+    private ColumnContract column(
+            String tableName,
+            String columnName,
+            String columnType,
+            String nullable,
+            String defaultValue,
+            String extra
+    ) {
+        return new ColumnContract(
+                tableName, columnName, columnType, nullable, defaultValue, extra
+        );
+    }
+
+    private void assertIndex(
+            String tableName,
+            String indexName,
+            boolean nonUnique,
+            String... columns
+    ) {
+        List<IndexColumn> actual = jdbc.query("""
+                SELECT column_name, non_unique
+                FROM information_schema.statistics
+                WHERE table_schema = DATABASE()
+                  AND table_name = ?
+                  AND index_name = ?
+                ORDER BY seq_in_index
+                """, (resultSet, rowNumber) -> new IndexColumn(
+                resultSet.getString("column_name"),
+                resultSet.getBoolean("non_unique")
+        ), tableName, indexName);
+        assertThat(actual).containsExactly(
+                java.util.Arrays.stream(columns)
+                        .map(column -> new IndexColumn(column, nonUnique))
+                        .toArray(IndexColumn[]::new)
+        );
+    }
+
+    private Set<String> checkConstraints() {
+        return Set.copyOf(jdbc.queryForList("""
+                SELECT constraint_name
+                FROM information_schema.table_constraints
+                WHERE table_schema = DATABASE()
+                  AND table_name IN ('roles', 'persons', 'role_relations')
+                  AND constraint_type = 'CHECK'
+                """, String.class));
+    }
+
+    private List<ForeignKeyContract> foreignKeys() {
+        return jdbc.query("""
+                SELECT
+                    kcu.constraint_name,
+                    GROUP_CONCAT(kcu.column_name ORDER BY kcu.ordinal_position) AS fk_columns,
+                    kcu.referenced_table_name,
+                    GROUP_CONCAT(
+                        kcu.referenced_column_name ORDER BY kcu.ordinal_position
+                    ) AS referenced_columns,
+                    rc.update_rule,
+                    rc.delete_rule
+                FROM information_schema.key_column_usage kcu
+                JOIN information_schema.referential_constraints rc
+                  ON rc.constraint_schema = kcu.constraint_schema
+                 AND rc.constraint_name = kcu.constraint_name
+                 AND rc.table_name = kcu.table_name
+                WHERE kcu.table_schema = DATABASE()
+                  AND kcu.table_name IN ('roles', 'persons', 'role_relations')
+                  AND kcu.referenced_table_name IS NOT NULL
+                GROUP BY kcu.constraint_name, kcu.referenced_table_name,
+                         rc.update_rule, rc.delete_rule
+                """, (resultSet, rowNumber) -> new ForeignKeyContract(
+                resultSet.getString("constraint_name"),
+                resultSet.getString("fk_columns"),
+                resultSet.getString("referenced_table_name"),
+                resultSet.getString("referenced_columns"),
+                resultSet.getString("update_rule"),
+                resultSet.getString("delete_rule")
+        ));
+    }
+
+    private void insertRole(long id, long playerId, String name) {
+        jdbc.update("""
+                INSERT INTO roles (
+                    id, player_id, role_type, name, created_at, updated_at
+                ) VALUES (?, ?, 'PERSONAL', ?, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6))
+                """, id, playerId, name);
+    }
+
+    private void insertPerson(
+            long id,
+            long ownerPlayerId,
+            Long linkedUserId,
+            String displayName
+    ) {
+        jdbc.update("""
+                INSERT INTO persons (
+                    id, owner_player_id, linked_user_id, display_name,
+                    created_at, updated_at
+                ) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6))
+                """, id, ownerPlayerId, linkedUserId, displayName);
+    }
+
+    private void insertRelation(
+            long id,
+            long playerId,
+            long roleId,
+            long personId
+    ) {
+        jdbc.update("""
+                INSERT INTO role_relations (
+                    id, player_id, role_id, person_id, relation_type,
+                    created_at, updated_at
+                ) VALUES (?, ?, ?, ?, 'KNOWN_AS', CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6))
+                """, id, playerId, roleId, personId);
+    }
+
+    private record TableContract(
+            String tableName,
+            String engine,
+            String collation
+    ) {
+    }
+
+    private record ColumnContract(
+            String tableName,
+            String columnName,
+            String columnType,
+            String nullable,
+            String defaultValue,
+            String extra
+    ) {
+    }
+
+    private record IndexColumn(String name, boolean nonUnique) {
+    }
+
+    private record ForeignKeyContract(
+            String name,
+            String columns,
+            String referencedTable,
+            String referencedColumns,
+            String updateRule,
+            String deleteRule
+    ) {
+    }
+}


### PR DESCRIPTION

## What

Role / Person 구현에 앞서 ownership과 identity 경계를 V19 schema로 고정한다.

```text
Player
├─ Role
└─ Person

Role + Person
→ RoleRelation
```

## Ownership

- Role owner: `player_id`
- Person owner: `owner_player_id`
- RoleRelation owner: `player_id`
- Person은 Service User와 동일하지 않음
- `linked_user_id`는 nullable reference

## Schema

```text
V19__role_person_persistence_foundation.sql
```

신규 table:

- `roles`
- `persons`
- `role_relations`

RoleRelation은 composite FK로 같은 Player 소유 Role과 Person만 연결한다.

```text
(role_id, player_id)
→ roles(id, player_id)

(person_id, player_id)
→ persons(id, owner_player_id)
```

## Person Link

```text
(owner_player_id, linked_user_id) UNIQUE
```

- 같은 owner가 같은 Service User를 중복 Person으로 연결하지 못함
- `linked_user_id = null`인 실제 인물은 여러 건 허용
- 다른 owner가 같은 Service User를 각자의 Person으로 기록하는 것은 허용

## Compatibility

- 기존 V1~V18 변경 없음
- 기존 API/Event 변경 없음
- 신규 Entity/API 없음
- Guild/Party 유지
- cross-domain Player/User FK 없음

## Test

- V1~V19 clean migration
- checksum/JPA validate
- table/column/index/check/FK contract
- duplicate relation rejection
- cross-owner relation rejection
- linked user uniqueness/null behavior
- full clean test/build

## Out of Scope

- Role/Person/RoleRelation CRUD
- RoleStat
- RoleEvent/RoleParty/RoleChat
- Quest role scope
- LifeLog connection
- Guild/Party migration
- Frontend

Closes #232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added foundational persistence for roles, persons, and relationships.
  * Enforced ownership, validation, versioning, and relationship integrity rules.
  * Added support for linked user associations and protected deletion behavior.

* **Tests**
  * Expanded migration coverage and schema validation through version 19.
  * Added integration tests covering tables, indexes, constraints, relationships, and data-integrity rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->