### PR TITLE
[Quest] Add QuestRoute long-term direction MVP

### DIFF
--- a/src/main/java/online/lifeasgame/quest/api/player/QuestRouteController.java
+++ b/src/main/java/online/lifeasgame/quest/api/player/QuestRouteController.java
@@ -1,0 +1,95 @@
+package online.lifeasgame.quest.api.player;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.response.ApiResponse;
+import online.lifeasgame.platform.web.response.ApiResponses;
+import online.lifeasgame.quest.api.player.mapper.QuestRouteWebMapper;
+import online.lifeasgame.quest.api.player.request.QuestRouteRequest;
+import online.lifeasgame.quest.api.player.response.QuestRouteResponse;
+import online.lifeasgame.quest.api.player.spec.QuestRouteSpecV1;
+import online.lifeasgame.quest.application.QuestRouteAdvanceService;
+import online.lifeasgame.quest.application.QuestRouteQueryService;
+import online.lifeasgame.quest.application.QuestRouteSelectService;
+import online.lifeasgame.quest.application.result.QuestRouteResult;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/quest-routes")
+public class QuestRouteController implements QuestRouteSpecV1 {
+
+    private final QuestRouteSelectService selectService;
+    private final QuestRouteAdvanceService advanceService;
+    private final QuestRouteQueryService queryService;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResponse<QuestRouteResponse.Routes>> routes() {
+        return ApiResponses.ok(QuestRouteWebMapper.toRoutes(
+                queryService.routes()
+        ));
+    }
+
+    @Override
+    @GetMapping("/{routeId}")
+    public ResponseEntity<ApiResponse<QuestRouteResponse.Route>> route(
+            @PathVariable Long routeId
+    ) {
+        return ApiResponses.ok(QuestRouteWebMapper.toRoute(
+                queryService.route(routeId)
+        ));
+    }
+
+    @Override
+    @PostMapping("/{routeId}/select")
+    public ResponseEntity<ApiResponse<QuestRouteResponse.Route>> select(
+            @PathVariable Long routeId
+    ) {
+        QuestRouteResult.Route result = selectService.select(routeId);
+        return ApiResponses.ok(QuestRouteWebMapper.toRoute(result));
+    }
+
+    @Override
+    @GetMapping("/my")
+    public ResponseEntity<ApiResponse<QuestRouteResponse.Routes>> myRoutes() {
+        return ApiResponses.ok(QuestRouteWebMapper.toRoutes(
+                queryService.myRoutes()
+        ));
+    }
+
+    @Override
+    @GetMapping("/my/{routeId}")
+    public ResponseEntity<ApiResponse<QuestRouteResponse.Route>> myRoute(
+            @PathVariable Long routeId
+    ) {
+        return ApiResponses.ok(QuestRouteWebMapper.toRoute(
+                queryService.myRoute(routeId)
+        ));
+    }
+
+    @Override
+    @GetMapping("/my/{routeId}/steps/{stepId}")
+    public ResponseEntity<ApiResponse<QuestRouteResponse.StepDetail>> myStep(
+            @PathVariable Long routeId,
+            @PathVariable Long stepId
+    ) {
+        return ApiResponses.ok(QuestRouteWebMapper.toStepDetail(
+                queryService.myStep(routeId, stepId)
+        ));
+    }
+
+    @Override
+    @PostMapping("/my/{routeId}/advance")
+    public ResponseEntity<ApiResponse<QuestRouteResponse.Route>> advance(
+            @PathVariable Long routeId,
+            @Valid @RequestBody QuestRouteRequest.Advance request
+    ) {
+        QuestRouteResult.Route result = advanceService.advance(
+                routeId,
+                QuestRouteWebMapper.toExpectedStepId(request)
+        );
+        return ApiResponses.ok(QuestRouteWebMapper.toRoute(result));
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/api/player/mapper/QuestRouteWebMapper.java
+++ b/src/main/java/online/lifeasgame/quest/api/player/mapper/QuestRouteWebMapper.java
@@ -1,0 +1,91 @@
+package online.lifeasgame.quest.api.player.mapper;
+
+import online.lifeasgame.quest.api.player.request.QuestRouteRequest;
+import online.lifeasgame.quest.api.player.response.QuestRouteResponse;
+import online.lifeasgame.quest.application.result.QuestRouteResult;
+
+public final class QuestRouteWebMapper {
+
+    private QuestRouteWebMapper() {
+    }
+
+    public static Long toExpectedStepId(QuestRouteRequest.Advance request) {
+        return request.expectedStepId();
+    }
+
+    public static QuestRouteResponse.Routes toRoutes(
+            QuestRouteResult.Routes result
+    ) {
+        return new QuestRouteResponse.Routes(
+                result.routes().stream()
+                        .map(QuestRouteWebMapper::toRoute)
+                        .toList()
+        );
+    }
+
+    public static QuestRouteResponse.Route toRoute(
+            QuestRouteResult.Route result
+    ) {
+        return new QuestRouteResponse.Route(
+                result.id(),
+                result.code(),
+                result.definitionVersion(),
+                result.title(),
+                result.description(),
+                result.primaryRoleTemplateCode(),
+                toProgress(result.playerProgress()),
+                result.steps().stream()
+                        .map(QuestRouteWebMapper::toStep)
+                        .toList()
+        );
+    }
+
+    public static QuestRouteResponse.StepDetail toStepDetail(
+            QuestRouteResult.StepDetail result
+    ) {
+        return new QuestRouteResponse.StepDetail(
+                result.routeId(),
+                result.routeCode(),
+                toProgress(result.playerProgress()),
+                toStep(result.step())
+        );
+    }
+
+    private static QuestRouteResponse.PlayerProgress toProgress(
+            QuestRouteResult.PlayerProgress result
+    ) {
+        if (result == null) return null;
+        return new QuestRouteResponse.PlayerProgress(
+                result.id(),
+                result.currentStepId(),
+                result.status(),
+                result.selectedAt(),
+                result.completedAt()
+        );
+    }
+
+    private static QuestRouteResponse.Step toStep(
+            QuestRouteResult.Step result
+    ) {
+        return new QuestRouteResponse.Step(
+                result.id(),
+                result.stepCode(),
+                result.stepOrder(),
+                result.title(),
+                result.description(),
+                result.criterionType(),
+                result.requiredEvidenceCount(),
+                result.userAdvanceRequired(),
+                result.retroactiveEvidenceAllowed(),
+                result.skipAllowed(),
+                result.criteriaSatisfied(),
+                result.state(),
+                result.questLinks().stream()
+                        .map(link -> new QuestRouteResponse.QuestLink(
+                                link.questId(),
+                                link.requirementType()
+                        ))
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/api/player/request/QuestRouteRequest.java
+++ b/src/main/java/online/lifeasgame/quest/api/player/request/QuestRouteRequest.java
@@ -1,0 +1,15 @@
+package online.lifeasgame.quest.api.player.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public final class QuestRouteRequest {
+
+    private QuestRouteRequest() {
+    }
+
+    public record Advance(
+            @NotNull @Positive Long expectedStepId
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/api/player/response/QuestRouteResponse.java
+++ b/src/main/java/online/lifeasgame/quest/api/player/response/QuestRouteResponse.java
@@ -1,0 +1,65 @@
+package online.lifeasgame.quest.api.player.response;
+
+import java.time.Instant;
+import java.util.List;
+
+public final class QuestRouteResponse {
+
+    private QuestRouteResponse() {
+    }
+
+    public record Routes(List<Route> routes) {
+    }
+
+    public record Route(
+            Long id,
+            String code,
+            int definitionVersion,
+            String title,
+            String description,
+            String primaryRoleTemplateCode,
+            PlayerProgress playerProgress,
+            List<Step> steps
+    ) {
+    }
+
+    public record PlayerProgress(
+            Long id,
+            Long currentStepId,
+            String status,
+            Instant selectedAt,
+            Instant completedAt
+    ) {
+    }
+
+    public record Step(
+            Long id,
+            String stepCode,
+            int stepOrder,
+            String title,
+            String description,
+            String criterionType,
+            int requiredEvidenceCount,
+            boolean userAdvanceRequired,
+            boolean retroactiveEvidenceAllowed,
+            boolean skipAllowed,
+            boolean criteriaSatisfied,
+            String state,
+            List<QuestLink> questLinks
+    ) {
+    }
+
+    public record QuestLink(
+            Long questId,
+            String requirementType
+    ) {
+    }
+
+    public record StepDetail(
+            Long routeId,
+            String routeCode,
+            PlayerProgress playerProgress,
+            Step step
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/api/player/spec/QuestRouteSpecV1.java
+++ b/src/main/java/online/lifeasgame/quest/api/player/spec/QuestRouteSpecV1.java
@@ -1,0 +1,48 @@
+package online.lifeasgame.quest.api.player.spec;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import online.lifeasgame.core.response.ApiResponse;
+import online.lifeasgame.quest.api.player.request.QuestRouteRequest;
+import online.lifeasgame.quest.api.player.response.QuestRouteResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Player Quest Route API V1")
+public interface QuestRouteSpecV1 {
+
+    @Operation(summary = "Quest Route 목록")
+    ResponseEntity<ApiResponse<QuestRouteResponse.Routes>> routes();
+
+    @Operation(summary = "Quest Route 상세")
+    ResponseEntity<ApiResponse<QuestRouteResponse.Route>> route(
+            @PathVariable Long routeId
+    );
+
+    @Operation(summary = "Quest Route 선택")
+    ResponseEntity<ApiResponse<QuestRouteResponse.Route>> select(
+            @PathVariable Long routeId
+    );
+
+    @Operation(summary = "내가 선택한 Quest Route 목록")
+    ResponseEntity<ApiResponse<QuestRouteResponse.Routes>> myRoutes();
+
+    @Operation(summary = "내 Quest Route 진행 상세")
+    ResponseEntity<ApiResponse<QuestRouteResponse.Route>> myRoute(
+            @PathVariable Long routeId
+    );
+
+    @Operation(summary = "내 Quest Route Step 상세")
+    ResponseEntity<ApiResponse<QuestRouteResponse.StepDetail>> myStep(
+            @PathVariable Long routeId,
+            @PathVariable Long stepId
+    );
+
+    @Operation(summary = "현재 Quest Route Step을 한 단계 진행")
+    ResponseEntity<ApiResponse<QuestRouteResponse.Route>> advance(
+            @PathVariable Long routeId,
+            @Valid @RequestBody QuestRouteRequest.Advance request
+    );
+}

--- a/src/main/java/online/lifeasgame/quest/application/QuestRouteAdvanceService.java
+++ b/src/main/java/online/lifeasgame/quest/application/QuestRouteAdvanceService.java
@@ -1,0 +1,62 @@
+package online.lifeasgame.quest.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.quest.application.result.QuestRouteResult;
+import online.lifeasgame.quest.domain.PlayerQuestRoute;
+import online.lifeasgame.quest.domain.QuestRoute;
+import online.lifeasgame.quest.domain.QuestRouteStep;
+import online.lifeasgame.quest.domain.error.QuestError;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+
+@Service
+@RequiredArgsConstructor
+public class QuestRouteAdvanceService {
+
+    private final QuestRouteReader routeReader;
+    private final QuestRouteCriteriaEvaluator criteriaEvaluator;
+    private final QuestRouteReadModelFactory readModelFactory;
+    private final CurrentPlayerAccessor currentPlayerAccessor;
+    private final Clock clock;
+
+    @Transactional
+    public QuestRouteResult.Route advance(
+            Long routeId,
+            Long expectedStepId
+    ) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        PlayerQuestRoute playerRoute = routeReader.getPlayerRouteForUpdate(
+                playerId,
+                routeId
+        );
+        if (playerRoute.isCompleted()) {
+            throw new DomainException(QuestError.ROUTE_ALREADY_COMPLETED);
+        }
+        QuestRoute route = routeReader.getRoute(routeId);
+        QuestRouteStep currentStep = route.getStep(
+                playerRoute.getCurrentStepId()
+        );
+
+        if (expectedStepId == null
+                || !currentStep.getId().equals(expectedStepId)) {
+            throw new DomainException(QuestError.ROUTE_STEP_NOT_CURRENT);
+        }
+        if (!criteriaEvaluator.isSatisfied(playerId, currentStep)) {
+            throw new DomainException(
+                    QuestError.ROUTE_STEP_CRITERIA_NOT_SATISFIED
+            );
+        }
+
+        QuestRouteStep nextStep = route.nextStep(currentStep.getId());
+        if (nextStep == null) {
+            playerRoute.complete(expectedStepId, clock.instant());
+        } else {
+            playerRoute.advanceTo(expectedStepId, nextStep.getId());
+        }
+        return readModelFactory.create(playerId, route, playerRoute);
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/application/QuestRouteCriteriaEvaluator.java
+++ b/src/main/java/online/lifeasgame/quest/application/QuestRouteCriteriaEvaluator.java
@@ -25,7 +25,6 @@ public class QuestRouteCriteriaEvaluator {
                         playerId,
                         requiredQuestIds
                 );
-        return completedQuestIds.containsAll(requiredQuestIds)
-                && completedQuestIds.size() >= step.getRequiredEvidenceCount();
+        return completedQuestIds.containsAll(requiredQuestIds);
     }
 }

--- a/src/main/java/online/lifeasgame/quest/application/QuestRouteCriteriaEvaluator.java
+++ b/src/main/java/online/lifeasgame/quest/application/QuestRouteCriteriaEvaluator.java
@@ -1,0 +1,31 @@
+package online.lifeasgame.quest.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.quest.domain.QuestRouteStep;
+import online.lifeasgame.quest.domain.repository.QuestAcceptanceRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+public class QuestRouteCriteriaEvaluator {
+
+    private final QuestAcceptanceRepository questAcceptanceRepository;
+
+    public boolean isSatisfied(Long playerId, QuestRouteStep step) {
+        Set<Long> requiredQuestIds = step.requiredQuestIds();
+        if (requiredQuestIds.isEmpty()) return false;
+
+        Set<Long> completedQuestIds =
+                questAcceptanceRepository.findCompletedQuestIds(
+                        playerId,
+                        requiredQuestIds
+                );
+        return completedQuestIds.containsAll(requiredQuestIds)
+                && completedQuestIds.size() >= step.getRequiredEvidenceCount();
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/application/QuestRouteQueryService.java
+++ b/src/main/java/online/lifeasgame/quest/application/QuestRouteQueryService.java
@@ -1,0 +1,94 @@
+package online.lifeasgame.quest.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.quest.application.result.QuestRouteResult;
+import online.lifeasgame.quest.domain.PlayerQuestRoute;
+import online.lifeasgame.quest.domain.QuestRoute;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuestRouteQueryService {
+
+    private final QuestRouteReader routeReader;
+    private final QuestRouteReadModelFactory readModelFactory;
+    private final CurrentPlayerAccessor currentPlayerAccessor;
+
+    public QuestRouteResult.Routes routes() {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        Map<Long, PlayerQuestRoute> playerRoutes = routeReader
+                .findPlayerRoutes(playerId)
+                .stream()
+                .collect(Collectors.toMap(
+                        PlayerQuestRoute::getRouteId,
+                        Function.identity()
+                ));
+        return new QuestRouteResult.Routes(
+                routeReader.findAllRoutes().stream()
+                        .map(route -> readModelFactory.create(
+                                playerId,
+                                route,
+                                playerRoutes.get(route.getId())
+                        ))
+                        .toList()
+        );
+    }
+
+    public QuestRouteResult.Route route(Long routeId) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        QuestRoute route = routeReader.getRoute(routeId);
+        PlayerQuestRoute playerRoute = routeReader
+                .findPlayerRoute(playerId, routeId)
+                .orElse(null);
+        return readModelFactory.create(playerId, route, playerRoute);
+    }
+
+    public QuestRouteResult.Routes myRoutes() {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        return new QuestRouteResult.Routes(
+                routeReader.findPlayerRoutes(playerId).stream()
+                        .map(playerRoute -> readModelFactory.create(
+                                playerId,
+                                routeReader.getRoute(playerRoute.getRouteId()),
+                                playerRoute
+                        ))
+                        .toList()
+        );
+    }
+
+    public QuestRouteResult.Route myRoute(Long routeId) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        PlayerQuestRoute playerRoute = routeReader.getPlayerRoute(
+                playerId,
+                routeId
+        );
+        return readModelFactory.create(
+                playerId,
+                routeReader.getRoute(routeId),
+                playerRoute
+        );
+    }
+
+    public QuestRouteResult.StepDetail myStep(Long routeId, Long stepId) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        PlayerQuestRoute playerRoute = routeReader.getPlayerRoute(
+                playerId,
+                routeId
+        );
+        QuestRoute route = routeReader.getRoute(routeId);
+        route.getStep(stepId);
+        return readModelFactory.createStepDetail(
+                playerId,
+                route,
+                playerRoute,
+                stepId
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/application/QuestRouteReadModelFactory.java
+++ b/src/main/java/online/lifeasgame/quest/application/QuestRouteReadModelFactory.java
@@ -1,0 +1,142 @@
+package online.lifeasgame.quest.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.quest.application.result.QuestRouteResult;
+import online.lifeasgame.quest.domain.PlayerQuestRoute;
+import online.lifeasgame.quest.domain.QuestRoute;
+import online.lifeasgame.quest.domain.QuestRouteStep;
+import online.lifeasgame.quest.domain.QuestRouteStepState;
+import online.lifeasgame.quest.domain.error.QuestError;
+import org.springframework.stereotype.Component;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+class QuestRouteReadModelFactory {
+
+    private final QuestRouteCriteriaEvaluator criteriaEvaluator;
+
+    QuestRouteResult.Route create(
+            Long playerId,
+            QuestRoute route,
+            PlayerQuestRoute playerRoute
+    ) {
+        QuestRouteStep currentStep = playerRoute == null
+                ? null
+                : route.getStep(playerRoute.getCurrentStepId());
+        List<QuestRouteResult.Step> steps = route.getSteps().stream()
+                .map(step -> createStep(
+                        playerId,
+                        step,
+                        playerRoute,
+                        currentStep
+                ))
+                .toList();
+        return new QuestRouteResult.Route(
+                route.getId(),
+                route.getCode(),
+                route.getDefinitionVersion(),
+                route.getTitle(),
+                route.getDescription(),
+                route.getPrimaryRoleTemplateCode(),
+                playerRoute == null ? null : progress(playerRoute),
+                steps
+        );
+    }
+
+    QuestRouteResult.StepDetail createStepDetail(
+            Long playerId,
+            QuestRoute route,
+            PlayerQuestRoute playerRoute,
+            Long stepId
+    ) {
+        QuestRouteResult.Route model = create(playerId, route, playerRoute);
+        QuestRouteResult.Step step = model.steps().stream()
+                .filter(candidate -> candidate.id().equals(stepId))
+                .findFirst()
+                .orElseThrow(() -> new DomainException(
+                        QuestError.ROUTE_STEP_NOT_FOUND
+                ));
+        return new QuestRouteResult.StepDetail(
+                route.getId(),
+                route.getCode(),
+                model.playerProgress(),
+                step
+        );
+    }
+
+    private QuestRouteResult.Step createStep(
+            Long playerId,
+            QuestRouteStep step,
+            PlayerQuestRoute playerRoute,
+            QuestRouteStep currentStep
+    ) {
+        boolean criteriaSatisfied = criteriaEvaluator.isSatisfied(
+                playerId,
+                step
+        );
+        QuestRouteStepState state = state(
+                step,
+                playerRoute,
+                currentStep,
+                criteriaSatisfied
+        );
+        List<QuestRouteResult.QuestLink> questLinks = step.getQuestLinks()
+                .stream()
+                .sorted(Comparator.comparing(link -> link.getQuestId()))
+                .map(link -> new QuestRouteResult.QuestLink(
+                        link.getQuestId(),
+                        link.getRequirementType().name()
+                ))
+                .toList();
+        return new QuestRouteResult.Step(
+                step.getId(),
+                step.getStepCode(),
+                step.getStepOrder(),
+                step.getTitle(),
+                step.getDescription(),
+                step.getCriterionType().name(),
+                step.getRequiredEvidenceCount(),
+                step.isUserAdvanceRequired(),
+                step.isRetroactiveEvidenceAllowed(),
+                step.isSkipAllowed(),
+                criteriaSatisfied,
+                state.name(),
+                questLinks
+        );
+    }
+
+    private QuestRouteStepState state(
+            QuestRouteStep step,
+            PlayerQuestRoute playerRoute,
+            QuestRouteStep currentStep,
+            boolean criteriaSatisfied
+    ) {
+        if (playerRoute == null) return QuestRouteStepState.LOCKED;
+        if (playerRoute.isCompleted()) return QuestRouteStepState.COMPLETED;
+        if (step.getStepOrder() < currentStep.getStepOrder()) {
+            return QuestRouteStepState.COMPLETED;
+        }
+        if (step.getId().equals(currentStep.getId())) {
+            return criteriaSatisfied
+                    ? QuestRouteStepState.READY_TO_ADVANCE
+                    : QuestRouteStepState.CURRENT;
+        }
+        return QuestRouteStepState.LOCKED;
+    }
+
+    private QuestRouteResult.PlayerProgress progress(
+            PlayerQuestRoute playerRoute
+    ) {
+        return new QuestRouteResult.PlayerProgress(
+                playerRoute.getId(),
+                playerRoute.getCurrentStepId(),
+                playerRoute.getStatus().name(),
+                playerRoute.getSelectedAt(),
+                playerRoute.getCompletedAt()
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/application/QuestRouteReader.java
+++ b/src/main/java/online/lifeasgame/quest/application/QuestRouteReader.java
@@ -1,0 +1,74 @@
+package online.lifeasgame.quest.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.quest.domain.PlayerQuestRoute;
+import online.lifeasgame.quest.domain.QuestRoute;
+import online.lifeasgame.quest.domain.error.QuestError;
+import online.lifeasgame.quest.domain.repository.PlayerQuestRouteRepository;
+import online.lifeasgame.quest.domain.repository.QuestRouteRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+class QuestRouteReader {
+
+    private final QuestRouteRepository questRouteRepository;
+    private final PlayerQuestRouteRepository playerQuestRouteRepository;
+
+    List<QuestRoute> findAllRoutes() {
+        return questRouteRepository.findAll().stream()
+                .peek(QuestRoute::validateDefinition)
+                .toList();
+    }
+
+    QuestRoute getRoute(Long routeId) {
+        QuestRoute route = questRouteRepository.findById(routeId)
+                .orElseThrow(() -> new DomainException(
+                        QuestError.ROUTE_NOT_FOUND
+                ));
+        route.validateDefinition();
+        return route;
+    }
+
+    QuestRoute getRouteForUpdate(Long routeId) {
+        QuestRoute route = questRouteRepository.findByIdForUpdate(routeId)
+                .orElseThrow(() -> new DomainException(
+                        QuestError.ROUTE_NOT_FOUND
+                ));
+        route.validateDefinition();
+        return route;
+    }
+
+    Optional<PlayerQuestRoute> findPlayerRoute(Long playerId, Long routeId) {
+        return playerQuestRouteRepository.findByPlayerIdAndRouteId(
+                playerId,
+                routeId
+        );
+    }
+
+    PlayerQuestRoute getPlayerRoute(Long playerId, Long routeId) {
+        return findPlayerRoute(playerId, routeId)
+                .orElseThrow(() -> new DomainException(
+                        QuestError.PLAYER_ROUTE_NOT_FOUND
+                ));
+    }
+
+    PlayerQuestRoute getPlayerRouteForUpdate(Long playerId, Long routeId) {
+        return playerQuestRouteRepository
+                .findByPlayerIdAndRouteIdForUpdate(playerId, routeId)
+                .orElseThrow(() -> new DomainException(
+                        QuestError.PLAYER_ROUTE_NOT_FOUND
+                ));
+    }
+
+    List<PlayerQuestRoute> findPlayerRoutes(Long playerId) {
+        return playerQuestRouteRepository.findAllByPlayerId(playerId);
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/application/QuestRouteReader.java
+++ b/src/main/java/online/lifeasgame/quest/application/QuestRouteReader.java
@@ -37,15 +37,6 @@ class QuestRouteReader {
         return route;
     }
 
-    QuestRoute getRouteForUpdate(Long routeId) {
-        QuestRoute route = questRouteRepository.findByIdForUpdate(routeId)
-                .orElseThrow(() -> new DomainException(
-                        QuestError.ROUTE_NOT_FOUND
-                ));
-        route.validateDefinition();
-        return route;
-    }
-
     Optional<PlayerQuestRoute> findPlayerRoute(Long playerId, Long routeId) {
         return playerQuestRouteRepository.findByPlayerIdAndRouteId(
                 playerId,
@@ -60,6 +51,7 @@ class QuestRouteReader {
                 ));
     }
 
+    @Transactional(propagation = Propagation.MANDATORY, readOnly = false)
     PlayerQuestRoute getPlayerRouteForUpdate(Long playerId, Long routeId) {
         return playerQuestRouteRepository
                 .findByPlayerIdAndRouteIdForUpdate(playerId, routeId)

--- a/src/main/java/online/lifeasgame/quest/application/QuestRouteSelectService.java
+++ b/src/main/java/online/lifeasgame/quest/application/QuestRouteSelectService.java
@@ -24,7 +24,7 @@ public class QuestRouteSelectService {
     @Transactional
     public QuestRouteResult.Route select(Long routeId) {
         Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
-        QuestRoute route = routeReader.getRouteForUpdate(routeId);
+        QuestRoute route = routeReader.getRoute(routeId);
         Long firstStepId = route.firstStep().getId();
         playerQuestRouteRepository.insertIfAbsent(
                 playerId,

--- a/src/main/java/online/lifeasgame/quest/application/QuestRouteSelectService.java
+++ b/src/main/java/online/lifeasgame/quest/application/QuestRouteSelectService.java
@@ -1,0 +1,41 @@
+package online.lifeasgame.quest.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.quest.application.result.QuestRouteResult;
+import online.lifeasgame.quest.domain.PlayerQuestRoute;
+import online.lifeasgame.quest.domain.QuestRoute;
+import online.lifeasgame.quest.domain.repository.PlayerQuestRouteRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+
+@Service
+@RequiredArgsConstructor
+public class QuestRouteSelectService {
+
+    private final QuestRouteReader routeReader;
+    private final PlayerQuestRouteRepository playerQuestRouteRepository;
+    private final QuestRouteReadModelFactory readModelFactory;
+    private final CurrentPlayerAccessor currentPlayerAccessor;
+    private final Clock clock;
+
+    @Transactional
+    public QuestRouteResult.Route select(Long routeId) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        QuestRoute route = routeReader.getRouteForUpdate(routeId);
+        Long firstStepId = route.firstStep().getId();
+        playerQuestRouteRepository.insertIfAbsent(
+                playerId,
+                route.getId(),
+                firstStepId,
+                clock.instant()
+        );
+        PlayerQuestRoute playerRoute = routeReader.getPlayerRouteForUpdate(
+                playerId,
+                route.getId()
+        );
+        return readModelFactory.create(playerId, route, playerRoute);
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/application/result/QuestRouteResult.java
+++ b/src/main/java/online/lifeasgame/quest/application/result/QuestRouteResult.java
@@ -1,0 +1,65 @@
+package online.lifeasgame.quest.application.result;
+
+import java.time.Instant;
+import java.util.List;
+
+public final class QuestRouteResult {
+
+    private QuestRouteResult() {
+    }
+
+    public record Routes(List<Route> routes) {
+    }
+
+    public record Route(
+            Long id,
+            String code,
+            int definitionVersion,
+            String title,
+            String description,
+            String primaryRoleTemplateCode,
+            PlayerProgress playerProgress,
+            List<Step> steps
+    ) {
+    }
+
+    public record PlayerProgress(
+            Long id,
+            Long currentStepId,
+            String status,
+            Instant selectedAt,
+            Instant completedAt
+    ) {
+    }
+
+    public record Step(
+            Long id,
+            String stepCode,
+            int stepOrder,
+            String title,
+            String description,
+            String criterionType,
+            int requiredEvidenceCount,
+            boolean userAdvanceRequired,
+            boolean retroactiveEvidenceAllowed,
+            boolean skipAllowed,
+            boolean criteriaSatisfied,
+            String state,
+            List<QuestLink> questLinks
+    ) {
+    }
+
+    public record QuestLink(
+            Long questId,
+            String requirementType
+    ) {
+    }
+
+    public record StepDetail(
+            Long routeId,
+            String routeCode,
+            PlayerProgress playerProgress,
+            Step step
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/domain/PlayerQuestRoute.java
+++ b/src/main/java/online/lifeasgame/quest/domain/PlayerQuestRoute.java
@@ -1,0 +1,114 @@
+package online.lifeasgame.quest.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import online.lifeasgame.core.annotation.AggregateRoot;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.platform.persistence.jpa.AbstractTime;
+import online.lifeasgame.quest.domain.error.QuestError;
+
+import java.time.Instant;
+
+@Getter
+@Entity
+@AggregateRoot
+@Table(
+        name = "player_quest_routes",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_player_quest_route",
+                columnNames = {"player_id", "route_id"}
+        )
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlayerQuestRoute extends AbstractTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "player_id", nullable = false)
+    private Long playerId;
+
+    @Column(name = "route_id", nullable = false)
+    private Long routeId;
+
+    @Column(name = "current_step_id", nullable = false)
+    private Long currentStepId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    private PlayerQuestRouteStatus status;
+
+    @Column(name = "selected_at", nullable = false)
+    private Instant selectedAt;
+
+    @Column(name = "completed_at")
+    private Instant completedAt;
+
+    @Version
+    private Long version;
+
+    private PlayerQuestRoute(
+            Long playerId,
+            Long routeId,
+            Long currentStepId,
+            Instant selectedAt
+    ) {
+        if (invalidId(playerId)
+                || invalidId(routeId)
+                || invalidId(currentStepId)
+                || selectedAt == null) {
+            throw new DomainException(QuestError.ROUTE_DEFINITION_INVALID);
+        }
+        this.playerId = playerId;
+        this.routeId = routeId;
+        this.currentStepId = currentStepId;
+        this.status = PlayerQuestRouteStatus.IN_PROGRESS;
+        this.selectedAt = selectedAt;
+    }
+
+    public static PlayerQuestRoute start(
+            Long playerId,
+            Long routeId,
+            Long firstStepId,
+            Instant selectedAt
+    ) {
+        return new PlayerQuestRoute(playerId, routeId, firstStepId, selectedAt);
+    }
+
+    public void advanceTo(Long expectedStepId, Long nextStepId) {
+        assertCanAdvance(expectedStepId);
+        if (invalidId(nextStepId) || currentStepId.equals(nextStepId)) {
+            throw new DomainException(QuestError.ROUTE_STEP_NOT_CURRENT);
+        }
+        currentStepId = nextStepId;
+    }
+
+    public void complete(Long expectedStepId, Instant completedAt) {
+        assertCanAdvance(expectedStepId);
+        if (completedAt == null) {
+            throw new DomainException(QuestError.ROUTE_DEFINITION_INVALID);
+        }
+        status = PlayerQuestRouteStatus.COMPLETED;
+        this.completedAt = completedAt;
+    }
+
+    public boolean isCompleted() {
+        return status == PlayerQuestRouteStatus.COMPLETED;
+    }
+
+    private void assertCanAdvance(Long expectedStepId) {
+        if (isCompleted()) {
+            throw new DomainException(QuestError.ROUTE_ALREADY_COMPLETED);
+        }
+        if (expectedStepId == null || !currentStepId.equals(expectedStepId)) {
+            throw new DomainException(QuestError.ROUTE_STEP_NOT_CURRENT);
+        }
+    }
+
+    private static boolean invalidId(Long value) {
+        return value == null || value <= 0;
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/domain/PlayerQuestRouteStatus.java
+++ b/src/main/java/online/lifeasgame/quest/domain/PlayerQuestRouteStatus.java
@@ -1,0 +1,6 @@
+package online.lifeasgame.quest.domain;
+
+public enum PlayerQuestRouteStatus {
+    IN_PROGRESS,
+    COMPLETED
+}

--- a/src/main/java/online/lifeasgame/quest/domain/QuestRoute.java
+++ b/src/main/java/online/lifeasgame/quest/domain/QuestRoute.java
@@ -1,0 +1,152 @@
+package online.lifeasgame.quest.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import online.lifeasgame.core.annotation.AggregateRoot;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.platform.persistence.jpa.AbstractTime;
+import online.lifeasgame.quest.domain.error.QuestError;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Getter
+@Entity
+@AggregateRoot
+@Table(name = "quest_routes")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestRoute extends AbstractTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 80, nullable = false, unique = true)
+    private String code;
+
+    @Column(name = "definition_version", nullable = false)
+    private int definitionVersion;
+
+    @Column(length = 120, nullable = false)
+    private String title;
+
+    @Lob
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "primary_role_template_code", length = 80)
+    private String primaryRoleTemplateCode;
+
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(
+            name = "route_id",
+            referencedColumnName = "id",
+            insertable = false,
+            updatable = false
+    )
+    @OrderBy("stepOrder ASC")
+    private List<QuestRouteStep> steps = new ArrayList<>();
+
+    private QuestRoute(
+            String code,
+            int definitionVersion,
+            String title,
+            String description,
+            String primaryRoleTemplateCode,
+            List<QuestRouteStep> steps
+    ) {
+        this.code = normalize(code, 80);
+        this.definitionVersion = definitionVersion;
+        this.title = normalize(title, 120);
+        this.description = normalizeNullable(description);
+        this.primaryRoleTemplateCode = normalizeNullable(
+                primaryRoleTemplateCode,
+                80
+        );
+        this.steps = new ArrayList<>(steps == null ? List.of() : steps);
+        validateDefinition();
+    }
+
+    public static QuestRoute define(
+            String code,
+            int definitionVersion,
+            String title,
+            String description,
+            String primaryRoleTemplateCode,
+            List<QuestRouteStep> steps
+    ) {
+        return new QuestRoute(
+                code,
+                definitionVersion,
+                title,
+                description,
+                primaryRoleTemplateCode,
+                steps
+        );
+    }
+
+    public QuestRouteStep firstStep() {
+        validateDefinition();
+        return steps.getFirst();
+    }
+
+    public QuestRouteStep getStep(Long stepId) {
+        return steps.stream()
+                .filter(step -> step.getId().equals(stepId))
+                .findFirst()
+                .orElseThrow(() -> new DomainException(QuestError.ROUTE_STEP_NOT_FOUND));
+    }
+
+    public QuestRouteStep nextStep(Long currentStepId) {
+        for (int index = 0; index < steps.size(); index++) {
+            if (steps.get(index).getId().equals(currentStepId)) {
+                return index + 1 < steps.size() ? steps.get(index + 1) : null;
+            }
+        }
+        throw new DomainException(QuestError.ROUTE_STEP_NOT_FOUND);
+    }
+
+    public void validateDefinition() {
+        if (definitionVersion < 1 || steps.isEmpty()) throw invalidDefinition();
+        Set<String> codes = new HashSet<>();
+        Set<Integer> orders = new HashSet<>();
+        for (int index = 0; index < steps.size(); index++) {
+            QuestRouteStep step = steps.get(index);
+            step.validateDefinition();
+            if (step.getStepOrder() != index + 1
+                    || !codes.add(step.getStepCode())
+                    || !orders.add(step.getStepOrder())) {
+                throw invalidDefinition();
+            }
+        }
+    }
+
+    private static String normalize(String value, int maxLength) {
+        if (value == null || value.isBlank()) throw invalidDefinition();
+        String normalized = value.trim();
+        if (normalized.length() > maxLength) throw invalidDefinition();
+        return normalized;
+    }
+
+    private static String normalizeNullable(String value) {
+        if (value == null) return null;
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    private static String normalizeNullable(String value, int maxLength) {
+        String normalized = normalizeNullable(value);
+        if (normalized != null && normalized.length() > maxLength) {
+            throw invalidDefinition();
+        }
+        return normalized;
+    }
+
+    private static DomainException invalidDefinition() {
+        return new DomainException(QuestError.ROUTE_DEFINITION_INVALID);
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/domain/QuestRouteCriterionType.java
+++ b/src/main/java/online/lifeasgame/quest/domain/QuestRouteCriterionType.java
@@ -1,0 +1,5 @@
+package online.lifeasgame.quest.domain;
+
+public enum QuestRouteCriterionType {
+    QUEST_COMPLETION_SET
+}

--- a/src/main/java/online/lifeasgame/quest/domain/QuestRouteQuestRequirementType.java
+++ b/src/main/java/online/lifeasgame/quest/domain/QuestRouteQuestRequirementType.java
@@ -1,0 +1,6 @@
+package online.lifeasgame.quest.domain;
+
+public enum QuestRouteQuestRequirementType {
+    REQUIRED,
+    OPTIONAL
+}

--- a/src/main/java/online/lifeasgame/quest/domain/QuestRouteStep.java
+++ b/src/main/java/online/lifeasgame/quest/domain/QuestRouteStep.java
@@ -1,0 +1,149 @@
+package online.lifeasgame.quest.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.quest.domain.error.QuestError;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@Getter
+@Entity
+@Table(
+        name = "quest_route_steps",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_quest_route_step_order",
+                        columnNames = {"route_id", "step_order"}
+                ),
+                @UniqueConstraint(
+                        name = "uq_quest_route_step_code",
+                        columnNames = {"route_id", "step_code"}
+                )
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestRouteStep {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "route_id", nullable = false)
+    private Long routeId;
+
+    @Column(name = "step_code", length = 80, nullable = false)
+    private String stepCode;
+
+    @Column(name = "step_order", nullable = false)
+    private int stepOrder;
+
+    @Column(length = 120, nullable = false)
+    private String title;
+
+    @Lob
+    @Column(name = "description")
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "criterion_type", length = 40, nullable = false)
+    private QuestRouteCriterionType criterionType;
+
+    @Column(name = "required_evidence_count", nullable = false)
+    private int requiredEvidenceCount;
+
+    @Column(name = "user_advance_required", nullable = false)
+    private boolean userAdvanceRequired;
+
+    @Column(name = "retroactive_evidence_allowed", nullable = false)
+    private boolean retroactiveEvidenceAllowed;
+
+    @Column(name = "skip_allowed", nullable = false)
+    private boolean skipAllowed;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(
+            name = "quest_route_step_quests",
+            joinColumns = @JoinColumn(name = "step_id")
+    )
+    private Set<QuestRouteStepQuest> questLinks = new LinkedHashSet<>();
+
+    private QuestRouteStep(
+            String stepCode,
+            int stepOrder,
+            String title,
+            String description,
+            int requiredEvidenceCount,
+            Set<QuestRouteStepQuest> questLinks
+    ) {
+        this.stepCode = normalize(stepCode, 80);
+        this.stepOrder = stepOrder;
+        this.title = normalize(title, 120);
+        this.description = normalizeNullable(description);
+        this.criterionType = QuestRouteCriterionType.QUEST_COMPLETION_SET;
+        this.requiredEvidenceCount = requiredEvidenceCount;
+        this.userAdvanceRequired = true;
+        this.retroactiveEvidenceAllowed = true;
+        this.skipAllowed = false;
+        this.questLinks = new LinkedHashSet<>(questLinks == null ? Set.of() : questLinks);
+        validateDefinition();
+    }
+
+    public static QuestRouteStep define(
+            String stepCode,
+            int stepOrder,
+            String title,
+            String description,
+            int requiredEvidenceCount,
+            Set<QuestRouteStepQuest> questLinks
+    ) {
+        return new QuestRouteStep(
+                stepCode,
+                stepOrder,
+                title,
+                description,
+                requiredEvidenceCount,
+                questLinks
+        );
+    }
+
+    public Set<Long> requiredQuestIds() {
+        return questLinks.stream()
+                .filter(QuestRouteStepQuest::isRequired)
+                .map(QuestRouteStepQuest::getQuestId)
+                .collect(java.util.stream.Collectors.toUnmodifiableSet());
+    }
+
+    void validateDefinition() {
+        long requiredQuestCount = questLinks.stream()
+                .filter(QuestRouteStepQuest::isRequired)
+                .count();
+        if (stepOrder < 1
+                || criterionType != QuestRouteCriterionType.QUEST_COMPLETION_SET
+                || requiredEvidenceCount < 1
+                || requiredEvidenceCount > requiredQuestCount
+                || !userAdvanceRequired
+                || !retroactiveEvidenceAllowed
+                || skipAllowed) {
+            throw invalidDefinition();
+        }
+    }
+
+    private static String normalize(String value, int maxLength) {
+        if (value == null || value.isBlank()) throw invalidDefinition();
+        String normalized = value.trim();
+        if (normalized.length() > maxLength) throw invalidDefinition();
+        return normalized;
+    }
+
+    private static String normalizeNullable(String value) {
+        return value == null ? null : value.trim();
+    }
+
+    private static DomainException invalidDefinition() {
+        return new DomainException(QuestError.ROUTE_DEFINITION_INVALID);
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/domain/QuestRouteStep.java
+++ b/src/main/java/online/lifeasgame/quest/domain/QuestRouteStep.java
@@ -124,7 +124,7 @@ public class QuestRouteStep {
         if (stepOrder < 1
                 || criterionType != QuestRouteCriterionType.QUEST_COMPLETION_SET
                 || requiredEvidenceCount < 1
-                || requiredEvidenceCount > requiredQuestCount
+                || requiredEvidenceCount != requiredQuestCount
                 || !userAdvanceRequired
                 || !retroactiveEvidenceAllowed
                 || skipAllowed) {

--- a/src/main/java/online/lifeasgame/quest/domain/QuestRouteStepQuest.java
+++ b/src/main/java/online/lifeasgame/quest/domain/QuestRouteStepQuest.java
@@ -1,0 +1,71 @@
+package online.lifeasgame.quest.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.quest.domain.error.QuestError;
+
+import java.util.Objects;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestRouteStepQuest {
+
+    @Column(name = "quest_id", nullable = false)
+    private Long questId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "requirement_type", length = 20, nullable = false)
+    private QuestRouteQuestRequirementType requirementType;
+
+    private QuestRouteStepQuest(
+            Long questId,
+            QuestRouteQuestRequirementType requirementType
+    ) {
+        if (questId == null || questId <= 0 || requirementType == null) {
+            throw invalidDefinition();
+        }
+        this.questId = questId;
+        this.requirementType = requirementType;
+    }
+
+    public static QuestRouteStepQuest required(Long questId) {
+        return new QuestRouteStepQuest(
+                questId,
+                QuestRouteQuestRequirementType.REQUIRED
+        );
+    }
+
+    public static QuestRouteStepQuest optional(Long questId) {
+        return new QuestRouteStepQuest(
+                questId,
+                QuestRouteQuestRequirementType.OPTIONAL
+        );
+    }
+
+    public boolean isRequired() {
+        return requirementType == QuestRouteQuestRequirementType.REQUIRED;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (!(other instanceof QuestRouteStepQuest that)) return false;
+        return Objects.equals(questId, that.questId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(questId);
+    }
+
+    private static DomainException invalidDefinition() {
+        return new DomainException(QuestError.ROUTE_DEFINITION_INVALID);
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/domain/QuestRouteStepState.java
+++ b/src/main/java/online/lifeasgame/quest/domain/QuestRouteStepState.java
@@ -1,0 +1,8 @@
+package online.lifeasgame.quest.domain;
+
+public enum QuestRouteStepState {
+    COMPLETED,
+    CURRENT,
+    READY_TO_ADVANCE,
+    LOCKED
+}

--- a/src/main/java/online/lifeasgame/quest/domain/error/QuestError.java
+++ b/src/main/java/online/lifeasgame/quest/domain/error/QuestError.java
@@ -136,6 +136,41 @@ public enum QuestError implements ErrorCode {
             "QUE-400-REWARD-CONTRACT-CONFLICT",
             "Reward profile and legacy inline reward cannot be changed together",
             400
+    ),
+    ROUTE_NOT_FOUND(
+            "QUE-404-ROUTE-NOT-FOUND",
+            "Quest route not found",
+            404
+    ),
+    PLAYER_ROUTE_NOT_FOUND(
+            "QUE-404-PLAYER-ROUTE-NOT-FOUND",
+            "Player quest route not found",
+            404
+    ),
+    ROUTE_STEP_NOT_FOUND(
+            "QUE-404-ROUTE-STEP-NOT-FOUND",
+            "Quest route step not found",
+            404
+    ),
+    ROUTE_ALREADY_COMPLETED(
+            "QUE-409-ROUTE-ALREADY-COMPLETED",
+            "Quest route is already completed",
+            409
+    ),
+    ROUTE_STEP_NOT_CURRENT(
+            "QUE-409-ROUTE-STEP-NOT-CURRENT",
+            "Expected step is not the current quest route step",
+            409
+    ),
+    ROUTE_STEP_CRITERIA_NOT_SATISFIED(
+            "QUE-409-ROUTE-STEP-CRITERIA-NOT-SATISFIED",
+            "Quest route step criteria are not satisfied",
+            409
+    ),
+    ROUTE_DEFINITION_INVALID(
+            "QUE-400-ROUTE-DEFINITION-INVALID",
+            "Quest route definition is invalid",
+            400
     )
     ;
 

--- a/src/main/java/online/lifeasgame/quest/domain/repository/PlayerQuestRouteRepository.java
+++ b/src/main/java/online/lifeasgame/quest/domain/repository/PlayerQuestRouteRepository.java
@@ -1,0 +1,28 @@
+package online.lifeasgame.quest.domain.repository;
+
+import online.lifeasgame.quest.domain.PlayerQuestRoute;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+public interface PlayerQuestRouteRepository {
+    void insertIfAbsent(
+            Long playerId,
+            Long routeId,
+            Long firstStepId,
+            Instant selectedAt
+    );
+
+    Optional<PlayerQuestRoute> findByPlayerIdAndRouteId(
+            Long playerId,
+            Long routeId
+    );
+
+    Optional<PlayerQuestRoute> findByPlayerIdAndRouteIdForUpdate(
+            Long playerId,
+            Long routeId
+    );
+
+    List<PlayerQuestRoute> findAllByPlayerId(Long playerId);
+}

--- a/src/main/java/online/lifeasgame/quest/domain/repository/QuestAcceptanceRepository.java
+++ b/src/main/java/online/lifeasgame/quest/domain/repository/QuestAcceptanceRepository.java
@@ -5,6 +5,7 @@ import online.lifeasgame.quest.domain.QuestStatus;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface QuestAcceptanceRepository {
     QuestAcceptance save(QuestAcceptance acceptance);
@@ -24,4 +25,6 @@ public interface QuestAcceptanceRepository {
     Optional<QuestAcceptance> findLatestByQuestAndPlayer(Long questId, Long playerId);
 
     boolean existsByPlayerIdAndId(Long playerId, Long questId);
+
+    Set<Long> findCompletedQuestIds(Long playerId, Set<Long> questIds);
 }

--- a/src/main/java/online/lifeasgame/quest/domain/repository/QuestRouteRepository.java
+++ b/src/main/java/online/lifeasgame/quest/domain/repository/QuestRouteRepository.java
@@ -1,0 +1,16 @@
+package online.lifeasgame.quest.domain.repository;
+
+import online.lifeasgame.quest.domain.QuestRoute;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface QuestRouteRepository {
+    List<QuestRoute> findAll();
+
+    Optional<QuestRoute> findById(Long routeId);
+
+    Optional<QuestRoute> findByIdForUpdate(Long routeId);
+
+    Optional<QuestRoute> findByCode(String code);
+}

--- a/src/main/java/online/lifeasgame/quest/domain/repository/QuestRouteRepository.java
+++ b/src/main/java/online/lifeasgame/quest/domain/repository/QuestRouteRepository.java
@@ -10,7 +10,5 @@ public interface QuestRouteRepository {
 
     Optional<QuestRoute> findById(Long routeId);
 
-    Optional<QuestRoute> findByIdForUpdate(Long routeId);
-
     Optional<QuestRoute> findByCode(String code);
 }

--- a/src/main/java/online/lifeasgame/quest/infra/JpaPlayerQuestRouteRepository.java
+++ b/src/main/java/online/lifeasgame/quest/infra/JpaPlayerQuestRouteRepository.java
@@ -34,7 +34,7 @@ public interface JpaPlayerQuestRouteRepository
 
     @Modifying(flushAutomatically = true)
     @Query(value = """
-            INSERT IGNORE INTO player_quest_routes (
+            INSERT INTO player_quest_routes (
                 player_id,
                 route_id,
                 current_step_id,
@@ -55,6 +55,7 @@ public interface JpaPlayerQuestRouteRepository
                 :selectedAt,
                 :selectedAt
             )
+            ON DUPLICATE KEY UPDATE id = id
             """, nativeQuery = true)
     int insertIfAbsent(
             @Param("playerId") Long playerId,

--- a/src/main/java/online/lifeasgame/quest/infra/JpaPlayerQuestRouteRepository.java
+++ b/src/main/java/online/lifeasgame/quest/infra/JpaPlayerQuestRouteRepository.java
@@ -1,0 +1,65 @@
+package online.lifeasgame.quest.infra;
+
+import online.lifeasgame.quest.domain.PlayerQuestRoute;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+public interface JpaPlayerQuestRouteRepository
+        extends JpaRepository<PlayerQuestRoute, Long> {
+
+    Optional<PlayerQuestRoute> findByPlayerIdAndRouteId(
+            Long playerId,
+            Long routeId
+    );
+
+    @Query(value = """
+            SELECT *
+            FROM player_quest_routes
+            WHERE player_id = :playerId
+              AND route_id = :routeId
+            FOR UPDATE
+            """, nativeQuery = true)
+    Optional<PlayerQuestRoute> findByPlayerIdAndRouteIdForUpdate(
+            @Param("playerId") Long playerId,
+            @Param("routeId") Long routeId
+    );
+
+    List<PlayerQuestRoute> findAllByPlayerId(Long playerId);
+
+    @Modifying(flushAutomatically = true)
+    @Query(value = """
+            INSERT IGNORE INTO player_quest_routes (
+                player_id,
+                route_id,
+                current_step_id,
+                status,
+                selected_at,
+                completed_at,
+                version,
+                created_at,
+                updated_at
+            ) VALUES (
+                :playerId,
+                :routeId,
+                :firstStepId,
+                'IN_PROGRESS',
+                :selectedAt,
+                NULL,
+                0,
+                :selectedAt,
+                :selectedAt
+            )
+            """, nativeQuery = true)
+    int insertIfAbsent(
+            @Param("playerId") Long playerId,
+            @Param("routeId") Long routeId,
+            @Param("firstStepId") Long firstStepId,
+            @Param("selectedAt") Instant selectedAt
+    );
+}

--- a/src/main/java/online/lifeasgame/quest/infra/JpaQuestAcceptanceRepository.java
+++ b/src/main/java/online/lifeasgame/quest/infra/JpaQuestAcceptanceRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface JpaQuestAcceptanceRepository extends JpaRepository<QuestAcceptance, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
@@ -29,4 +30,17 @@ public interface JpaQuestAcceptanceRepository extends JpaRepository<QuestAccepta
     Optional<QuestAcceptance> findTopByQuestIdAndPlayerIdOrderByIdDesc(Long questId, Long playerId);
 
     boolean existsByPlayerIdAndId(Long playerId, Long id);
+
+    @Query("""
+            SELECT DISTINCT acceptance.questId
+            FROM QuestAcceptance acceptance
+            WHERE acceptance.playerId = :playerId
+              AND acceptance.status = :status
+              AND acceptance.questId IN :questIds
+            """)
+    Set<Long> findQuestIdsByPlayerIdAndStatus(
+            @Param("playerId") Long playerId,
+            @Param("status") QuestStatus status,
+            @Param("questIds") Set<Long> questIds
+    );
 }

--- a/src/main/java/online/lifeasgame/quest/infra/JpaQuestRouteRepository.java
+++ b/src/main/java/online/lifeasgame/quest/infra/JpaQuestRouteRepository.java
@@ -1,18 +1,10 @@
 package online.lifeasgame.quest.infra;
 
-import jakarta.persistence.LockModeType;
 import online.lifeasgame.quest.domain.QuestRoute;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface JpaQuestRouteRepository extends JpaRepository<QuestRoute, Long> {
     Optional<QuestRoute> findByCode(String code);
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT route FROM QuestRoute route WHERE route.id = :routeId")
-    Optional<QuestRoute> findByIdForUpdate(@Param("routeId") Long routeId);
 }

--- a/src/main/java/online/lifeasgame/quest/infra/JpaQuestRouteRepository.java
+++ b/src/main/java/online/lifeasgame/quest/infra/JpaQuestRouteRepository.java
@@ -1,0 +1,18 @@
+package online.lifeasgame.quest.infra;
+
+import jakarta.persistence.LockModeType;
+import online.lifeasgame.quest.domain.QuestRoute;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface JpaQuestRouteRepository extends JpaRepository<QuestRoute, Long> {
+    Optional<QuestRoute> findByCode(String code);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT route FROM QuestRoute route WHERE route.id = :routeId")
+    Optional<QuestRoute> findByIdForUpdate(@Param("routeId") Long routeId);
+}

--- a/src/main/java/online/lifeasgame/quest/infra/PlayerQuestRouteRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/quest/infra/PlayerQuestRouteRepositoryAdapter.java
@@ -1,0 +1,57 @@
+package online.lifeasgame.quest.infra;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.quest.domain.PlayerQuestRoute;
+import online.lifeasgame.quest.domain.repository.PlayerQuestRouteRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class PlayerQuestRouteRepositoryAdapter
+        implements PlayerQuestRouteRepository {
+
+    private final JpaPlayerQuestRouteRepository jpaRepository;
+
+    @Override
+    public void insertIfAbsent(
+            Long playerId,
+            Long routeId,
+            Long firstStepId,
+            Instant selectedAt
+    ) {
+        jpaRepository.insertIfAbsent(
+                playerId,
+                routeId,
+                firstStepId,
+                selectedAt
+        );
+    }
+
+    @Override
+    public Optional<PlayerQuestRoute> findByPlayerIdAndRouteId(
+            Long playerId,
+            Long routeId
+    ) {
+        return jpaRepository.findByPlayerIdAndRouteId(playerId, routeId);
+    }
+
+    @Override
+    public Optional<PlayerQuestRoute> findByPlayerIdAndRouteIdForUpdate(
+            Long playerId,
+            Long routeId
+    ) {
+        return jpaRepository.findByPlayerIdAndRouteIdForUpdate(
+                playerId,
+                routeId
+        );
+    }
+
+    @Override
+    public List<PlayerQuestRoute> findAllByPlayerId(Long playerId) {
+        return jpaRepository.findAllByPlayerId(playerId);
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/infra/QuestAcceptanceRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/quest/infra/QuestAcceptanceRepositoryAdapter.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 @RequiredArgsConstructor
@@ -58,5 +59,17 @@ public class QuestAcceptanceRepositoryAdapter implements QuestAcceptanceReposito
     @Override
     public boolean existsByPlayerIdAndId(Long playerId, Long questId) {
         return jpaQuestAcceptanceRepository.existsByPlayerIdAndId(playerId, questId);
+    }
+
+    @Override
+    public Set<Long> findCompletedQuestIds(
+            Long playerId,
+            Set<Long> questIds
+    ) {
+        return jpaQuestAcceptanceRepository.findQuestIdsByPlayerIdAndStatus(
+                playerId,
+                QuestStatus.COMPLETED,
+                questIds
+        );
     }
 }

--- a/src/main/java/online/lifeasgame/quest/infra/QuestRouteRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/quest/infra/QuestRouteRepositoryAdapter.java
@@ -25,11 +25,6 @@ public class QuestRouteRepositoryAdapter implements QuestRouteRepository {
     }
 
     @Override
-    public Optional<QuestRoute> findByIdForUpdate(Long routeId) {
-        return jpaRepository.findByIdForUpdate(routeId);
-    }
-
-    @Override
     public Optional<QuestRoute> findByCode(String code) {
         return jpaRepository.findByCode(code);
     }

--- a/src/main/java/online/lifeasgame/quest/infra/QuestRouteRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/quest/infra/QuestRouteRepositoryAdapter.java
@@ -1,0 +1,36 @@
+package online.lifeasgame.quest.infra;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.quest.domain.QuestRoute;
+import online.lifeasgame.quest.domain.repository.QuestRouteRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class QuestRouteRepositoryAdapter implements QuestRouteRepository {
+
+    private final JpaQuestRouteRepository jpaRepository;
+
+    @Override
+    public List<QuestRoute> findAll() {
+        return jpaRepository.findAll();
+    }
+
+    @Override
+    public Optional<QuestRoute> findById(Long routeId) {
+        return jpaRepository.findById(routeId);
+    }
+
+    @Override
+    public Optional<QuestRoute> findByIdForUpdate(Long routeId) {
+        return jpaRepository.findByIdForUpdate(routeId);
+    }
+
+    @Override
+    public Optional<QuestRoute> findByCode(String code) {
+        return jpaRepository.findByCode(code);
+    }
+}

--- a/src/main/resources/db/migration/V20__quest_route_mvp.sql
+++ b/src/main/resources/db/migration/V20__quest_route_mvp.sql
@@ -1,0 +1,254 @@
+CREATE TABLE quest_routes (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    code VARCHAR(80) NOT NULL,
+    definition_version INT NOT NULL,
+    title VARCHAR(120) NOT NULL,
+    description TINYTEXT NULL,
+    primary_role_template_code VARCHAR(80) NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_quest_route_code UNIQUE (code),
+    CONSTRAINT ck_quest_route_code CHECK (
+        CHAR_LENGTH(TRIM(code)) BETWEEN 1 AND 80
+    ),
+    CONSTRAINT ck_quest_route_definition_version CHECK (
+        definition_version >= 1
+    ),
+    CONSTRAINT ck_quest_route_title CHECK (
+        CHAR_LENGTH(TRIM(title)) BETWEEN 1 AND 120
+    ),
+    CONSTRAINT ck_quest_route_role_template CHECK (
+        primary_role_template_code IS NULL
+        OR CHAR_LENGTH(TRIM(primary_role_template_code)) BETWEEN 1 AND 80
+    )
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE quest_route_steps (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    route_id BIGINT NOT NULL,
+    step_code VARCHAR(80) NOT NULL,
+    step_order INT NOT NULL,
+    title VARCHAR(120) NOT NULL,
+    description TINYTEXT NULL,
+    criterion_type VARCHAR(40) NOT NULL,
+    required_evidence_count INT NOT NULL,
+    user_advance_required BIT NOT NULL,
+    retroactive_evidence_allowed BIT NOT NULL,
+    skip_allowed BIT NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_quest_route_step_id_route UNIQUE (id, route_id),
+    CONSTRAINT uq_quest_route_step_order UNIQUE (route_id, step_order),
+    CONSTRAINT uq_quest_route_step_code UNIQUE (route_id, step_code),
+    CONSTRAINT ck_quest_route_step_order CHECK (step_order >= 1),
+    CONSTRAINT ck_quest_route_step_code CHECK (
+        CHAR_LENGTH(TRIM(step_code)) BETWEEN 1 AND 80
+    ),
+    CONSTRAINT ck_quest_route_step_title CHECK (
+        CHAR_LENGTH(TRIM(title)) BETWEEN 1 AND 120
+    ),
+    CONSTRAINT ck_quest_route_step_criterion CHECK (
+        criterion_type = 'QUEST_COMPLETION_SET'
+    ),
+    CONSTRAINT ck_quest_route_step_evidence_count CHECK (
+        required_evidence_count >= 1
+    ),
+    CONSTRAINT ck_quest_route_step_explicit_advance CHECK (
+        user_advance_required = b'1'
+    ),
+    CONSTRAINT ck_quest_route_step_retroactive CHECK (
+        retroactive_evidence_allowed = b'1'
+    ),
+    CONSTRAINT ck_quest_route_step_skip CHECK (
+        skip_allowed = b'0'
+    ),
+    CONSTRAINT fk_quest_route_step_route
+        FOREIGN KEY (route_id)
+        REFERENCES quest_routes (id)
+        ON DELETE RESTRICT
+        ON UPDATE RESTRICT
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE quest_route_step_quests (
+    step_id BIGINT NOT NULL,
+    quest_id BIGINT NOT NULL,
+    requirement_type VARCHAR(20) NOT NULL,
+    PRIMARY KEY (step_id, quest_id),
+    CONSTRAINT ck_quest_route_step_quest_requirement CHECK (
+        requirement_type IN ('REQUIRED', 'OPTIONAL')
+    ),
+    CONSTRAINT fk_quest_route_step_quest_step
+        FOREIGN KEY (step_id)
+        REFERENCES quest_route_steps (id)
+        ON DELETE RESTRICT
+        ON UPDATE RESTRICT,
+    CONSTRAINT fk_quest_route_step_quest_quest
+        FOREIGN KEY (quest_id)
+        REFERENCES quests (id)
+        ON DELETE RESTRICT
+        ON UPDATE RESTRICT
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE player_quest_routes (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    player_id BIGINT NOT NULL,
+    route_id BIGINT NOT NULL,
+    current_step_id BIGINT NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    selected_at DATETIME(6) NOT NULL,
+    completed_at DATETIME(6) NULL,
+    version BIGINT NOT NULL DEFAULT 0,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_player_quest_route UNIQUE (player_id, route_id),
+    CONSTRAINT ck_player_quest_route_player CHECK (player_id > 0),
+    CONSTRAINT ck_player_quest_route_status CHECK (
+        status IN ('IN_PROGRESS', 'COMPLETED')
+    ),
+    CONSTRAINT ck_player_quest_route_completion CHECK (
+        (status = 'IN_PROGRESS' AND completed_at IS NULL)
+        OR (status = 'COMPLETED' AND completed_at IS NOT NULL)
+    ),
+    INDEX idx_player_quest_route_status (player_id, status, id),
+    CONSTRAINT fk_player_quest_route_route
+        FOREIGN KEY (route_id)
+        REFERENCES quest_routes (id)
+        ON DELETE RESTRICT
+        ON UPDATE RESTRICT,
+    CONSTRAINT fk_player_quest_route_current_step
+        FOREIGN KEY (current_step_id, route_id)
+        REFERENCES quest_route_steps (id, route_id)
+        ON DELETE RESTRICT
+        ON UPDATE RESTRICT
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_0900_ai_ci;
+
+-- The three required Quest definitions are the existing Level 1 content contract.
+-- INSERT IGNORE only fills a clean database; existing definitions remain authoritative.
+INSERT IGNORE INTO quests (
+    reward_exp,
+    definition_version,
+    target_value,
+    created_at,
+    due_at,
+    updated_at,
+    code,
+    title_id,
+    reward_stats,
+    reward_profile_code,
+    category,
+    semantic_category,
+    description_md,
+    repeat_rule,
+    completion_policy,
+    role_template_code,
+    target_type,
+    progress_source
+) VALUES
+    (
+        0, 1, 1, CURRENT_TIMESTAMP(6), NULL, CURRENT_TIMESTAMP(6),
+        'Q_RECORD_FIRST_TRACE', '첫 흔적 남기기', JSON_OBJECT(),
+        'RP_EXP_TINY_10', NULL, 'RECORD',
+        '오늘의 생각·행동·기억 중 하나를 짧게 남겨보세요.',
+        'ONCE', 'AUTO', NULL, 'COUNT', 'RECORD_CREATED'
+    ),
+    (
+        0, 1, 3, CURRENT_TIMESTAMP(6), NULL, CURRENT_TIMESTAMP(6),
+        'Q_RECORD_THREE_TRACES', '흔적 세 개 이어보기', JSON_OBJECT(),
+        'RP_EXP_AND_ITEM_FIRST_STEP_20', NULL, 'RECORD',
+        '서로 다른 순간의 기록을 세 개 남겨 작은 흐름을 만들어보세요.',
+        'ONCE', 'AUTO', NULL, 'COUNT', 'RECORD_CREATED'
+    ),
+    (
+        0, 1, 1, CURRENT_TIMESTAMP(6), NULL, CURRENT_TIMESTAMP(6),
+        'Q_RECORD_WEEKLY_LOOKBACK', '이번 주 흔적 돌아보기', JSON_OBJECT(),
+        'RP_NONE', NULL, 'RECORD',
+        '이번 주 기록 중 하나를 골라 지금의 나에게 남길 한 줄을 적어보세요.',
+        'WEEKLY', 'AUTO', NULL, 'COUNT', 'RECORD_CREATED'
+    );
+
+INSERT INTO quest_routes (
+    code,
+    definition_version,
+    title,
+    description,
+    primary_role_template_code,
+    created_at,
+    updated_at
+) VALUES (
+    'ROUTE_RECORD_START',
+    1,
+    '기록으로 시작하기',
+    '작은 기록을 남기고 연결하며 돌아보는 장기 방향입니다.',
+    NULL,
+    CURRENT_TIMESTAMP(6),
+    CURRENT_TIMESTAMP(6)
+);
+
+INSERT INTO quest_route_steps (
+    route_id,
+    step_code,
+    step_order,
+    title,
+    description,
+    criterion_type,
+    required_evidence_count,
+    user_advance_required,
+    retroactive_evidence_allowed,
+    skip_allowed
+)
+SELECT
+    route.id,
+    seed.step_code,
+    seed.step_order,
+    seed.title,
+    seed.description,
+    'QUEST_COMPLETION_SET',
+    1,
+    b'1',
+    b'1',
+    b'0'
+FROM quest_routes route
+JOIN (
+    SELECT
+        'RS_RECORD_01_LEAVE_TRACE' AS step_code,
+        1 AS step_order,
+        '첫 흔적 남기기' AS title,
+        '첫 번째 기록 Quest를 완료하고 다음 단계로 직접 이동합니다.' AS description
+    UNION ALL
+    SELECT
+        'RS_RECORD_02_CONNECT_TRACES',
+        2,
+        '흔적 연결하기',
+        '세 개의 기록을 연결한 뒤 다음 단계로 직접 이동합니다.'
+    UNION ALL
+    SELECT
+        'RS_RECORD_03_LOOK_BACK',
+        3,
+        '돌아보기',
+        '주간 회고 Quest를 완료하고 Route를 직접 완료합니다.'
+) seed
+WHERE route.code = 'ROUTE_RECORD_START';
+
+INSERT INTO quest_route_step_quests (
+    step_id,
+    quest_id,
+    requirement_type
+)
+SELECT step.id, quest.id, 'REQUIRED'
+FROM quest_route_steps step
+JOIN quest_routes route ON route.id = step.route_id
+JOIN quests quest ON quest.code = CASE step.step_code
+    WHEN 'RS_RECORD_01_LEAVE_TRACE' THEN 'Q_RECORD_FIRST_TRACE'
+    WHEN 'RS_RECORD_02_CONNECT_TRACES' THEN 'Q_RECORD_THREE_TRACES'
+    WHEN 'RS_RECORD_03_LOOK_BACK' THEN 'Q_RECORD_WEEKLY_LOOKBACK'
+END
+WHERE route.code = 'ROUTE_RECORD_START';

--- a/src/main/resources/db/migration/V20__quest_route_mvp.sql
+++ b/src/main/resources/db/migration/V20__quest_route_mvp.sql
@@ -132,8 +132,8 @@ CREATE TABLE player_quest_routes (
   COLLATE=utf8mb4_0900_ai_ci;
 
 -- The three required Quest definitions are the existing Level 1 content contract.
--- INSERT IGNORE only fills a clean database; existing definitions remain authoritative.
-INSERT IGNORE INTO quests (
+-- A stable code conflict preserves its existing authoritative definition.
+INSERT INTO quests (
     reward_exp,
     definition_version,
     target_value,
@@ -173,7 +173,8 @@ INSERT IGNORE INTO quests (
         'RP_NONE', NULL, 'RECORD',
         '이번 주 기록 중 하나를 골라 지금의 나에게 남길 한 줄을 적어보세요.',
         'WEEKLY', 'AUTO', NULL, 'COUNT', 'RECORD_CREATED'
-    );
+    )
+ON DUPLICATE KEY UPDATE code = VALUES(code);
 
 INSERT INTO quest_routes (
     code,

--- a/src/test/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryIntegrationTest.java
@@ -99,7 +99,7 @@ class InventoryRewardDeliveryIntegrationTest {
     @DisplayName("V17 receipt table은 JPA validate와 unique/check/index 계약을 만족한다")
     void validatesMigrationContract() {
         assertThat(flyway.info().current().getVersion().getVersion())
-                .isEqualTo("19");
+                .isEqualTo("20");
         assertThat(environment.getProperty("spring.jpa.hibernate.ddl-auto"))
                 .isEqualTo("validate");
 

--- a/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
@@ -63,7 +63,7 @@ class FlywayExplicitBaselineTest {
     class ApplyExplicitBaseline {
 
         @Test
-        @DisplayName("V1을 재실행하지 않고 V2부터 V19까지 적용한 뒤 JPA validate를 통과한다")
+        @DisplayName("V1을 재실행하지 않고 V2부터 V20까지 적용한 뒤 JPA validate를 통과한다")
         void migratesFromVersionTwoAndValidatesJpa() throws Exception {
             String jdbcUrl = createV1EquivalentDatabase();
             Flyway flyway = migrationFlyway(jdbcUrl);
@@ -72,12 +72,12 @@ class FlywayExplicitBaselineTest {
             MigrateResult migrateResult = flyway.migrate();
             List<HistoryRow> history = successfulHistory(jdbcUrl);
 
-            assertThat(migrateResult.migrationsExecuted).isEqualTo(18);
+            assertThat(migrateResult.migrationsExecuted).isEqualTo(19);
             assertThat(history).extracting(HistoryRow::version)
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
-                            "14", "15", "16", "17", "18", "19"
+                            "14", "15", "16", "17", "18", "19", "20"
                     );
             assertThat(history.getFirst().type()).isEqualTo("BASELINE");
             assertThat(history.getFirst().script())
@@ -106,7 +106,8 @@ class FlywayExplicitBaselineTest {
                             "V16__quest_acceptance_fact_context.sql",
                             "V17__inventory_reward_delivery_foundation.sql",
                             "V18__reward_item_code_snapshot.sql",
-                            "V19__role_person_persistence_foundation.sql"
+                            "V19__role_person_persistence_foundation.sql",
+                            "V20__quest_route_mvp.sql"
                     );
             assertThat(history.subList(1, history.size()))
                     .allSatisfy(row -> assertThat(row.checksum()).isNotNull());
@@ -126,7 +127,7 @@ class FlywayExplicitBaselineTest {
                         "spring.jpa.hibernate.ddl-auto"
                 )).isEqualTo("validate");
                 assertThat(context.getBean(Flyway.class).info().current().getVersion().getVersion())
-                        .isEqualTo("19");
+                        .isEqualTo("20");
             }
         }
     }

--- a/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
@@ -33,10 +33,10 @@ class FlywayHistoryChecksumTest {
     class MigrateAgain {
 
         @Test
-        @DisplayName("V1~V18 checksum을 보존하고 V19 이후 두 번째 실행은 no-op이다")
+        @DisplayName("V1~V19 checksum을 보존하고 V20 이후 두 번째 실행은 no-op이다")
         void keepsMigrationHistory() throws Exception {
-            Flyway throughV18 = flyway(MigrationVersion.fromVersion("18"));
-            MigrateResult legacy = throughV18.migrate();
+            Flyway throughV19 = flyway(MigrationVersion.fromVersion("19"));
+            MigrateResult legacy = throughV19.migrate();
             List<HistoryRow> legacyHistory = successfulHistory();
             Flyway flyway = flyway(null);
 
@@ -46,7 +46,7 @@ class FlywayHistoryChecksumTest {
             MigrateResult second = flyway.migrate();
             List<HistoryRow> secondHistory = successfulHistory();
 
-            assertThat(legacy.migrationsExecuted).isEqualTo(18);
+            assertThat(legacy.migrationsExecuted).isEqualTo(19);
             assertThat(first.migrationsExecuted).isEqualTo(1);
             assertThat(second.migrationsExecuted).isZero();
             assertThat(secondHistory).isEqualTo(firstHistory);
@@ -56,7 +56,7 @@ class FlywayHistoryChecksumTest {
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
-                            "14", "15", "16", "17", "18", "19"
+                            "14", "15", "16", "17", "18", "19", "20"
                     );
             assertThat(secondHistory).allSatisfy(history -> {
                 assertThat(history.checksum()).isNotNull();

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -39,7 +39,7 @@ class FlywayMigrationTest {
     class MigrateCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V19까지 적용되고 persistence foundation을 추가한다")
+        @DisplayName("V1부터 V20까지 적용되고 QuestRoute foundation을 추가한다")
         void migratesSchemaAndSeedsRewardProfiles() throws Exception {
             Flyway throughV10 = flyway(MigrationVersion.fromVersion("10"));
             MigrateResult legacyResult = throughV10.migrate();
@@ -58,12 +58,12 @@ class FlywayMigrationTest {
             assertThat(legacyResult.migrationsExecuted).isEqualTo(10);
             assertThat(semanticResult.migrationsExecuted).isEqualTo(1);
             assertThat(itemResult.migrationsExecuted).isEqualTo(1);
-            assertThat(result.migrationsExecuted).isEqualTo(7);
+            assertThat(result.migrationsExecuted).isEqualTo(8);
             assertThat(appliedVersions())
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
-                            "14", "15", "16", "17", "18", "19"
+                            "14", "15", "16", "17", "18", "19", "20"
                     );
             assertThat(existingTables(
                     "users",
@@ -84,7 +84,11 @@ class FlywayMigrationTest {
                     "inventory_reward_deliveries",
                     "roles",
                     "persons",
-                    "role_relations"
+                    "role_relations",
+                    "quest_routes",
+                    "quest_route_steps",
+                    "quest_route_step_quests",
+                    "player_quest_routes"
             )).containsExactlyInAnyOrder(
                     "users",
                     "player",
@@ -104,7 +108,11 @@ class FlywayMigrationTest {
                     "inventory_reward_deliveries",
                     "roles",
                     "persons",
-                    "role_relations"
+                    "role_relations",
+                    "quest_routes",
+                    "quest_route_steps",
+                    "quest_route_step_quests",
+                    "player_quest_routes"
             );
             assertThat(existingTables(
                     "quick_lifelog_entries",

--- a/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
@@ -149,7 +149,7 @@ class FlywayProfileCutoverTest {
     class StartLocalWithCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V19까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
+        @DisplayName("V1부터 V20까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
         void migratesThenValidates() {
             ConfigurableEnvironment environment =
                     (ConfigurableEnvironment) applicationContext.getEnvironment();
@@ -161,8 +161,8 @@ class FlywayProfileCutoverTest {
             assertThat(environment.getProperty(
                     "spring.flyway.baseline-on-migrate", Boolean.class
             )).isFalse();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("19");
-            assertThat(appliedMigrationCount()).isEqualTo(19);
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("20");
+            assertThat(appliedMigrationCount()).isEqualTo(20);
         }
     }
 

--- a/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 @SpringBootTest
 @ActiveProfiles({"test", "migration-test"})
-@DisplayName("V19 migration 이후 JPA schema validation")
+@DisplayName("V20 migration 이후 JPA schema validation")
 class JpaValidateAfterMigrationTest {
 
     @Container
@@ -79,14 +79,14 @@ class JpaValidateAfterMigrationTest {
     private QuestDefinitionBootstrapper questDefinitionBootstrapper;
 
     @Nested
-    @DisplayName("V1부터 V19까지 적용된 schema로 ApplicationContext를 기동할 때")
+    @DisplayName("V1부터 V20까지 적용된 schema로 ApplicationContext를 기동할 때")
     class LoadApplicationContext {
 
         @Test
         @DisplayName("ddl-auto validate 상태로 정상 기동한다")
         void loadsWithJpaValidation() {
             assertThat(applicationContext).isNotNull();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("19");
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("20");
             assertThat(applicationContext.getEnvironment().getProperty("spring.jpa.hibernate.ddl-auto"))
                     .isEqualTo("validate");
             assertThat(applicationContext.getEnvironment()

--- a/src/test/java/online/lifeasgame/migration/QuestRouteFlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/QuestRouteFlywayMigrationTest.java
@@ -1,0 +1,339 @@
+package online.lifeasgame.migration;
+
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+@DisplayName("V20 QuestRoute MVP migration")
+class QuestRouteFlywayMigrationTest {
+
+    @Container
+    private static final MySQLContainer<?> MYSQL =
+            new MySQLContainer<>("mysql:8.0.39")
+                    .withDatabaseName("lifeasgame_quest_route_migration")
+                    .withUsername("lifeasgame")
+                    .withPassword("lifeasgame");
+
+    private Flyway flyway;
+    private JdbcTemplate jdbc;
+
+    @BeforeEach
+    void migrateCleanDatabase() {
+        flyway = Flyway.configure()
+                .dataSource(
+                        MYSQL.getJdbcUrl(),
+                        MYSQL.getUsername(),
+                        MYSQL.getPassword()
+                )
+                .locations("classpath:db/migration")
+                .baselineOnMigrate(false)
+                .cleanDisabled(false)
+                .load();
+        flyway.clean();
+        flyway.migrate();
+        jdbc = new JdbcTemplate(new DriverManagerDataSource(
+                MYSQL.getJdbcUrl(),
+                MYSQL.getUsername(),
+                MYSQL.getPassword()
+        ));
+    }
+
+    @Nested
+    @DisplayName("빈 MySQL에 V20을 적용하면")
+    class CreateQuestRouteFoundation {
+
+        @Test
+        @DisplayName("definition/runtime 4개 table과 필요한 constraint만 만든다")
+        void createsSeparatedDefinitionAndRuntimeTables() {
+            assertThat(flyway.info().current().getVersion().getVersion())
+                    .isEqualTo("20");
+            assertThat(tableNames()).containsExactly(
+                    "player_quest_routes",
+                    "quest_route_step_quests",
+                    "quest_route_steps",
+                    "quest_routes"
+            );
+            assertThat(uniqueIndexes("player_quest_routes"))
+                    .containsExactly("PRIMARY", "uq_player_quest_route");
+            assertThat(indexColumns(
+                    "player_quest_routes",
+                    "uq_player_quest_route"
+            )).containsExactly("player_id", "route_id");
+            assertThat(foreignKeys()).containsExactlyInAnyOrder(
+                    "fk_player_quest_route_current_step",
+                    "fk_player_quest_route_route",
+                    "fk_quest_route_step_quest_quest",
+                    "fk_quest_route_step_quest_step",
+                    "fk_quest_route_step_route"
+            );
+            assertThat(columnNames("quest_routes"))
+                    .contains("primary_role_template_code")
+                    .doesNotContain("role_id", "reward_id", "achievement_id");
+            assertThat(columnNames("player_quest_routes"))
+                    .doesNotContain("role_id", "reward_id", "achievement_id");
+        }
+
+        @Test
+        @DisplayName("Player별 Route 중복만 막고 다른 Route 선택 가능성은 유지한다")
+        void scopesUniquenessToPlayerAndRoute() {
+            Long routeId = routeId("ROUTE_RECORD_START");
+            Long firstStepId = stepId(routeId, 1);
+            insertPlayerRoute(2501L, routeId, firstStepId);
+
+            assertThatThrownBy(() -> insertPlayerRoute(
+                    2501L,
+                    routeId,
+                    firstStepId
+            )).isInstanceOf(DataIntegrityViolationException.class);
+
+            Long secondRouteId = insertSecondRoute();
+            Long secondStepId = insertSecondRouteStep(secondRouteId);
+            insertPlayerRoute(2501L, secondRouteId, secondStepId);
+
+            assertThat(jdbc.queryForObject(
+                    "SELECT COUNT(*) FROM player_quest_routes WHERE player_id = 2501",
+                    Integer.class
+            )).isEqualTo(2);
+            assertThatThrownBy(() -> insertPlayerRoute(
+                    2502L,
+                    secondRouteId,
+                    firstStepId
+            )).isInstanceOf(DataIntegrityViolationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("대표 Route content를 seed하면")
+    class SeedRepresentativeRoute {
+
+        @Test
+        @DisplayName("ROUTE_RECORD_START 하나와 순서가 고정된 세 Step만 활성화한다")
+        void seedsOnlyRecordStartRoute() {
+            assertThat(jdbc.queryForList(
+                    "SELECT code FROM quest_routes ORDER BY id",
+                    String.class
+            )).containsExactly("ROUTE_RECORD_START");
+            assertThat(seedSteps()).containsExactly(
+                    new SeedStep(
+                            "RS_RECORD_01_LEAVE_TRACE",
+                            1,
+                            "첫 흔적 남기기",
+                            "QUEST_COMPLETION_SET",
+                            1,
+                            true,
+                            true,
+                            false,
+                            "Q_RECORD_FIRST_TRACE",
+                            "REQUIRED"
+                    ),
+                    new SeedStep(
+                            "RS_RECORD_02_CONNECT_TRACES",
+                            2,
+                            "흔적 연결하기",
+                            "QUEST_COMPLETION_SET",
+                            1,
+                            true,
+                            true,
+                            false,
+                            "Q_RECORD_THREE_TRACES",
+                            "REQUIRED"
+                    ),
+                    new SeedStep(
+                            "RS_RECORD_03_LOOK_BACK",
+                            3,
+                            "돌아보기",
+                            "QUEST_COMPLETION_SET",
+                            1,
+                            true,
+                            true,
+                            false,
+                            "Q_RECORD_WEEKLY_LOOKBACK",
+                            "REQUIRED"
+                    )
+            );
+        }
+    }
+
+    private List<String> tableNames() {
+        return jdbc.queryForList("""
+                SELECT table_name
+                FROM information_schema.tables
+                WHERE table_schema = DATABASE()
+                  AND table_name IN (
+                    'quest_routes',
+                    'quest_route_steps',
+                    'quest_route_step_quests',
+                    'player_quest_routes'
+                  )
+                ORDER BY table_name
+                """, String.class);
+    }
+
+    private Set<String> columnNames(String tableName) {
+        return Set.copyOf(jdbc.queryForList("""
+                SELECT column_name
+                FROM information_schema.columns
+                WHERE table_schema = DATABASE()
+                  AND table_name = ?
+                """, String.class, tableName));
+    }
+
+    private List<String> uniqueIndexes(String tableName) {
+        return jdbc.queryForList("""
+                SELECT DISTINCT index_name
+                FROM information_schema.statistics
+                WHERE table_schema = DATABASE()
+                  AND table_name = ?
+                  AND non_unique = 0
+                ORDER BY index_name
+                """, String.class, tableName);
+    }
+
+    private List<String> indexColumns(String tableName, String indexName) {
+        return jdbc.queryForList("""
+                SELECT column_name
+                FROM information_schema.statistics
+                WHERE table_schema = DATABASE()
+                  AND table_name = ?
+                  AND index_name = ?
+                ORDER BY seq_in_index
+                """, String.class, tableName, indexName);
+    }
+
+    private Set<String> foreignKeys() {
+        return Set.copyOf(jdbc.queryForList("""
+                SELECT constraint_name
+                FROM information_schema.referential_constraints
+                WHERE constraint_schema = DATABASE()
+                  AND table_name IN (
+                    'quest_route_steps',
+                    'quest_route_step_quests',
+                    'player_quest_routes'
+                  )
+                """, String.class));
+    }
+
+    private List<SeedStep> seedSteps() {
+        return jdbc.query("""
+                SELECT
+                    step.step_code,
+                    step.step_order,
+                    step.title,
+                    step.criterion_type,
+                    step.required_evidence_count,
+                    step.user_advance_required,
+                    step.retroactive_evidence_allowed,
+                    step.skip_allowed,
+                    quest.code AS quest_code,
+                    link.requirement_type
+                FROM quest_route_steps step
+                JOIN quest_routes route ON route.id = step.route_id
+                JOIN quest_route_step_quests link ON link.step_id = step.id
+                JOIN quests quest ON quest.id = link.quest_id
+                WHERE route.code = 'ROUTE_RECORD_START'
+                ORDER BY step.step_order
+                """, (resultSet, rowNumber) -> new SeedStep(
+                resultSet.getString("step_code"),
+                resultSet.getInt("step_order"),
+                resultSet.getString("title"),
+                resultSet.getString("criterion_type"),
+                resultSet.getInt("required_evidence_count"),
+                resultSet.getBoolean("user_advance_required"),
+                resultSet.getBoolean("retroactive_evidence_allowed"),
+                resultSet.getBoolean("skip_allowed"),
+                resultSet.getString("quest_code"),
+                resultSet.getString("requirement_type")
+        ));
+    }
+
+    private Long routeId(String code) {
+        return jdbc.queryForObject(
+                "SELECT id FROM quest_routes WHERE code = ?",
+                Long.class,
+                code
+        );
+    }
+
+    private Long stepId(Long routeId, int stepOrder) {
+        return jdbc.queryForObject(
+                "SELECT id FROM quest_route_steps WHERE route_id = ? AND step_order = ?",
+                Long.class,
+                routeId,
+                stepOrder
+        );
+    }
+
+    private Long insertSecondRoute() {
+        jdbc.update("""
+                INSERT INTO quest_routes (
+                    code, definition_version, title, description,
+                    primary_role_template_code, created_at, updated_at
+                ) VALUES (
+                    'ROUTE_TEST_SECOND', 1, 'Second', NULL, NULL,
+                    CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
+                )
+                """);
+        return routeId("ROUTE_TEST_SECOND");
+    }
+
+    private Long insertSecondRouteStep(Long routeId) {
+        jdbc.update("""
+                INSERT INTO quest_route_steps (
+                    route_id, step_code, step_order, title, description,
+                    criterion_type, required_evidence_count,
+                    user_advance_required, retroactive_evidence_allowed,
+                    skip_allowed
+                ) VALUES (
+                    ?, 'ROUTE_TEST_SECOND_STEP', 1, 'Second step', NULL,
+                    'QUEST_COMPLETION_SET', 1, b'1', b'1', b'0'
+                )
+                """, routeId);
+        return stepId(routeId, 1);
+    }
+
+    private void insertPlayerRoute(
+            Long playerId,
+            Long routeId,
+            Long currentStepId
+    ) {
+        jdbc.update("""
+                INSERT INTO player_quest_routes (
+                    player_id, route_id, current_step_id, status,
+                    selected_at, completed_at, version,
+                    created_at, updated_at
+                ) VALUES (
+                    ?, ?, ?, 'IN_PROGRESS', CURRENT_TIMESTAMP(6), NULL, 0,
+                    CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
+                )
+                """, playerId, routeId, currentStepId);
+    }
+
+    private record SeedStep(
+            String stepCode,
+            int stepOrder,
+            String title,
+            String criterionType,
+            int requiredEvidenceCount,
+            boolean userAdvanceRequired,
+            boolean retroactiveEvidenceAllowed,
+            boolean skipAllowed,
+            String questCode,
+            String requirementType
+    ) {
+    }
+}

--- a/src/test/java/online/lifeasgame/migration/QuestRouteFlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/QuestRouteFlywayMigrationTest.java
@@ -1,6 +1,7 @@
 package online.lifeasgame.migration;
 
 import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -166,6 +167,63 @@ class QuestRouteFlywayMigrationTest {
                             "REQUIRED"
                     )
             );
+        }
+
+        @Test
+        @DisplayName("동일한 stable Quest code가 있으면 기존 정의를 덮어쓰지 않는다")
+        void preservesExistingQuestDefinitionOnStableCodeConflict() {
+            flyway.clean();
+            Flyway.configure()
+                    .dataSource(
+                            MYSQL.getJdbcUrl(),
+                            MYSQL.getUsername(),
+                            MYSQL.getPassword()
+                    )
+                    .locations("classpath:db/migration")
+                    .target(MigrationVersion.fromVersion("19"))
+                    .baselineOnMigrate(false)
+                    .cleanDisabled(false)
+                    .load()
+                    .migrate();
+            jdbc.update("""
+                    INSERT INTO quests (
+                        reward_exp,
+                        definition_version,
+                        target_value,
+                        created_at,
+                        due_at,
+                        updated_at,
+                        code,
+                        title_id,
+                        reward_stats,
+                        reward_profile_code,
+                        category,
+                        semantic_category,
+                        description_md,
+                        repeat_rule,
+                        completion_policy,
+                        role_template_code,
+                        target_type,
+                        progress_source
+                    ) VALUES (
+                        0, 7, 1, CURRENT_TIMESTAMP(6), NULL,
+                        CURRENT_TIMESTAMP(6), 'Q_RECORD_FIRST_TRACE',
+                        '기존 정의', JSON_OBJECT(), 'RP_NONE', NULL,
+                        'RECORD', '기존 설명', 'ONCE', 'AUTO', NULL,
+                        'COUNT', 'RECORD_CREATED'
+                    )
+                    """);
+
+            flyway.migrate();
+
+            assertThat(jdbc.queryForMap("""
+                    SELECT definition_version, title_id
+                    FROM quests
+                    WHERE code = 'Q_RECORD_FIRST_TRACE'
+                    """))
+                    .containsEntry("definition_version", 7)
+                    .containsEntry("title_id", "기존 정의");
+            assertThat(routeId("ROUTE_RECORD_START")).isPositive();
         }
     }
 

--- a/src/test/java/online/lifeasgame/migration/RolePersonPersistenceFoundationFlywayTest.java
+++ b/src/test/java/online/lifeasgame/migration/RolePersonPersistenceFoundationFlywayTest.java
@@ -46,9 +46,9 @@ class RolePersonPersistenceFoundationFlywayTest {
     }
 
     @Test
-    @DisplayName("V1~V19가 clean MySQL에 적용되고 table/column/index/check/FK 계약을 고정한다")
+    @DisplayName("V20까지 적용된 schema에서 V19 Role/Person 계약을 고정한다")
     void createsSchemaContract() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("19");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("20");
         assertThat(tableContracts()).containsExactly(
                 new TableContract("roles", "InnoDB", "utf8mb4_0900_ai_ci"),
                 new TableContract("persons", "InnoDB", "utf8mb4_0900_ai_ci"),

--- a/src/test/java/online/lifeasgame/quest/api/player/QuestRouteControllerTest.java
+++ b/src/test/java/online/lifeasgame/quest/api/player/QuestRouteControllerTest.java
@@ -1,0 +1,233 @@
+package online.lifeasgame.quest.api.player;
+
+import online.lifeasgame.platform.security.jwt.JwtPrincipal;
+import online.lifeasgame.platform.security.jwt.JwtProvider;
+import online.lifeasgame.platform.web.error.docs.ErrorDocLinker;
+import online.lifeasgame.quest.application.QuestRouteAdvanceService;
+import online.lifeasgame.quest.application.QuestRouteQueryService;
+import online.lifeasgame.quest.application.QuestRouteSelectService;
+import online.lifeasgame.quest.application.result.QuestRouteResult;
+import online.lifeasgame.support.WebMvcTestConfig;
+import online.lifeasgame.system.bootstrap.error.handler.AppErrorProperties;
+import online.lifeasgame.system.bootstrap.security.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = QuestRouteController.class)
+@Import({SecurityConfig.class, WebMvcTestConfig.class})
+@DisplayName("QuestRoute player API")
+class QuestRouteControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private QuestRouteSelectService selectService;
+
+    @MockitoBean
+    private QuestRouteAdvanceService advanceService;
+
+    @MockitoBean
+    private QuestRouteQueryService queryService;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private AppErrorProperties appErrorProperties;
+
+    @MockitoBean
+    private ErrorDocLinker errorDocLinker;
+
+    @Nested
+    @DisplayName("Route catalog를 조회할 때")
+    class QueryCatalog {
+
+        @Test
+        @DisplayName("definition과 미선택 Step 상태를 반환한다")
+        void returnsRouteCatalog() throws Exception {
+            when(queryService.routes()).thenReturn(
+                    new QuestRouteResult.Routes(List.of(route(null)))
+            );
+
+            mockMvc.perform(authenticated(get("/api/v1/quest-routes")))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result.routes[0].code")
+                            .value("ROUTE_RECORD_START"))
+                    .andExpect(jsonPath("$.result.routes[0].steps[0].state")
+                            .value("LOCKED"));
+
+            verify(queryService).routes();
+        }
+
+        @Test
+        @DisplayName("고정된 /my 경로는 routeId 상세와 충돌하지 않는다")
+        void returnsMySelectedRoutes() throws Exception {
+            when(queryService.myRoutes()).thenReturn(
+                    new QuestRouteResult.Routes(List.of(route(progress(350L))))
+            );
+
+            mockMvc.perform(authenticated(get("/api/v1/quest-routes/my")))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result.routes[0].playerProgress.status")
+                            .value("IN_PROGRESS"));
+
+            verify(queryService).myRoutes();
+        }
+
+        @Test
+        @DisplayName("내 Route의 Step 상세 경로를 그대로 매핑한다")
+        void returnsMyStepDetail() throws Exception {
+            QuestRouteResult.Route route = route(progress(350L));
+            when(queryService.myStep(250L, 350L)).thenReturn(
+                    new QuestRouteResult.StepDetail(
+                            route.id(),
+                            route.code(),
+                            route.playerProgress(),
+                            route.steps().getFirst()
+                    )
+            );
+
+            mockMvc.perform(authenticated(get(
+                            "/api/v1/quest-routes/my/{routeId}/steps/{stepId}",
+                            250L,
+                            350L
+                    )))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result.routeId").value(250L))
+                    .andExpect(jsonPath("$.result.step.id").value(350L));
+
+            verify(queryService).myStep(250L, 350L);
+        }
+    }
+
+    @Nested
+    @DisplayName("Route를 선택할 때")
+    class SelectRoute {
+
+        @Test
+        @DisplayName("path routeId만 전달하고 선택된 runtime을 반환한다")
+        void selectsWithSelfIdentityOwnedByService() throws Exception {
+            when(selectService.select(250L)).thenReturn(route(progress(350L)));
+
+            mockMvc.perform(authenticated(post(
+                            "/api/v1/quest-routes/{routeId}/select",
+                            250L
+                    )))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result.playerProgress.currentStepId")
+                            .value(350L));
+
+            verify(selectService).select(250L);
+        }
+    }
+
+    @Nested
+    @DisplayName("현재 Step을 진행할 때")
+    class AdvanceRoute {
+
+        @Test
+        @DisplayName("request의 expectedStepId만 command 경계로 전달한다")
+        void advancesWithExpectedStepOnly() throws Exception {
+            when(advanceService.advance(250L, 350L))
+                    .thenReturn(route(progress(351L)));
+
+            mockMvc.perform(authenticated(post(
+                            "/api/v1/quest-routes/my/{routeId}/advance",
+                            250L
+                    )).contentType("application/json")
+                            .content("{\"expectedStepId\":350}"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result.playerProgress.currentStepId")
+                            .value(351L));
+
+            verify(advanceService).advance(250L, 350L);
+        }
+
+        @Test
+        @DisplayName("expectedStepId가 없으면 Application Service를 호출하지 않고 400을 반환한다")
+        void rejectsMissingExpectedStep() throws Exception {
+            mockMvc.perform(authenticated(post(
+                            "/api/v1/quest-routes/my/{routeId}/advance",
+                            250L
+                    )).contentType("application/json")
+                            .content("{}"))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    private MockHttpServletRequestBuilder authenticated(
+            MockHttpServletRequestBuilder request
+    ) {
+        return request.with(authentication(
+                        new UsernamePasswordAuthenticationToken(
+                                new JwtPrincipal(250L, 250001L),
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        )
+                ))
+                .header("Authorization", "Bearer test-token");
+    }
+
+    private QuestRouteResult.Route route(
+            QuestRouteResult.PlayerProgress progress
+    ) {
+        return new QuestRouteResult.Route(
+                250L,
+                "ROUTE_RECORD_START",
+                1,
+                "기록으로 시작하기",
+                "기록을 남기는 방향",
+                null,
+                progress,
+                List.of(new QuestRouteResult.Step(
+                        350L,
+                        "RS_RECORD_01_LEAVE_TRACE",
+                        1,
+                        "첫 흔적 남기기",
+                        null,
+                        "QUEST_COMPLETION_SET",
+                        1,
+                        true,
+                        true,
+                        false,
+                        false,
+                        progress == null ? "LOCKED" : "CURRENT",
+                        List.of(new QuestRouteResult.QuestLink(
+                                450L,
+                                "REQUIRED"
+                        ))
+                ))
+        );
+    }
+
+    private QuestRouteResult.PlayerProgress progress(Long currentStepId) {
+        return new QuestRouteResult.PlayerProgress(
+                550L,
+                currentStepId,
+                "IN_PROGRESS",
+                Instant.parse("2026-08-10T01:00:00Z"),
+                null
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/quest/application/QuestArchitectureAlignmentTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/QuestArchitectureAlignmentTest.java
@@ -4,6 +4,8 @@ import online.lifeasgame.core.event.DomainEventPublisher;
 import online.lifeasgame.core.security.CurrentPlayerAccessor;
 import online.lifeasgame.quest.application.automation.QuestSignalProcessingAttempt;
 import online.lifeasgame.quest.application.command.QuestCommand;
+import online.lifeasgame.quest.api.player.QuestRouteController;
+import online.lifeasgame.quest.api.player.request.QuestRouteRequest;
 import online.lifeasgame.quest.application.internal.event.QuestRewardReadyFact;
 import online.lifeasgame.quest.application.query.QuestQuery;
 import online.lifeasgame.quest.domain.event.QuestEvent;
@@ -11,6 +13,7 @@ import online.lifeasgame.reward.application.event.QuestRewardReadyBridge;
 import org.junit.jupiter.api.Test;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -26,6 +29,7 @@ class QuestArchitectureAlignmentTest {
     void simpleFacadeAndMisleadingOrchestrationNamesAreRemoved() {
         for (String className : Set.of(
                 "online.lifeasgame.quest.application.QuestFacade",
+                "online.lifeasgame.quest.application.QuestRouteFacade",
                 "online.lifeasgame.quest.application.automation.QuestAutomationService",
                 "online.lifeasgame.quest.application.saga.QuestRewardSaga"
         )) {
@@ -39,10 +43,22 @@ class QuestArchitectureAlignmentTest {
         for (Class<?> type : List.of(
                 QuestService.class,
                 QuestQueryService.class,
-                QuestManualCheckService.class
+                QuestManualCheckService.class,
+                QuestRouteSelectService.class,
+                QuestRouteAdvanceService.class,
+                QuestRouteQueryService.class
         )) {
             assertThat(fieldTypes(type)).contains(CurrentPlayerAccessor.class);
         }
+        assertThat(fieldTypes(QuestRouteController.class))
+                .doesNotContain(CurrentPlayerAccessor.class);
+        assertThat(Arrays.stream(
+                        QuestRouteRequest.Advance.class.getRecordComponents()
+                ).map(component -> component.getName()))
+                .containsExactly("expectedStepId");
+        assertThat(QuestRouteController.class
+                .getAnnotation(RequestMapping.class).value())
+                .containsExactly("/api/v1/quest-routes");
     }
 
     @Test

--- a/src/test/java/online/lifeasgame/quest/application/QuestRouteApplicationIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/QuestRouteApplicationIntegrationTest.java
@@ -6,17 +6,21 @@ import online.lifeasgame.quest.application.result.QuestRouteResult;
 import online.lifeasgame.quest.domain.PlayerQuestRouteStatus;
 import online.lifeasgame.quest.domain.QuestRouteStepState;
 import online.lifeasgame.quest.domain.error.QuestError;
+import online.lifeasgame.quest.domain.repository.PlayerQuestRouteRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -75,6 +79,12 @@ class QuestRouteApplicationIntegrationTest {
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PlayerQuestRouteRepository playerQuestRouteRepository;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
 
     @MockitoBean
     private CurrentPlayerAccessor currentPlayerAccessor;
@@ -152,6 +162,22 @@ class QuestRouteApplicationIntegrationTest {
         }
 
         @Test
+        @DisplayName("서로 다른 Player가 같은 Route를 동시에 선택하면 각각 runtime을 생성한다")
+        void createsIndependentRuntimesAcrossPlayers() throws Exception {
+            Long routeId = routeId();
+            when(currentPlayerAccessor.currentPlayerIdOrThrow())
+                    .thenReturn(PLAYER_ID, OTHER_PLAYER_ID);
+
+            List<String> outcomes = runConcurrently(
+                    () -> selectService.select(routeId).code()
+            );
+
+            assertThat(outcomes).containsOnly("ROUTE_RECORD_START");
+            assertThat(playerRouteCount(PLAYER_ID)).isEqualTo(1);
+            assertThat(playerRouteCount(OTHER_PLAYER_ID)).isEqualTo(1);
+        }
+
+        @Test
         @DisplayName("다른 Route를 선택해도 기존 Route를 취소하지 않는다")
         void keepsMultipleSelectedRoutes() {
             Long anotherRouteId = insertAnotherRoute();
@@ -162,6 +188,37 @@ class QuestRouteApplicationIntegrationTest {
             assertThat(playerRouteCount(PLAYER_ID)).isEqualTo(2);
             assertThat(playerRouteStatuses(PLAYER_ID))
                     .containsOnly(PlayerQuestRouteStatus.IN_PROGRESS.name());
+        }
+    }
+
+    @Nested
+    @DisplayName("선택 runtime을 DB에 생성할 때")
+    class PersistSelectedRoute {
+
+        @Test
+        @DisplayName("존재하지 않는 Route 또는 Step 참조의 무결성 실패를 전파한다")
+        void propagatesForeignKeyViolation() {
+            TransactionTemplate transaction =
+                    new TransactionTemplate(transactionManager);
+            Long routeId = routeId();
+            Long firstStepId = stepId("RS_RECORD_01_LEAVE_TRACE");
+
+            assertThatThrownBy(() -> transaction.executeWithoutResult(
+                    status -> playerQuestRouteRepository.insertIfAbsent(
+                            PLAYER_ID,
+                            Long.MAX_VALUE,
+                            firstStepId,
+                            COMPLETED_AT
+                    )
+            )).isInstanceOf(DataIntegrityViolationException.class);
+            assertThatThrownBy(() -> transaction.executeWithoutResult(
+                    status -> playerQuestRouteRepository.insertIfAbsent(
+                            PLAYER_ID,
+                            routeId,
+                            Long.MAX_VALUE,
+                            COMPLETED_AT
+                    )
+            )).isInstanceOf(DataIntegrityViolationException.class);
         }
     }
 
@@ -638,17 +695,24 @@ class QuestRouteApplicationIntegrationTest {
 
     private List<String> runConcurrently(ConcurrentAction action)
             throws Exception {
+        return runConcurrently(action, action);
+    }
+
+    private List<String> runConcurrently(
+            ConcurrentAction firstAction,
+            ConcurrentAction secondAction
+    ) throws Exception {
         ExecutorService executor = Executors.newFixedThreadPool(2);
         CountDownLatch ready = new CountDownLatch(2);
         CountDownLatch start = new CountDownLatch(1);
         try {
             Future<String> first = executor.submit(() -> run(
-                    action,
+                    firstAction,
                     ready,
                     start
             ));
             Future<String> second = executor.submit(() -> run(
-                    action,
+                    secondAction,
                     ready,
                     start
             ));

--- a/src/test/java/online/lifeasgame/quest/application/QuestRouteApplicationIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/QuestRouteApplicationIntegrationTest.java
@@ -1,0 +1,691 @@
+package online.lifeasgame.quest.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.quest.application.result.QuestRouteResult;
+import online.lifeasgame.quest.domain.PlayerQuestRouteStatus;
+import online.lifeasgame.quest.domain.QuestRouteStepState;
+import online.lifeasgame.quest.domain.error.QuestError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles({"test", "migration-test"})
+@DisplayName("QuestRoute Application 흐름")
+class QuestRouteApplicationIntegrationTest {
+
+    private static final Long PLAYER_ID = 250001L;
+    private static final Long OTHER_PLAYER_ID = 250002L;
+    private static final Instant COMPLETED_AT =
+            Instant.parse("2026-08-09T01:00:00Z");
+
+    @Container
+    private static final MySQLContainer<?> MYSQL =
+            new MySQLContainer<>("mysql:8.0.39")
+                    .withDatabaseName("lifeasgame_quest_route")
+                    .withUsername("lifeasgame")
+                    .withPassword("lifeasgame");
+
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add(
+                "spring.datasource.driver-class-name",
+                MYSQL::getDriverClassName
+        );
+        registry.add("app.outbox.enabled", () -> false);
+    }
+
+    @Autowired
+    private QuestRouteSelectService selectService;
+
+    @Autowired
+    private QuestRouteAdvanceService advanceService;
+
+    @Autowired
+    private QuestRouteQueryService queryService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @MockitoBean
+    private CurrentPlayerAccessor currentPlayerAccessor;
+
+    @BeforeEach
+    void setUp() {
+        when(currentPlayerAccessor.currentPlayerIdOrThrow())
+                .thenReturn(PLAYER_ID);
+        jdbcTemplate.update(
+                "DELETE FROM player_quest_routes WHERE player_id IN (?, ?)",
+                PLAYER_ID,
+                OTHER_PLAYER_ID
+        );
+        jdbcTemplate.update(
+                "DELETE FROM quest_acceptances WHERE player_id IN (?, ?)",
+                PLAYER_ID,
+                OTHER_PLAYER_ID
+        );
+        deleteTestRoute();
+        jdbcTemplate.update("""
+                DELETE link
+                FROM quest_route_step_quests link
+                JOIN quest_route_steps step ON step.id = link.step_id
+                JOIN quest_routes route ON route.id = step.route_id
+                JOIN quests quest ON quest.id = link.quest_id
+                WHERE route.code = 'ROUTE_RECORD_START'
+                  AND step.step_code = 'RS_RECORD_01_LEAVE_TRACE'
+                  AND quest.code = 'Q_RECORD_THREE_TRACES'
+                  AND link.requirement_type = 'OPTIONAL'
+                """);
+    }
+
+    @Nested
+    @DisplayName("Route를 선택할 때")
+    class SelectRoute {
+
+        @Test
+        @DisplayName("처음 선택하면 첫 Step이 current이고 Quest는 자동 수락하지 않는다")
+        void selectsFirstStepWithoutAcceptingQuest() {
+            QuestRouteResult.Route selected = selectService.select(routeId());
+
+            assertThat(selected.playerProgress().status())
+                    .isEqualTo(PlayerQuestRouteStatus.IN_PROGRESS.name());
+            assertThat(selected.playerProgress().currentStepId())
+                    .isEqualTo(stepId("RS_RECORD_01_LEAVE_TRACE"));
+            assertThat(selected.steps()).extracting(QuestRouteResult.Step::state)
+                    .containsExactly(
+                            QuestRouteStepState.CURRENT.name(),
+                            QuestRouteStepState.LOCKED.name(),
+                            QuestRouteStepState.LOCKED.name()
+                    );
+            assertThat(acceptanceCount(PLAYER_ID)).isZero();
+        }
+
+        @Test
+        @DisplayName("같은 Route를 순차 재선택하면 기존 runtime을 반환한다")
+        void returnsExistingRuntimeOnSequentialReplay() {
+            QuestRouteResult.Route first = selectService.select(routeId());
+            QuestRouteResult.Route replay = selectService.select(routeId());
+
+            assertThat(replay.playerProgress().id())
+                    .isEqualTo(first.playerProgress().id());
+            assertThat(playerRouteCount(PLAYER_ID)).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("같은 Route를 동시에 선택해도 runtime은 하나만 생성된다")
+        void createsOneRuntimeOnConcurrentSelection() throws Exception {
+            List<String> outcomes = runConcurrently(
+                    () -> selectService.select(routeId()).code()
+            );
+
+            assertThat(outcomes).containsOnly("ROUTE_RECORD_START");
+            assertThat(playerRouteCount(PLAYER_ID)).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("다른 Route를 선택해도 기존 Route를 취소하지 않는다")
+        void keepsMultipleSelectedRoutes() {
+            Long anotherRouteId = insertAnotherRoute();
+
+            selectService.select(routeId());
+            selectService.select(anotherRouteId);
+
+            assertThat(playerRouteCount(PLAYER_ID)).isEqualTo(2);
+            assertThat(playerRouteStatuses(PLAYER_ID))
+                    .containsOnly(PlayerQuestRouteStatus.IN_PROGRESS.name());
+        }
+    }
+
+    @Nested
+    @DisplayName("현재 Step의 Quest completion criteria를 평가할 때")
+    class EvaluateCriteria {
+
+        @Test
+        @DisplayName("required Quest가 미완료이면 current 상태를 유지한다")
+        void keepsCurrentWhenRequiredQuestIsIncomplete() {
+            selectService.select(routeId());
+
+            QuestRouteResult.Step current = queryService.myRoute(routeId())
+                    .steps().getFirst();
+
+            assertThat(current.criteriaSatisfied()).isFalse();
+            assertThat(current.state())
+                    .isEqualTo(QuestRouteStepState.CURRENT.name());
+        }
+
+        @Test
+        @DisplayName("Route 선택 전에 완료한 required Quest도 인정한다")
+        void countsRetroactiveQuestCompletion() {
+            completeQuest(
+                    PLAYER_ID,
+                    "Q_RECORD_FIRST_TRACE",
+                    COMPLETED_AT
+            );
+
+            selectService.select(routeId());
+            QuestRouteResult.Step current = queryService.myRoute(routeId())
+                    .steps().getFirst();
+
+            assertThat(current.criteriaSatisfied()).isTrue();
+            assertThat(current.state())
+                    .isEqualTo(QuestRouteStepState.READY_TO_ADVANCE.name());
+        }
+
+        @Test
+        @DisplayName("Optional Quest가 미완료여도 required criterion을 막지 않는다")
+        void ignoresIncompleteOptionalQuest() {
+            addOptionalQuestToFirstStep();
+            completeQuest(
+                    PLAYER_ID,
+                    "Q_RECORD_FIRST_TRACE",
+                    COMPLETED_AT
+            );
+            selectService.select(routeId());
+
+            QuestRouteResult.Step current = queryService.myRoute(routeId())
+                    .steps().getFirst();
+
+            assertThat(current.criteriaSatisfied()).isTrue();
+            assertThat(current.questLinks()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("다른 Player의 Quest 완료는 인정하지 않는다")
+        void ignoresAnotherPlayersCompletion() {
+            completeQuest(
+                    OTHER_PLAYER_ID,
+                    "Q_RECORD_FIRST_TRACE",
+                    COMPLETED_AT
+            );
+            selectService.select(routeId());
+
+            QuestRouteResult.Step current = queryService.myRoute(routeId())
+                    .steps().getFirst();
+
+            assertThat(current.criteriaSatisfied()).isFalse();
+            assertThat(current.state())
+                    .isEqualTo(QuestRouteStepState.CURRENT.name());
+        }
+    }
+
+    @Nested
+    @DisplayName("현재 Step을 명시적으로 advance할 때")
+    class AdvanceCurrentStep {
+
+        @Test
+        @DisplayName("criteria가 충족되지 않으면 상태를 변경하지 않는다")
+        void rejectsUnsatisfiedCriteria() {
+            Long routeId = routeId();
+            Long firstStepId = stepId("RS_RECORD_01_LEAVE_TRACE");
+            selectService.select(routeId);
+
+            assertRouteError(
+                    () -> advanceService.advance(routeId, firstStepId),
+                    QuestError.ROUTE_STEP_CRITERIA_NOT_SATISFIED
+            );
+            assertThat(currentStepId(PLAYER_ID, routeId))
+                    .isEqualTo(firstStepId);
+        }
+
+        @Test
+        @DisplayName("Quest 완료만으로 current Step은 이동하지 않는다")
+        void neverAutoAdvancesOnQuestCompletion() {
+            Long routeId = routeId();
+            Long firstStepId = stepId("RS_RECORD_01_LEAVE_TRACE");
+            selectService.select(routeId);
+
+            completeQuest(
+                    PLAYER_ID,
+                    "Q_RECORD_FIRST_TRACE",
+                    COMPLETED_AT
+            );
+
+            assertThat(currentStepId(PLAYER_ID, routeId))
+                    .isEqualTo(firstStepId);
+            assertThat(queryService.myRoute(routeId).steps().getFirst().state())
+                    .isEqualTo(QuestRouteStepState.READY_TO_ADVANCE.name());
+        }
+
+        @Test
+        @DisplayName("criteria가 충족되면 정확히 다음 한 Step으로 이동한다")
+        void advancesExactlyOneStep() {
+            Long routeId = routeId();
+            Long firstStepId = stepId("RS_RECORD_01_LEAVE_TRACE");
+            Long secondStepId = stepId("RS_RECORD_02_CONNECT_TRACES");
+            selectService.select(routeId);
+            completeQuest(
+                    PLAYER_ID,
+                    "Q_RECORD_FIRST_TRACE",
+                    COMPLETED_AT
+            );
+
+            QuestRouteResult.Route advanced = advanceService.advance(
+                    routeId,
+                    firstStepId
+            );
+
+            assertThat(advanced.playerProgress().currentStepId())
+                    .isEqualTo(secondStepId);
+            assertThat(currentStepId(PLAYER_ID, routeId))
+                    .isEqualTo(secondStepId);
+        }
+
+        @Test
+        @DisplayName("같은 expectedStepId replay는 두 번째 Step까지 넘기지 않는다")
+        void rejectsStaleReplay() {
+            Long routeId = routeId();
+            Long firstStepId = stepId("RS_RECORD_01_LEAVE_TRACE");
+            Long secondStepId = stepId("RS_RECORD_02_CONNECT_TRACES");
+            selectService.select(routeId);
+            completeQuest(
+                    PLAYER_ID,
+                    "Q_RECORD_FIRST_TRACE",
+                    COMPLETED_AT
+            );
+            advanceService.advance(routeId, firstStepId);
+
+            assertRouteError(
+                    () -> advanceService.advance(routeId, firstStepId),
+                    QuestError.ROUTE_STEP_NOT_CURRENT
+            );
+            assertThat(currentStepId(PLAYER_ID, routeId))
+                    .isEqualTo(secondStepId);
+        }
+
+        @Test
+        @DisplayName("동일 Step 동시 advance는 최대 한 번만 전이한다")
+        void serializesConcurrentAdvance() throws Exception {
+            Long routeId = routeId();
+            Long firstStepId = stepId("RS_RECORD_01_LEAVE_TRACE");
+            Long secondStepId = stepId("RS_RECORD_02_CONNECT_TRACES");
+            selectService.select(routeId);
+            completeQuest(
+                    PLAYER_ID,
+                    "Q_RECORD_FIRST_TRACE",
+                    COMPLETED_AT
+            );
+
+            List<String> outcomes = runConcurrently(() -> {
+                try {
+                    advanceService.advance(routeId, firstStepId);
+                    return "ADVANCED";
+                } catch (DomainException exception) {
+                    return exception.code();
+                }
+            });
+
+            assertThat(outcomes).containsExactlyInAnyOrder(
+                    "ADVANCED",
+                    QuestError.ROUTE_STEP_NOT_CURRENT.code()
+            );
+            assertThat(currentStepId(PLAYER_ID, routeId))
+                    .isEqualTo(secondStepId);
+        }
+
+        @Test
+        @DisplayName("마지막 Step advance는 Route를 완료하고 replay를 거부한다")
+        void completesFinalStepOnce() {
+            Long routeId = routeId();
+            Long first = stepId("RS_RECORD_01_LEAVE_TRACE");
+            Long second = stepId("RS_RECORD_02_CONNECT_TRACES");
+            Long third = stepId("RS_RECORD_03_LOOK_BACK");
+            completeQuest(
+                    PLAYER_ID,
+                    "Q_RECORD_FIRST_TRACE",
+                    COMPLETED_AT
+            );
+            completeQuest(
+                    PLAYER_ID,
+                    "Q_RECORD_THREE_TRACES",
+                    COMPLETED_AT.plusSeconds(1)
+            );
+            completeQuest(
+                    PLAYER_ID,
+                    "Q_RECORD_WEEKLY_LOOKBACK",
+                    COMPLETED_AT.plusSeconds(2)
+            );
+            selectService.select(routeId);
+            advanceService.advance(routeId, first);
+            advanceService.advance(routeId, second);
+
+            QuestRouteResult.Route completed = advanceService.advance(
+                    routeId,
+                    third
+            );
+
+            assertThat(completed.playerProgress().status())
+                    .isEqualTo(PlayerQuestRouteStatus.COMPLETED.name());
+            assertThat(completed.playerProgress().completedAt()).isNotNull();
+            assertThat(completed.steps())
+                    .extracting(QuestRouteResult.Step::state)
+                    .containsOnly(QuestRouteStepState.COMPLETED.name());
+            assertRouteError(
+                    () -> advanceService.advance(routeId, third),
+                    QuestError.ROUTE_ALREADY_COMPLETED
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("Route 진행 상태를 조회할 때")
+    class QueryRouteProgress {
+
+        @Test
+        @DisplayName("미선택 Route의 모든 Step은 LOCKED다")
+        void showsAllStepsLockedBeforeSelection() {
+            QuestRouteResult.Route route = queryService.route(routeId());
+
+            assertThat(route.playerProgress()).isNull();
+            assertThat(route.steps())
+                    .extracting(QuestRouteResult.Step::state)
+                    .containsOnly(QuestRouteStepState.LOCKED.name());
+        }
+
+        @Test
+        @DisplayName("선택 후 지난 Step, 준비된 current, 이후 Step을 구분한다")
+        void derivesCompletedReadyAndLockedStates() {
+            Long routeId = routeId();
+            completeQuest(
+                    PLAYER_ID,
+                    "Q_RECORD_FIRST_TRACE",
+                    COMPLETED_AT
+            );
+            completeQuest(
+                    PLAYER_ID,
+                    "Q_RECORD_THREE_TRACES",
+                    COMPLETED_AT.plusSeconds(1)
+            );
+            selectService.select(routeId);
+            advanceService.advance(
+                    routeId,
+                    stepId("RS_RECORD_01_LEAVE_TRACE")
+            );
+
+            QuestRouteResult.Route route = queryService.myRoute(routeId);
+
+            assertThat(route.steps()).extracting(QuestRouteResult.Step::state)
+                    .containsExactly(
+                            QuestRouteStepState.COMPLETED.name(),
+                            QuestRouteStepState.READY_TO_ADVANCE.name(),
+                            QuestRouteStepState.LOCKED.name()
+                    );
+            assertThat(queryService.myStep(
+                    routeId,
+                    stepId("RS_RECORD_02_CONNECT_TRACES")
+            ).step().state()).isEqualTo(
+                    QuestRouteStepState.READY_TO_ADVANCE.name()
+            );
+        }
+    }
+
+    private Long routeId() {
+        return jdbcTemplate.queryForObject(
+                "SELECT id FROM quest_routes WHERE code = 'ROUTE_RECORD_START'",
+                Long.class
+        );
+    }
+
+    private Long stepId(String stepCode) {
+        return jdbcTemplate.queryForObject(
+                """
+                SELECT step.id
+                FROM quest_route_steps step
+                JOIN quest_routes route ON route.id = step.route_id
+                WHERE route.code = 'ROUTE_RECORD_START'
+                  AND step.step_code = ?
+                """,
+                Long.class,
+                stepCode
+        );
+    }
+
+    private void completeQuest(
+            Long playerId,
+            String questCode,
+            Instant completedAt
+    ) {
+        Long questId = jdbcTemplate.queryForObject(
+                "SELECT id FROM quests WHERE code = ?",
+                Long.class,
+                questCode
+        );
+        jdbcTemplate.update("""
+                INSERT INTO quest_acceptances (
+                    period_start,
+                    period_end,
+                    accepted_at,
+                    period_key,
+                    progress_value,
+                    completed_at,
+                    goal_reached_at,
+                    created_at,
+                    guild_id,
+                    party_id,
+                    player_id,
+                    quest_id,
+                    updated_at,
+                    version,
+                    idempotency_key,
+                    status
+                ) VALUES (?, ?, ?, NULL, 1, ?, ?, ?, NULL, NULL, ?, ?, ?, 0, NULL, 'COMPLETED')
+                """,
+                LocalDate.of(1970, 1, 1),
+                LocalDate.of(9999, 12, 31),
+                completedAt.minusSeconds(1),
+                completedAt,
+                completedAt,
+                completedAt,
+                playerId,
+                questId,
+                completedAt
+        );
+    }
+
+    private void addOptionalQuestToFirstStep() {
+        jdbcTemplate.update("""
+                INSERT INTO quest_route_step_quests (
+                    step_id,
+                    quest_id,
+                    requirement_type
+                )
+                SELECT ?, quest.id, 'OPTIONAL'
+                FROM quests quest
+                WHERE quest.code = 'Q_RECORD_THREE_TRACES'
+                """, stepId("RS_RECORD_01_LEAVE_TRACE"));
+    }
+
+    private Long insertAnotherRoute() {
+        jdbcTemplate.update("""
+                INSERT INTO quest_routes (
+                    code,
+                    definition_version,
+                    title,
+                    description,
+                    primary_role_template_code,
+                    created_at,
+                    updated_at
+                ) VALUES (
+                    'ROUTE_TEST_SECOND',
+                    1,
+                    '두 번째 방향',
+                    NULL,
+                    NULL,
+                    CURRENT_TIMESTAMP(6),
+                    CURRENT_TIMESTAMP(6)
+                )
+                """);
+        Long routeId = jdbcTemplate.queryForObject(
+                "SELECT id FROM quest_routes WHERE code = 'ROUTE_TEST_SECOND'",
+                Long.class
+        );
+        jdbcTemplate.update("""
+                INSERT INTO quest_route_steps (
+                    route_id,
+                    step_code,
+                    step_order,
+                    title,
+                    description,
+                    criterion_type,
+                    required_evidence_count,
+                    user_advance_required,
+                    retroactive_evidence_allowed,
+                    skip_allowed
+                ) VALUES (?, 'ROUTE_TEST_SECOND_STEP', 1, '두 번째 단계', NULL,
+                    'QUEST_COMPLETION_SET', 1, b'1', b'1', b'0')
+                """, routeId);
+        Long stepId = jdbcTemplate.queryForObject(
+                "SELECT id FROM quest_route_steps WHERE route_id = ?",
+                Long.class,
+                routeId
+        );
+        jdbcTemplate.update("""
+                INSERT INTO quest_route_step_quests (
+                    step_id,
+                    quest_id,
+                    requirement_type
+                )
+                SELECT ?, quest.id, 'REQUIRED'
+                FROM quests quest
+                WHERE quest.code = 'Q_RECORD_FIRST_TRACE'
+                """, stepId);
+        return routeId;
+    }
+
+    private void deleteTestRoute() {
+        jdbcTemplate.update("""
+                DELETE link
+                FROM quest_route_step_quests link
+                JOIN quest_route_steps step ON step.id = link.step_id
+                JOIN quest_routes route ON route.id = step.route_id
+                WHERE route.code = 'ROUTE_TEST_SECOND'
+                """);
+        jdbcTemplate.update("""
+                DELETE step
+                FROM quest_route_steps step
+                JOIN quest_routes route ON route.id = step.route_id
+                WHERE route.code = 'ROUTE_TEST_SECOND'
+                """);
+        jdbcTemplate.update(
+                "DELETE FROM quest_routes WHERE code = 'ROUTE_TEST_SECOND'"
+        );
+    }
+
+    private long acceptanceCount(Long playerId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM quest_acceptances WHERE player_id = ?",
+                Long.class,
+                playerId
+        );
+    }
+
+    private long playerRouteCount(Long playerId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM player_quest_routes WHERE player_id = ?",
+                Long.class,
+                playerId
+        );
+    }
+
+    private List<String> playerRouteStatuses(Long playerId) {
+        return jdbcTemplate.queryForList(
+                "SELECT status FROM player_quest_routes WHERE player_id = ?",
+                String.class,
+                playerId
+        );
+    }
+
+    private Long currentStepId(Long playerId, Long routeId) {
+        return jdbcTemplate.queryForObject(
+                """
+                SELECT current_step_id
+                FROM player_quest_routes
+                WHERE player_id = ? AND route_id = ?
+                """,
+                Long.class,
+                playerId,
+                routeId
+        );
+    }
+
+    private List<String> runConcurrently(ConcurrentAction action)
+            throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        try {
+            Future<String> first = executor.submit(() -> run(
+                    action,
+                    ready,
+                    start
+            ));
+            Future<String> second = executor.submit(() -> run(
+                    action,
+                    ready,
+                    start
+            ));
+            assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+            start.countDown();
+            return List.of(
+                    first.get(20, TimeUnit.SECONDS),
+                    second.get(20, TimeUnit.SECONDS)
+            );
+        } finally {
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(5, TimeUnit.SECONDS))
+                    .isTrue();
+        }
+    }
+
+    private String run(
+            ConcurrentAction action,
+            CountDownLatch ready,
+            CountDownLatch start
+    ) throws Exception {
+        ready.countDown();
+        start.await();
+        return action.run();
+    }
+
+    private void assertRouteError(Runnable action, QuestError error) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(
+                        DomainException.class,
+                        exception -> assertThat(exception.getErrorCode())
+                                .isEqualTo(error)
+                );
+    }
+
+    @FunctionalInterface
+    private interface ConcurrentAction {
+        String run() throws Exception;
+    }
+}

--- a/src/test/java/online/lifeasgame/quest/application/automation/LifeLogRecordedQuestProgressIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/automation/LifeLogRecordedQuestProgressIntegrationTest.java
@@ -14,6 +14,7 @@ import online.lifeasgame.quest.domain.QuestCode;
 import online.lifeasgame.quest.domain.QuestStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -129,200 +130,216 @@ class LifeLogRecordedQuestProgressIntegrationTest {
         transactionTemplate = new TransactionTemplate(transactionManager);
     }
 
-    @Test
-    @DisplayName("Acceptance가 없던 Fact는 나중에 수락해도 replay로 진행하지 않는다")
-    void neverReplaysFactSeenWithoutAcceptance() {
-        LifeLogRecorded firstDelivery = regular(
-                "215-no-acceptance-a",
-                215100L,
-                ACCEPTED_AT.plusSeconds(1)
-        );
+    @Nested
+    @DisplayName("LifeLog Fact와 Quest Acceptance 시간 경계를 평가할 때")
+    class AcceptanceBoundary {
 
-        appendAndRelay(firstDelivery);
+        @Test
+        @DisplayName("Acceptance가 없던 Fact는 나중에 수락해도 replay로 진행하지 않는다")
+        void neverReplaysFactSeenWithoutAcceptance() {
+            LifeLogRecorded firstDelivery = regular(
+                    "215-no-acceptance-a",
+                    215100L,
+                    ACCEPTED_AT.plusSeconds(1)
+            );
 
-        assertThat(acceptanceCount()).isZero();
-        assertThat(receiptCount()).isEqualTo(2);
+            appendAndRelay(firstDelivery);
 
-        accept(QuestCode.Q_RECORD_THREE_TRACES);
-        appendAndRelay(regular(
-                "215-no-acceptance-b",
-                firstDelivery.lifeLogId(),
-                firstDelivery.occurredAt()
-        ));
+            assertThat(acceptanceCount()).isZero();
+            assertThat(receiptCount()).isEqualTo(2);
 
-        assertThat(progress(QuestCode.Q_RECORD_THREE_TRACES)).isZero();
-        assertThat(receiptCount(QuestCode.Q_RECORD_THREE_TRACES))
-                .isEqualTo(1);
-    }
+            accept(QuestCode.Q_RECORD_THREE_TRACES);
+            appendAndRelay(regular(
+                    "215-no-acceptance-b",
+                    firstDelivery.lifeLogId(),
+                    firstDelivery.occurredAt()
+            ));
 
-    @Test
-    @DisplayName("acceptedAt 이전 Fact는 다른 eventId 재전달까지 영구 무시한다")
-    void permanentlyIgnoresPreAcceptanceFact() {
-        accept(QuestCode.Q_RECORD_THREE_TRACES);
-        LifeLogRecorded beforeAcceptance = regular(
-                "215-pre-accept-a",
-                215101L,
-                ACCEPTED_AT.minusSeconds(1)
-        );
-
-        appendAndRelay(beforeAcceptance);
-        appendAndRelay(regular(
-                "215-pre-accept-b",
-                beforeAcceptance.lifeLogId(),
-                beforeAcceptance.occurredAt()
-        ));
-
-        assertThat(progress(QuestCode.Q_RECORD_THREE_TRACES)).isZero();
-        assertThat(receiptCount(QuestCode.Q_RECORD_THREE_TRACES))
-                .isEqualTo(1);
-    }
-
-    @Test
-    @DisplayName("취소 후 같은 period 재수락은 기존 row를 초기화하고 old Fact를 이월하지 않는다")
-    void restartsCanceledAcceptanceWithoutCarryingOldFacts() {
-        accept(QuestCode.Q_RECORD_THREE_TRACES);
-        appendAndRelay(regular(
-                "215-reaccept-before-cancel",
-                215108L,
-                ACCEPTED_AT.plusSeconds(1)
-        ));
-        assertThat(progress(QuestCode.Q_RECORD_THREE_TRACES)).isEqualTo(1);
-        LifeLogRecorded oldFact = regular(
-                "215-reaccept-old-a",
-                215109L,
-                ACCEPTED_AT.plusSeconds(2)
-        );
-
-        questService.cancel(
-                PLAYER_ID,
-                new QuestCommand.Cancel(
-                        QuestCode.Q_RECORD_THREE_TRACES.value(),
-                        "restart integration test"
-                )
-        );
-        Instant restartedAt = ACCEPTED_AT.plusSeconds(10);
-        clock.set(restartedAt);
-        accept(QuestCode.Q_RECORD_THREE_TRACES);
-
-        assertThat(acceptanceCount()).isEqualTo(1);
-        assertThat(acceptedAt(QuestCode.Q_RECORD_THREE_TRACES))
-                .isEqualTo(restartedAt);
-        assertThat(status(QuestCode.Q_RECORD_THREE_TRACES))
-                .isEqualTo(QuestStatus.IN_PROGRESS.name());
-        assertThat(progress(QuestCode.Q_RECORD_THREE_TRACES)).isZero();
-
-        appendAndRelay(oldFact);
-
-        assertThat(progress(QuestCode.Q_RECORD_THREE_TRACES)).isZero();
-        assertThat(receiptCount(QuestCode.Q_RECORD_THREE_TRACES))
-                .isEqualTo(2);
-
-        appendAndRelay(regular(
-                "215-reaccept-new",
-                215110L,
-                restartedAt.plusSeconds(1)
-        ));
-
-        assertThat(progress(QuestCode.Q_RECORD_THREE_TRACES)).isEqualTo(1);
-        assertThat(status(QuestCode.Q_RECORD_THREE_TRACES))
-                .isEqualTo(QuestStatus.IN_PROGRESS.name());
-
-        appendAndRelay(regular(
-                "215-reaccept-old-b",
-                oldFact.lifeLogId(),
-                oldFact.occurredAt()
-        ));
-
-        assertThat(progress(QuestCode.Q_RECORD_THREE_TRACES)).isEqualTo(1);
-        assertThat(receiptCount(QuestCode.Q_RECORD_THREE_TRACES))
-                .isEqualTo(3);
-    }
-
-    @Test
-    @DisplayName("한 LifeLog가 첫 기록과 세 기록 Quest를 동시에 진행한다")
-    void progressesFirstAndThreeTracesTogether() {
-        accept(QuestCode.Q_RECORD_FIRST_TRACE);
-        accept(QuestCode.Q_RECORD_THREE_TRACES);
-
-        appendAndRelay(regular(
-                "215-simultaneous",
-                215102L,
-                ACCEPTED_AT.plusSeconds(1)
-        ));
-
-        assertThat(progress(QuestCode.Q_RECORD_FIRST_TRACE)).isEqualTo(1);
-        assertThat(status(QuestCode.Q_RECORD_FIRST_TRACE))
-                .isEqualTo(QuestStatus.COMPLETED.name());
-        assertThat(progress(QuestCode.Q_RECORD_THREE_TRACES)).isEqualTo(1);
-        assertThat(status(QuestCode.Q_RECORD_THREE_TRACES))
-                .isEqualTo(QuestStatus.IN_PROGRESS.name());
-    }
-
-    @Test
-    @DisplayName("같은 global lifeLogId의 다른 eventId는 durable Receipt replay다")
-    void replaysSameLifeLogWithDifferentEventId() {
-        accept(QuestCode.Q_RECORD_THREE_TRACES);
-        LifeLogRecorded first = regular(
-                "215-replay-a",
-                215103L,
-                ACCEPTED_AT.plusSeconds(1)
-        );
-
-        appendAndRelay(first);
-        appendAndRelay(regular(
-                "215-replay-b",
-                first.lifeLogId(),
-                first.occurredAt()
-        ));
-
-        assertThat(progress(QuestCode.Q_RECORD_THREE_TRACES)).isEqualTo(1);
-        assertThat(receiptCount(QuestCode.Q_RECORD_THREE_TRACES))
-                .isEqualTo(1);
-        assertThat(correlations(QuestCode.Q_RECORD_THREE_TRACES))
-                .containsExactly("lifelog:" + first.lifeLogId());
-    }
-
-    @Test
-    @DisplayName("동일 LifeLog Signal 동시 중복은 한 번만 적용한다")
-    void appliesConcurrentDuplicateOnce() throws Exception {
-        accept(QuestCode.Q_RECORD_THREE_TRACES);
-        QuestSignal signal = trigger.translate(regular(
-                        "215-concurrent",
-                        215104L,
-                        ACCEPTED_AT.plusSeconds(1)
-                )).stream()
-                .filter(candidate -> candidate.questCode()
-                        == QuestCode.Q_RECORD_THREE_TRACES)
-                .findFirst()
-                .orElseThrow();
-        ExecutorService executor = Executors.newFixedThreadPool(2);
-        CountDownLatch ready = new CountDownLatch(2);
-        CountDownLatch start = new CountDownLatch(1);
-        try {
-            Future<QuestSignalProcessingResult> first =
-                    submit(executor, ready, start, signal);
-            Future<QuestSignalProcessingResult> second =
-                    submit(executor, ready, start, signal);
-            assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
-            start.countDown();
-
-            assertThat(List.of(
-                    first.get(20, TimeUnit.SECONDS),
-                    second.get(20, TimeUnit.SECONDS)
-            )).extracting(QuestSignalProcessingResult::outcome)
-                    .containsExactlyInAnyOrder(
-                            QuestSignalProcessingResult.Outcome.APPLIED,
-                            QuestSignalProcessingResult.Outcome.REPLAYED
-                    );
-        } finally {
-            executor.shutdownNow();
-            assertThat(executor.awaitTermination(5, TimeUnit.SECONDS))
-                    .isTrue();
+            assertThat(progress(QuestCode.Q_RECORD_THREE_TRACES)).isZero();
+            assertThat(receiptCount(QuestCode.Q_RECORD_THREE_TRACES))
+                    .isEqualTo(1);
         }
 
-        assertThat(progress(QuestCode.Q_RECORD_THREE_TRACES)).isEqualTo(1);
-        assertThat(receiptCount(QuestCode.Q_RECORD_THREE_TRACES))
-                .isEqualTo(1);
+        @Test
+        @DisplayName("acceptedAt 이전 Fact는 다른 eventId 재전달까지 영구 무시한다")
+        void permanentlyIgnoresPreAcceptanceFact() {
+            accept(QuestCode.Q_RECORD_THREE_TRACES);
+            LifeLogRecorded beforeAcceptance = regular(
+                    "215-pre-accept-a",
+                    215101L,
+                    ACCEPTED_AT.minusSeconds(1)
+            );
+
+            appendAndRelay(beforeAcceptance);
+            appendAndRelay(regular(
+                    "215-pre-accept-b",
+                    beforeAcceptance.lifeLogId(),
+                    beforeAcceptance.occurredAt()
+            ));
+
+            assertThat(progress(QuestCode.Q_RECORD_THREE_TRACES)).isZero();
+            assertThat(receiptCount(QuestCode.Q_RECORD_THREE_TRACES))
+                    .isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("취소 후 같은 period 재수락은 기존 row를 초기화하고 old Fact를 이월하지 않는다")
+        void restartsCanceledAcceptanceWithoutCarryingOldFacts() {
+            accept(QuestCode.Q_RECORD_THREE_TRACES);
+            appendAndRelay(regular(
+                    "215-reaccept-before-cancel",
+                    215108L,
+                    ACCEPTED_AT.plusSeconds(1)
+            ));
+            assertThat(progress(QuestCode.Q_RECORD_THREE_TRACES))
+                    .isEqualTo(1);
+            LifeLogRecorded oldFact = regular(
+                    "215-reaccept-old-a",
+                    215109L,
+                    ACCEPTED_AT.plusSeconds(2)
+            );
+
+            questService.cancel(
+                    PLAYER_ID,
+                    new QuestCommand.Cancel(
+                            QuestCode.Q_RECORD_THREE_TRACES.value(),
+                            "restart integration test"
+                    )
+            );
+            Instant restartedAt = ACCEPTED_AT.plusSeconds(10);
+            clock.set(restartedAt);
+            accept(QuestCode.Q_RECORD_THREE_TRACES);
+
+            assertThat(acceptanceCount()).isEqualTo(1);
+            assertThat(acceptedAt(QuestCode.Q_RECORD_THREE_TRACES))
+                    .isEqualTo(restartedAt);
+            assertThat(status(QuestCode.Q_RECORD_THREE_TRACES))
+                    .isEqualTo(QuestStatus.IN_PROGRESS.name());
+            assertThat(progress(QuestCode.Q_RECORD_THREE_TRACES)).isZero();
+
+            appendAndRelay(oldFact);
+
+            assertThat(progress(QuestCode.Q_RECORD_THREE_TRACES)).isZero();
+            assertThat(receiptCount(QuestCode.Q_RECORD_THREE_TRACES))
+                    .isEqualTo(2);
+
+            appendAndRelay(regular(
+                    "215-reaccept-new",
+                    215110L,
+                    restartedAt.plusSeconds(1)
+            ));
+
+            assertThat(progress(QuestCode.Q_RECORD_THREE_TRACES))
+                    .isEqualTo(1);
+            assertThat(status(QuestCode.Q_RECORD_THREE_TRACES))
+                    .isEqualTo(QuestStatus.IN_PROGRESS.name());
+
+            appendAndRelay(regular(
+                    "215-reaccept-old-b",
+                    oldFact.lifeLogId(),
+                    oldFact.occurredAt()
+            ));
+
+            assertThat(progress(QuestCode.Q_RECORD_THREE_TRACES))
+                    .isEqualTo(1);
+            assertThat(receiptCount(QuestCode.Q_RECORD_THREE_TRACES))
+                    .isEqualTo(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("LifeLog Fact로 여러 Quest 진행을 반영할 때")
+    class ProgressAndReplay {
+
+        @Test
+        @DisplayName("한 LifeLog가 첫 기록과 세 기록 Quest를 동시에 진행한다")
+        void progressesFirstAndThreeTracesTogether() {
+            accept(QuestCode.Q_RECORD_FIRST_TRACE);
+            accept(QuestCode.Q_RECORD_THREE_TRACES);
+
+            appendAndRelay(regular(
+                    "215-simultaneous",
+                    215102L,
+                    ACCEPTED_AT.plusSeconds(1)
+            ));
+
+            assertThat(progress(QuestCode.Q_RECORD_FIRST_TRACE)).isEqualTo(1);
+            assertThat(status(QuestCode.Q_RECORD_FIRST_TRACE))
+                    .isEqualTo(QuestStatus.COMPLETED.name());
+            assertThat(progress(QuestCode.Q_RECORD_THREE_TRACES))
+                    .isEqualTo(1);
+            assertThat(status(QuestCode.Q_RECORD_THREE_TRACES))
+                    .isEqualTo(QuestStatus.IN_PROGRESS.name());
+        }
+
+        @Test
+        @DisplayName("같은 global lifeLogId의 다른 eventId는 durable Receipt replay다")
+        void replaysSameLifeLogWithDifferentEventId() {
+            accept(QuestCode.Q_RECORD_THREE_TRACES);
+            LifeLogRecorded first = regular(
+                    "215-replay-a",
+                    215103L,
+                    ACCEPTED_AT.plusSeconds(1)
+            );
+
+            appendAndRelay(first);
+            appendAndRelay(regular(
+                    "215-replay-b",
+                    first.lifeLogId(),
+                    first.occurredAt()
+            ));
+
+            assertThat(progress(QuestCode.Q_RECORD_THREE_TRACES))
+                    .isEqualTo(1);
+            assertThat(receiptCount(QuestCode.Q_RECORD_THREE_TRACES))
+                    .isEqualTo(1);
+            assertThat(correlations(QuestCode.Q_RECORD_THREE_TRACES))
+                    .containsExactly("lifelog:" + first.lifeLogId());
+        }
+
+        @Test
+        @DisplayName("동일 LifeLog Signal 동시 중복은 한 번만 적용한다")
+        void appliesConcurrentDuplicateOnce() throws Exception {
+            accept(QuestCode.Q_RECORD_THREE_TRACES);
+            QuestSignal signal = trigger.translate(regular(
+                            "215-concurrent",
+                            215104L,
+                            ACCEPTED_AT.plusSeconds(1)
+                    )).stream()
+                    .filter(candidate -> candidate.questCode()
+                            == QuestCode.Q_RECORD_THREE_TRACES)
+                    .findFirst()
+                    .orElseThrow();
+            ExecutorService executor = Executors.newFixedThreadPool(2);
+            CountDownLatch ready = new CountDownLatch(2);
+            CountDownLatch start = new CountDownLatch(1);
+            try {
+                Future<QuestSignalProcessingResult> first =
+                        submit(executor, ready, start, signal);
+                Future<QuestSignalProcessingResult> second =
+                        submit(executor, ready, start, signal);
+                assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+                start.countDown();
+
+                assertThat(List.of(
+                        first.get(20, TimeUnit.SECONDS),
+                        second.get(20, TimeUnit.SECONDS)
+                )).extracting(QuestSignalProcessingResult::outcome)
+                        .containsExactlyInAnyOrder(
+                                QuestSignalProcessingResult.Outcome.APPLIED,
+                                QuestSignalProcessingResult.Outcome.REPLAYED
+                        );
+            } finally {
+                executor.shutdownNow();
+                assertThat(executor.awaitTermination(5, TimeUnit.SECONDS))
+                        .isTrue();
+            }
+
+            assertThat(progress(QuestCode.Q_RECORD_THREE_TRACES))
+                    .isEqualTo(1);
+            assertThat(receiptCount(QuestCode.Q_RECORD_THREE_TRACES))
+                    .isEqualTo(1);
+        }
     }
 
     @Test

--- a/src/test/java/online/lifeasgame/quest/domain/PlayerQuestRouteTest.java
+++ b/src/test/java/online/lifeasgame/quest/domain/PlayerQuestRouteTest.java
@@ -1,0 +1,115 @@
+package online.lifeasgame.quest.domain;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.quest.domain.error.QuestError;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("PlayerQuestRoute 진행")
+class PlayerQuestRouteTest {
+
+    private static final Instant SELECTED_AT =
+            Instant.parse("2026-08-10T01:00:00Z");
+
+    @Nested
+    @DisplayName("Route를 처음 선택하면")
+    class StartRoute {
+
+        @Test
+        @DisplayName("첫 Step이 current인 IN_PROGRESS runtime을 만든다")
+        void startsAtFirstStep() {
+            PlayerQuestRoute playerRoute = PlayerQuestRoute.start(
+                    1001L,
+                    201L,
+                    301L,
+                    SELECTED_AT
+            );
+
+            assertThat(playerRoute.getPlayerId()).isEqualTo(1001L);
+            assertThat(playerRoute.getRouteId()).isEqualTo(201L);
+            assertThat(playerRoute.getCurrentStepId()).isEqualTo(301L);
+            assertThat(playerRoute.getStatus())
+                    .isEqualTo(PlayerQuestRouteStatus.IN_PROGRESS);
+            assertThat(playerRoute.getSelectedAt()).isEqualTo(SELECTED_AT);
+            assertThat(playerRoute.getCompletedAt()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("현재 Step을 명시적으로 진행하면")
+    class AdvanceRoute {
+
+        @Test
+        @DisplayName("정확히 다음 한 Step으로 이동한다")
+        void advancesOneStep() {
+            PlayerQuestRoute playerRoute = playerRoute();
+
+            playerRoute.advanceTo(301L, 302L);
+
+            assertThat(playerRoute.getCurrentStepId()).isEqualTo(302L);
+            assertThat(playerRoute.getStatus())
+                    .isEqualTo(PlayerQuestRouteStatus.IN_PROGRESS);
+        }
+
+        @Test
+        @DisplayName("stale expectedStepId는 다시 진행시키지 않는다")
+        void rejectsStaleExpectedStep() {
+            PlayerQuestRoute playerRoute = playerRoute();
+            playerRoute.advanceTo(301L, 302L);
+
+            assertError(
+                    () -> playerRoute.advanceTo(301L, 303L),
+                    QuestError.ROUTE_STEP_NOT_CURRENT
+            );
+            assertThat(playerRoute.getCurrentStepId()).isEqualTo(302L);
+        }
+
+        @Test
+        @DisplayName("마지막 Step의 명시적 진행은 완료 시각을 기록한다")
+        void completesFinalStep() {
+            PlayerQuestRoute playerRoute = playerRoute();
+            Instant completedAt = SELECTED_AT.plusSeconds(60);
+
+            playerRoute.complete(301L, completedAt);
+
+            assertThat(playerRoute.getStatus())
+                    .isEqualTo(PlayerQuestRouteStatus.COMPLETED);
+            assertThat(playerRoute.getCompletedAt()).isEqualTo(completedAt);
+            assertThat(playerRoute.getCurrentStepId()).isEqualTo(301L);
+        }
+
+        @Test
+        @DisplayName("완료된 Route는 다시 진행하지 않는다")
+        void rejectsAdvanceAfterCompletion() {
+            PlayerQuestRoute playerRoute = playerRoute();
+            playerRoute.complete(301L, SELECTED_AT.plusSeconds(60));
+
+            assertError(
+                    () -> playerRoute.complete(
+                            301L,
+                            SELECTED_AT.plusSeconds(120)
+                    ),
+                    QuestError.ROUTE_ALREADY_COMPLETED
+            );
+        }
+    }
+
+    private PlayerQuestRoute playerRoute() {
+        return PlayerQuestRoute.start(1001L, 201L, 301L, SELECTED_AT);
+    }
+
+    private void assertError(Runnable action, QuestError error) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(
+                        DomainException.class,
+                        exception -> assertThat(exception.getErrorCode())
+                                .isEqualTo(error)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/quest/domain/QuestRouteTest.java
+++ b/src/test/java/online/lifeasgame/quest/domain/QuestRouteTest.java
@@ -1,0 +1,155 @@
+package online.lifeasgame.quest.domain;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.quest.domain.error.QuestError;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("QuestRoute 정의")
+class QuestRouteTest {
+
+    @Nested
+    @DisplayName("순서가 있는 Step으로 Route를 정의할 때")
+    class DefineRoute {
+
+        @Test
+        @DisplayName("첫 Step과 Quest completion-set 계약을 보존한다")
+        void preservesOrderedStepsAndQuestLinks() {
+            QuestRouteStep first = step(1, 101L);
+            QuestRouteStep second = step(2, 102L);
+
+            QuestRoute route = QuestRoute.define(
+                    "ROUTE_RECORD_START",
+                    1,
+                    "기록으로 시작하기",
+                    "기록을 남기고 연결하는 방향",
+                    null,
+                    List.of(first, second)
+            );
+
+            assertThat(route.firstStep()).isSameAs(first);
+            assertThat(route.getSteps()).containsExactly(first, second);
+            assertThat(first.requiredQuestIds()).containsExactly(101L);
+            assertThat(first.getCriterionType())
+                    .isEqualTo(QuestRouteCriterionType.QUEST_COMPLETION_SET);
+            assertThat(first.isUserAdvanceRequired()).isTrue();
+            assertThat(first.isRetroactiveEvidenceAllowed()).isTrue();
+            assertThat(first.isSkipAllowed()).isFalse();
+        }
+
+        @Test
+        @DisplayName("Step order가 1부터 연속되지 않으면 정의를 거부한다")
+        void rejectsNonContiguousStepOrder() {
+            assertInvalidDefinition(() -> QuestRoute.define(
+                    "ROUTE_RECORD_START",
+                    1,
+                    "기록으로 시작하기",
+                    null,
+                    null,
+                    List.of(step(1, 101L), step(3, 102L))
+            ));
+        }
+
+        @Test
+        @DisplayName("같은 Step code가 중복되면 정의를 거부한다")
+        void rejectsDuplicateStepCode() {
+            QuestRouteStep first = QuestRouteStep.define(
+                    "SAME_STEP",
+                    1,
+                    "첫 단계",
+                    null,
+                    1,
+                    Set.of(QuestRouteStepQuest.required(101L))
+            );
+            QuestRouteStep second = QuestRouteStep.define(
+                    "SAME_STEP",
+                    2,
+                    "둘째 단계",
+                    null,
+                    1,
+                    Set.of(QuestRouteStepQuest.required(102L))
+            );
+
+            assertInvalidDefinition(() -> QuestRoute.define(
+                    "ROUTE_RECORD_START",
+                    1,
+                    "기록으로 시작하기",
+                    null,
+                    null,
+                    List.of(first, second)
+            ));
+        }
+    }
+
+    @Nested
+    @DisplayName("Step의 Quest evidence 계약을 정의할 때")
+    class DefineStepCriteria {
+
+        @Test
+        @DisplayName("Optional Quest는 required evidence 수에 포함하지 않는다")
+        void excludesOptionalQuestFromRequiredEvidence() {
+            QuestRouteStep step = QuestRouteStep.define(
+                    "STEP_ONE",
+                    1,
+                    "첫 단계",
+                    null,
+                    1,
+                    Set.of(
+                            QuestRouteStepQuest.required(101L),
+                            QuestRouteStepQuest.optional(102L)
+                    )
+            );
+
+            assertThat(step.requiredQuestIds()).containsExactly(101L);
+        }
+
+        @Test
+        @DisplayName("required Quest보다 많은 evidence를 요구하면 정의를 거부한다")
+        void rejectsImpossibleRequiredEvidenceCount() {
+            assertInvalidDefinition(() -> QuestRouteStep.define(
+                    "STEP_ONE",
+                    1,
+                    "첫 단계",
+                    null,
+                    2,
+                    Set.of(
+                            QuestRouteStepQuest.required(101L),
+                            QuestRouteStepQuest.optional(102L)
+                    )
+            ));
+        }
+
+        @Test
+        @DisplayName("Quest ID가 유효하지 않으면 link 생성을 거부한다")
+        void rejectsInvalidQuestLink() {
+            assertInvalidDefinition(() -> QuestRouteStepQuest.required(0L));
+        }
+    }
+
+    private QuestRouteStep step(int order, Long questId) {
+        return QuestRouteStep.define(
+                "STEP_" + order,
+                order,
+                "단계 " + order,
+                null,
+                1,
+                Set.of(QuestRouteStepQuest.required(questId))
+        );
+    }
+
+    private void assertInvalidDefinition(Runnable action) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(
+                        DomainException.class,
+                        exception -> assertThat(exception.getErrorCode())
+                                .isEqualTo(QuestError.ROUTE_DEFINITION_INVALID)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/quest/domain/QuestRouteTest.java
+++ b/src/test/java/online/lifeasgame/quest/domain/QuestRouteTest.java
@@ -89,8 +89,61 @@ class QuestRouteTest {
     }
 
     @Nested
-    @DisplayName("Step의 Quest evidence 계약을 정의할 때")
+    @DisplayName("Route Step 정의를 검증할 때")
     class DefineStepCriteria {
+
+        @Test
+        @DisplayName("required Quest 하나에는 evidence 하나를 요구할 수 있다")
+        void acceptsOneRequiredQuestAndOneEvidence() {
+            QuestRouteStep step = QuestRouteStep.define(
+                    "STEP_ONE",
+                    1,
+                    "첫 단계",
+                    null,
+                    1,
+                    Set.of(QuestRouteStepQuest.required(101L))
+            );
+
+            assertThat(step.getRequiredEvidenceCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("required Quest 둘에는 evidence 둘을 요구할 수 있다")
+        void acceptsTwoRequiredQuestsAndTwoEvidence() {
+            QuestRouteStep step = QuestRouteStep.define(
+                    "STEP_ONE",
+                    1,
+                    "첫 단계",
+                    null,
+                    2,
+                    Set.of(
+                            QuestRouteStepQuest.required(101L),
+                            QuestRouteStepQuest.required(102L)
+                    )
+            );
+
+            assertThat(step.requiredQuestIds()).containsExactlyInAnyOrder(
+                    101L,
+                    102L
+            );
+            assertThat(step.getRequiredEvidenceCount()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("required Quest 둘에 evidence 하나만 요구하면 정의를 거부한다")
+        void rejectsEvidenceCountBelowRequiredQuestCount() {
+            assertInvalidDefinition(() -> QuestRouteStep.define(
+                    "STEP_ONE",
+                    1,
+                    "첫 단계",
+                    null,
+                    1,
+                    Set.of(
+                            QuestRouteStepQuest.required(101L),
+                            QuestRouteStepQuest.required(102L)
+                    )
+            ));
+        }
 
         @Test
         @DisplayName("Optional Quest는 required evidence 수에 포함하지 않는다")

--- a/src/test/java/online/lifeasgame/role/application/RolePersonPersistenceIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/role/application/RolePersonPersistenceIntegrationTest.java
@@ -100,7 +100,7 @@ class RolePersonPersistenceIntegrationTest {
 
     @Test
     void persistsOwnerScopedCrudAndKeepsArchivedRows() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("19");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("20");
 
         var role = roleService.create(
                 new RoleCommand.Create("work", "Developer", "Builds")

--- a/src/test/java/online/lifeasgame/role/application/RoleRelationPersistenceIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/role/application/RoleRelationPersistenceIntegrationTest.java
@@ -93,7 +93,7 @@ class RoleRelationPersistenceIntegrationTest {
 
     @Test
     void persistsCrudRejectsActiveDuplicateAndReactivatesArchivedRow() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("19");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("20");
         Long roleId = createRole("Owner role");
         Long personId = createPerson("Alice");
 


### PR DESCRIPTION
## Purpose

Introduce the QuestRoute MVP as LifeAsGame's long-term direction runtime.

The core product boundary is:

```text
Quest
= a concrete action the player can perform now

QuestRoute
= a long-term direction represented as ordered journey steps
```

This PR intentionally avoids treating a Route as only a Quest folder.

---

## Runtime model

Added separate responsibilities for:

```text
QuestRoute
→ Route definition and ordered Steps

PlayerQuestRoute
→ player-owned Route runtime state
```

Route definitions remain separate from per-player progress.

No global single-active-Route constraint is introduced.

---

## Representative content

Activated only the representative P0 Route:

```text
ROUTE_RECORD_START
```

with:

```text
RS_RECORD_01_LEAVE_TRACE
→ Q_RECORD_FIRST_TRACE

RS_RECORD_02_CONNECT_TRACES
→ Q_RECORD_THREE_TRACES

RS_RECORD_03_LOOK_BACK
→ Q_RECORD_WEEKLY_LOOKBACK
```

Other catalog Routes remain gated for later delivery waves.

---

## Selection

Route selection is explicit and self-owned.

Selection:

- resolves the current player inside the Application Service
- starts at the first Step
- is duplicate-safe
- does not auto-accept linked Quests
- does not cancel other Routes
- does not grant Reward/Achievement/Item

No identity-only Facade is introduced.

---

## Step criteria

The MVP Step criterion is based on completed Quest facts.

For the representative Route:

```text
criterion = QUEST_COMPLETION_SET
retroactive evidence = allowed
```

A Quest completed before Route selection may therefore satisfy a Step.

Quest completion remains Quest-owned truth.

---

## Explicit Route progression

A completed Quest does **not** automatically advance a Route.

The flow is:

```text
Quest completed
→ Step criteria satisfied
→ READY_TO_ADVANCE
→ player explicitly confirms
→ one Step transition
```

Advance requests carry the expected current Step identity so stale or duplicate retries cannot skip additional Steps.

Concurrent same-Step advances converge to at most one transition.

The final Step also requires explicit player confirmation before the Route becomes completed.

---

## Read model

Route queries expose derived Step states such as:

```text
COMPLETED
CURRENT
READY_TO_ADVANCE
LOCKED
```

These are read-model semantics rather than unnecessary persisted workflow states.

---

## Migration

Added:

```text
V20__quest_route_mvp.sql
```

The migration introduces the Route definition, Step/Quest links, and player Route runtime state while preserving V1-V19 history.

No Role FK or Role-specific Quest scope is added.

---

## Existing Quest correctness

Preserved the existing Quest closed loop:

- Quest acceptance/repeat behavior
- GOAL_REACHED / COMPLETED separation
- AUTO / USER_CONFIRM completion
- durable signal processing
- transactional outbox behavior
- typed Quest → Reward contract
- reward settlement identity

QuestRoute consumes completed Quest facts without redefining Quest completion.

---

## Test structure

New behavior-oriented tests use JUnit 5 `@Nested` and `@DisplayName` so they read as domain scenarios.

Related existing Quest tests were incrementally reorganized only where the current change made their flat structure difficult to follow.

Assertions, replay/idempotency, concurrency, rollback, and negative scenarios remain intact.

---

## Out of scope

- Role Quest / QuestAcceptance role scope
- RoleEvent / RoleParty / RoleChat
- Route pause/resume/archive
- Step skipping/backtracking
- automatic Route advancement
- Route Reward/Achievement/Title/Cosmetic
- non-representative Route activation
- Home/Timeline projections
- Social/Economy
- frontend

Closes #250


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quest-route browsing, route details, and personal progress views.
  * Players can select routes, view step details, and advance through steps.
  * Added progress states, completion tracking, quest requirements, and route criteria validation.
  * Added an initial quest route with three ordered steps and linked quests.
* **Bug Fixes**
  * Prevented invalid, stale, incomplete, or already-completed route advances.
* **Tests**
  * Added comprehensive coverage for route selection, progression, completion, concurrency, validation, and database migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->