### PR TITLE
[Role] Add RoleRelation CRUD and same-owner enforcement

### DIFF
--- a/src/main/java/online/lifeasgame/person/application/PersonLookupService.java
+++ b/src/main/java/online/lifeasgame/person/application/PersonLookupService.java
@@ -1,0 +1,57 @@
+package online.lifeasgame.person.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.person.application.internal.PersonLookupApi;
+import online.lifeasgame.person.domain.Person;
+import online.lifeasgame.person.domain.PersonStatus;
+import online.lifeasgame.person.domain.error.PersonError;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+public class PersonLookupService implements PersonLookupApi {
+
+    private final PersonReader reader;
+
+    @Override
+    public PersonReference getOwnedActive(Long personId, Long ownerPlayerId) {
+        Person person = reader.getOwned(personId, ownerPlayerId);
+        if (person.getStatus() == PersonStatus.ARCHIVED) {
+            throw new DomainException(PersonError.PERSON_ARCHIVED);
+        }
+        return reference(person);
+    }
+
+    @Override
+    public Map<Long, PersonReference> findOwnedByIds(
+            Set<Long> personIds,
+            Long ownerPlayerId
+    ) {
+        if (personIds.isEmpty()) {
+            return Map.of();
+        }
+        return reader.findOwnedByIds(personIds, ownerPlayerId).stream()
+                .map(PersonLookupService::reference)
+                .collect(Collectors.toUnmodifiableMap(
+                        PersonReference::id,
+                        Function.identity()
+                ));
+    }
+
+    private static PersonReference reference(Person person) {
+        return new PersonReference(
+                person.getId(),
+                person.getLinkedUserId(),
+                person.getDisplayName()
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/person/application/PersonReader.java
+++ b/src/main/java/online/lifeasgame/person/application/PersonReader.java
@@ -9,6 +9,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Set;
+
 @Component
 @RequiredArgsConstructor
 @Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
@@ -19,5 +22,9 @@ class PersonReader {
     Person getOwned(Long personId, Long ownerPlayerId) {
         return repository.findByIdAndOwnerPlayerId(personId, ownerPlayerId)
                 .orElseThrow(() -> new DomainException(PersonError.PERSON_NOT_FOUND));
+    }
+
+    List<Person> findOwnedByIds(Set<Long> personIds, Long ownerPlayerId) {
+        return repository.findAllByIdInAndOwnerPlayerId(personIds, ownerPlayerId);
     }
 }

--- a/src/main/java/online/lifeasgame/person/application/internal/PersonLookupApi.java
+++ b/src/main/java/online/lifeasgame/person/application/internal/PersonLookupApi.java
@@ -1,0 +1,21 @@
+package online.lifeasgame.person.application.internal;
+
+import java.util.Map;
+import java.util.Set;
+
+public interface PersonLookupApi {
+
+    PersonReference getOwnedActive(Long personId, Long ownerPlayerId);
+
+    Map<Long, PersonReference> findOwnedByIds(
+            Set<Long> personIds,
+            Long ownerPlayerId
+    );
+
+    record PersonReference(
+            Long id,
+            Long linkedUserId,
+            String displayName
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/person/domain/repository/PersonRepository.java
+++ b/src/main/java/online/lifeasgame/person/domain/repository/PersonRepository.java
@@ -1,10 +1,18 @@
 package online.lifeasgame.person.domain.repository;
 
 import online.lifeasgame.person.domain.Person;
+
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface PersonRepository {
     Person save(Person person);
 
     Optional<Person> findByIdAndOwnerPlayerId(Long id, Long ownerPlayerId);
+
+    List<Person> findAllByIdInAndOwnerPlayerId(
+            Set<Long> ids,
+            Long ownerPlayerId
+    );
 }

--- a/src/main/java/online/lifeasgame/person/infra/JpaPersonRepository.java
+++ b/src/main/java/online/lifeasgame/person/infra/JpaPersonRepository.java
@@ -6,9 +6,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface JpaPersonRepository extends JpaRepository<Person, Long> {
     Optional<Person> findByIdAndOwnerPlayerId(Long id, Long ownerPlayerId);
+
+    List<Person> findAllByIdInAndOwnerPlayerId(
+            Set<Long> ids,
+            Long ownerPlayerId
+    );
 
     List<Person> findAllByOwnerPlayerIdAndStatusOrderByIdAsc(
             Long ownerPlayerId,

--- a/src/main/java/online/lifeasgame/person/infra/PersonRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/person/infra/PersonRepositoryAdapter.java
@@ -6,6 +6,8 @@ import online.lifeasgame.person.domain.repository.PersonRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import java.util.List;
+import java.util.Set;
 
 @Repository
 @RequiredArgsConstructor
@@ -21,5 +23,13 @@ public class PersonRepositoryAdapter implements PersonRepository {
     @Override
     public Optional<Person> findByIdAndOwnerPlayerId(Long id, Long ownerPlayerId) {
         return repository.findByIdAndOwnerPlayerId(id, ownerPlayerId);
+    }
+
+    @Override
+    public List<Person> findAllByIdInAndOwnerPlayerId(
+            Set<Long> ids,
+            Long ownerPlayerId
+    ) {
+        return repository.findAllByIdInAndOwnerPlayerId(ids, ownerPlayerId);
     }
 }

--- a/src/main/java/online/lifeasgame/role/api/RoleRelationController.java
+++ b/src/main/java/online/lifeasgame/role/api/RoleRelationController.java
@@ -1,0 +1,97 @@
+package online.lifeasgame.role.api;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.response.ApiResponse;
+import online.lifeasgame.platform.web.response.ApiResponses;
+import online.lifeasgame.role.api.mapper.RoleRelationWebMapper;
+import online.lifeasgame.role.api.request.RoleRelationRequest;
+import online.lifeasgame.role.api.response.RoleRelationResponse;
+import online.lifeasgame.role.api.spec.RoleRelationApiSpecV1;
+import online.lifeasgame.role.application.RoleRelationQueryService;
+import online.lifeasgame.role.application.RoleRelationService;
+import online.lifeasgame.role.application.result.RoleRelationResult;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/roles/{roleId}/relations")
+public class RoleRelationController implements RoleRelationApiSpecV1 {
+
+    private final RoleRelationService relationService;
+    private final RoleRelationQueryService relationQueryService;
+
+    @Override
+    @PostMapping
+    public ResponseEntity<ApiResponse<RoleRelationResponse.Detail>> create(
+            @PathVariable Long roleId,
+            @Valid @RequestBody RoleRelationRequest.Create request
+    ) {
+        RoleRelationResult.Detail result = relationService.create(
+                roleId,
+                RoleRelationWebMapper.toCreateCommand(request)
+        );
+        return ApiResponses.created(
+                URI.create("/api/v1/roles/" + roleId + "/relations/" + result.id()),
+                RoleRelationWebMapper.toDetail(result)
+        );
+    }
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<RoleRelationResponse.Detail>>> list(
+            @PathVariable Long roleId
+    ) {
+        return ApiResponses.ok(relationQueryService.list(roleId).stream()
+                .map(RoleRelationWebMapper::toDetail)
+                .toList());
+    }
+
+    @Override
+    @GetMapping("/{relationId}")
+    public ResponseEntity<ApiResponse<RoleRelationResponse.Detail>> detail(
+            @PathVariable Long roleId,
+            @PathVariable Long relationId
+    ) {
+        return ApiResponses.ok(RoleRelationWebMapper.toDetail(
+                relationQueryService.detail(roleId, relationId)
+        ));
+    }
+
+    @Override
+    @PutMapping("/{relationId}")
+    public ResponseEntity<ApiResponse<RoleRelationResponse.Detail>> update(
+            @PathVariable Long roleId,
+            @PathVariable Long relationId,
+            @Valid @RequestBody RoleRelationRequest.Update request
+    ) {
+        return ApiResponses.ok(RoleRelationWebMapper.toDetail(
+                relationService.update(
+                        roleId,
+                        relationId,
+                        RoleRelationWebMapper.toUpdateCommand(request)
+                )
+        ));
+    }
+
+    @Override
+    @DeleteMapping("/{relationId}")
+    public ResponseEntity<ApiResponse<Void>> archive(
+            @PathVariable Long roleId,
+            @PathVariable Long relationId
+    ) {
+        relationService.archive(roleId, relationId);
+        return ApiResponses.noContent();
+    }
+}

--- a/src/main/java/online/lifeasgame/role/api/mapper/RoleRelationWebMapper.java
+++ b/src/main/java/online/lifeasgame/role/api/mapper/RoleRelationWebMapper.java
@@ -1,0 +1,48 @@
+package online.lifeasgame.role.api.mapper;
+
+import online.lifeasgame.role.api.request.RoleRelationRequest;
+import online.lifeasgame.role.api.response.RoleRelationResponse;
+import online.lifeasgame.role.application.command.RoleRelationCommand;
+import online.lifeasgame.role.application.result.RoleRelationResult;
+
+public final class RoleRelationWebMapper {
+
+    private RoleRelationWebMapper() {
+    }
+
+    public static RoleRelationCommand.Create toCreateCommand(
+            RoleRelationRequest.Create request
+    ) {
+        return new RoleRelationCommand.Create(
+                request.personId(),
+                request.relationType(),
+                request.roleNotes()
+        );
+    }
+
+    public static RoleRelationCommand.Update toUpdateCommand(
+            RoleRelationRequest.Update request
+    ) {
+        return new RoleRelationCommand.Update(
+                request.relationType(),
+                request.roleNotes()
+        );
+    }
+
+    public static RoleRelationResponse.Detail toDetail(
+            RoleRelationResult.Detail result
+    ) {
+        return new RoleRelationResponse.Detail(
+                result.id(),
+                result.personId(),
+                result.personDisplayName(),
+                result.linkedUserId(),
+                result.relationType(),
+                result.roleNotes(),
+                result.status(),
+                result.createdAt(),
+                result.updatedAt(),
+                result.version()
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/role/api/request/RoleRelationRequest.java
+++ b/src/main/java/online/lifeasgame/role/api/request/RoleRelationRequest.java
@@ -1,0 +1,17 @@
+package online.lifeasgame.role.api.request;
+
+public final class RoleRelationRequest {
+
+    private RoleRelationRequest() {
+    }
+
+    public record Create(
+            Long personId,
+            String relationType,
+            String roleNotes
+    ) {
+    }
+
+    public record Update(String relationType, String roleNotes) {
+    }
+}

--- a/src/main/java/online/lifeasgame/role/api/response/RoleRelationResponse.java
+++ b/src/main/java/online/lifeasgame/role/api/response/RoleRelationResponse.java
@@ -1,0 +1,23 @@
+package online.lifeasgame.role.api.response;
+
+import java.time.Instant;
+
+public final class RoleRelationResponse {
+
+    private RoleRelationResponse() {
+    }
+
+    public record Detail(
+            Long id,
+            Long personId,
+            String personDisplayName,
+            Long linkedUserId,
+            String relationType,
+            String roleNotes,
+            String status,
+            Instant createdAt,
+            Instant updatedAt,
+            Long version
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/role/api/spec/RoleRelationApiSpecV1.java
+++ b/src/main/java/online/lifeasgame/role/api/spec/RoleRelationApiSpecV1.java
@@ -1,0 +1,47 @@
+package online.lifeasgame.role.api.spec;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import online.lifeasgame.core.response.ApiResponse;
+import online.lifeasgame.role.api.request.RoleRelationRequest;
+import online.lifeasgame.role.api.response.RoleRelationResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@Tag(name = "Role Relation API V1 (Player)")
+public interface RoleRelationApiSpecV1 {
+
+    @Operation(summary = "Role에 Person 관계 생성")
+    ResponseEntity<ApiResponse<RoleRelationResponse.Detail>> create(
+            @PathVariable Long roleId,
+            @Valid @RequestBody RoleRelationRequest.Create request
+    );
+
+    @Operation(summary = "Role의 활성 관계 목록")
+    ResponseEntity<ApiResponse<List<RoleRelationResponse.Detail>>> list(
+            @PathVariable Long roleId
+    );
+
+    @Operation(summary = "Role 관계 상세")
+    ResponseEntity<ApiResponse<RoleRelationResponse.Detail>> detail(
+            @PathVariable Long roleId,
+            @PathVariable Long relationId
+    );
+
+    @Operation(summary = "Role 관계 수정")
+    ResponseEntity<ApiResponse<RoleRelationResponse.Detail>> update(
+            @PathVariable Long roleId,
+            @PathVariable Long relationId,
+            @Valid @RequestBody RoleRelationRequest.Update request
+    );
+
+    @Operation(summary = "Role 관계 archive")
+    ResponseEntity<ApiResponse<Void>> archive(
+            @PathVariable Long roleId,
+            @PathVariable Long relationId
+    );
+}

--- a/src/main/java/online/lifeasgame/role/application/RoleReader.java
+++ b/src/main/java/online/lifeasgame/role/application/RoleReader.java
@@ -20,4 +20,9 @@ class RoleReader {
         return repository.findByIdAndPlayerId(roleId, playerId)
                 .orElseThrow(() -> new DomainException(RoleError.ROLE_NOT_FOUND));
     }
+
+    Role getOwnedForUpdate(Long roleId, Long playerId) {
+        return repository.findByIdAndPlayerIdForUpdate(roleId, playerId)
+                .orElseThrow(() -> new DomainException(RoleError.ROLE_NOT_FOUND));
+    }
 }

--- a/src/main/java/online/lifeasgame/role/application/RoleRelationQueryService.java
+++ b/src/main/java/online/lifeasgame/role/application/RoleRelationQueryService.java
@@ -1,0 +1,84 @@
+package online.lifeasgame.role.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.person.application.internal.PersonLookupApi;
+import online.lifeasgame.person.application.internal.PersonLookupApi.PersonReference;
+import online.lifeasgame.person.domain.error.PersonError;
+import online.lifeasgame.role.application.query.RoleRelationQuery;
+import online.lifeasgame.role.application.result.RoleRelationResult;
+import online.lifeasgame.role.domain.error.RoleError;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RoleRelationQueryService {
+
+    private final RoleReader roleReader;
+    private final RoleRelationQuery query;
+    private final PersonLookupApi personLookupApi;
+    private final CurrentPlayerAccessor currentPlayerAccessor;
+
+    public List<RoleRelationResult.Detail> list(Long roleId) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        roleReader.getOwned(roleId, playerId);
+        List<RoleRelationResult.Stored> relations = query.findActive(
+                playerId,
+                roleId
+        );
+        Map<Long, PersonReference> persons = persons(relations, playerId);
+        return relations.stream()
+                .map(relation -> RoleRelationResult.Detail.from(
+                        relation,
+                        person(relation.personId(), persons)
+                ))
+                .toList();
+    }
+
+    public RoleRelationResult.Detail detail(Long roleId, Long relationId) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        roleReader.getOwned(roleId, playerId);
+        RoleRelationResult.Stored relation = query.findOwned(
+                        relationId,
+                        roleId,
+                        playerId
+                )
+                .orElseThrow(() -> new DomainException(
+                        RoleError.ROLE_RELATION_NOT_FOUND
+                ));
+        Map<Long, PersonReference> persons = persons(List.of(relation), playerId);
+        return RoleRelationResult.Detail.from(
+                relation,
+                person(relation.personId(), persons)
+        );
+    }
+
+    private Map<Long, PersonReference> persons(
+            List<RoleRelationResult.Stored> relations,
+            Long playerId
+    ) {
+        Set<Long> personIds = relations.stream()
+                .map(RoleRelationResult.Stored::personId)
+                .collect(Collectors.toUnmodifiableSet());
+        return personLookupApi.findOwnedByIds(personIds, playerId);
+    }
+
+    private PersonReference person(
+            Long personId,
+            Map<Long, PersonReference> persons
+    ) {
+        PersonReference person = persons.get(personId);
+        if (person == null) {
+            throw new DomainException(PersonError.PERSON_NOT_FOUND);
+        }
+        return person;
+    }
+}

--- a/src/main/java/online/lifeasgame/role/application/RoleRelationReader.java
+++ b/src/main/java/online/lifeasgame/role/application/RoleRelationReader.java
@@ -1,0 +1,43 @@
+package online.lifeasgame.role.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.role.domain.RoleRelation;
+import online.lifeasgame.role.domain.error.RoleError;
+import online.lifeasgame.role.domain.repository.RoleRelationRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+class RoleRelationReader {
+
+    private final RoleRelationRepository repository;
+
+    RoleRelation getOwned(Long relationId, Long roleId, Long playerId) {
+        return repository.findByIdAndRoleIdAndPlayerId(
+                        relationId,
+                        roleId,
+                        playerId
+                )
+                .orElseThrow(() -> new DomainException(
+                        RoleError.ROLE_RELATION_NOT_FOUND
+                ));
+    }
+
+    Optional<RoleRelation> findPair(
+            Long roleId,
+            Long personId,
+            Long playerId
+    ) {
+        return repository.findByRoleIdAndPersonIdAndPlayerId(
+                roleId,
+                personId,
+                playerId
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/role/application/RoleRelationService.java
+++ b/src/main/java/online/lifeasgame/role/application/RoleRelationService.java
@@ -1,0 +1,133 @@
+package online.lifeasgame.role.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.person.application.internal.PersonLookupApi;
+import online.lifeasgame.person.application.internal.PersonLookupApi.PersonReference;
+import online.lifeasgame.person.domain.error.PersonError;
+import online.lifeasgame.role.application.command.RoleRelationCommand;
+import online.lifeasgame.role.application.result.RoleRelationResult;
+import online.lifeasgame.role.domain.Role;
+import online.lifeasgame.role.domain.RoleRelation;
+import online.lifeasgame.role.domain.RoleRelationStatus;
+import online.lifeasgame.role.domain.RoleRelationType;
+import online.lifeasgame.role.domain.RoleStatus;
+import online.lifeasgame.role.domain.error.RoleError;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class RoleRelationService {
+
+    private final RoleReader roleReader;
+    private final RoleRelationReader relationReader;
+    private final RoleRelationWriter relationWriter;
+    private final PersonLookupApi personLookupApi;
+    private final CurrentPlayerAccessor currentPlayerAccessor;
+
+    @Transactional
+    public RoleRelationResult.Detail create(
+            Long roleId,
+            RoleRelationCommand.Create command
+    ) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        RoleRelationType relationType = RoleRelationType.of(command.relationType());
+        Role role = roleReader.getOwnedForUpdate(roleId, playerId);
+        requireActive(role);
+
+        RoleRelation relation = relationReader.findPair(
+                        roleId,
+                        command.personId(),
+                        playerId
+                )
+                .orElse(null);
+        if (relation != null && relation.getStatus() == RoleRelationStatus.ACTIVE) {
+            throw new DomainException(RoleError.ROLE_RELATION_ALREADY_EXISTS);
+        }
+
+        PersonReference person = personLookupApi.getOwnedActive(
+                command.personId(),
+                playerId
+        );
+        if (relation == null) {
+            relation = RoleRelation.create(
+                    playerId,
+                    roleId,
+                    command.personId(),
+                    relationType,
+                    command.roleNotes()
+            );
+        } else {
+            relation.reactivate(relationType, command.roleNotes());
+        }
+
+        try {
+            return RoleRelationResult.Detail.from(
+                    relationWriter.saveAndFlush(relation),
+                    person
+            );
+        } catch (DataIntegrityViolationException exception) {
+            throw new DomainException(
+                    RoleError.ROLE_RELATION_ALREADY_EXISTS,
+                    null,
+                    exception
+            );
+        }
+    }
+
+    @Transactional
+    public RoleRelationResult.Detail update(
+            Long roleId,
+            Long relationId,
+            RoleRelationCommand.Update command
+    ) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        roleReader.getOwned(roleId, playerId);
+        RoleRelation relation = relationReader.getOwned(
+                relationId,
+                roleId,
+                playerId
+        );
+        relation.update(
+                RoleRelationType.of(command.relationType()),
+                command.roleNotes()
+        );
+        RoleRelation saved = relationWriter.saveAndFlush(relation);
+        return RoleRelationResult.Detail.from(saved, person(saved, playerId));
+    }
+
+    @Transactional
+    public void archive(Long roleId, Long relationId) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        roleReader.getOwned(roleId, playerId);
+        RoleRelation relation = relationReader.getOwned(
+                relationId,
+                roleId,
+                playerId
+        );
+        relation.archive();
+        relationWriter.saveAndFlush(relation);
+    }
+
+    private PersonReference person(RoleRelation relation, Long playerId) {
+        PersonReference person = personLookupApi.findOwnedByIds(
+                Set.of(relation.getPersonId()),
+                playerId
+        ).get(relation.getPersonId());
+        if (person == null) {
+            throw new DomainException(PersonError.PERSON_NOT_FOUND);
+        }
+        return person;
+    }
+
+    private void requireActive(Role role) {
+        if (role.getStatus() == RoleStatus.ARCHIVED) {
+            throw new DomainException(RoleError.ROLE_ARCHIVED);
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/role/application/RoleRelationWriter.java
+++ b/src/main/java/online/lifeasgame/role/application/RoleRelationWriter.java
@@ -1,0 +1,20 @@
+package online.lifeasgame.role.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.role.domain.RoleRelation;
+import online.lifeasgame.role.domain.repository.RoleRelationRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.MANDATORY)
+class RoleRelationWriter {
+
+    private final RoleRelationRepository repository;
+
+    RoleRelation saveAndFlush(RoleRelation relation) {
+        return repository.saveAndFlush(relation);
+    }
+}

--- a/src/main/java/online/lifeasgame/role/application/command/RoleRelationCommand.java
+++ b/src/main/java/online/lifeasgame/role/application/command/RoleRelationCommand.java
@@ -1,0 +1,17 @@
+package online.lifeasgame.role.application.command;
+
+public final class RoleRelationCommand {
+
+    private RoleRelationCommand() {
+    }
+
+    public record Create(
+            Long personId,
+            String relationType,
+            String roleNotes
+    ) {
+    }
+
+    public record Update(String relationType, String roleNotes) {
+    }
+}

--- a/src/main/java/online/lifeasgame/role/application/query/RoleRelationQuery.java
+++ b/src/main/java/online/lifeasgame/role/application/query/RoleRelationQuery.java
@@ -1,0 +1,17 @@
+package online.lifeasgame.role.application.query;
+
+import online.lifeasgame.role.application.result.RoleRelationResult;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RoleRelationQuery {
+
+    List<RoleRelationResult.Stored> findActive(Long playerId, Long roleId);
+
+    Optional<RoleRelationResult.Stored> findOwned(
+            Long relationId,
+            Long roleId,
+            Long playerId
+    );
+}

--- a/src/main/java/online/lifeasgame/role/application/result/RoleRelationResult.java
+++ b/src/main/java/online/lifeasgame/role/application/result/RoleRelationResult.java
@@ -1,0 +1,76 @@
+package online.lifeasgame.role.application.result;
+
+import online.lifeasgame.person.application.internal.PersonLookupApi.PersonReference;
+import online.lifeasgame.role.domain.RoleRelation;
+
+import java.time.Instant;
+
+public final class RoleRelationResult {
+
+    private RoleRelationResult() {
+    }
+
+    public record Stored(
+            Long id,
+            Long playerId,
+            Long roleId,
+            Long personId,
+            String relationType,
+            String roleNotes,
+            String status,
+            Instant createdAt,
+            Instant updatedAt,
+            Long version
+    ) {
+        public static Stored from(RoleRelation relation) {
+            return new Stored(
+                    relation.getId(),
+                    relation.getPlayerId(),
+                    relation.getRoleId(),
+                    relation.getPersonId(),
+                    relation.getRelationType().value(),
+                    relation.getRoleNotes(),
+                    relation.getStatus().name(),
+                    relation.getCreatedAt(),
+                    relation.getUpdatedAt(),
+                    relation.getVersion()
+            );
+        }
+    }
+
+    public record Detail(
+            Long id,
+            Long playerId,
+            Long roleId,
+            Long personId,
+            String personDisplayName,
+            Long linkedUserId,
+            String relationType,
+            String roleNotes,
+            String status,
+            Instant createdAt,
+            Instant updatedAt,
+            Long version
+    ) {
+        public static Detail from(RoleRelation relation, PersonReference person) {
+            return from(Stored.from(relation), person);
+        }
+
+        public static Detail from(Stored stored, PersonReference person) {
+            return new Detail(
+                    stored.id(),
+                    stored.playerId(),
+                    stored.roleId(),
+                    stored.personId(),
+                    person.displayName(),
+                    person.linkedUserId(),
+                    stored.relationType(),
+                    stored.roleNotes(),
+                    stored.status(),
+                    stored.createdAt(),
+                    stored.updatedAt(),
+                    stored.version()
+            );
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/role/domain/RoleRelation.java
+++ b/src/main/java/online/lifeasgame/role/domain/RoleRelation.java
@@ -1,0 +1,133 @@
+package online.lifeasgame.role.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import online.lifeasgame.core.annotation.AggregateRoot;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.guard.Guard;
+import online.lifeasgame.platform.persistence.jpa.AbstractTime;
+import online.lifeasgame.role.domain.error.RoleError;
+
+@Entity
+@AggregateRoot
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "role_relations",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_role_relation_role_person",
+                columnNames = {"role_id", "person_id"}
+        ),
+        indexes = {
+                @Index(
+                        name = "idx_role_relation_player_role_status",
+                        columnList = "player_id,role_id,status,id"
+                ),
+                @Index(
+                        name = "idx_role_relation_player_person_status",
+                        columnList = "player_id,person_id,status,id"
+                )
+        }
+)
+public class RoleRelation extends AbstractTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "player_id", nullable = false, updatable = false)
+    private Long playerId;
+
+    @Column(name = "role_id", nullable = false, updatable = false)
+    private Long roleId;
+
+    @Column(name = "person_id", nullable = false, updatable = false)
+    private Long personId;
+
+    @Embedded
+    private RoleRelationType relationType;
+
+    @Column(name = "role_notes", columnDefinition = "text")
+    private String roleNotes;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private RoleRelationStatus status;
+
+    @Version
+    @Column(nullable = false)
+    private Long version;
+
+    private RoleRelation(
+            Long playerId,
+            Long roleId,
+            Long personId,
+            RoleRelationType relationType,
+            String roleNotes
+    ) {
+        this.playerId = positive(playerId, "playerId");
+        this.roleId = positive(roleId, "roleId");
+        this.personId = positive(personId, "personId");
+        this.relationType = Guard.notNull(relationType, "relationType");
+        this.roleNotes = optionalNotes(roleNotes);
+        this.status = RoleRelationStatus.ACTIVE;
+    }
+
+    public static RoleRelation create(
+            Long playerId,
+            Long roleId,
+            Long personId,
+            RoleRelationType relationType,
+            String roleNotes
+    ) {
+        return new RoleRelation(
+                playerId,
+                roleId,
+                personId,
+                relationType,
+                roleNotes
+        );
+    }
+
+    public void update(RoleRelationType relationType, String roleNotes) {
+        if (status == RoleRelationStatus.ARCHIVED) {
+            throw new DomainException(RoleError.ROLE_RELATION_ARCHIVED);
+        }
+        apply(relationType, roleNotes);
+    }
+
+    public void archive() {
+        status = RoleRelationStatus.ARCHIVED;
+    }
+
+    public void reactivate(RoleRelationType relationType, String roleNotes) {
+        apply(relationType, roleNotes);
+        status = RoleRelationStatus.ACTIVE;
+    }
+
+    private void apply(RoleRelationType relationType, String roleNotes) {
+        this.relationType = Guard.notNull(relationType, "relationType");
+        this.roleNotes = optionalNotes(roleNotes);
+    }
+
+    private static Long positive(Long value, String name) {
+        return Guard.minValue(Guard.notNull(value, name), 1, name);
+    }
+
+    private static String optionalNotes(String value) {
+        return value == null || value.isBlank() ? null : value.strip();
+    }
+}

--- a/src/main/java/online/lifeasgame/role/domain/RoleRelationStatus.java
+++ b/src/main/java/online/lifeasgame/role/domain/RoleRelationStatus.java
@@ -1,0 +1,6 @@
+package online.lifeasgame.role.domain;
+
+public enum RoleRelationStatus {
+    ACTIVE,
+    ARCHIVED
+}

--- a/src/main/java/online/lifeasgame/role/domain/RoleRelationType.java
+++ b/src/main/java/online/lifeasgame/role/domain/RoleRelationType.java
@@ -1,0 +1,39 @@
+package online.lifeasgame.role.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.role.domain.error.RoleError;
+
+import java.util.Locale;
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RoleRelationType {
+
+    @Column(name = "relation_type", nullable = false, length = 40)
+    private String value;
+
+    private RoleRelationType(String raw) {
+        if (raw == null) {
+            throw new DomainException(RoleError.INVALID_ROLE_RELATION_TYPE);
+        }
+        String normalized = raw.strip().toUpperCase(Locale.ROOT);
+        if (normalized.isEmpty() || normalized.length() > 40) {
+            throw new DomainException(RoleError.INVALID_ROLE_RELATION_TYPE);
+        }
+        this.value = normalized;
+    }
+
+    public static RoleRelationType of(String raw) {
+        return new RoleRelationType(raw);
+    }
+
+    public String value() {
+        return value;
+    }
+}

--- a/src/main/java/online/lifeasgame/role/domain/error/RoleError.java
+++ b/src/main/java/online/lifeasgame/role/domain/error/RoleError.java
@@ -6,8 +6,12 @@ public enum RoleError implements ErrorCode {
     INVALID_ROLE_TYPE("ROL-400-INVALID-ROLE-TYPE", "Invalid Role type", 400),
     INVALID_ROLE_NAME("ROL-400-INVALID-ROLE-NAME", "Invalid Role name", 400),
     INVALID_ROLE_DESCRIPTION("ROL-400-INVALID-ROLE-DESCRIPTION", "Invalid Role description", 400),
+    INVALID_ROLE_RELATION_TYPE("ROL-400-INVALID-ROLE-RELATION-TYPE", "Invalid Role relation type", 400),
     ROLE_NOT_FOUND("ROL-404-NOT-FOUND", "Role not found", 404),
-    ROLE_ARCHIVED("ROL-409-ARCHIVED", "Archived Role cannot be updated", 409);
+    ROLE_RELATION_NOT_FOUND("ROL-404-RELATION-NOT-FOUND", "Role relation not found", 404),
+    ROLE_ARCHIVED("ROL-409-ARCHIVED", "Archived Role cannot be updated", 409),
+    ROLE_RELATION_ALREADY_EXISTS("ROL-409-RELATION-ALREADY-EXISTS", "Role relation already exists", 409),
+    ROLE_RELATION_ARCHIVED("ROL-409-RELATION-ARCHIVED", "Archived Role relation cannot be updated", 409);
 
     private final String code;
     private final String message;

--- a/src/main/java/online/lifeasgame/role/domain/repository/RoleRelationRepository.java
+++ b/src/main/java/online/lifeasgame/role/domain/repository/RoleRelationRepository.java
@@ -1,0 +1,22 @@
+package online.lifeasgame.role.domain.repository;
+
+import online.lifeasgame.role.domain.RoleRelation;
+
+import java.util.Optional;
+
+public interface RoleRelationRepository {
+
+    RoleRelation saveAndFlush(RoleRelation relation);
+
+    Optional<RoleRelation> findByIdAndRoleIdAndPlayerId(
+            Long id,
+            Long roleId,
+            Long playerId
+    );
+
+    Optional<RoleRelation> findByRoleIdAndPersonIdAndPlayerId(
+            Long roleId,
+            Long personId,
+            Long playerId
+    );
+}

--- a/src/main/java/online/lifeasgame/role/domain/repository/RoleRepository.java
+++ b/src/main/java/online/lifeasgame/role/domain/repository/RoleRepository.java
@@ -7,4 +7,6 @@ public interface RoleRepository {
     Role save(Role role);
 
     Optional<Role> findByIdAndPlayerId(Long id, Long playerId);
+
+    Optional<Role> findByIdAndPlayerIdForUpdate(Long id, Long playerId);
 }

--- a/src/main/java/online/lifeasgame/role/infra/JpaRoleRelationRepository.java
+++ b/src/main/java/online/lifeasgame/role/infra/JpaRoleRelationRepository.java
@@ -1,0 +1,29 @@
+package online.lifeasgame.role.infra;
+
+import online.lifeasgame.role.domain.RoleRelation;
+import online.lifeasgame.role.domain.RoleRelationStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface JpaRoleRelationRepository extends JpaRepository<RoleRelation, Long> {
+
+    Optional<RoleRelation> findByIdAndRoleIdAndPlayerId(
+            Long id,
+            Long roleId,
+            Long playerId
+    );
+
+    Optional<RoleRelation> findByRoleIdAndPersonIdAndPlayerId(
+            Long roleId,
+            Long personId,
+            Long playerId
+    );
+
+    List<RoleRelation> findAllByPlayerIdAndRoleIdAndStatusOrderByIdAsc(
+            Long playerId,
+            Long roleId,
+            RoleRelationStatus status
+    );
+}

--- a/src/main/java/online/lifeasgame/role/infra/JpaRoleRepository.java
+++ b/src/main/java/online/lifeasgame/role/infra/JpaRoleRepository.java
@@ -2,13 +2,24 @@ package online.lifeasgame.role.infra;
 
 import online.lifeasgame.role.domain.Role;
 import online.lifeasgame.role.domain.RoleStatus;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface JpaRoleRepository extends JpaRepository<Role, Long> {
     Optional<Role> findByIdAndPlayerId(Long id, Long playerId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select role from Role role where role.id = :roleId and role.playerId = :playerId")
+    Optional<Role> findByIdAndPlayerIdForUpdate(
+            @Param("roleId") Long roleId,
+            @Param("playerId") Long playerId
+    );
 
     List<Role> findAllByPlayerIdAndStatusOrderByIdAsc(Long playerId, RoleStatus status);
 }

--- a/src/main/java/online/lifeasgame/role/infra/RoleRelationQueryAdapter.java
+++ b/src/main/java/online/lifeasgame/role/infra/RoleRelationQueryAdapter.java
@@ -1,0 +1,45 @@
+package online.lifeasgame.role.infra;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.role.application.query.RoleRelationQuery;
+import online.lifeasgame.role.application.result.RoleRelationResult;
+import online.lifeasgame.role.domain.RoleRelationStatus;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class RoleRelationQueryAdapter implements RoleRelationQuery {
+
+    private final JpaRoleRelationRepository repository;
+
+    @Override
+    public List<RoleRelationResult.Stored> findActive(
+            Long playerId,
+            Long roleId
+    ) {
+        return repository.findAllByPlayerIdAndRoleIdAndStatusOrderByIdAsc(
+                        playerId,
+                        roleId,
+                        RoleRelationStatus.ACTIVE
+                ).stream()
+                .map(RoleRelationResult.Stored::from)
+                .toList();
+    }
+
+    @Override
+    public Optional<RoleRelationResult.Stored> findOwned(
+            Long relationId,
+            Long roleId,
+            Long playerId
+    ) {
+        return repository.findByIdAndRoleIdAndPlayerId(
+                        relationId,
+                        roleId,
+                        playerId
+                )
+                .map(RoleRelationResult.Stored::from);
+    }
+}

--- a/src/main/java/online/lifeasgame/role/infra/RoleRelationRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/role/infra/RoleRelationRepositoryAdapter.java
@@ -1,0 +1,42 @@
+package online.lifeasgame.role.infra;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.role.domain.RoleRelation;
+import online.lifeasgame.role.domain.repository.RoleRelationRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class RoleRelationRepositoryAdapter implements RoleRelationRepository {
+
+    private final JpaRoleRelationRepository repository;
+
+    @Override
+    public RoleRelation saveAndFlush(RoleRelation relation) {
+        return repository.saveAndFlush(relation);
+    }
+
+    @Override
+    public Optional<RoleRelation> findByIdAndRoleIdAndPlayerId(
+            Long id,
+            Long roleId,
+            Long playerId
+    ) {
+        return repository.findByIdAndRoleIdAndPlayerId(id, roleId, playerId);
+    }
+
+    @Override
+    public Optional<RoleRelation> findByRoleIdAndPersonIdAndPlayerId(
+            Long roleId,
+            Long personId,
+            Long playerId
+    ) {
+        return repository.findByRoleIdAndPersonIdAndPlayerId(
+                roleId,
+                personId,
+                playerId
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/role/infra/RoleRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/role/infra/RoleRepositoryAdapter.java
@@ -22,4 +22,9 @@ public class RoleRepositoryAdapter implements RoleRepository {
     public Optional<Role> findByIdAndPlayerId(Long id, Long playerId) {
         return repository.findByIdAndPlayerId(id, playerId);
     }
+
+    @Override
+    public Optional<Role> findByIdAndPlayerIdForUpdate(Long id, Long playerId) {
+        return repository.findByIdAndPlayerIdForUpdate(id, playerId);
+    }
 }

--- a/src/test/java/online/lifeasgame/person/application/PersonLookupServiceTest.java
+++ b/src/test/java/online/lifeasgame/person/application/PersonLookupServiceTest.java
@@ -1,0 +1,88 @@
+package online.lifeasgame.person.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.person.domain.Person;
+import online.lifeasgame.person.domain.error.PersonError;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class PersonLookupServiceTest {
+
+    @Mock
+    private PersonReader reader;
+
+    @InjectMocks
+    private PersonLookupService service;
+
+    @Test
+    void returnsProviderOwnedReferenceForOwnedActivePerson() {
+        Person person = Person.create(1L, "Alice", null, null, null);
+        ReflectionTestUtils.setField(person, "id", 2L);
+        given(reader.getOwned(2L, 1L)).willReturn(person);
+
+        var reference = service.getOwnedActive(2L, 1L);
+
+        assertThat(reference.displayName()).isEqualTo("Alice");
+        assertThat(reference.linkedUserId()).isNull();
+    }
+
+    @Test
+    void preservesCrossOwnerNotFound() {
+        given(reader.getOwned(2L, 1L)).willThrow(
+                new DomainException(PersonError.PERSON_NOT_FOUND)
+        );
+
+        assertError(
+                () -> service.getOwnedActive(2L, 1L),
+                PersonError.PERSON_NOT_FOUND
+        );
+    }
+
+    @Test
+    void rejectsArchivedPerson() {
+        Person person = Person.create(1L, "Alice", null, null, null);
+        person.archive();
+        given(reader.getOwned(2L, 1L)).willReturn(person);
+
+        assertError(
+                () -> service.getOwnedActive(2L, 1L),
+                PersonError.PERSON_ARCHIVED
+        );
+    }
+
+    @Test
+    void returnsOwnedBatchIncludingArchivedReferences() {
+        Person active = Person.create(1L, "Alice", null, null, null);
+        Person archived = Person.create(1L, "Bob", null, null, null);
+        ReflectionTestUtils.setField(active, "id", 2L);
+        ReflectionTestUtils.setField(archived, "id", 3L);
+        archived.archive();
+        given(reader.findOwnedByIds(Set.of(2L, 3L), 1L))
+                .willReturn(List.of(active, archived));
+
+        var references = service.findOwnedByIds(Set.of(2L, 3L), 1L);
+
+        assertThat(references.values())
+                .extracting(reference -> reference.displayName())
+                .containsExactlyInAnyOrder("Alice", "Bob");
+    }
+
+    private void assertError(Runnable action, PersonError error) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(error)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/role/api/RoleRelationApiContractTest.java
+++ b/src/test/java/online/lifeasgame/role/api/RoleRelationApiContractTest.java
@@ -1,0 +1,199 @@
+package online.lifeasgame.role.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.platform.web.error.docs.ErrorDocLinker;
+import online.lifeasgame.role.api.request.RoleRelationRequest;
+import online.lifeasgame.role.application.RoleRelationQueryService;
+import online.lifeasgame.role.application.RoleRelationService;
+import online.lifeasgame.role.application.command.RoleRelationCommand;
+import online.lifeasgame.role.application.result.RoleRelationResult;
+import online.lifeasgame.role.domain.RoleRelation;
+import online.lifeasgame.role.domain.RoleRelationType;
+import online.lifeasgame.role.domain.error.RoleError;
+import online.lifeasgame.support.ControllerSliceTest;
+import online.lifeasgame.system.bootstrap.error.handler.AppErrorProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import java.lang.reflect.RecordComponent;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ControllerSliceTest(controllers = RoleRelationController.class)
+class RoleRelationApiContractTest {
+
+    @Autowired
+    private RequestMappingHandlerMapping handlerMapping;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private RoleRelationService relationService;
+
+    @MockitoBean
+    private RoleRelationQueryService relationQueryService;
+
+    @MockitoBean
+    private AppErrorProperties appErrorProperties;
+
+    @MockitoBean
+    private ErrorDocLinker errorDocLinker;
+
+    @Test
+    void exposesExactCrudMappings() {
+        String collection = "/api/v1/roles/{roleId}/relations";
+        String detail = collection + "/{relationId}";
+
+        assertMapping(RequestMethod.POST, collection);
+        assertMapping(RequestMethod.GET, collection);
+        assertMapping(RequestMethod.GET, detail);
+        assertMapping(RequestMethod.PUT, detail);
+        assertMapping(RequestMethod.DELETE, detail);
+    }
+
+    @Test
+    void keepsOwnerAndImmutableIdentityOutOfRequests() {
+        assertThat(componentNames(RoleRelationRequest.Create.class))
+                .containsExactlyInAnyOrder("personId", "relationType", "roleNotes")
+                .doesNotContain("playerId", "ownerPlayerId", "roleId");
+        assertThat(componentNames(RoleRelationRequest.Update.class))
+                .containsExactlyInAnyOrder("relationType", "roleNotes")
+                .doesNotContain("personId", "playerId", "ownerPlayerId", "roleId");
+    }
+
+    @Test
+    void servesPostGetPutDeleteWithoutOwnerIdentity() throws Exception {
+        RoleRelationResult.Detail detail = detail();
+        given(relationService.create(eq(2L), any())).willReturn(detail);
+        given(relationQueryService.list(2L)).willReturn(List.of(detail));
+        given(relationQueryService.detail(2L, 9L)).willReturn(detail);
+        given(relationService.update(eq(2L), eq(9L), any())).willReturn(detail);
+
+        mockMvc.perform(post("/api/v1/roles/2/relations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(new RoleRelationRequest.Create(
+                                3L,
+                                "FAMILY",
+                                "note"
+                        ))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.result.id").value(9L))
+                .andExpect(jsonPath("$.result.personDisplayName").value("Alice"))
+                .andExpect(jsonPath("$.result.linkedUserId").value(4L))
+                .andExpect(jsonPath("$.result.status").value("ACTIVE"))
+                .andExpect(jsonPath("$.result.playerId").doesNotExist())
+                .andExpect(jsonPath("$.result.ownerPlayerId").doesNotExist())
+                .andExpect(jsonPath("$.result.roleId").doesNotExist());
+
+        mockMvc.perform(get("/api/v1/roles/2/relations"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result[0].id").value(9L));
+
+        mockMvc.perform(get("/api/v1/roles/2/relations/9"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.personId").value(3L));
+
+        mockMvc.perform(put("/api/v1/roles/2/relations/9")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(new RoleRelationRequest.Update("FRIEND", null))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.id").value(9L))
+                .andExpect(jsonPath("$.result.status").value("ACTIVE"));
+
+        mockMvc.perform(delete("/api/v1/roles/2/relations/9"))
+                .andExpect(status().isNoContent());
+        verify(relationService).archive(2L, 9L);
+    }
+
+    @Test
+    void returnsDomainCodesForInvalidTypeAndDuplicate() throws Exception {
+        given(relationService.create(eq(2L), any())).willAnswer(invocation -> {
+            RoleRelationCommand.Create command = invocation.getArgument(1);
+            RoleRelation.create(
+                    1L,
+                    2L,
+                    command.personId(),
+                    RoleRelationType.of(command.relationType()),
+                    command.roleNotes()
+            );
+            return detail();
+        });
+
+        mockMvc.perform(post("/api/v1/roles/2/relations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(new RoleRelationRequest.Create(3L, "   ", null))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(
+                        RoleError.INVALID_ROLE_RELATION_TYPE.code()
+                ));
+
+        given(relationService.create(eq(2L), any())).willThrow(
+                new DomainException(RoleError.ROLE_RELATION_ALREADY_EXISTS)
+        );
+        mockMvc.perform(post("/api/v1/roles/2/relations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(new RoleRelationRequest.Create(3L, "FAMILY", null))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value(
+                        RoleError.ROLE_RELATION_ALREADY_EXISTS.code()
+                ));
+    }
+
+    private RoleRelationResult.Detail detail() {
+        return new RoleRelationResult.Detail(
+                9L,
+                1L,
+                2L,
+                3L,
+                "Alice",
+                4L,
+                "FAMILY",
+                "note",
+                "ACTIVE",
+                null,
+                null,
+                0L
+        );
+    }
+
+    private void assertMapping(RequestMethod method, String path) {
+        assertThat(handlerMapping.getHandlerMethods().keySet()).anyMatch(mapping ->
+                mapping.getMethodsCondition().getMethods().contains(method)
+                        && mapping.getPatternValues().contains(path)
+        );
+    }
+
+    private Set<String> componentNames(Class<?> type) {
+        return Arrays.stream(type.getRecordComponents())
+                .map(RecordComponent::getName)
+                .collect(Collectors.toSet());
+    }
+
+    private String json(Object value) throws Exception {
+        return objectMapper.writeValueAsString(value);
+    }
+}

--- a/src/test/java/online/lifeasgame/role/application/RoleRelationApplicationTest.java
+++ b/src/test/java/online/lifeasgame/role/application/RoleRelationApplicationTest.java
@@ -1,0 +1,228 @@
+package online.lifeasgame.role.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.error.ErrorCode;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.person.application.internal.PersonLookupApi;
+import online.lifeasgame.person.application.internal.PersonLookupApi.PersonReference;
+import online.lifeasgame.person.domain.error.PersonError;
+import online.lifeasgame.role.application.command.RoleRelationCommand;
+import online.lifeasgame.role.application.query.RoleRelationQuery;
+import online.lifeasgame.role.application.result.RoleRelationResult;
+import online.lifeasgame.role.domain.Role;
+import online.lifeasgame.role.domain.RoleRelation;
+import online.lifeasgame.role.domain.RoleRelationStatus;
+import online.lifeasgame.role.domain.RoleRelationType;
+import online.lifeasgame.role.domain.RoleType;
+import online.lifeasgame.role.domain.error.RoleError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class RoleRelationApplicationTest {
+
+    private static final Long PLAYER_ID = 1L;
+    private static final Long ROLE_ID = 2L;
+    private static final Long PERSON_ID = 3L;
+
+    @Mock
+    private RoleReader roleReader;
+
+    @Mock
+    private RoleRelationReader relationReader;
+
+    @Mock
+    private RoleRelationWriter relationWriter;
+
+    @Mock
+    private RoleRelationQuery query;
+
+    @Mock
+    private PersonLookupApi personLookupApi;
+
+    @Mock
+    private CurrentPlayerAccessor currentPlayerAccessor;
+
+    @InjectMocks
+    private RoleRelationService service;
+
+    @InjectMocks
+    private RoleRelationQueryService queryService;
+
+    @BeforeEach
+    void currentPlayer() {
+        given(currentPlayerAccessor.currentPlayerIdOrThrow()).willReturn(PLAYER_ID);
+    }
+
+    @Test
+    void createsSameOwnerRelationUsingCurrentPlayer() {
+        willReturn(role()).given(roleReader).getOwnedForUpdate(ROLE_ID, PLAYER_ID);
+        given(relationReader.findPair(ROLE_ID, PERSON_ID, PLAYER_ID))
+                .willReturn(Optional.empty());
+        given(personLookupApi.getOwnedActive(PERSON_ID, PLAYER_ID)).willReturn(person());
+        given(relationWriter.saveAndFlush(any()))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        var result = service.create(ROLE_ID, create());
+
+        assertThat(result.playerId()).isEqualTo(PLAYER_ID);
+        assertThat(result.roleId()).isEqualTo(ROLE_ID);
+        assertThat(result.personId()).isEqualTo(PERSON_ID);
+        assertThat(result.personDisplayName()).isEqualTo("Alice");
+    }
+
+    @Test
+    void rejectsActiveDuplicateBeforePersonLookup() {
+        RoleRelation existing = relation();
+        given(roleReader.getOwnedForUpdate(ROLE_ID, PLAYER_ID)).willReturn(role());
+        given(relationReader.findPair(ROLE_ID, PERSON_ID, PLAYER_ID))
+                .willReturn(Optional.of(existing));
+
+        assertError(
+                () -> service.create(ROLE_ID, create()),
+                RoleError.ROLE_RELATION_ALREADY_EXISTS
+        );
+        verifyNoInteractions(personLookupApi);
+    }
+
+    @Test
+    void reactivatesArchivedPairOnTheSameAggregate() {
+        RoleRelation existing = relation();
+        existing.archive();
+        given(roleReader.getOwnedForUpdate(ROLE_ID, PLAYER_ID)).willReturn(role());
+        given(relationReader.findPair(ROLE_ID, PERSON_ID, PLAYER_ID))
+                .willReturn(Optional.of(existing));
+        given(personLookupApi.getOwnedActive(PERSON_ID, PLAYER_ID)).willReturn(person());
+        given(relationWriter.saveAndFlush(existing)).willReturn(existing);
+
+        var result = service.create(
+                ROLE_ID,
+                new RoleRelationCommand.Create(PERSON_ID, "FRIEND", "new")
+        );
+
+        assertThat(existing.getStatus()).isEqualTo(RoleRelationStatus.ACTIVE);
+        assertThat(existing.getRelationType().value()).isEqualTo("FRIEND");
+        assertThat(result.status()).isEqualTo("ACTIVE");
+        verify(relationWriter).saveAndFlush(existing);
+    }
+
+    @Test
+    void preservesCrossOwnerRolePersonAndRelationErrors() {
+        given(roleReader.getOwnedForUpdate(ROLE_ID, PLAYER_ID)).willThrow(
+                new DomainException(RoleError.ROLE_NOT_FOUND)
+        );
+        assertError(
+                () -> service.create(ROLE_ID, create()),
+                RoleError.ROLE_NOT_FOUND
+        );
+
+        willReturn(role()).given(roleReader).getOwnedForUpdate(ROLE_ID, PLAYER_ID);
+        given(relationReader.findPair(ROLE_ID, PERSON_ID, PLAYER_ID))
+                .willReturn(Optional.empty());
+        given(personLookupApi.getOwnedActive(PERSON_ID, PLAYER_ID)).willThrow(
+                new DomainException(PersonError.PERSON_NOT_FOUND)
+        );
+        assertError(
+                () -> service.create(ROLE_ID, create()),
+                PersonError.PERSON_NOT_FOUND
+        );
+
+        given(roleReader.getOwned(ROLE_ID, PLAYER_ID)).willReturn(role());
+        given(relationReader.getOwned(9L, ROLE_ID, PLAYER_ID)).willThrow(
+                new DomainException(RoleError.ROLE_RELATION_NOT_FOUND)
+        );
+        assertError(
+                () -> service.update(
+                        ROLE_ID,
+                        9L,
+                        new RoleRelationCommand.Update("FRIEND", null)
+                ),
+                RoleError.ROLE_RELATION_NOT_FOUND
+        );
+    }
+
+    @Test
+    void rejectsCreateForArchivedRole() {
+        Role role = role();
+        role.archive();
+        given(roleReader.getOwnedForUpdate(ROLE_ID, PLAYER_ID)).willReturn(role);
+
+        assertError(
+                () -> service.create(ROLE_ID, create()),
+                RoleError.ROLE_ARCHIVED
+        );
+    }
+
+    @Test
+    void queryServiceUsesBatchPersonLookup() {
+        RoleRelationResult.Stored stored = new RoleRelationResult.Stored(
+                9L,
+                PLAYER_ID,
+                ROLE_ID,
+                PERSON_ID,
+                "FAMILY",
+                null,
+                "ACTIVE",
+                null,
+                null,
+                0L
+        );
+        given(roleReader.getOwned(ROLE_ID, PLAYER_ID)).willReturn(role());
+        given(query.findActive(PLAYER_ID, ROLE_ID)).willReturn(List.of(stored));
+        given(personLookupApi.findOwnedByIds(
+                java.util.Set.of(PERSON_ID),
+                PLAYER_ID
+        )).willReturn(Map.of(PERSON_ID, person()));
+
+        var result = queryService.list(ROLE_ID);
+
+        assertThat(result).singleElement()
+                .extracting(RoleRelationResult.Detail::personDisplayName)
+                .isEqualTo("Alice");
+    }
+
+    private Role role() {
+        return Role.create(PLAYER_ID, RoleType.of("SELF"), "Self", null);
+    }
+
+    private RoleRelation relation() {
+        return RoleRelation.create(
+                PLAYER_ID,
+                ROLE_ID,
+                PERSON_ID,
+                RoleRelationType.of("FAMILY"),
+                null
+        );
+    }
+
+    private PersonReference person() {
+        return new PersonReference(PERSON_ID, null, "Alice");
+    }
+
+    private RoleRelationCommand.Create create() {
+        return new RoleRelationCommand.Create(PERSON_ID, "FAMILY", null);
+    }
+
+    private void assertError(Runnable action, ErrorCode error) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(error)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/role/application/RoleRelationPersistenceIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/role/application/RoleRelationPersistenceIntegrationTest.java
@@ -1,0 +1,312 @@
+package online.lifeasgame.role.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.person.application.PersonService;
+import online.lifeasgame.person.application.command.PersonCommand;
+import online.lifeasgame.person.domain.error.PersonError;
+import online.lifeasgame.role.application.command.RoleCommand;
+import online.lifeasgame.role.application.command.RoleRelationCommand;
+import online.lifeasgame.role.domain.RoleRelation;
+import online.lifeasgame.role.domain.RoleRelationStatus;
+import online.lifeasgame.role.domain.RoleRelationType;
+import online.lifeasgame.role.domain.error.RoleError;
+import online.lifeasgame.role.infra.JpaRoleRelationRepository;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles({"test", "migration-test"})
+class RoleRelationPersistenceIntegrationTest {
+
+    private static final Long OWNER = 23701L;
+    private static final Long OTHER_OWNER = 23702L;
+
+    @Container
+    private static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0.39")
+            .withDatabaseName("lifeasgame_role_relation_crud")
+            .withUsername("lifeasgame")
+            .withPassword("lifeasgame");
+
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", MYSQL::getDriverClassName);
+    }
+
+    @Autowired
+    private RoleService roleService;
+
+    @Autowired
+    private PersonService personService;
+
+    @Autowired
+    private RoleRelationService relationService;
+
+    @Autowired
+    private RoleRelationQueryService relationQueryService;
+
+    @Autowired
+    private JpaRoleRelationRepository relationRepository;
+
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @Autowired
+    private Flyway flyway;
+
+    @MockitoBean
+    private CurrentPlayerAccessor currentPlayerAccessor;
+
+    @BeforeEach
+    void cleanState() {
+        asCurrent(OWNER);
+        jdbc.update("DELETE FROM role_relations");
+        jdbc.update("DELETE FROM roles");
+        jdbc.update("DELETE FROM persons");
+    }
+
+    @Test
+    void persistsCrudRejectsActiveDuplicateAndReactivatesArchivedRow() {
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("19");
+        Long roleId = createRole("Owner role");
+        Long personId = createPerson("Alice");
+
+        var created = relationService.create(
+                roleId,
+                new RoleRelationCommand.Create(personId, " family ", " note ")
+        );
+        assertThat(created.relationType()).isEqualTo("FAMILY");
+        assertThat(created.personDisplayName()).isEqualTo("Alice");
+        assertThat(relationQueryService.list(roleId)).extracting(result -> result.id())
+                .containsExactly(created.id());
+
+        assertDomainError(
+                () -> relationService.create(
+                        roleId,
+                        new RoleRelationCommand.Create(personId, "FRIEND", null)
+                ),
+                RoleError.ROLE_RELATION_ALREADY_EXISTS
+        );
+
+        relationService.archive(roleId, created.id());
+        relationService.archive(roleId, created.id());
+        assertThat(relationQueryService.list(roleId)).isEmpty();
+        assertThat(relationRepository.count()).isEqualTo(1);
+
+        var reactivated = relationService.create(
+                roleId,
+                new RoleRelationCommand.Create(personId, "FRIEND", "again")
+        );
+        assertThat(reactivated.id()).isEqualTo(created.id());
+        assertThat(reactivated.status()).isEqualTo("ACTIVE");
+        assertThat(reactivated.relationType()).isEqualTo("FRIEND");
+        assertThat(relationRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    void enforcesCurrentPlayerOwnershipAndArchivedProviderState() {
+        Long roleId = createRole("Owner role");
+        Long personId = createPerson("Owner person");
+        Long relationId = relationService.create(
+                roleId,
+                new RoleRelationCommand.Create(personId, "FRIEND", null)
+        ).id();
+        Long secondRoleId = createRole("Second role");
+
+        asCurrent(OTHER_OWNER);
+        Long otherRoleId = createRole("Other role");
+        Long otherPersonId = createPerson("Other person");
+        asCurrent(OWNER);
+
+        assertDomainError(
+                () -> relationService.create(
+                        otherRoleId,
+                        new RoleRelationCommand.Create(personId, "FRIEND", null)
+                ),
+                RoleError.ROLE_NOT_FOUND
+        );
+        assertDomainError(
+                () -> relationService.create(
+                        roleId,
+                        new RoleRelationCommand.Create(otherPersonId, "FRIEND", null)
+                ),
+                PersonError.PERSON_NOT_FOUND
+        );
+        assertDomainError(
+                () -> relationService.update(
+                        secondRoleId,
+                        relationId,
+                        new RoleRelationCommand.Update("FAMILY", null)
+                ),
+                RoleError.ROLE_RELATION_NOT_FOUND
+        );
+
+        personService.archive(personId);
+        relationService.archive(roleId, relationId);
+        assertDomainError(
+                () -> relationService.create(
+                        roleId,
+                        new RoleRelationCommand.Create(personId, "FAMILY", null)
+                ),
+                PersonError.PERSON_ARCHIVED
+        );
+    }
+
+    @Test
+    void v19ConstraintsRejectDuplicatePairAndCrossOwnerPerson() {
+        Long roleId = createRole("Owner role");
+        Long personId = createPerson("Owner person");
+        relationService.create(
+                roleId,
+                new RoleRelationCommand.Create(personId, "FRIEND", null)
+        );
+
+        RoleRelation duplicate = RoleRelation.create(
+                OWNER,
+                roleId,
+                personId,
+                RoleRelationType.of("FAMILY"),
+                null
+        );
+        assertThatThrownBy(() -> transaction().executeWithoutResult(
+                status -> relationRepository.saveAndFlush(duplicate)
+        )).isInstanceOf(DataIntegrityViolationException.class);
+
+        asCurrent(OTHER_OWNER);
+        Long otherPersonId = createPerson("Other person");
+        RoleRelation crossOwner = RoleRelation.create(
+                OWNER,
+                roleId,
+                otherPersonId,
+                RoleRelationType.of("FRIEND"),
+                null
+        );
+        assertThatThrownBy(() -> transaction().executeWithoutResult(
+                status -> relationRepository.saveAndFlush(crossOwner)
+        )).isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void enforcesOptimisticLockingAndRollsBackWrites() {
+        Long roleId = createRole("Owner role");
+        Long personId = createPerson("Alice");
+        Long relationId = relationService.create(
+                roleId,
+                new RoleRelationCommand.Create(personId, "FRIEND", null)
+        ).id();
+        RoleRelation updateFirst = detachedRelation(relationId);
+        RoleRelation updateStale = detachedRelation(relationId);
+
+        updateFirst.update(RoleRelationType.of("FAMILY"), null);
+        transaction().executeWithoutResult(
+                status -> relationRepository.saveAndFlush(updateFirst)
+        );
+        updateStale.update(RoleRelationType.of("MENTOR"), null);
+        assertThatThrownBy(() -> transaction().executeWithoutResult(
+                status -> relationRepository.saveAndFlush(updateStale)
+        )).isInstanceOf(OptimisticLockingFailureException.class);
+
+        Long archivePersonId = createPerson("Archive target");
+        Long archiveRelationId = relationService.create(
+                roleId,
+                new RoleRelationCommand.Create(archivePersonId, "FRIEND", null)
+        ).id();
+        RoleRelation archiveFirst = detachedRelation(archiveRelationId);
+        RoleRelation archiveStale = detachedRelation(archiveRelationId);
+        archiveFirst.archive();
+        transaction().executeWithoutResult(
+                status -> relationRepository.saveAndFlush(archiveFirst)
+        );
+        archiveStale.archive();
+        assertThatThrownBy(() -> transaction().executeWithoutResult(
+                status -> relationRepository.saveAndFlush(archiveStale)
+        )).isInstanceOf(OptimisticLockingFailureException.class);
+
+        Long rollbackPersonId = createPerson("Bob");
+        forceRollback(() -> relationService.create(
+                roleId,
+                new RoleRelationCommand.Create(rollbackPersonId, "FRIEND", null)
+        ));
+        assertThat(relationRepository.findByRoleIdAndPersonIdAndPlayerId(
+                roleId,
+                rollbackPersonId,
+                OWNER
+        )).isEmpty();
+
+        Long mutableId = relationService.create(
+                roleId,
+                new RoleRelationCommand.Create(rollbackPersonId, "FRIEND", null)
+        ).id();
+        forceRollback(() -> relationService.update(
+                roleId,
+                mutableId,
+                new RoleRelationCommand.Update("FAMILY", null)
+        ));
+        assertThat(relationRepository.findById(mutableId).orElseThrow()
+                .getRelationType().value()).isEqualTo("FRIEND");
+
+        forceRollback(() -> relationService.archive(roleId, mutableId));
+        assertThat(relationRepository.findById(mutableId).orElseThrow().getStatus())
+                .isEqualTo(RoleRelationStatus.ACTIVE);
+    }
+
+    private Long createRole(String name) {
+        return roleService.create(new RoleCommand.Create("WORK", name, null)).id();
+    }
+
+    private Long createPerson(String name) {
+        return personService.create(new PersonCommand.Create(name, null, null, null)).id();
+    }
+
+    private RoleRelation detachedRelation(Long id) {
+        return transaction().execute(status -> relationRepository.findById(id).orElseThrow());
+    }
+
+    private TransactionTemplate transaction() {
+        return new TransactionTemplate(transactionManager);
+    }
+
+    private void forceRollback(Runnable action) {
+        assertThatThrownBy(() -> transaction().executeWithoutResult(status -> {
+            action.run();
+            throw new IllegalStateException("force rollback");
+        })).isInstanceOf(IllegalStateException.class);
+    }
+
+    private void assertDomainError(Runnable action, Object expected) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(expected)
+                );
+    }
+
+    private void asCurrent(Long playerId) {
+        given(currentPlayerAccessor.currentPlayerIdOrThrow()).willReturn(playerId);
+    }
+}

--- a/src/test/java/online/lifeasgame/role/application/RoleRelationTransactionContractTest.java
+++ b/src/test/java/online/lifeasgame/role/application/RoleRelationTransactionContractTest.java
@@ -1,0 +1,138 @@
+package online.lifeasgame.role.application;
+
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.person.application.internal.PersonLookupApi;
+import online.lifeasgame.role.application.command.RoleRelationCommand;
+import online.lifeasgame.role.domain.Role;
+import online.lifeasgame.role.domain.RoleRelation;
+import online.lifeasgame.role.domain.RoleRelationType;
+import online.lifeasgame.role.domain.RoleType;
+import online.lifeasgame.role.domain.repository.RoleRelationRepository;
+import online.lifeasgame.role.domain.repository.RoleRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.transaction.IllegalTransactionStateException;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@SpringJUnitConfig(RoleRelationTransactionContractTest.Config.class)
+class RoleRelationTransactionContractTest {
+
+    @Autowired
+    private RoleRelationReader reader;
+
+    @Autowired
+    private RoleRelationWriter writer;
+
+    @Autowired
+    private RoleRelationService service;
+
+    @Test
+    void readerSupportsWithoutTransactionAndWriterRequiresOne() {
+        assertThat(reader.getOwned(4L, 2L, 1L)).isNotNull();
+        assertThatThrownBy(() -> writer.saveAndFlush(relation()))
+                .isInstanceOf(IllegalTransactionStateException.class);
+    }
+
+    @Test
+    void writeServiceOpensTransactionForMandatoryWriter() {
+        assertThat(service.create(
+                2L,
+                new RoleRelationCommand.Create(3L, "FAMILY", null)
+        ).status()).isEqualTo("ACTIVE");
+    }
+
+    private RoleRelation relation() {
+        return Config.relation();
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableTransactionManagement
+    @Import({
+            RoleReader.class,
+            RoleRelationReader.class,
+            RoleRelationWriter.class,
+            RoleRelationService.class
+    })
+    static class Config {
+
+        @Bean
+        RoleRepository roleRepository() {
+            RoleRepository repository = mock(RoleRepository.class);
+            given(repository.findByIdAndPlayerIdForUpdate(any(), any()))
+                    .willReturn(Optional.of(role()));
+            given(repository.findByIdAndPlayerId(any(), any()))
+                    .willReturn(Optional.of(role()));
+            return repository;
+        }
+
+        @Bean
+        RoleRelationRepository relationRepository() {
+            RoleRelationRepository repository = mock(RoleRelationRepository.class);
+            given(repository.findByIdAndRoleIdAndPlayerId(any(), any(), any()))
+                    .willReturn(Optional.of(relation()));
+            given(repository.findByRoleIdAndPersonIdAndPlayerId(any(), any(), any()))
+                    .willReturn(Optional.empty());
+            given(repository.saveAndFlush(any()))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+            return repository;
+        }
+
+        @Bean
+        PersonLookupApi personLookupApi() {
+            PersonLookupApi api = mock(PersonLookupApi.class);
+            given(api.getOwnedActive(any(), any())).willReturn(
+                    new PersonLookupApi.PersonReference(3L, null, "Alice")
+            );
+            return api;
+        }
+
+        @Bean
+        CurrentPlayerAccessor currentPlayerAccessor() {
+            return () -> Optional.of(1L);
+        }
+
+        @Bean
+        EmbeddedDatabase dataSource() {
+            return new EmbeddedDatabaseBuilder()
+                    .generateUniqueName(true)
+                    .setType(EmbeddedDatabaseType.H2)
+                    .build();
+        }
+
+        @Bean
+        PlatformTransactionManager transactionManager(EmbeddedDatabase dataSource) {
+            return new DataSourceTransactionManager(dataSource);
+        }
+
+        private static Role role() {
+            return Role.create(1L, RoleType.of("SELF"), "Self", null);
+        }
+
+        private static RoleRelation relation() {
+            return RoleRelation.create(
+                    1L,
+                    2L,
+                    3L,
+                    RoleRelationType.of("FAMILY"),
+                    null
+            );
+        }
+    }
+}

--- a/src/test/java/online/lifeasgame/role/domain/RoleRelationTest.java
+++ b/src/test/java/online/lifeasgame/role/domain/RoleRelationTest.java
@@ -1,0 +1,72 @@
+package online.lifeasgame.role.domain;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.role.domain.error.RoleError;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RoleRelationTest {
+
+    @Test
+    void createsUpdatesArchivesAndReactivates() {
+        RoleRelation relation = relation("  family  ", " note ");
+
+        assertThat(relation.getRelationType().value()).isEqualTo("FAMILY");
+        assertThat(relation.getRoleNotes()).isEqualTo("note");
+        assertThat(relation.getStatus()).isEqualTo(RoleRelationStatus.ACTIVE);
+
+        relation.update(RoleRelationType.of("friend"), " updated ");
+        assertThat(relation.getRelationType().value()).isEqualTo("FRIEND");
+        assertThat(relation.getRoleNotes()).isEqualTo("updated");
+
+        relation.archive();
+        relation.archive();
+        assertThat(relation.getStatus()).isEqualTo(RoleRelationStatus.ARCHIVED);
+        assertThatThrownBy(() -> relation.update(
+                RoleRelationType.of("WORK"),
+                null
+        )).isInstanceOfSatisfying(DomainException.class, exception ->
+                assertThat(exception.getErrorCode())
+                        .isEqualTo(RoleError.ROLE_RELATION_ARCHIVED)
+        );
+
+        relation.reactivate(RoleRelationType.of("work"), "   ");
+        assertThat(relation.getRelationType().value()).isEqualTo("WORK");
+        assertThat(relation.getRoleNotes()).isNull();
+        assertThat(relation.getStatus()).isEqualTo(RoleRelationStatus.ACTIVE);
+    }
+
+    @Test
+    void rejectsInvalidRelationType() {
+        assertInvalidType(null);
+        assertInvalidType("   ");
+        assertInvalidType("x".repeat(41));
+    }
+
+    @Test
+    void acceptsTrimmedFortyCharacterOpenCode() {
+        RoleRelation relation = relation("  " + "x".repeat(40) + "  ", null);
+
+        assertThat(relation.getRelationType().value()).isEqualTo("X".repeat(40));
+    }
+
+    private RoleRelation relation(String relationType, String roleNotes) {
+        return RoleRelation.create(
+                1L,
+                2L,
+                3L,
+                RoleRelationType.of(relationType),
+                roleNotes
+        );
+    }
+
+    private void assertInvalidType(String value) {
+        assertThatThrownBy(() -> RoleRelationType.of(value))
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode())
+                                .isEqualTo(RoleError.INVALID_ROLE_RELATION_TYPE)
+                );
+    }
+}


### PR DESCRIPTION
## What

V19 `role_relations` persistence foundation 위에
Current Player 소유의 Role과 Person을 연결하는
RoleRelation CRUD를 추가한다.

```text
Current Player
└─ Role
   └─ RoleRelation
      └─ Person
```

RoleRelation은 Person 자체가 아니라
해당 Role에서의 관계 맥락을 저장한다.

## Architecture

```text
Controller
→ RoleRelationService / RoleRelationQueryService
→ Reader / Writer / Query Port
→ Domain / Infra
```

단순 CRUD Facade는 추가하지 않는다.

Person은 별도 Context이므로
Role Context에서 Person Entity/Repository를 직접 참조하지 않는다.

```text
Role
→ PersonLookupApi
→ PersonLookupService
```

provider-owned InternalApi로만 Person을 조회한다.

## API

```http
POST   /api/v1/roles/{roleId}/relations
GET    /api/v1/roles/{roleId}/relations
GET    /api/v1/roles/{roleId}/relations/{relationId}
PUT    /api/v1/roles/{roleId}/relations/{relationId}
DELETE /api/v1/roles/{roleId}/relations/{relationId}
```

## Pair Policy

V19 unique pair:

```text
(role_id, person_id)
```

- new pair → ACTIVE relation 생성
- ACTIVE duplicate → conflict
- ARCHIVED duplicate → 기존 row reactivation

## Ownership

owner identity는 `CurrentPlayerAccessor`만 사용한다.

Request는 다음을 받지 않는다.

- playerId
- ownerPlayerId
- userId

Application에서 same-owner를 검증하고
V19 composite FK를 최종 safety net으로 유지한다.

## Archive

DELETE는 physical delete가 아니다.

```text
ACTIVE
→ ARCHIVED
```

archive replay는 no-op이다.

Role/Person archive가 Relation을 자동 archive하지 않는다.

## Concurrency

V19 `version`을 `@Version`으로 매핑한다.

- stale update reject
- stale archive reject
- DB unique pair 유지
- Redis/distributed lock 없음

## Migration

신규 Migration 없음.

V19 변경 없음.

## Test

- RoleRelation domain lifecycle
- Person provider-owned InternalApi
- ownership / cross-owner rejection
- duplicate / reactivation
- Reader / Writer Transaction contract
- persistence / unique / composite FK
- optimistic stale update/archive
- API contract
- targeted tests
- final build

## Out of Scope

- RoleStat
- RoleEvent
- RoleParty
- RoleChat
- Quest role scope
- LifeLog connection
- linked User write flow
- Person roles reverse API
- Guild/Party migration
- frontend

Closes #237
