### PR TITLE
[Role] Add RoleEvent foundation and explicit LifeLog linkage

### DIFF
--- a/src/main/java/online/lifeasgame/lifelog/api/player/mapper/PlayerCollectionWebMapper.java
+++ b/src/main/java/online/lifeasgame/lifelog/api/player/mapper/PlayerCollectionWebMapper.java
@@ -38,7 +38,9 @@ public final class PlayerCollectionWebMapper {
                 request.tags(),
                 new LifeLogRecordMetadataCommand(
                         request.lifeLogSubtype(),
-                        request.reflectionScope()
+                        request.reflectionScope(),
+                        request.primaryRoleId(),
+                        request.roleEventId()
                 )
         );
     }

--- a/src/main/java/online/lifeasgame/lifelog/api/player/mapper/PlayerExerciseWebMapper.java
+++ b/src/main/java/online/lifeasgame/lifelog/api/player/mapper/PlayerExerciseWebMapper.java
@@ -39,7 +39,9 @@ public final class PlayerExerciseWebMapper {
                 request.memo(),
                 new LifeLogRecordMetadataCommand(
                         request.lifeLogSubtype(),
-                        request.reflectionScope()
+                        request.reflectionScope(),
+                        request.primaryRoleId(),
+                        request.roleEventId()
                 )
         );
     }

--- a/src/main/java/online/lifeasgame/lifelog/api/player/mapper/PlayerMediaLogWebMapper.java
+++ b/src/main/java/online/lifeasgame/lifelog/api/player/mapper/PlayerMediaLogWebMapper.java
@@ -39,7 +39,9 @@ public final class PlayerMediaLogWebMapper {
                 request.tags(),
                 new LifeLogRecordMetadataCommand(
                         request.lifeLogSubtype(),
-                        request.reflectionScope()
+                        request.reflectionScope(),
+                        request.primaryRoleId(),
+                        request.roleEventId()
                 )
         );
     }

--- a/src/main/java/online/lifeasgame/lifelog/api/player/request/PlayerCollectionRequest.java
+++ b/src/main/java/online/lifeasgame/lifelog/api/player/request/PlayerCollectionRequest.java
@@ -3,6 +3,7 @@ package online.lifeasgame.lifelog.api.player.request;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 import java.util.Set;
 
@@ -20,8 +21,36 @@ public final class PlayerCollectionRequest {
             String acquiredFrom,
             Set<String> tags,
             String lifeLogSubtype,
-            String reflectionScope
+            String reflectionScope,
+            @Positive Long primaryRoleId,
+            @Positive Long roleEventId
     ) {
+        public Create(
+                String category,
+                String title,
+                String originalTitle,
+                Integer quantity,
+                String conditionNote,
+                String acquiredFrom,
+                Set<String> tags,
+                String lifeLogSubtype,
+                String reflectionScope
+        ) {
+            this(
+                    category,
+                    title,
+                    originalTitle,
+                    quantity,
+                    conditionNote,
+                    acquiredFrom,
+                    tags,
+                    lifeLogSubtype,
+                    reflectionScope,
+                    null,
+                    null
+            );
+        }
+
         public Create(
                 String category,
                 String title,
@@ -39,6 +68,8 @@ public final class PlayerCollectionRequest {
                     conditionNote,
                     acquiredFrom,
                     tags,
+                    null,
+                    null,
                     null,
                     null
             );

--- a/src/main/java/online/lifeasgame/lifelog/api/player/request/PlayerExerciseRequest.java
+++ b/src/main/java/online/lifeasgame/lifelog/api/player/request/PlayerExerciseRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 import java.time.LocalDate;
 
@@ -19,8 +20,34 @@ public final class PlayerExerciseRequest {
             @NotNull LocalDate exercisedOn,
             String memo,
             String lifeLogSubtype,
-            String reflectionScope
+            String reflectionScope,
+            @Positive Long primaryRoleId,
+            @Positive Long roleEventId
     ) {
+        public Create(
+                String category,
+                Integer durationMinutes,
+                Double distanceKm,
+                Integer calories,
+                LocalDate exercisedOn,
+                String memo,
+                String lifeLogSubtype,
+                String reflectionScope
+        ) {
+            this(
+                    category,
+                    durationMinutes,
+                    distanceKm,
+                    calories,
+                    exercisedOn,
+                    memo,
+                    lifeLogSubtype,
+                    reflectionScope,
+                    null,
+                    null
+            );
+        }
+
         public Create(
                 String category,
                 Integer durationMinutes,
@@ -36,6 +63,8 @@ public final class PlayerExerciseRequest {
                     calories,
                     exercisedOn,
                     memo,
+                    null,
+                    null,
                     null,
                     null
             );

--- a/src/main/java/online/lifeasgame/lifelog/api/player/request/PlayerMediaLogRequest.java
+++ b/src/main/java/online/lifeasgame/lifelog/api/player/request/PlayerMediaLogRequest.java
@@ -18,8 +18,36 @@ public final class PlayerMediaLogRequest {
             @NotBlank String status,
             Set<String> tags,
             String lifeLogSubtype,
-            String reflectionScope
+            String reflectionScope,
+            @Positive Long primaryRoleId,
+            @Positive Long roleEventId
     ) {
+        public Create(
+                String category,
+                String title,
+                String originalTitle,
+                Integer currentEpisode,
+                Integer totalEpisode,
+                String status,
+                Set<String> tags,
+                String lifeLogSubtype,
+                String reflectionScope
+        ) {
+            this(
+                    category,
+                    title,
+                    originalTitle,
+                    currentEpisode,
+                    totalEpisode,
+                    status,
+                    tags,
+                    lifeLogSubtype,
+                    reflectionScope,
+                    null,
+                    null
+            );
+        }
+
         public Create(
                 String category,
                 String title,
@@ -37,6 +65,8 @@ public final class PlayerMediaLogRequest {
                     totalEpisode,
                     status,
                     tags,
+                    null,
+                    null,
                     null,
                     null
             );

--- a/src/main/java/online/lifeasgame/lifelog/application/record/LifeLogRecordMetadataCommand.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/record/LifeLogRecordMetadataCommand.java
@@ -5,30 +5,56 @@ import online.lifeasgame.lifelog.domain.record.LifeLogSubtype;
 
 public record LifeLogRecordMetadataCommand(
         String lifeLogSubtype,
-        String reflectionScope
+        String reflectionScope,
+        Long primaryRoleId,
+        Long roleEventId
 ) {
 
+    public LifeLogRecordMetadataCommand(
+            String lifeLogSubtype,
+            String reflectionScope
+    ) {
+        this(lifeLogSubtype, reflectionScope, null, null);
+    }
+
     public static LifeLogRecordMetadataCommand none() {
-        return new LifeLogRecordMetadataCommand(null, null);
+        return new LifeLogRecordMetadataCommand(null, null, null, null);
     }
 
     public boolean isPresent() {
-        return lifeLogSubtype != null || reflectionScope != null;
+        return lifeLogSubtype != null
+                || reflectionScope != null
+                || primaryRoleId != null
+                || roleEventId != null;
     }
 
     public Resolved resolve() {
         if (!isPresent()) {
-            return new Resolved(null, null);
+            return new Resolved(null, null, null, null);
         }
-        LifeLogSubtype subtype = LifeLogSubtype.parse(lifeLogSubtype);
+        LifeLogSubtype subtype = lifeLogSubtype == null
+                ? null
+                : LifeLogSubtype.parse(lifeLogSubtype);
         LifeLogReflectionScope scope =
                 LifeLogReflectionScope.parse(reflectionScope);
-        return new Resolved(subtype, scope);
+        if (subtype == null && scope != null) {
+            throw new IllegalArgumentException(
+                    "reflection metadata requires lifeLogSubtype"
+            );
+        }
+        return new Resolved(
+                subtype,
+                scope,
+                primaryRoleId,
+                roleEventId
+        );
     }
 
     public record Resolved(
             LifeLogSubtype subtype,
-            LifeLogReflectionScope reflectionScope
+            LifeLogReflectionScope reflectionScope,
+            Long primaryRoleId,
+            Long roleEventId
     ) {
     }
 }

--- a/src/main/java/online/lifeasgame/lifelog/application/record/LifeLogRecordRegistrar.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/record/LifeLogRecordRegistrar.java
@@ -1,12 +1,16 @@
 package online.lifeasgame.lifelog.application.record;
 
 import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.lifelog.domain.error.LifeLogError;
 import online.lifeasgame.lifelog.domain.record.LifeLogEntryMode;
 import online.lifeasgame.lifelog.domain.record.LifeLogPeriodKey;
 import online.lifeasgame.lifelog.domain.record.LifeLogRecord;
 import online.lifeasgame.lifelog.domain.record.LifeLogReflectionScope;
 import online.lifeasgame.lifelog.domain.record.LifeLogSourceType;
 import online.lifeasgame.lifelog.domain.record.repository.LifeLogRecordRepository;
+import online.lifeasgame.role.application.internal.RoleEventLookupApi;
+import online.lifeasgame.role.application.internal.RoleLookupApi;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +25,8 @@ public class LifeLogRecordRegistrar {
 
     private final LifeLogRecordRepository repository;
     private final PlayerTimezoneResolver timezoneResolver;
+    private final RoleLookupApi roleLookupApi;
+    private final RoleEventLookupApi roleEventLookupApi;
     private final Clock clock;
 
     public LifeLogRecord register(
@@ -36,6 +42,7 @@ public class LifeLogRecordRegistrar {
                         : metadata;
         LifeLogRecordMetadataCommand.Resolved resolved = command.resolve();
         Instant occurredAt = clock.instant();
+        RoleContext roleContext = resolveRoleContext(playerId, resolved);
 
         if (resolved.subtype() == null) {
             return repository.saveAndFlush(LifeLogRecord.legacy(
@@ -43,6 +50,8 @@ public class LifeLogRecordRegistrar {
                     sourceType,
                     sourceId,
                     entryMode,
+                    roleContext.primaryRoleId(),
+                    roleContext.roleEventId(),
                     occurredAt
             ));
         }
@@ -63,7 +72,33 @@ public class LifeLogRecordRegistrar {
                 entryMode,
                 resolved.reflectionScope(),
                 periodKey,
+                roleContext.primaryRoleId(),
+                roleContext.roleEventId(),
                 occurredAt
         ));
+    }
+
+    private RoleContext resolveRoleContext(
+            Long playerId,
+            LifeLogRecordMetadataCommand.Resolved metadata
+    ) {
+        Long roleId = metadata.primaryRoleId();
+        Long eventId = metadata.roleEventId();
+        if (eventId != null) {
+            var event = roleEventLookupApi.getOwned(eventId, playerId);
+            if (roleId != null && !roleId.equals(event.roleId())) {
+                throw new DomainException(
+                        LifeLogError.ROLE_EVENT_CONTEXT_MISMATCH
+                );
+            }
+            roleId = event.roleId();
+        }
+        if (metadata.primaryRoleId() != null) {
+            roleLookupApi.getOwned(metadata.primaryRoleId(), playerId);
+        }
+        return new RoleContext(roleId, eventId);
+    }
+
+    private record RoleContext(Long primaryRoleId, Long roleEventId) {
     }
 }

--- a/src/main/java/online/lifeasgame/lifelog/domain/error/LifeLogError.java
+++ b/src/main/java/online/lifeasgame/lifelog/domain/error/LifeLogError.java
@@ -12,7 +12,8 @@ public enum LifeLogError implements ErrorCode {
     INVALID_MEDIA_CATEGORY("LIF-400-INVALID-MEDIA-CATEGORY", "Invalid Media Category", 400),
     INVALID_COLLECTION_CATEGORY("LIF-400-INVALID-COLLECTION-CATEGORY", "Invalid Collection Category", 400),
     INVALID_WATCH_STATUS("LIF-400-INVALID-WATCH-STATUS", "Invalid Watch Status", 400),
-    INVALID_EXERCISE_CATEGORY("LIF-400-INVALID-EXERCISE-CATEGORY", "Invalid Exercise Category", 400);
+    INVALID_EXERCISE_CATEGORY("LIF-400-INVALID-EXERCISE-CATEGORY", "Invalid Exercise Category", 400),
+    ROLE_EVENT_CONTEXT_MISMATCH("LIF-400-ROLE-EVENT-CONTEXT-MISMATCH", "Role event does not belong to the requested Role", 400);
 
     private final String code;
     private final String message;

--- a/src/main/java/online/lifeasgame/lifelog/domain/event/LifeLogRecorded.java
+++ b/src/main/java/online/lifeasgame/lifelog/domain/event/LifeLogRecorded.java
@@ -43,11 +43,7 @@ public record LifeLogRecorded(
         Guard.notNull(occurredAt, "occurredAt");
         positive(playerId, "playerId");
         positive(lifeLogId, "lifeLogId");
-        if (primaryRoleId != null) {
-            throw new IllegalArgumentException(
-                    "primaryRoleId must be null until Role Domain is available"
-            );
-        }
+        if (primaryRoleId != null) positive(primaryRoleId, "primaryRoleId");
 
         if (sourceDefinitionVersion == null) {
             if (subtype != null

--- a/src/main/java/online/lifeasgame/lifelog/domain/record/LifeLogRecord.java
+++ b/src/main/java/online/lifeasgame/lifelog/domain/record/LifeLogRecord.java
@@ -82,6 +82,9 @@ public class LifeLogRecord extends AbstractTime {
     @Column(name = "primary_role_id", updatable = false)
     private Long primaryRoleId;
 
+    @Column(name = "role_event_id", updatable = false)
+    private Long roleEventId;
+
     @Column(name = "occurred_at", nullable = false, updatable = false)
     private Instant occurredAt;
 
@@ -95,6 +98,7 @@ public class LifeLogRecord extends AbstractTime {
             LifeLogReflectionScope reflectionScope,
             String periodKey,
             Long primaryRoleId,
+            Long roleEventId,
             Instant occurredAt
     ) {
         this.playerId = positive(playerId, "playerId");
@@ -111,12 +115,13 @@ public class LifeLogRecord extends AbstractTime {
         validateReflection(subtype, reflectionScope, periodKey);
         this.reflectionScope = reflectionScope;
         this.periodKey = periodKey;
-        if (primaryRoleId != null) {
+        this.primaryRoleId = nullablePositive(primaryRoleId, "primaryRoleId");
+        this.roleEventId = nullablePositive(roleEventId, "roleEventId");
+        if (this.roleEventId != null && this.primaryRoleId == null) {
             throw new IllegalArgumentException(
-                    "primaryRoleId must be null until Role Domain is available"
+                    "roleEventId requires primaryRoleId"
             );
         }
-        this.primaryRoleId = null;
         this.occurredAt = Guard.notNull(occurredAt, "occurredAt");
     }
 
@@ -137,6 +142,31 @@ public class LifeLogRecord extends AbstractTime {
                 null,
                 null,
                 null,
+                null,
+                occurredAt
+        );
+    }
+
+    public static LifeLogRecord legacy(
+            Long playerId,
+            LifeLogSourceType sourceType,
+            Long sourceId,
+            LifeLogEntryMode entryMode,
+            Long primaryRoleId,
+            Long roleEventId,
+            Instant occurredAt
+    ) {
+        return new LifeLogRecord(
+                playerId,
+                sourceType,
+                sourceId,
+                SOURCE_DEFINITION_VERSION,
+                null,
+                entryMode,
+                null,
+                null,
+                primaryRoleId,
+                roleEventId,
                 occurredAt
         );
     }
@@ -161,6 +191,34 @@ public class LifeLogRecord extends AbstractTime {
                 reflectionScope,
                 periodKey == null ? null : periodKey.value(),
                 null,
+                null,
+                occurredAt
+        );
+    }
+
+    public static LifeLogRecord contentReady(
+            Long playerId,
+            LifeLogSourceType sourceType,
+            Long sourceId,
+            LifeLogSubtype subtype,
+            LifeLogEntryMode entryMode,
+            LifeLogReflectionScope reflectionScope,
+            LifeLogPeriodKey periodKey,
+            Long primaryRoleId,
+            Long roleEventId,
+            Instant occurredAt
+    ) {
+        return new LifeLogRecord(
+                playerId,
+                sourceType,
+                sourceId,
+                SOURCE_DEFINITION_VERSION,
+                Guard.notNull(subtype, "subtype"),
+                entryMode,
+                reflectionScope,
+                periodKey == null ? null : periodKey.value(),
+                primaryRoleId,
+                roleEventId,
                 occurredAt
         );
     }
@@ -173,6 +231,10 @@ public class LifeLogRecord extends AbstractTime {
         Guard.notNull(value, name);
         Guard.minValue(value, 1L, name);
         return value;
+    }
+
+    private static Long nullablePositive(Long value, String name) {
+        return value == null ? null : positive(value, name);
     }
 
     public static void validateReflection(

--- a/src/main/java/online/lifeasgame/lifelog/quick/api/QuickRecordRequest.java
+++ b/src/main/java/online/lifeasgame/lifelog/quick/api/QuickRecordRequest.java
@@ -2,6 +2,7 @@ package online.lifeasgame.lifelog.quick.api;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 import online.lifeasgame.lifelog.api.player.request.PlayerCollectionRequest;
 import online.lifeasgame.lifelog.api.player.request.PlayerExerciseRequest;
 import online.lifeasgame.lifelog.api.player.request.PlayerMediaLogRequest;
@@ -15,17 +16,48 @@ public final class QuickRecordRequest {
             @NotBlank String type,
             String lifeLogSubtype,
             String reflectionScope,
+            @Positive Long primaryRoleId,
+            @Positive Long roleEventId,
             @Valid PlayerCollectionRequest.Create collection,
             @Valid PlayerExerciseRequest.Create exercise,
             @Valid PlayerMediaLogRequest.Create media
     ) {
         public Create(
                 String type,
+                String lifeLogSubtype,
+                String reflectionScope,
                 PlayerCollectionRequest.Create collection,
                 PlayerExerciseRequest.Create exercise,
                 PlayerMediaLogRequest.Create media
         ) {
-            this(type, null, null, collection, exercise, media);
+            this(
+                    type,
+                    lifeLogSubtype,
+                    reflectionScope,
+                    null,
+                    null,
+                    collection,
+                    exercise,
+                    media
+            );
+        }
+
+        public Create(
+                String type,
+                PlayerCollectionRequest.Create collection,
+                PlayerExerciseRequest.Create exercise,
+                PlayerMediaLogRequest.Create media
+        ) {
+            this(
+                    type,
+                    null,
+                    null,
+                    null,
+                    null,
+                    collection,
+                    exercise,
+                    media
+            );
         }
     }
 }

--- a/src/main/java/online/lifeasgame/lifelog/quick/api/QuickRecordWebMapper.java
+++ b/src/main/java/online/lifeasgame/lifelog/quick/api/QuickRecordWebMapper.java
@@ -18,6 +18,8 @@ public final class QuickRecordWebMapper {
                 request.type(),
                 request.lifeLogSubtype(),
                 request.reflectionScope(),
+                request.primaryRoleId(),
+                request.roleEventId(),
                 request.collection() == null
                         ? null
                         : PlayerCollectionWebMapper.toCreateCommand(

--- a/src/main/java/online/lifeasgame/lifelog/quick/application/QuickRecordCommand.java
+++ b/src/main/java/online/lifeasgame/lifelog/quick/application/QuickRecordCommand.java
@@ -22,17 +22,48 @@ public final class QuickRecordCommand {
             String type,
             String lifeLogSubtype,
             String reflectionScope,
+            Long primaryRoleId,
+            Long roleEventId,
             CollectionCommand.Create collection,
             ExerciseCommand.Create exercise,
             MediaLogCommand.Create media
     ) {
         public Create(
                 String type,
+                String lifeLogSubtype,
+                String reflectionScope,
                 CollectionCommand.Create collection,
                 ExerciseCommand.Create exercise,
                 MediaLogCommand.Create media
         ) {
-            this(type, null, null, collection, exercise, media);
+            this(
+                    type,
+                    lifeLogSubtype,
+                    reflectionScope,
+                    null,
+                    null,
+                    collection,
+                    exercise,
+                    media
+            );
+        }
+
+        public Create(
+                String type,
+                CollectionCommand.Create collection,
+                ExerciseCommand.Create exercise,
+                MediaLogCommand.Create media
+        ) {
+            this(
+                    type,
+                    null,
+                    null,
+                    null,
+                    null,
+                    collection,
+                    exercise,
+                    media
+            );
         }
 
         public Create {
@@ -68,7 +99,9 @@ public final class QuickRecordCommand {
                     selectedType,
                     new LifeLogRecordMetadataCommand(
                             lifeLogSubtype,
-                            reflectionScope
+                            reflectionScope,
+                            primaryRoleId,
+                            roleEventId
                     ),
                     collection,
                     exercise,

--- a/src/main/java/online/lifeasgame/lifelog/quick/application/QuickRecordRequestHasher.java
+++ b/src/main/java/online/lifeasgame/lifelog/quick/application/QuickRecordRequestHasher.java
@@ -59,6 +59,20 @@ public class QuickRecordRequestHasher {
                         ? null
                         : resolved.reflectionScope().name()
         );
+        if (resolved.primaryRoleId() != null) {
+            appendNumber(
+                    target,
+                    "primaryRoleId",
+                    resolved.primaryRoleId()
+            );
+        }
+        if (resolved.roleEventId() != null) {
+            appendNumber(
+                    target,
+                    "roleEventId",
+                    resolved.roleEventId()
+            );
+        }
     }
 
     private void appendCollection(

--- a/src/main/java/online/lifeasgame/role/api/RoleEventController.java
+++ b/src/main/java/online/lifeasgame/role/api/RoleEventController.java
@@ -1,0 +1,140 @@
+package online.lifeasgame.role.api;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.response.ApiResponse;
+import online.lifeasgame.platform.web.response.ApiResponses;
+import online.lifeasgame.role.api.mapper.RoleEventWebMapper;
+import online.lifeasgame.role.api.request.RoleEventRequest;
+import online.lifeasgame.role.api.response.RoleEventResponse;
+import online.lifeasgame.role.api.spec.RoleEventApiSpecV1;
+import online.lifeasgame.role.application.RoleEventQueryService;
+import online.lifeasgame.role.application.RoleEventService;
+import online.lifeasgame.role.application.result.RoleEventResult;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/roles/{roleId}/events")
+public class RoleEventController implements RoleEventApiSpecV1 {
+
+    private final RoleEventService roleEventService;
+    private final RoleEventQueryService roleEventQueryService;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<RoleEventResponse.Detail>>> list(
+            @PathVariable Long roleId
+    ) {
+        return ApiResponses.ok(roleEventQueryService.list(roleId).stream()
+                .map(RoleEventWebMapper::toDetail)
+                .toList());
+    }
+
+    @Override
+    @GetMapping("/{eventId}")
+    public ResponseEntity<ApiResponse<RoleEventResponse.Detail>> detail(
+            @PathVariable Long roleId,
+            @PathVariable Long eventId
+    ) {
+        return ApiResponses.ok(RoleEventWebMapper.toDetail(
+                roleEventQueryService.detail(roleId, eventId)
+        ));
+    }
+
+    @Override
+    @PostMapping
+    public ResponseEntity<ApiResponse<RoleEventResponse.Detail>> create(
+            @PathVariable Long roleId,
+            @Valid @RequestBody RoleEventRequest.Create request
+    ) {
+        RoleEventResult.Detail result = roleEventService.create(
+                roleId,
+                RoleEventWebMapper.toCreateCommand(request)
+        );
+        return ApiResponses.created(
+                URI.create("/api/v1/roles/" + roleId + "/events/" + result.id()),
+                RoleEventWebMapper.toDetail(result)
+        );
+    }
+
+    @Override
+    @PatchMapping("/{eventId}")
+    public ResponseEntity<ApiResponse<RoleEventResponse.Detail>> update(
+            @PathVariable Long roleId,
+            @PathVariable Long eventId,
+            @Valid @RequestBody RoleEventRequest.Update request
+    ) {
+        return ApiResponses.ok(RoleEventWebMapper.toDetail(
+                roleEventService.update(
+                        roleId,
+                        eventId,
+                        RoleEventWebMapper.toUpdateCommand(request)
+                )
+        ));
+    }
+
+    @Override
+    @PostMapping("/{eventId}/complete")
+    public ResponseEntity<ApiResponse<RoleEventResponse.Detail>> complete(
+            @PathVariable Long roleId,
+            @PathVariable Long eventId
+    ) {
+        return ApiResponses.ok(RoleEventWebMapper.toDetail(
+                roleEventService.complete(roleId, eventId)
+        ));
+    }
+
+    @Override
+    @PostMapping("/{eventId}/cancel")
+    public ResponseEntity<ApiResponse<RoleEventResponse.Detail>> cancel(
+            @PathVariable Long roleId,
+            @PathVariable Long eventId
+    ) {
+        return ApiResponses.ok(RoleEventWebMapper.toDetail(
+                roleEventService.cancel(roleId, eventId)
+        ));
+    }
+
+    @Override
+    @PostMapping("/{eventId}/participants")
+    public ResponseEntity<ApiResponse<RoleEventResponse.Participant>> addParticipant(
+            @PathVariable Long roleId,
+            @PathVariable Long eventId,
+            @Valid @RequestBody RoleEventRequest.AddParticipant request
+    ) {
+        return ApiResponses.ok(RoleEventWebMapper.toParticipant(
+                roleEventService.addParticipant(
+                        roleId,
+                        eventId,
+                        RoleEventWebMapper.toAddParticipantCommand(request)
+                )
+        ));
+    }
+
+    @Override
+    @DeleteMapping("/{eventId}/participants/{participantLinkId}")
+    public ResponseEntity<ApiResponse<Void>> removeParticipant(
+            @PathVariable Long roleId,
+            @PathVariable Long eventId,
+            @PathVariable Long participantLinkId
+    ) {
+        roleEventService.removeParticipant(
+                roleId,
+                eventId,
+                participantLinkId
+        );
+        return ApiResponses.noContent();
+    }
+}

--- a/src/main/java/online/lifeasgame/role/api/mapper/RoleEventWebMapper.java
+++ b/src/main/java/online/lifeasgame/role/api/mapper/RoleEventWebMapper.java
@@ -1,0 +1,74 @@
+package online.lifeasgame.role.api.mapper;
+
+import online.lifeasgame.role.api.request.RoleEventRequest;
+import online.lifeasgame.role.api.response.RoleEventResponse;
+import online.lifeasgame.role.application.command.RoleEventCommand;
+import online.lifeasgame.role.application.result.RoleEventResult;
+
+public final class RoleEventWebMapper {
+
+    private RoleEventWebMapper() {
+    }
+
+    public static RoleEventCommand.Create toCreateCommand(
+            RoleEventRequest.Create request
+    ) {
+        return new RoleEventCommand.Create(
+                request.title(),
+                request.description(),
+                request.startsAt(),
+                request.endsAt()
+        );
+    }
+
+    public static RoleEventCommand.Update toUpdateCommand(
+            RoleEventRequest.Update request
+    ) {
+        return new RoleEventCommand.Update(
+                request.title(),
+                request.description(),
+                request.startsAt(),
+                request.endsAt()
+        );
+    }
+
+    public static RoleEventCommand.AddParticipant toAddParticipantCommand(
+            RoleEventRequest.AddParticipant request
+    ) {
+        return new RoleEventCommand.AddParticipant(
+                request.participantType(),
+                request.participantId()
+        );
+    }
+
+    public static RoleEventResponse.Detail toDetail(
+            RoleEventResult.Detail result
+    ) {
+        return new RoleEventResponse.Detail(
+                result.id(),
+                result.roleId(),
+                result.title(),
+                result.description(),
+                result.startsAt(),
+                result.endsAt(),
+                result.status(),
+                result.completedAt(),
+                result.participants().stream()
+                        .map(RoleEventWebMapper::toParticipant)
+                        .toList(),
+                result.createdAt(),
+                result.updatedAt(),
+                result.version()
+        );
+    }
+
+    public static RoleEventResponse.Participant toParticipant(
+            RoleEventResult.Participant result
+    ) {
+        return new RoleEventResponse.Participant(
+                result.participantLinkId(),
+                result.participantType(),
+                result.participantId()
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/role/api/request/RoleEventRequest.java
+++ b/src/main/java/online/lifeasgame/role/api/request/RoleEventRequest.java
@@ -1,0 +1,36 @@
+package online.lifeasgame.role.api.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+import java.time.Instant;
+
+public final class RoleEventRequest {
+
+    private RoleEventRequest() {
+    }
+
+    public record Create(
+            @NotBlank @Size(max = 120) String title,
+            @Size(max = 1000) String description,
+            Instant startsAt,
+            Instant endsAt
+    ) {
+    }
+
+    public record Update(
+            @NotBlank @Size(max = 120) String title,
+            @Size(max = 1000) String description,
+            Instant startsAt,
+            Instant endsAt
+    ) {
+    }
+
+    public record AddParticipant(
+            @NotBlank String participantType,
+            @NotNull @Positive Long participantId
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/role/api/response/RoleEventResponse.java
+++ b/src/main/java/online/lifeasgame/role/api/response/RoleEventResponse.java
@@ -1,0 +1,33 @@
+package online.lifeasgame.role.api.response;
+
+import java.time.Instant;
+import java.util.List;
+
+public final class RoleEventResponse {
+
+    private RoleEventResponse() {
+    }
+
+    public record Detail(
+            Long id,
+            Long roleId,
+            String title,
+            String description,
+            Instant startsAt,
+            Instant endsAt,
+            String status,
+            Instant completedAt,
+            List<Participant> participants,
+            Instant createdAt,
+            Instant updatedAt,
+            Long version
+    ) {
+    }
+
+    public record Participant(
+            Long participantLinkId,
+            String participantType,
+            Long participantId
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/role/api/spec/RoleEventApiSpecV1.java
+++ b/src/main/java/online/lifeasgame/role/api/spec/RoleEventApiSpecV1.java
@@ -1,0 +1,67 @@
+package online.lifeasgame.role.api.spec;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import online.lifeasgame.core.response.ApiResponse;
+import online.lifeasgame.role.api.request.RoleEventRequest;
+import online.lifeasgame.role.api.response.RoleEventResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@Tag(name = "Role Event API V1 (Player)")
+public interface RoleEventApiSpecV1 {
+
+    @Operation(summary = "Role Event 목록")
+    ResponseEntity<ApiResponse<List<RoleEventResponse.Detail>>> list(
+            @PathVariable Long roleId
+    );
+
+    @Operation(summary = "Role Event 상세")
+    ResponseEntity<ApiResponse<RoleEventResponse.Detail>> detail(
+            @PathVariable Long roleId,
+            @PathVariable Long eventId
+    );
+
+    @Operation(summary = "Role Event 생성")
+    ResponseEntity<ApiResponse<RoleEventResponse.Detail>> create(
+            @PathVariable Long roleId,
+            @Valid @RequestBody RoleEventRequest.Create request
+    );
+
+    @Operation(summary = "Role Event 수정")
+    ResponseEntity<ApiResponse<RoleEventResponse.Detail>> update(
+            @PathVariable Long roleId,
+            @PathVariable Long eventId,
+            @Valid @RequestBody RoleEventRequest.Update request
+    );
+
+    @Operation(summary = "Role Event 완료")
+    ResponseEntity<ApiResponse<RoleEventResponse.Detail>> complete(
+            @PathVariable Long roleId,
+            @PathVariable Long eventId
+    );
+
+    @Operation(summary = "Role Event 취소")
+    ResponseEntity<ApiResponse<RoleEventResponse.Detail>> cancel(
+            @PathVariable Long roleId,
+            @PathVariable Long eventId
+    );
+
+    @Operation(summary = "Role Event 참여자 추가")
+    ResponseEntity<ApiResponse<RoleEventResponse.Participant>> addParticipant(
+            @PathVariable Long roleId,
+            @PathVariable Long eventId,
+            @Valid @RequestBody RoleEventRequest.AddParticipant request
+    );
+
+    @Operation(summary = "Role Event 참여자 제거")
+    ResponseEntity<ApiResponse<Void>> removeParticipant(
+            @PathVariable Long roleId,
+            @PathVariable Long eventId,
+            @PathVariable Long participantLinkId
+    );
+}

--- a/src/main/java/online/lifeasgame/role/application/RoleEventLookupService.java
+++ b/src/main/java/online/lifeasgame/role/application/RoleEventLookupService.java
@@ -1,0 +1,26 @@
+package online.lifeasgame.role.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.role.application.internal.RoleEventLookupApi;
+import online.lifeasgame.role.domain.RoleEvent;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+public class RoleEventLookupService implements RoleEventLookupApi {
+
+    private final RoleEventReader reader;
+
+    @Override
+    public RoleEventReference getOwned(Long roleEventId, Long playerId) {
+        RoleEvent event = reader.getOwned(roleEventId, playerId);
+        return new RoleEventReference(
+                event.getId(),
+                event.getRoleId(),
+                event.getStatus().name()
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/role/application/RoleEventQueryService.java
+++ b/src/main/java/online/lifeasgame/role/application/RoleEventQueryService.java
@@ -1,0 +1,36 @@
+package online.lifeasgame.role.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.role.application.result.RoleEventResult;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RoleEventQueryService {
+
+    private final RoleReader roleReader;
+    private final RoleEventReader eventReader;
+    private final CurrentPlayerAccessor currentPlayerAccessor;
+
+    public List<RoleEventResult.Detail> list(Long roleId) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        roleReader.getOwned(roleId, playerId);
+        return eventReader.findAllOwned(roleId, playerId).stream()
+                .map(RoleEventResult.Detail::from)
+                .toList();
+    }
+
+    public RoleEventResult.Detail detail(Long roleId, Long eventId) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        return RoleEventResult.Detail.from(eventReader.getOwned(
+                eventId,
+                roleId,
+                playerId
+        ));
+    }
+}

--- a/src/main/java/online/lifeasgame/role/application/RoleEventReader.java
+++ b/src/main/java/online/lifeasgame/role/application/RoleEventReader.java
@@ -1,0 +1,50 @@
+package online.lifeasgame.role.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.role.domain.RoleEvent;
+import online.lifeasgame.role.domain.error.RoleError;
+import online.lifeasgame.role.domain.repository.RoleEventRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+class RoleEventReader {
+
+    private final RoleEventRepository repository;
+
+    List<RoleEvent> findAllOwned(Long roleId, Long playerId) {
+        return repository.findAllOwned(roleId, playerId);
+    }
+
+    RoleEvent getOwned(Long eventId, Long roleId, Long playerId) {
+        return repository.findOwned(eventId, roleId, playerId)
+                .orElseThrow(() -> new DomainException(
+                        RoleError.ROLE_EVENT_NOT_FOUND
+                ));
+    }
+
+    RoleEvent getOwned(Long eventId, Long playerId) {
+        return repository.findByIdAndPlayerId(eventId, playerId)
+                .orElseThrow(() -> new DomainException(
+                        RoleError.ROLE_EVENT_NOT_FOUND
+                ));
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY, readOnly = false)
+    RoleEvent getOwnedForUpdate(
+            Long eventId,
+            Long roleId,
+            Long playerId
+    ) {
+        return repository.findOwnedForUpdate(eventId, roleId, playerId)
+                .orElseThrow(() -> new DomainException(
+                        RoleError.ROLE_EVENT_NOT_FOUND
+                ));
+    }
+}

--- a/src/main/java/online/lifeasgame/role/application/RoleEventService.java
+++ b/src/main/java/online/lifeasgame/role/application/RoleEventService.java
@@ -1,0 +1,157 @@
+package online.lifeasgame.role.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.person.application.internal.PersonLookupApi;
+import online.lifeasgame.role.application.command.RoleEventCommand;
+import online.lifeasgame.role.application.result.RoleEventResult;
+import online.lifeasgame.role.domain.Role;
+import online.lifeasgame.role.domain.RoleEvent;
+import online.lifeasgame.role.domain.RoleEventParticipant;
+import online.lifeasgame.role.domain.RoleEventParticipantType;
+import online.lifeasgame.role.domain.RoleStatus;
+import online.lifeasgame.role.domain.error.RoleError;
+import online.lifeasgame.user.application.internal.UserLookupApi;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+
+@Service
+@RequiredArgsConstructor
+public class RoleEventService {
+
+    private final RoleReader roleReader;
+    private final RoleEventReader eventReader;
+    private final RoleEventWriter eventWriter;
+    private final PersonLookupApi personLookupApi;
+    private final UserLookupApi userLookupApi;
+    private final CurrentPlayerAccessor currentPlayerAccessor;
+    private final Clock clock;
+
+    @Transactional
+    public RoleEventResult.Detail create(
+            Long roleId,
+            RoleEventCommand.Create command
+    ) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        Role role = roleReader.getOwnedForUpdate(roleId, playerId);
+        requireActive(role);
+        return RoleEventResult.Detail.from(eventWriter.saveAndFlush(
+                RoleEvent.create(
+                        playerId,
+                        roleId,
+                        command.title(),
+                        command.description(),
+                        command.startsAt(),
+                        command.endsAt()
+                )
+        ));
+    }
+
+    @Transactional
+    public RoleEventResult.Detail update(
+            Long roleId,
+            Long eventId,
+            RoleEventCommand.Update command
+    ) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        RoleEvent event = eventReader.getOwnedForUpdate(
+                eventId,
+                roleId,
+                playerId
+        );
+        event.update(
+                command.title(),
+                command.description(),
+                command.startsAt(),
+                command.endsAt()
+        );
+        return RoleEventResult.Detail.from(eventWriter.saveAndFlush(event));
+    }
+
+    @Transactional
+    public RoleEventResult.Detail complete(Long roleId, Long eventId) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        RoleEvent event = eventReader.getOwnedForUpdate(
+                eventId,
+                roleId,
+                playerId
+        );
+        event.complete(clock.instant());
+        return RoleEventResult.Detail.from(eventWriter.saveAndFlush(event));
+    }
+
+    @Transactional
+    public RoleEventResult.Detail cancel(Long roleId, Long eventId) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        RoleEvent event = eventReader.getOwnedForUpdate(
+                eventId,
+                roleId,
+                playerId
+        );
+        event.cancel();
+        return RoleEventResult.Detail.from(eventWriter.saveAndFlush(event));
+    }
+
+    @Transactional
+    public RoleEventResult.Participant addParticipant(
+            Long roleId,
+            Long eventId,
+            RoleEventCommand.AddParticipant command
+    ) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        RoleEvent event = eventReader.getOwnedForUpdate(
+                eventId,
+                roleId,
+                playerId
+        );
+        RoleEventParticipantType type = RoleEventParticipantType.parse(
+                command.participantType()
+        );
+        validateParticipant(type, command.participantId(), playerId);
+        RoleEventParticipant participant = event.addParticipant(
+                type,
+                command.participantId()
+        );
+        eventWriter.saveAndFlush(event);
+        return RoleEventResult.Participant.from(participant);
+    }
+
+    @Transactional
+    public void removeParticipant(
+            Long roleId,
+            Long eventId,
+            Long participantLinkId
+    ) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        RoleEvent event = eventReader.getOwnedForUpdate(
+                eventId,
+                roleId,
+                playerId
+        );
+        event.removeParticipant(participantLinkId);
+        eventWriter.saveAndFlush(event);
+    }
+
+    private void validateParticipant(
+            RoleEventParticipantType type,
+            Long participantId,
+            Long playerId
+    ) {
+        switch (type) {
+            case PERSON -> personLookupApi.getOwnedActive(
+                    participantId,
+                    playerId
+            );
+            case SERVICE_USER -> userLookupApi.getActive(participantId);
+        }
+    }
+
+    private void requireActive(Role role) {
+        if (role.getStatus() == RoleStatus.ARCHIVED) {
+            throw new DomainException(RoleError.ROLE_ARCHIVED);
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/role/application/RoleEventWriter.java
+++ b/src/main/java/online/lifeasgame/role/application/RoleEventWriter.java
@@ -1,0 +1,20 @@
+package online.lifeasgame.role.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.role.domain.RoleEvent;
+import online.lifeasgame.role.domain.repository.RoleEventRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.MANDATORY)
+class RoleEventWriter {
+
+    private final RoleEventRepository repository;
+
+    RoleEvent saveAndFlush(RoleEvent roleEvent) {
+        return repository.saveAndFlush(roleEvent);
+    }
+}

--- a/src/main/java/online/lifeasgame/role/application/RoleLookupService.java
+++ b/src/main/java/online/lifeasgame/role/application/RoleLookupService.java
@@ -1,0 +1,26 @@
+package online.lifeasgame.role.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.role.application.internal.RoleLookupApi;
+import online.lifeasgame.role.domain.Role;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+public class RoleLookupService implements RoleLookupApi {
+
+    private final RoleReader reader;
+
+    @Override
+    public RoleReference getOwned(Long roleId, Long playerId) {
+        Role role = reader.getOwned(roleId, playerId);
+        return new RoleReference(
+                role.getId(),
+                role.getName(),
+                role.getStatus().name()
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/role/application/command/RoleEventCommand.java
+++ b/src/main/java/online/lifeasgame/role/application/command/RoleEventCommand.java
@@ -1,0 +1,31 @@
+package online.lifeasgame.role.application.command;
+
+import java.time.Instant;
+
+public final class RoleEventCommand {
+
+    private RoleEventCommand() {
+    }
+
+    public record Create(
+            String title,
+            String description,
+            Instant startsAt,
+            Instant endsAt
+    ) {
+    }
+
+    public record Update(
+            String title,
+            String description,
+            Instant startsAt,
+            Instant endsAt
+    ) {
+    }
+
+    public record AddParticipant(
+            String participantType,
+            Long participantId
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/role/application/internal/RoleEventLookupApi.java
+++ b/src/main/java/online/lifeasgame/role/application/internal/RoleEventLookupApi.java
@@ -1,0 +1,9 @@
+package online.lifeasgame.role.application.internal;
+
+public interface RoleEventLookupApi {
+
+    RoleEventReference getOwned(Long roleEventId, Long playerId);
+
+    record RoleEventReference(Long id, Long roleId, String status) {
+    }
+}

--- a/src/main/java/online/lifeasgame/role/application/internal/RoleLookupApi.java
+++ b/src/main/java/online/lifeasgame/role/application/internal/RoleLookupApi.java
@@ -1,0 +1,9 @@
+package online.lifeasgame.role.application.internal;
+
+public interface RoleLookupApi {
+
+    RoleReference getOwned(Long roleId, Long playerId);
+
+    record RoleReference(Long id, String name, String status) {
+    }
+}

--- a/src/main/java/online/lifeasgame/role/application/result/RoleEventResult.java
+++ b/src/main/java/online/lifeasgame/role/application/result/RoleEventResult.java
@@ -1,0 +1,61 @@
+package online.lifeasgame.role.application.result;
+
+import online.lifeasgame.role.domain.RoleEvent;
+import online.lifeasgame.role.domain.RoleEventParticipant;
+
+import java.time.Instant;
+import java.util.List;
+
+public final class RoleEventResult {
+
+    private RoleEventResult() {
+    }
+
+    public record Detail(
+            Long id,
+            Long roleId,
+            String title,
+            String description,
+            Instant startsAt,
+            Instant endsAt,
+            String status,
+            Instant completedAt,
+            List<Participant> participants,
+            Instant createdAt,
+            Instant updatedAt,
+            Long version
+    ) {
+        public static Detail from(RoleEvent event) {
+            return new Detail(
+                    event.getId(),
+                    event.getRoleId(),
+                    event.getTitle(),
+                    event.getDescription(),
+                    event.getStartsAt(),
+                    event.getEndsAt(),
+                    event.getStatus().name(),
+                    event.getCompletedAt(),
+                    event.getParticipants().stream()
+                            .map(Participant::from)
+                            .toList(),
+                    event.getCreatedAt(),
+                    event.getUpdatedAt(),
+                    event.getVersion()
+            );
+        }
+    }
+
+    public record Participant(
+            Long participantLinkId,
+            String participantType,
+            Long participantId
+    ) {
+        public static Participant from(RoleEventParticipant participant) {
+            return new Participant(
+                    participant.getId(),
+                    participant.getParticipantType().name(),
+                    participant.getParticipantId()
+            );
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/role/domain/RoleEvent.java
+++ b/src/main/java/online/lifeasgame/role/domain/RoleEvent.java
@@ -1,0 +1,227 @@
+package online.lifeasgame.role.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import online.lifeasgame.core.annotation.AggregateRoot;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.guard.Guard;
+import online.lifeasgame.platform.persistence.jpa.AbstractTime;
+import online.lifeasgame.role.domain.error.RoleError;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Entity
+@AggregateRoot
+@Getter
+@Table(
+        name = "role_events",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_role_event_id_role_player",
+                columnNames = {"id", "role_id", "player_id"}
+        ),
+        indexes = @Index(
+                name = "idx_role_event_player_role_status",
+                columnList = "player_id,role_id,status,id"
+        )
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RoleEvent extends AbstractTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "player_id", nullable = false, updatable = false)
+    private Long playerId;
+
+    @Column(name = "role_id", nullable = false, updatable = false)
+    private Long roleId;
+
+    @Column(nullable = false, length = 120)
+    private String title;
+
+    @Column(length = 1000)
+    private String description;
+
+    @Column(name = "starts_at")
+    private Instant startsAt;
+
+    @Column(name = "ends_at")
+    private Instant endsAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private RoleEventStatus status;
+
+    @Column(name = "completed_at")
+    private Instant completedAt;
+
+    @Version
+    @Column(nullable = false)
+    private Long version;
+
+    @OneToMany(
+            mappedBy = "roleEvent",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true
+    )
+    @OrderBy("id ASC")
+    private List<RoleEventParticipant> participants = new ArrayList<>();
+
+    private RoleEvent(
+            Long playerId,
+            Long roleId,
+            String title,
+            String description,
+            Instant startsAt,
+            Instant endsAt
+    ) {
+        this.playerId = positive(playerId, "playerId");
+        this.roleId = positive(roleId, "roleId");
+        applyStructure(title, description, startsAt, endsAt);
+        this.status = RoleEventStatus.PLANNED;
+    }
+
+    public static RoleEvent create(
+            Long playerId,
+            Long roleId,
+            String title,
+            String description,
+            Instant startsAt,
+            Instant endsAt
+    ) {
+        return new RoleEvent(
+                playerId,
+                roleId,
+                title,
+                description,
+                startsAt,
+                endsAt
+        );
+    }
+
+    public void update(
+            String title,
+            String description,
+            Instant startsAt,
+            Instant endsAt
+    ) {
+        requirePlanned();
+        applyStructure(title, description, startsAt, endsAt);
+    }
+
+    public void complete(Instant completedAt) {
+        requirePlanned();
+        this.status = RoleEventStatus.COMPLETED;
+        this.completedAt = Guard.notNull(completedAt, "completedAt");
+    }
+
+    public void cancel() {
+        requirePlanned();
+        this.status = RoleEventStatus.CANCELED;
+    }
+
+    public RoleEventParticipant addParticipant(
+            RoleEventParticipantType type,
+            Long participantId
+    ) {
+        requirePlanned();
+        if (participants.stream().anyMatch(
+                participant -> participant.matches(type, participantId)
+        )) {
+            throw new DomainException(
+                    RoleError.ROLE_EVENT_PARTICIPANT_ALREADY_EXISTS
+            );
+        }
+        RoleEventParticipant participant = new RoleEventParticipant(
+                this,
+                type,
+                participantId
+        );
+        participants.add(participant);
+        return participant;
+    }
+
+    public void removeParticipant(Long participantLinkId) {
+        requirePlanned();
+        boolean removed = participants.removeIf(
+                participant -> participant.getId().equals(participantLinkId)
+        );
+        if (!removed) {
+            throw new DomainException(
+                    RoleError.ROLE_EVENT_PARTICIPANT_NOT_FOUND
+            );
+        }
+    }
+
+    public List<RoleEventParticipant> getParticipants() {
+        return Collections.unmodifiableList(participants);
+    }
+
+    private void applyStructure(
+            String title,
+            String description,
+            Instant startsAt,
+            Instant endsAt
+    ) {
+        if (startsAt != null && endsAt != null && endsAt.isBefore(startsAt)) {
+            throw new DomainException(RoleError.INVALID_ROLE_EVENT_TIME_RANGE);
+        }
+        this.title = requiredTitle(title);
+        this.description = optionalDescription(description);
+        this.startsAt = startsAt;
+        this.endsAt = endsAt;
+    }
+
+    private void requirePlanned() {
+        if (status != RoleEventStatus.PLANNED) {
+            throw new DomainException(RoleError.ROLE_EVENT_NOT_PLANNED);
+        }
+    }
+
+    private static String requiredTitle(String value) {
+        if (value == null || value.isBlank()) {
+            throw new DomainException(RoleError.INVALID_ROLE_EVENT_TITLE);
+        }
+        String normalized = value.strip();
+        if (normalized.length() > 120) {
+            throw new DomainException(RoleError.INVALID_ROLE_EVENT_TITLE);
+        }
+        return normalized;
+    }
+
+    private static String optionalDescription(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String normalized = value.strip();
+        if (normalized.length() > 1000) {
+            throw new DomainException(
+                    RoleError.INVALID_ROLE_EVENT_DESCRIPTION
+            );
+        }
+        return normalized;
+    }
+
+    private static Long positive(Long value, String name) {
+        return Guard.minValue(Guard.notNull(value, name), 1L, name);
+    }
+}

--- a/src/main/java/online/lifeasgame/role/domain/RoleEventParticipant.java
+++ b/src/main/java/online/lifeasgame/role/domain/RoleEventParticipant.java
@@ -1,0 +1,76 @@
+package online.lifeasgame.role.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import online.lifeasgame.core.guard.Guard;
+import online.lifeasgame.platform.persistence.jpa.AbstractTime;
+
+@Entity
+@Getter
+@Table(
+        name = "role_event_participants",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_role_event_participant",
+                columnNames = {
+                        "role_event_id",
+                        "participant_type",
+                        "participant_id"
+                }
+        )
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RoleEventParticipant extends AbstractTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "role_event_id", nullable = false, updatable = false)
+    @Getter(AccessLevel.NONE)
+    private RoleEvent roleEvent;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "participant_type", nullable = false, length = 20, updatable = false)
+    private RoleEventParticipantType participantType;
+
+    @Column(name = "participant_id", nullable = false, updatable = false)
+    private Long participantId;
+
+    RoleEventParticipant(
+            RoleEvent roleEvent,
+            RoleEventParticipantType participantType,
+            Long participantId
+    ) {
+        this.roleEvent = Guard.notNull(roleEvent, "roleEvent");
+        this.participantType = Guard.notNull(
+                participantType,
+                "participantType"
+        );
+        this.participantId = positive(participantId, "participantId");
+    }
+
+    boolean matches(
+            RoleEventParticipantType type,
+            Long candidateId
+    ) {
+        return participantType == type && participantId.equals(candidateId);
+    }
+
+    private static Long positive(Long value, String name) {
+        return Guard.minValue(Guard.notNull(value, name), 1L, name);
+    }
+}

--- a/src/main/java/online/lifeasgame/role/domain/RoleEventParticipantType.java
+++ b/src/main/java/online/lifeasgame/role/domain/RoleEventParticipantType.java
@@ -1,0 +1,30 @@
+package online.lifeasgame.role.domain;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.role.domain.error.RoleError;
+
+public enum RoleEventParticipantType {
+    PERSON,
+    SERVICE_USER;
+
+    public static RoleEventParticipantType parse(String raw) {
+        if (raw == null) {
+            throw invalid();
+        }
+        try {
+            return valueOf(raw);
+        } catch (IllegalArgumentException exception) {
+            throw new DomainException(
+                    RoleError.INVALID_ROLE_EVENT_PARTICIPANT_TYPE,
+                    null,
+                    exception
+            );
+        }
+    }
+
+    private static DomainException invalid() {
+        return new DomainException(
+                RoleError.INVALID_ROLE_EVENT_PARTICIPANT_TYPE
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/role/domain/RoleEventStatus.java
+++ b/src/main/java/online/lifeasgame/role/domain/RoleEventStatus.java
@@ -1,0 +1,7 @@
+package online.lifeasgame.role.domain;
+
+public enum RoleEventStatus {
+    PLANNED,
+    COMPLETED,
+    CANCELED
+}

--- a/src/main/java/online/lifeasgame/role/domain/error/RoleError.java
+++ b/src/main/java/online/lifeasgame/role/domain/error/RoleError.java
@@ -11,7 +11,15 @@ public enum RoleError implements ErrorCode {
     ROLE_RELATION_NOT_FOUND("ROL-404-RELATION-NOT-FOUND", "Role relation not found", 404),
     ROLE_ARCHIVED("ROL-409-ARCHIVED", "Archived Role cannot be updated", 409),
     ROLE_RELATION_ALREADY_EXISTS("ROL-409-RELATION-ALREADY-EXISTS", "Role relation already exists", 409),
-    ROLE_RELATION_ARCHIVED("ROL-409-RELATION-ARCHIVED", "Archived Role relation cannot be updated", 409);
+    ROLE_RELATION_ARCHIVED("ROL-409-RELATION-ARCHIVED", "Archived Role relation cannot be updated", 409),
+    ROLE_EVENT_NOT_FOUND("ROL-404-EVENT-NOT-FOUND", "Role event not found", 404),
+    ROLE_EVENT_PARTICIPANT_NOT_FOUND("ROL-404-EVENT-PARTICIPANT-NOT-FOUND", "Role event participant not found", 404),
+    INVALID_ROLE_EVENT_TITLE("ROL-400-INVALID-EVENT-TITLE", "Invalid Role event title", 400),
+    INVALID_ROLE_EVENT_DESCRIPTION("ROL-400-INVALID-EVENT-DESCRIPTION", "Invalid Role event description", 400),
+    INVALID_ROLE_EVENT_TIME_RANGE("ROL-400-INVALID-EVENT-TIME-RANGE", "Invalid Role event time range", 400),
+    INVALID_ROLE_EVENT_PARTICIPANT_TYPE("ROL-400-INVALID-EVENT-PARTICIPANT-TYPE", "Invalid Role event participant type", 400),
+    ROLE_EVENT_NOT_PLANNED("ROL-409-EVENT-NOT-PLANNED", "Only planned Role events can be changed", 409),
+    ROLE_EVENT_PARTICIPANT_ALREADY_EXISTS("ROL-409-EVENT-PARTICIPANT-ALREADY-EXISTS", "Role event participant already exists", 409);
 
     private final String code;
     private final String message;

--- a/src/main/java/online/lifeasgame/role/domain/repository/RoleEventRepository.java
+++ b/src/main/java/online/lifeasgame/role/domain/repository/RoleEventRepository.java
@@ -1,0 +1,23 @@
+package online.lifeasgame.role.domain.repository;
+
+import online.lifeasgame.role.domain.RoleEvent;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RoleEventRepository {
+
+    RoleEvent saveAndFlush(RoleEvent roleEvent);
+
+    List<RoleEvent> findAllOwned(Long roleId, Long playerId);
+
+    Optional<RoleEvent> findOwned(Long eventId, Long roleId, Long playerId);
+
+    Optional<RoleEvent> findOwnedForUpdate(
+            Long eventId,
+            Long roleId,
+            Long playerId
+    );
+
+    Optional<RoleEvent> findByIdAndPlayerId(Long eventId, Long playerId);
+}

--- a/src/main/java/online/lifeasgame/role/infra/JpaRoleEventRepository.java
+++ b/src/main/java/online/lifeasgame/role/infra/JpaRoleEventRepository.java
@@ -1,0 +1,45 @@
+package online.lifeasgame.role.infra;
+
+import jakarta.persistence.LockModeType;
+import online.lifeasgame.role.domain.RoleEvent;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface JpaRoleEventRepository extends JpaRepository<RoleEvent, Long> {
+
+    @EntityGraph(attributePaths = "participants")
+    List<RoleEvent> findAllByRoleIdAndPlayerIdOrderByIdAsc(
+            Long roleId,
+            Long playerId
+    );
+
+    @EntityGraph(attributePaths = "participants")
+    Optional<RoleEvent> findByIdAndRoleIdAndPlayerId(
+            Long eventId,
+            Long roleId,
+            Long playerId
+    );
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @EntityGraph(attributePaths = "participants")
+    @Query("""
+            SELECT event
+            FROM RoleEvent event
+            WHERE event.id = :eventId
+              AND event.roleId = :roleId
+              AND event.playerId = :playerId
+            """)
+    Optional<RoleEvent> findOwnedForUpdate(
+            @Param("eventId") Long eventId,
+            @Param("roleId") Long roleId,
+            @Param("playerId") Long playerId
+    );
+
+    Optional<RoleEvent> findByIdAndPlayerId(Long eventId, Long playerId);
+}

--- a/src/main/java/online/lifeasgame/role/infra/RoleEventRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/role/infra/RoleEventRepositoryAdapter.java
@@ -1,0 +1,59 @@
+package online.lifeasgame.role.infra;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.role.domain.RoleEvent;
+import online.lifeasgame.role.domain.repository.RoleEventRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class RoleEventRepositoryAdapter implements RoleEventRepository {
+
+    private final JpaRoleEventRepository repository;
+
+    @Override
+    public RoleEvent saveAndFlush(RoleEvent roleEvent) {
+        return repository.saveAndFlush(roleEvent);
+    }
+
+    @Override
+    public List<RoleEvent> findAllOwned(Long roleId, Long playerId) {
+        return repository.findAllByRoleIdAndPlayerIdOrderByIdAsc(
+                roleId,
+                playerId
+        );
+    }
+
+    @Override
+    public Optional<RoleEvent> findOwned(
+            Long eventId,
+            Long roleId,
+            Long playerId
+    ) {
+        return repository.findByIdAndRoleIdAndPlayerId(
+                eventId,
+                roleId,
+                playerId
+        );
+    }
+
+    @Override
+    public Optional<RoleEvent> findOwnedForUpdate(
+            Long eventId,
+            Long roleId,
+            Long playerId
+    ) {
+        return repository.findOwnedForUpdate(eventId, roleId, playerId);
+    }
+
+    @Override
+    public Optional<RoleEvent> findByIdAndPlayerId(
+            Long eventId,
+            Long playerId
+    ) {
+        return repository.findByIdAndPlayerId(eventId, playerId);
+    }
+}

--- a/src/main/java/online/lifeasgame/user/application/UserLookupService.java
+++ b/src/main/java/online/lifeasgame/user/application/UserLookupService.java
@@ -1,0 +1,31 @@
+package online.lifeasgame.user.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.user.application.internal.UserLookupApi;
+import online.lifeasgame.user.domain.User;
+import online.lifeasgame.user.domain.UserStatus;
+import online.lifeasgame.user.domain.error.UserError;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+public class UserLookupService implements UserLookupApi {
+
+    private final UserReader reader;
+
+    @Override
+    public UserReference getActive(Long userId) {
+        User user = reader.findByIdOrElseThrow(userId);
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            throw new DomainException(UserError.USER_NOT_ACTIVE);
+        }
+        return new UserReference(
+                user.getId(),
+                user.getNickname().getValue()
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/user/application/internal/UserLookupApi.java
+++ b/src/main/java/online/lifeasgame/user/application/internal/UserLookupApi.java
@@ -1,0 +1,9 @@
+package online.lifeasgame.user.application.internal;
+
+public interface UserLookupApi {
+
+    UserReference getActive(Long userId);
+
+    record UserReference(Long id, String nickname) {
+    }
+}

--- a/src/main/java/online/lifeasgame/user/domain/error/UserError.java
+++ b/src/main/java/online/lifeasgame/user/domain/error/UserError.java
@@ -22,6 +22,12 @@ public enum UserError implements ErrorCode {
             404
     ),
 
+    USER_NOT_ACTIVE(
+            "USR-409-NOT-ACTIVE",
+            "User is not active",
+            409
+    ),
+
     NICKNAME_DUPLICATE(
             "USR-409-NICKNAME-DUP",
             "Nickname already in use",

--- a/src/main/resources/db/migration/V21__role_event_lifelog_linkage.sql
+++ b/src/main/resources/db/migration/V21__role_event_lifelog_linkage.sql
@@ -1,0 +1,90 @@
+CREATE TABLE role_events (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    player_id BIGINT NOT NULL,
+    role_id BIGINT NOT NULL,
+    title VARCHAR(120) NOT NULL,
+    description VARCHAR(1000) NULL,
+    starts_at DATETIME(6) NULL,
+    ends_at DATETIME(6) NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'PLANNED',
+    completed_at DATETIME(6) NULL,
+    version BIGINT NOT NULL DEFAULT 0,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_role_event_id_role_player
+        UNIQUE (id, role_id, player_id),
+    CONSTRAINT ck_role_event_player CHECK (player_id > 0),
+    CONSTRAINT ck_role_event_role CHECK (role_id > 0),
+    CONSTRAINT ck_role_event_title CHECK (
+        CHAR_LENGTH(TRIM(title)) BETWEEN 1 AND 120
+    ),
+    CONSTRAINT ck_role_event_time_range CHECK (
+        starts_at IS NULL OR ends_at IS NULL OR ends_at >= starts_at
+    ),
+    CONSTRAINT ck_role_event_status CHECK (
+        status IN ('PLANNED', 'COMPLETED', 'CANCELED')
+    ),
+    CONSTRAINT ck_role_event_completion CHECK (
+        (status = 'COMPLETED' AND completed_at IS NOT NULL)
+        OR (status IN ('PLANNED', 'CANCELED') AND completed_at IS NULL)
+    ),
+    INDEX idx_role_event_player_role_status (
+        player_id, role_id, status, id
+    ),
+    CONSTRAINT fk_role_event_role_owner
+        FOREIGN KEY (role_id, player_id)
+        REFERENCES roles (id, player_id)
+        ON DELETE RESTRICT
+        ON UPDATE RESTRICT
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE role_event_participants (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    role_event_id BIGINT NOT NULL,
+    participant_type VARCHAR(20) NOT NULL,
+    participant_id BIGINT NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_role_event_participant UNIQUE (
+        role_event_id, participant_type, participant_id
+    ),
+    CONSTRAINT ck_role_event_participant_type CHECK (
+        participant_type IN ('PERSON', 'SERVICE_USER')
+    ),
+    CONSTRAINT ck_role_event_participant_id CHECK (participant_id > 0),
+    CONSTRAINT fk_role_event_participant_event
+        FOREIGN KEY (role_event_id)
+        REFERENCES role_events (id)
+        ON DELETE RESTRICT
+        ON UPDATE RESTRICT
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_0900_ai_ci;
+
+ALTER TABLE life_log_records
+    DROP CHECK ck_life_log_record_primary_role,
+    ADD COLUMN role_event_id BIGINT NULL AFTER primary_role_id,
+    ADD CONSTRAINT ck_life_log_record_primary_role
+        CHECK (primary_role_id IS NULL OR primary_role_id > 0),
+    ADD CONSTRAINT ck_life_log_record_role_event
+        CHECK (
+            role_event_id IS NULL
+            OR (role_event_id > 0 AND primary_role_id IS NOT NULL)
+        ),
+    ADD INDEX idx_life_log_record_player_role_event (
+        player_id, primary_role_id, role_event_id, id
+    ),
+    ADD CONSTRAINT fk_life_log_record_role_owner
+        FOREIGN KEY (primary_role_id, player_id)
+        REFERENCES roles (id, player_id)
+        ON DELETE RESTRICT
+        ON UPDATE RESTRICT,
+    ADD CONSTRAINT fk_life_log_record_role_event_context
+        FOREIGN KEY (role_event_id, primary_role_id, player_id)
+        REFERENCES role_events (id, role_id, player_id)
+        ON DELETE RESTRICT
+        ON UPDATE RESTRICT;

--- a/src/test/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryIntegrationTest.java
@@ -99,7 +99,7 @@ class InventoryRewardDeliveryIntegrationTest {
     @DisplayName("V17 receipt table은 JPA validate와 unique/check/index 계약을 만족한다")
     void validatesMigrationContract() {
         assertThat(flyway.info().current().getVersion().getVersion())
-                .isEqualTo("20");
+                .isEqualTo("21");
         assertThat(environment.getProperty("spring.jpa.hibernate.ddl-auto"))
                 .isEqualTo("validate");
 

--- a/src/test/java/online/lifeasgame/lifelog/api/player/mapper/LifeLogRecordMetadataWebMapperTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/api/player/mapper/LifeLogRecordMetadataWebMapperTest.java
@@ -6,9 +6,11 @@ import online.lifeasgame.lifelog.api.player.request.PlayerMediaLogRequest;
 import online.lifeasgame.lifelog.quick.api.QuickRecordRequest;
 import online.lifeasgame.lifelog.quick.api.QuickRecordWebMapper;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -110,5 +112,69 @@ class LifeLogRecordMetadataWebMapperTest {
                 .isEqualTo("REFLECTION");
         assertThat(command.lifeLogMetadata().reflectionScope())
                 .isEqualTo("WEEKLY_LOOKBACK");
+    }
+
+    @Nested
+    @DisplayName("Role/Event flat field를 create command로 옮길 때")
+    class MapRoleContext {
+
+        @Test
+        @DisplayName("Collection/Exercise/Media 모두 동일한 canonical metadata를 보존한다")
+        void mapsAllDirectCreateRoleContexts() {
+            var collection = PlayerCollectionWebMapper.toCreateCommand(
+                    new PlayerCollectionRequest.Create(
+                            "BOOK", "title", null, 1, null, null,
+                            Set.of(), null, null, 10L, 20L
+                    )
+            );
+            var exercise = PlayerExerciseWebMapper.toCreateCommand(
+                    new PlayerExerciseRequest.Create(
+                            "RUNNING", 10, null, null,
+                            LocalDate.of(2026, 8, 11), null,
+                            null, null, 10L, 20L
+                    )
+            );
+            var media = PlayerMediaLogWebMapper.toCreateCommand(
+                    new PlayerMediaLogRequest.Create(
+                            "BOOK", "title", null, 0, 1, "PLANNED",
+                            Set.of(), null, null, 10L, 20L
+                    )
+            );
+
+            assertThat(List.of(
+                    collection.lifeLogMetadata(),
+                    exercise.lifeLogMetadata(),
+                    media.lifeLogMetadata()
+            )).allSatisfy(metadata -> {
+                assertThat(metadata.primaryRoleId()).isEqualTo(10L);
+                assertThat(metadata.roleEventId()).isEqualTo(20L);
+                assertThat(metadata.lifeLogSubtype()).isNull();
+            });
+        }
+
+        @Test
+        @DisplayName("Quick Record는 top-level Role/Event만 selected metadata로 전달한다")
+        void mapsQuickTopLevelRoleContext() {
+            var selected = QuickRecordWebMapper.toCommand(
+                    new QuickRecordRequest.Create(
+                            "COLLECTION",
+                            null,
+                            null,
+                            10L,
+                            20L,
+                            new PlayerCollectionRequest.Create(
+                                    "BOOK", "title", null, 1,
+                                    null, null, Set.of()
+                            ),
+                            null,
+                            null
+                    )
+            ).selected();
+
+            assertThat(selected.lifeLogMetadata().primaryRoleId())
+                    .isEqualTo(10L);
+            assertThat(selected.lifeLogMetadata().roleEventId())
+                    .isEqualTo(20L);
+        }
     }
 }

--- a/src/test/java/online/lifeasgame/lifelog/application/record/LifeLogRecordRoleLinkageTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/application/record/LifeLogRecordRoleLinkageTest.java
@@ -1,0 +1,250 @@
+package online.lifeasgame.lifelog.application.record;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.lifelog.domain.error.LifeLogError;
+import online.lifeasgame.lifelog.domain.record.LifeLogEntryMode;
+import online.lifeasgame.lifelog.domain.record.LifeLogRecord;
+import online.lifeasgame.lifelog.domain.record.LifeLogSourceType;
+import online.lifeasgame.lifelog.domain.record.repository.LifeLogRecordRepository;
+import online.lifeasgame.role.application.internal.RoleEventLookupApi;
+import online.lifeasgame.role.application.internal.RoleLookupApi;
+import online.lifeasgame.role.domain.error.RoleError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("LifeLog canonical RoleEvent linkage")
+class LifeLogRecordRoleLinkageTest {
+
+    private static final Long PLAYER_ID = 252L;
+    private static final Long ROLE_ID = 25L;
+    private static final Long EVENT_ID = 52L;
+    private static final Instant NOW =
+            Instant.parse("2026-08-11T04:00:00Z");
+
+    @Mock
+    private LifeLogRecordRepository repository;
+
+    @Mock
+    private PlayerTimezoneResolver timezoneResolver;
+
+    @Mock
+    private RoleLookupApi roleLookupApi;
+
+    @Mock
+    private RoleEventLookupApi roleEventLookupApi;
+
+    @Mock
+    private Clock clock;
+
+    @InjectMocks
+    private LifeLogRecordRegistrar registrar;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(clock.instant()).thenReturn(NOW);
+        lenient().when(repository.saveAndFlush(any()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Nested
+    @DisplayName("LifeLog에 Role context를 지정하지 않으면")
+    class WithoutRoleContext {
+
+        @Test
+        @DisplayName("기존 canonical header를 동일하게 저장한다")
+        void preservesLegacyHeader() {
+            LifeLogRecord record = register(
+                    LifeLogRecordMetadataCommand.none()
+            );
+
+            assertThat(record.getPrimaryRoleId()).isNull();
+            assertThat(record.getRoleEventId()).isNull();
+            assertThat(record.getOccurredAt()).isEqualTo(NOW);
+            verifyNoInteractions(roleLookupApi, roleEventLookupApi);
+        }
+    }
+
+    @Nested
+    @DisplayName("LifeLog에 Role만 지정하면")
+    class WithRoleOnly {
+
+        @Test
+        @DisplayName("subtype 없이도 owned Role을 canonical header에 저장한다")
+        void storesOwnedRoleWithoutSubtype() {
+            given(roleLookupApi.getOwned(ROLE_ID, PLAYER_ID)).willReturn(
+                    roleReference()
+            );
+
+            LifeLogRecord record = register(new LifeLogRecordMetadataCommand(
+                    null,
+                    null,
+                    ROLE_ID,
+                    null
+            ));
+
+            assertThat(record.getPrimaryRoleId()).isEqualTo(ROLE_ID);
+            assertThat(record.getRoleEventId()).isNull();
+            assertThat(record.isContentReady()).isFalse();
+            verifyNoInteractions(roleEventLookupApi);
+        }
+
+        @Test
+        @DisplayName("다른 Player의 Role은 provider ownership 오류로 거부한다")
+        void rejectsAnotherPlayersRole() {
+            given(roleLookupApi.getOwned(ROLE_ID, PLAYER_ID)).willThrow(
+                    new DomainException(RoleError.ROLE_NOT_FOUND)
+            );
+
+            assertThatThrownBy(() -> register(
+                    new LifeLogRecordMetadataCommand(
+                            null,
+                            null,
+                            ROLE_ID,
+                            null
+                    )
+            )).isInstanceOfSatisfying(
+                    DomainException.class,
+                    exception -> assertThat(exception.getErrorCode())
+                            .isEqualTo(RoleError.ROLE_NOT_FOUND)
+            );
+            verifyNoInteractions(repository, roleEventLookupApi);
+        }
+    }
+
+    @Nested
+    @DisplayName("LifeLog에 RoleEvent를 연결하면")
+    class WithRoleEvent {
+
+        @Test
+        @DisplayName("eventId만 지정해도 Event의 roleId를 derive해 둘 다 저장한다")
+        void derivesRoleFromEvent() {
+            given(roleEventLookupApi.getOwned(EVENT_ID, PLAYER_ID))
+                    .willReturn(eventReference(ROLE_ID));
+
+            LifeLogRecord record = register(new LifeLogRecordMetadataCommand(
+                    null,
+                    null,
+                    null,
+                    EVENT_ID
+            ));
+
+            assertThat(record.getPrimaryRoleId()).isEqualTo(ROLE_ID);
+            assertThat(record.getRoleEventId()).isEqualTo(EVENT_ID);
+            verifyNoInteractions(roleLookupApi);
+        }
+
+        @Test
+        @DisplayName("명시한 Role과 Event의 Role이 같으면 linkage를 저장한다")
+        void storesMatchingRoleAndEvent() {
+            given(roleEventLookupApi.getOwned(EVENT_ID, PLAYER_ID))
+                    .willReturn(eventReference(ROLE_ID));
+            given(roleLookupApi.getOwned(ROLE_ID, PLAYER_ID)).willReturn(
+                    roleReference()
+            );
+
+            LifeLogRecord record = register(new LifeLogRecordMetadataCommand(
+                    "MEMORY",
+                    null,
+                    ROLE_ID,
+                    EVENT_ID
+            ));
+
+            assertThat(record.getPrimaryRoleId()).isEqualTo(ROLE_ID);
+            assertThat(record.getRoleEventId()).isEqualTo(EVENT_ID);
+            assertThat(record.isContentReady()).isTrue();
+            verify(repository).saveAndFlush(record);
+        }
+
+        @Test
+        @DisplayName("명시한 Role과 Event의 Role이 다르면 저장 전에 거부한다")
+        void rejectsMismatchedRoleAndEvent() {
+            given(roleEventLookupApi.getOwned(EVENT_ID, PLAYER_ID))
+                    .willReturn(eventReference(99L));
+
+            assertThatThrownBy(() -> register(
+                    new LifeLogRecordMetadataCommand(
+                            null,
+                            null,
+                            ROLE_ID,
+                            EVENT_ID
+                    )
+            )).isInstanceOfSatisfying(
+                    DomainException.class,
+                    exception -> assertThat(exception.getErrorCode())
+                            .isEqualTo(
+                                    LifeLogError.ROLE_EVENT_CONTEXT_MISMATCH
+                            )
+            );
+            verifyNoInteractions(repository, roleLookupApi);
+        }
+
+        @Test
+        @DisplayName("다른 Player의 Event는 provider ownership 오류로 거부한다")
+        void rejectsAnotherPlayersEvent() {
+            given(roleEventLookupApi.getOwned(EVENT_ID, PLAYER_ID))
+                    .willThrow(new DomainException(
+                            RoleError.ROLE_EVENT_NOT_FOUND
+                    ));
+
+            assertThatThrownBy(() -> register(
+                    new LifeLogRecordMetadataCommand(
+                            null,
+                            null,
+                            null,
+                            EVENT_ID
+                    )
+            )).isInstanceOfSatisfying(
+                    DomainException.class,
+                    exception -> assertThat(exception.getErrorCode())
+                            .isEqualTo(RoleError.ROLE_EVENT_NOT_FOUND)
+            );
+            verifyNoInteractions(repository, roleLookupApi);
+        }
+    }
+
+    private LifeLogRecord register(LifeLogRecordMetadataCommand metadata) {
+        return registrar.register(
+                PLAYER_ID,
+                LifeLogSourceType.COLLECTION,
+                1L,
+                LifeLogEntryMode.FULL,
+                metadata
+        );
+    }
+
+    private RoleLookupApi.RoleReference roleReference() {
+        return new RoleLookupApi.RoleReference(
+                ROLE_ID,
+                "Developer",
+                "ACTIVE"
+        );
+    }
+
+    private RoleEventLookupApi.RoleEventReference eventReference(
+            Long roleId
+    ) {
+        return new RoleEventLookupApi.RoleEventReference(
+                EVENT_ID,
+                roleId,
+                "PLANNED"
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/lifelog/domain/event/LifeLogRecordedTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/domain/event/LifeLogRecordedTest.java
@@ -4,6 +4,7 @@ import online.lifeasgame.lifelog.domain.record.LifeLogEntryMode;
 import online.lifeasgame.lifelog.domain.record.LifeLogReflectionScope;
 import online.lifeasgame.lifelog.domain.record.LifeLogSubtype;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -108,7 +109,7 @@ class LifeLogRecordedTest {
                 LifeLogRecorded.EVENT_TYPE,
                 1,
                 1,
-                31L
+                0L
         )).isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -130,6 +131,31 @@ class LifeLogRecordedTest {
                 null,
                 null
         )).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Nested
+    @DisplayName("v1 Fact에 primary Role snapshot을 기록할 때")
+    class PrimaryRoleSnapshot {
+
+        @Test
+        @DisplayName("기존 null primaryRoleId를 계속 허용한다")
+        void acceptsNullPrimaryRole() {
+            assertThat(contentReady().primaryRoleId()).isNull();
+        }
+
+        @Test
+        @DisplayName("positive primaryRoleId를 additive field로 허용한다")
+        void acceptsPositivePrimaryRole() {
+            LifeLogRecorded event = withContract(
+                    LifeLogRecorded.EVENT_TYPE,
+                    LifeLogRecorded.EVENT_VERSION,
+                    1,
+                    31L
+            );
+
+            assertThat(event.eventVersion()).isEqualTo(1);
+            assertThat(event.primaryRoleId()).isEqualTo(31L);
+        }
     }
 
     private LifeLogRecorded contentReady() {

--- a/src/test/java/online/lifeasgame/lifelog/domain/record/LifeLogRecordTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/domain/record/LifeLogRecordTest.java
@@ -1,6 +1,7 @@
 package online.lifeasgame.lifelog.domain.record;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -131,5 +132,58 @@ class LifeLogRecordTest {
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> new LifeLogPeriodKey("2025-W53"))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Nested
+    @DisplayName("canonical header에 Role context를 기록할 때")
+    class RoleContext {
+
+        @Test
+        @DisplayName("Role만 지정한 legacy header를 허용한다")
+        void acceptsRoleOnly() {
+            LifeLogRecord record = LifeLogRecord.legacy(
+                    1L,
+                    LifeLogSourceType.COLLECTION,
+                    1L,
+                    LifeLogEntryMode.FULL,
+                    10L,
+                    null,
+                    OCCURRED_AT
+            );
+
+            assertThat(record.getPrimaryRoleId()).isEqualTo(10L);
+            assertThat(record.getRoleEventId()).isNull();
+        }
+
+        @Test
+        @DisplayName("RoleEvent를 지정하면 primary Role도 함께 보존한다")
+        void acceptsRoleAndEvent() {
+            LifeLogRecord record = LifeLogRecord.legacy(
+                    1L,
+                    LifeLogSourceType.COLLECTION,
+                    1L,
+                    LifeLogEntryMode.FULL,
+                    10L,
+                    20L,
+                    OCCURRED_AT
+            );
+
+            assertThat(record.getPrimaryRoleId()).isEqualTo(10L);
+            assertThat(record.getRoleEventId()).isEqualTo(20L);
+        }
+
+        @Test
+        @DisplayName("Role 없이 RoleEvent만 가진 비정규 header는 거부한다")
+        void rejectsEventWithoutRole() {
+            assertThatThrownBy(() -> LifeLogRecord.legacy(
+                    1L,
+                    LifeLogSourceType.COLLECTION,
+                    1L,
+                    LifeLogEntryMode.FULL,
+                    null,
+                    20L,
+                    OCCURRED_AT
+            )).isInstanceOf(IllegalArgumentException.class);
+        }
     }
 }

--- a/src/test/java/online/lifeasgame/lifelog/quick/application/QuickRecordRequestHasherTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/quick/application/QuickRecordRequestHasherTest.java
@@ -8,6 +8,7 @@ import online.lifeasgame.lifelog.application.record.LifeLogRecordMetadataCommand
 import online.lifeasgame.lifelog.domain.event.LifeLogType;
 import online.lifeasgame.lifelog.quick.domain.error.QuickRecordError;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
@@ -203,6 +204,48 @@ class QuickRecordRequestHasherTest {
         ));
 
         assertThat(first).isNotEqualTo(second);
+    }
+
+    @Nested
+    @DisplayName("Quick Record idempotency에 Role context를 포함할 때")
+    class RoleContextHash {
+
+        @Test
+        @DisplayName("Role/Event가 다르면 서로 다른 request hash를 만든다")
+        void distinguishesRoleContext() {
+            var payload = collection("title", Set.of("tag"));
+
+            String roleOnly = hash(new QuickRecordCommand.Create(
+                    "COLLECTION", null, null, 10L, null,
+                    payload, null, null
+            ));
+            String firstEvent = hash(new QuickRecordCommand.Create(
+                    "COLLECTION", null, null, 10L, 20L,
+                    payload, null, null
+            ));
+            String secondEvent = hash(new QuickRecordCommand.Create(
+                    "COLLECTION", null, null, 10L, 21L,
+                    payload, null, null
+            ));
+
+            assertThat(Set.of(roleOnly, firstEvent, secondEvent)).hasSize(3);
+        }
+
+        @Test
+        @DisplayName("Role context가 없으면 기존 constructor와 동일한 hash를 유지한다")
+        void preservesExistingHashWithoutRoleContext() {
+            var payload = collection("title", Set.of("tag"));
+            var existing = new QuickRecordCommand.Create(
+                    "COLLECTION", "MEMORY", null,
+                    payload, null, null
+            );
+            var expanded = new QuickRecordCommand.Create(
+                    "COLLECTION", "MEMORY", null, null, null,
+                    payload, null, null
+            );
+
+            assertThat(hash(expanded)).isEqualTo(hash(existing));
+        }
     }
 
     private String hash(QuickRecordCommand.Create command) {

--- a/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
@@ -63,7 +63,7 @@ class FlywayExplicitBaselineTest {
     class ApplyExplicitBaseline {
 
         @Test
-        @DisplayName("V1을 재실행하지 않고 V2부터 V20까지 적용한 뒤 JPA validate를 통과한다")
+        @DisplayName("V1을 재실행하지 않고 V2부터 V21까지 적용한 뒤 JPA validate를 통과한다")
         void migratesFromVersionTwoAndValidatesJpa() throws Exception {
             String jdbcUrl = createV1EquivalentDatabase();
             Flyway flyway = migrationFlyway(jdbcUrl);
@@ -72,12 +72,13 @@ class FlywayExplicitBaselineTest {
             MigrateResult migrateResult = flyway.migrate();
             List<HistoryRow> history = successfulHistory(jdbcUrl);
 
-            assertThat(migrateResult.migrationsExecuted).isEqualTo(19);
+            assertThat(migrateResult.migrationsExecuted).isEqualTo(20);
             assertThat(history).extracting(HistoryRow::version)
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
-                            "14", "15", "16", "17", "18", "19", "20"
+                            "14", "15", "16", "17", "18", "19", "20",
+                            "21"
                     );
             assertThat(history.getFirst().type()).isEqualTo("BASELINE");
             assertThat(history.getFirst().script())
@@ -107,7 +108,8 @@ class FlywayExplicitBaselineTest {
                             "V17__inventory_reward_delivery_foundation.sql",
                             "V18__reward_item_code_snapshot.sql",
                             "V19__role_person_persistence_foundation.sql",
-                            "V20__quest_route_mvp.sql"
+                            "V20__quest_route_mvp.sql",
+                            "V21__role_event_lifelog_linkage.sql"
                     );
             assertThat(history.subList(1, history.size()))
                     .allSatisfy(row -> assertThat(row.checksum()).isNotNull());
@@ -127,7 +129,7 @@ class FlywayExplicitBaselineTest {
                         "spring.jpa.hibernate.ddl-auto"
                 )).isEqualTo("validate");
                 assertThat(context.getBean(Flyway.class).info().current().getVersion().getVersion())
-                        .isEqualTo("20");
+                        .isEqualTo("21");
             }
         }
     }

--- a/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
@@ -33,10 +33,10 @@ class FlywayHistoryChecksumTest {
     class MigrateAgain {
 
         @Test
-        @DisplayName("V1~V19 checksum을 보존하고 V20 이후 두 번째 실행은 no-op이다")
+        @DisplayName("V1~V20 checksum을 보존하고 V21 이후 두 번째 실행은 no-op이다")
         void keepsMigrationHistory() throws Exception {
-            Flyway throughV19 = flyway(MigrationVersion.fromVersion("19"));
-            MigrateResult legacy = throughV19.migrate();
+            Flyway throughV20 = flyway(MigrationVersion.fromVersion("20"));
+            MigrateResult legacy = throughV20.migrate();
             List<HistoryRow> legacyHistory = successfulHistory();
             Flyway flyway = flyway(null);
 
@@ -46,7 +46,7 @@ class FlywayHistoryChecksumTest {
             MigrateResult second = flyway.migrate();
             List<HistoryRow> secondHistory = successfulHistory();
 
-            assertThat(legacy.migrationsExecuted).isEqualTo(19);
+            assertThat(legacy.migrationsExecuted).isEqualTo(20);
             assertThat(first.migrationsExecuted).isEqualTo(1);
             assertThat(second.migrationsExecuted).isZero();
             assertThat(secondHistory).isEqualTo(firstHistory);
@@ -56,7 +56,8 @@ class FlywayHistoryChecksumTest {
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
-                            "14", "15", "16", "17", "18", "19", "20"
+                            "14", "15", "16", "17", "18", "19", "20",
+                            "21"
                     );
             assertThat(secondHistory).allSatisfy(history -> {
                 assertThat(history.checksum()).isNotNull();

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -39,7 +39,7 @@ class FlywayMigrationTest {
     class MigrateCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V20까지 적용되고 QuestRoute foundation을 추가한다")
+        @DisplayName("V1부터 V21까지 적용되고 RoleEvent linkage를 추가한다")
         void migratesSchemaAndSeedsRewardProfiles() throws Exception {
             Flyway throughV10 = flyway(MigrationVersion.fromVersion("10"));
             MigrateResult legacyResult = throughV10.migrate();
@@ -58,12 +58,13 @@ class FlywayMigrationTest {
             assertThat(legacyResult.migrationsExecuted).isEqualTo(10);
             assertThat(semanticResult.migrationsExecuted).isEqualTo(1);
             assertThat(itemResult.migrationsExecuted).isEqualTo(1);
-            assertThat(result.migrationsExecuted).isEqualTo(8);
+            assertThat(result.migrationsExecuted).isEqualTo(9);
             assertThat(appliedVersions())
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
-                            "14", "15", "16", "17", "18", "19", "20"
+                            "14", "15", "16", "17", "18", "19", "20",
+                            "21"
                     );
             assertThat(existingTables(
                     "users",
@@ -88,7 +89,9 @@ class FlywayMigrationTest {
                     "quest_routes",
                     "quest_route_steps",
                     "quest_route_step_quests",
-                    "player_quest_routes"
+                    "player_quest_routes",
+                    "role_events",
+                    "role_event_participants"
             )).containsExactlyInAnyOrder(
                     "users",
                     "player",
@@ -112,7 +115,9 @@ class FlywayMigrationTest {
                     "quest_routes",
                     "quest_route_steps",
                     "quest_route_step_quests",
-                    "player_quest_routes"
+                    "player_quest_routes",
+                    "role_events",
+                    "role_event_participants"
             );
             assertThat(existingTables(
                     "quick_lifelog_entries",
@@ -291,6 +296,7 @@ class FlywayMigrationTest {
                     "reflection_scope",
                     "period_key",
                     "primary_role_id",
+                    "role_event_id",
                     "occurred_at",
                     "created_at",
                     "updated_at"
@@ -312,7 +318,8 @@ class FlywayMigrationTest {
                     "ck_life_log_record_reflection_scope",
                     "ck_life_log_record_reflection_pairing",
                     "ck_life_log_record_non_reflection_metadata",
-                    "ck_life_log_record_primary_role"
+                    "ck_life_log_record_primary_role",
+                    "ck_life_log_record_role_event"
             );
             assertThat(lifeLogRecordCount()).isZero();
             assertLifeLogRecordReflectionCheckContract();

--- a/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
@@ -149,7 +149,7 @@ class FlywayProfileCutoverTest {
     class StartLocalWithCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V20까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
+        @DisplayName("V1부터 V21까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
         void migratesThenValidates() {
             ConfigurableEnvironment environment =
                     (ConfigurableEnvironment) applicationContext.getEnvironment();
@@ -161,8 +161,8 @@ class FlywayProfileCutoverTest {
             assertThat(environment.getProperty(
                     "spring.flyway.baseline-on-migrate", Boolean.class
             )).isFalse();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("20");
-            assertThat(appliedMigrationCount()).isEqualTo(20);
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("21");
+            assertThat(appliedMigrationCount()).isEqualTo(21);
         }
     }
 

--- a/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 @SpringBootTest
 @ActiveProfiles({"test", "migration-test"})
-@DisplayName("V20 migration 이후 JPA schema validation")
+@DisplayName("V21 migration 이후 JPA schema validation")
 class JpaValidateAfterMigrationTest {
 
     @Container
@@ -79,14 +79,14 @@ class JpaValidateAfterMigrationTest {
     private QuestDefinitionBootstrapper questDefinitionBootstrapper;
 
     @Nested
-    @DisplayName("V1부터 V20까지 적용된 schema로 ApplicationContext를 기동할 때")
+    @DisplayName("V1부터 V21까지 적용된 schema로 ApplicationContext를 기동할 때")
     class LoadApplicationContext {
 
         @Test
         @DisplayName("ddl-auto validate 상태로 정상 기동한다")
         void loadsWithJpaValidation() {
             assertThat(applicationContext).isNotNull();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("20");
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("21");
             assertThat(applicationContext.getEnvironment().getProperty("spring.jpa.hibernate.ddl-auto"))
                     .isEqualTo("validate");
             assertThat(applicationContext.getEnvironment()

--- a/src/test/java/online/lifeasgame/migration/QuestRouteFlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/QuestRouteFlywayMigrationTest.java
@@ -42,6 +42,7 @@ class QuestRouteFlywayMigrationTest {
                         MYSQL.getPassword()
                 )
                 .locations("classpath:db/migration")
+                .target(MigrationVersion.fromVersion("20"))
                 .baselineOnMigrate(false)
                 .cleanDisabled(false)
                 .load();

--- a/src/test/java/online/lifeasgame/migration/RoleEventLifeLogLinkageFlywayTest.java
+++ b/src/test/java/online/lifeasgame/migration/RoleEventLifeLogLinkageFlywayTest.java
@@ -1,0 +1,270 @@
+package online.lifeasgame.migration;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+@DisplayName("V21 RoleEvent와 LifeLog linkage migration")
+class RoleEventLifeLogLinkageFlywayTest {
+
+    @Container
+    private static final MySQLContainer<?> MYSQL =
+            new MySQLContainer<>("mysql:8.0.39")
+                    .withDatabaseName("lifeasgame_role_event_migration")
+                    .withUsername("lifeasgame")
+                    .withPassword("lifeasgame");
+
+    private Flyway flyway;
+    private JdbcTemplate jdbc;
+
+    @BeforeEach
+    void migrateCleanDatabase() {
+        flyway = flyway(null);
+        flyway.clean();
+        flyway.migrate();
+        jdbc = new JdbcTemplate(new DriverManagerDataSource(
+                MYSQL.getJdbcUrl(),
+                MYSQL.getUsername(),
+                MYSQL.getPassword()
+        ));
+    }
+
+    @Nested
+    @DisplayName("빈 MySQL에 V21을 적용하면")
+    class CreateFoundation {
+
+        @Test
+        @DisplayName("RoleEvent 두 table과 canonical role_event_id를 추가한다")
+        void createsTablesAndColumn() {
+            assertThat(flyway.info().current().getVersion().getVersion())
+                    .isEqualTo("21");
+            assertThat(tableNames()).containsExactlyInAnyOrder(
+                    "role_event_participants",
+                    "role_events"
+            );
+            assertThat(columnNames("life_log_records"))
+                    .contains("primary_role_id", "role_event_id")
+                    .doesNotContain("role_party_id", "role_chat_id");
+            assertThat(foreignKeys()).contains(
+                    "fk_role_event_role_owner",
+                    "fk_role_event_participant_event",
+                    "fk_life_log_record_role_owner",
+                    "fk_life_log_record_role_event_context"
+            );
+        }
+
+        @Test
+        @DisplayName("같은 participant type과 ID만 중복을 막고 두 type 의미는 분리한다")
+        void enforcesParticipantIdentity() {
+            Long roleId = insertRole(1L, "Developer");
+            Long eventId = insertRoleEvent(1L, roleId);
+
+            insertParticipant(eventId, "PERSON", 7L);
+            insertParticipant(eventId, "SERVICE_USER", 7L);
+
+            assertThat(participantCount(eventId)).isEqualTo(2);
+            assertThatThrownBy(() -> insertParticipant(
+                    eventId,
+                    "PERSON",
+                    7L
+            )).isInstanceOf(DataIntegrityViolationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("canonical LifeLog에 RoleEvent를 연결하면")
+    class LinkLifeLog {
+
+        @Test
+        @DisplayName("같은 Player와 Role의 Event linkage만 허용한다")
+        void enforcesRoleEventPlayerConsistency() {
+            Long roleId = insertRole(1L, "Developer");
+            Long otherRoleId = insertRole(1L, "Parent");
+            Long eventId = insertRoleEvent(1L, roleId);
+
+            insertLifeLog(1L, 101L, roleId, eventId);
+            insertLifeLog(1L, 102L, roleId, null);
+
+            assertThatThrownBy(() -> insertLifeLog(
+                    1L,
+                    103L,
+                    otherRoleId,
+                    eventId
+            )).isInstanceOf(DataIntegrityViolationException.class);
+            assertThatThrownBy(() -> insertLifeLog(
+                    2L,
+                    104L,
+                    roleId,
+                    null
+            )).isInstanceOf(DataIntegrityViolationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("V20의 기존 LifeLog를 V21로 올리면")
+    class UpgradeExistingRows {
+
+        @Test
+        @DisplayName("Role context가 없던 기존 row를 그대로 유지한다")
+        void keepsExistingLifeLogRowsValid() {
+            flyway.clean();
+            flyway(MigrationVersion.fromVersion("20")).migrate();
+            insertLifeLogBeforeV21(1L, 201L);
+
+            flyway.migrate();
+
+            assertThat(jdbc.queryForMap("""
+                    SELECT primary_role_id, role_event_id
+                    FROM life_log_records
+                    WHERE source_type = 'COLLECTION' AND source_id = 201
+                    """))
+                    .containsEntry("primary_role_id", null)
+                    .containsEntry("role_event_id", null);
+        }
+    }
+
+    private Flyway flyway(MigrationVersion target) {
+        var configuration = Flyway.configure()
+                .dataSource(
+                        MYSQL.getJdbcUrl(),
+                        MYSQL.getUsername(),
+                        MYSQL.getPassword()
+                )
+                .locations("classpath:db/migration")
+                .baselineOnMigrate(false)
+                .cleanDisabled(false);
+        if (target != null) configuration.target(target);
+        return configuration.load();
+    }
+
+    private Set<String> tableNames() {
+        return Set.copyOf(jdbc.queryForList("""
+                SELECT table_name
+                FROM information_schema.tables
+                WHERE table_schema = DATABASE()
+                  AND table_name IN ('role_events', 'role_event_participants')
+                """, String.class));
+    }
+
+    private Set<String> columnNames(String table) {
+        return Set.copyOf(jdbc.queryForList("""
+                SELECT column_name
+                FROM information_schema.columns
+                WHERE table_schema = DATABASE() AND table_name = ?
+                """, String.class, table));
+    }
+
+    private Set<String> foreignKeys() {
+        return Set.copyOf(jdbc.queryForList("""
+                SELECT constraint_name
+                FROM information_schema.referential_constraints
+                WHERE constraint_schema = DATABASE()
+                  AND table_name IN (
+                    'role_events',
+                    'role_event_participants',
+                    'life_log_records'
+                  )
+                """, String.class));
+    }
+
+    private Long insertRole(Long playerId, String name) {
+        jdbc.update("""
+                INSERT INTO roles (
+                    player_id, role_type, name, description, status,
+                    created_at, updated_at, version
+                ) VALUES (?, 'SELF', ?, NULL, 'ACTIVE',
+                    CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6), 0)
+                """, playerId, name);
+        return jdbc.queryForObject(
+                "SELECT id FROM roles WHERE player_id = ? AND name = ?",
+                Long.class,
+                playerId,
+                name
+        );
+    }
+
+    private Long insertRoleEvent(Long playerId, Long roleId) {
+        jdbc.update("""
+                INSERT INTO role_events (
+                    player_id, role_id, title, description,
+                    starts_at, ends_at, status, completed_at,
+                    version, created_at, updated_at
+                ) VALUES (?, ?, '회고', NULL, NULL, NULL, 'PLANNED', NULL,
+                    0, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6))
+                """, playerId, roleId);
+        return jdbc.queryForObject(
+                "SELECT id FROM role_events WHERE player_id = ? AND role_id = ?",
+                Long.class,
+                playerId,
+                roleId
+        );
+    }
+
+    private void insertParticipant(
+            Long eventId,
+            String type,
+            Long participantId
+    ) {
+        jdbc.update("""
+                INSERT INTO role_event_participants (
+                    role_event_id, participant_type, participant_id,
+                    created_at, updated_at
+                ) VALUES (?, ?, ?, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6))
+                """, eventId, type, participantId);
+    }
+
+    private int participantCount(Long eventId) {
+        return jdbc.queryForObject(
+                "SELECT COUNT(*) FROM role_event_participants WHERE role_event_id = ?",
+                Integer.class,
+                eventId
+        );
+    }
+
+    private void insertLifeLog(
+            Long playerId,
+            Long sourceId,
+            Long roleId,
+            Long eventId
+    ) {
+        jdbc.update("""
+                INSERT INTO life_log_records (
+                    player_id, source_type, source_id,
+                    source_definition_version, subtype, entry_mode,
+                    reflection_scope, period_key,
+                    primary_role_id, role_event_id, occurred_at,
+                    created_at, updated_at
+                ) VALUES (?, 'COLLECTION', ?, 1, NULL, 'FULL',
+                    NULL, NULL, ?, ?, CURRENT_TIMESTAMP(6),
+                    CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6))
+                """, playerId, sourceId, roleId, eventId);
+    }
+
+    private void insertLifeLogBeforeV21(Long playerId, Long sourceId) {
+        jdbc.update("""
+                INSERT INTO life_log_records (
+                    player_id, source_type, source_id,
+                    source_definition_version, subtype, entry_mode,
+                    reflection_scope, period_key, primary_role_id,
+                    occurred_at, created_at, updated_at
+                ) VALUES (?, 'COLLECTION', ?, 1, NULL, 'FULL',
+                    NULL, NULL, NULL, CURRENT_TIMESTAMP(6),
+                    CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6))
+                """, playerId, sourceId);
+    }
+}

--- a/src/test/java/online/lifeasgame/migration/RolePersonPersistenceFoundationFlywayTest.java
+++ b/src/test/java/online/lifeasgame/migration/RolePersonPersistenceFoundationFlywayTest.java
@@ -46,9 +46,9 @@ class RolePersonPersistenceFoundationFlywayTest {
     }
 
     @Test
-    @DisplayName("V20까지 적용된 schema에서 V19 Role/Person 계약을 고정한다")
+    @DisplayName("V21까지 적용된 schema에서 V19 Role/Person 계약을 고정한다")
     void createsSchemaContract() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("20");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("21");
         assertThat(tableContracts()).containsExactly(
                 new TableContract("roles", "InnoDB", "utf8mb4_0900_ai_ci"),
                 new TableContract("persons", "InnoDB", "utf8mb4_0900_ai_ci"),

--- a/src/test/java/online/lifeasgame/platform/outbox/application/codec/LifeLogRecordedCodecTest.java
+++ b/src/test/java/online/lifeasgame/platform/outbox/application/codec/LifeLogRecordedCodecTest.java
@@ -13,6 +13,7 @@ import online.lifeasgame.lifelog.domain.record.LifeLogSubtype;
 import online.lifeasgame.platform.outbox.domain.error.OutboxError;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -174,6 +175,43 @@ class LifeLogRecordedCodecTest {
                 );
 
         assertCodecFailure(payload);
+    }
+
+    @Nested
+    @DisplayName("v1 payload에 Role snapshot을 encode할 때")
+    class EncodeRoleSnapshot {
+
+        @Test
+        @DisplayName("primaryRoleId만 활성화하고 roleEventId field는 추가하지 않는다")
+        void keepsVersionOneShape() throws Exception {
+            LifeLogRecorded source = new LifeLogRecorded(
+                    "role-event",
+                    LifeLogRecorded.EVENT_TYPE,
+                    LifeLogRecorded.EVENT_VERSION,
+                    OCCURRED_AT,
+                    197L,
+                    213L,
+                    1,
+                    LifeLogSubtype.MEMORY,
+                    LifeLogEntryMode.FULL,
+                    null,
+                    null,
+                    31L,
+                    null
+            );
+
+            OutboxEventEnvelope envelope = registry.encode(source);
+            JsonNode json = objectMapper.readTree(envelope.payload());
+            LifeLogRecorded decoded = (LifeLogRecorded) registry.decode(
+                    envelope.eventType(),
+                    envelope.payload()
+            );
+
+            assertThat(json.get("eventVersion").asInt()).isEqualTo(1);
+            assertThat(json.get("primaryRoleId").asLong()).isEqualTo(31L);
+            assertThat(json.has("roleEventId")).isFalse();
+            assertThat(decoded.primaryRoleId()).isEqualTo(31L);
+        }
     }
 
     private void assertCodecFailure(String payload) {

--- a/src/test/java/online/lifeasgame/quest/application/trigger/LifeLogRecordedQuestTriggerTest.java
+++ b/src/test/java/online/lifeasgame/quest/application/trigger/LifeLogRecordedQuestTriggerTest.java
@@ -10,6 +10,7 @@ import online.lifeasgame.quest.application.automation.QuestSignalAcceptancePolic
 import online.lifeasgame.quest.application.automation.QuestSignalFingerprint;
 import online.lifeasgame.quest.domain.QuestCode;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -181,12 +182,59 @@ class LifeLogRecordedQuestTriggerTest {
                 .isEqualTo(fingerprint.fingerprint(first));
     }
 
+    @Nested
+    @DisplayName("Role-linked LifeLogRecorded를 번역할 때")
+    class TranslateRoleLinkedFact {
+
+        @Test
+        @DisplayName("primaryRoleId를 attribute로 보존하고 기존 Quest Signal만 만든다")
+        void preservesExistingQuestMeaning() {
+            List<QuestSignal> signals = trigger.translate(event(
+                    "role-linked",
+                    LifeLogSubtype.MEMORY,
+                    LifeLogEntryMode.FULL,
+                    null,
+                    null,
+                    31L
+            ));
+
+            assertThat(signals)
+                    .extracting(QuestSignal::questCode)
+                    .containsExactly(
+                            QuestCode.Q_RECORD_FIRST_TRACE,
+                            QuestCode.Q_RECORD_THREE_TRACES
+                    );
+            assertThat(signals).allSatisfy(signal ->
+                    assertThat(signal.attributes())
+                            .containsEntry("primaryRoleId", 31L)
+            );
+        }
+    }
+
     private LifeLogRecorded event(
             String eventId,
             LifeLogSubtype subtype,
             LifeLogEntryMode entryMode,
             LifeLogReflectionScope reflectionScope,
             String periodKey
+    ) {
+        return event(
+                eventId,
+                subtype,
+                entryMode,
+                reflectionScope,
+                periodKey,
+                null
+        );
+    }
+
+    private LifeLogRecorded event(
+            String eventId,
+            LifeLogSubtype subtype,
+            LifeLogEntryMode entryMode,
+            LifeLogReflectionScope reflectionScope,
+            String periodKey,
+            Long primaryRoleId
     ) {
         return new LifeLogRecorded(
                 eventId,
@@ -200,7 +248,7 @@ class LifeLogRecordedQuestTriggerTest {
                 entryMode,
                 reflectionScope,
                 periodKey,
-                null,
+                primaryRoleId,
                 null
         );
     }

--- a/src/test/java/online/lifeasgame/role/api/RoleEventApiContractTest.java
+++ b/src/test/java/online/lifeasgame/role/api/RoleEventApiContractTest.java
@@ -1,0 +1,212 @@
+package online.lifeasgame.role.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import online.lifeasgame.platform.web.error.docs.ErrorDocLinker;
+import online.lifeasgame.role.api.request.RoleEventRequest;
+import online.lifeasgame.role.application.RoleEventQueryService;
+import online.lifeasgame.role.application.RoleEventService;
+import online.lifeasgame.role.application.result.RoleEventResult;
+import online.lifeasgame.support.ControllerSliceTest;
+import online.lifeasgame.system.bootstrap.error.handler.AppErrorProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import java.lang.reflect.RecordComponent;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ControllerSliceTest(controllers = RoleEventController.class)
+@DisplayName("RoleEvent player API")
+class RoleEventApiContractTest {
+
+    @Autowired
+    private RequestMappingHandlerMapping handlerMapping;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private RoleEventService service;
+
+    @MockitoBean
+    private RoleEventQueryService queryService;
+
+    @MockitoBean
+    private AppErrorProperties appErrorProperties;
+
+    @MockitoBean
+    private ErrorDocLinker errorDocLinker;
+
+    @Nested
+    @DisplayName("self RoleEvent endpoint를 노출할 때")
+    class Endpoints {
+
+        @Test
+        @DisplayName("요청된 CRUD·complete·cancel·participant mapping만 제공한다")
+        void exposesExactMappings() {
+            String collection = "/api/v1/roles/{roleId}/events";
+            String detail = collection + "/{eventId}";
+
+            assertMapping(RequestMethod.GET, collection);
+            assertMapping(RequestMethod.GET, detail);
+            assertMapping(RequestMethod.POST, collection);
+            assertMapping(RequestMethod.PATCH, detail);
+            assertMapping(RequestMethod.POST, detail + "/complete");
+            assertMapping(RequestMethod.POST, detail + "/cancel");
+            assertMapping(RequestMethod.POST, detail + "/participants");
+            assertMapping(
+                    RequestMethod.DELETE,
+                    detail + "/participants/{participantLinkId}"
+            );
+        }
+
+        @Test
+        @DisplayName("request body에 playerId를 받지 않는다")
+        void keepsSelfIdentityOutOfRequests() {
+            assertThat(componentNames(RoleEventRequest.Create.class))
+                    .doesNotContain("playerId", "roleId", "eventId");
+            assertThat(componentNames(RoleEventRequest.Update.class))
+                    .doesNotContain("playerId", "roleId", "eventId");
+            assertThat(componentNames(RoleEventRequest.AddParticipant.class))
+                    .containsExactlyInAnyOrder(
+                            "participantType",
+                            "participantId"
+                    )
+                    .doesNotContain("playerId", "roleId", "eventId");
+        }
+    }
+
+    @Nested
+    @DisplayName("RoleEvent API를 호출하면")
+    class DelegateUseCases {
+
+        @Test
+        @DisplayName("create/list/detail/update/상태 전이를 Application use case에 위임한다")
+        void delegatesLifecycle() throws Exception {
+            RoleEventResult.Detail detail = detail();
+            given(service.create(eq(2L), any())).willReturn(detail);
+            given(queryService.list(2L)).willReturn(List.of(detail));
+            given(queryService.detail(2L, 5L)).willReturn(detail);
+            given(service.update(eq(2L), eq(5L), any())).willReturn(detail);
+            given(service.complete(2L, 5L)).willReturn(detail);
+            given(service.cancel(2L, 5L)).willReturn(detail);
+
+            mockMvc.perform(post("/api/v1/roles/2/events")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json(new RoleEventRequest.Create(
+                                    "팀 회고", null, null, null
+                            ))))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.result.id").value(5L))
+                    .andExpect(jsonPath("$.result.playerId").doesNotExist());
+            mockMvc.perform(get("/api/v1/roles/2/events"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result[0].status")
+                            .value("PLANNED"));
+            mockMvc.perform(get("/api/v1/roles/2/events/5"))
+                    .andExpect(status().isOk());
+            mockMvc.perform(patch("/api/v1/roles/2/events/5")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json(new RoleEventRequest.Update(
+                                    "팀 회고", null, null, null
+                            ))))
+                    .andExpect(status().isOk());
+            mockMvc.perform(post("/api/v1/roles/2/events/5/complete"))
+                    .andExpect(status().isOk());
+            mockMvc.perform(post("/api/v1/roles/2/events/5/cancel"))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("participant link ID로 추가와 제거를 위임한다")
+        void delegatesParticipantChanges() throws Exception {
+            given(service.addParticipant(eq(2L), eq(5L), any()))
+                    .willReturn(new RoleEventResult.Participant(
+                            9L,
+                            "PERSON",
+                            3L
+                    ));
+
+            mockMvc.perform(post("/api/v1/roles/2/events/5/participants")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json(
+                                    new RoleEventRequest.AddParticipant(
+                                            "PERSON",
+                                            3L
+                                    )
+                            )))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result.participantLinkId")
+                            .value(9L))
+                    .andExpect(jsonPath("$.result.participantType")
+                            .value("PERSON"));
+
+            mockMvc.perform(delete(
+                            "/api/v1/roles/2/events/5/participants/9"
+                    ))
+                    .andExpect(status().isNoContent());
+            verify(service).removeParticipant(2L, 5L, 9L);
+        }
+    }
+
+    private RoleEventResult.Detail detail() {
+        return new RoleEventResult.Detail(
+                5L,
+                2L,
+                "팀 회고",
+                null,
+                null,
+                null,
+                "PLANNED",
+                null,
+                List.of(),
+                Instant.parse("2026-08-11T01:00:00Z"),
+                Instant.parse("2026-08-11T01:00:00Z"),
+                0L
+        );
+    }
+
+    private void assertMapping(RequestMethod method, String path) {
+        assertThat(handlerMapping.getHandlerMethods().keySet())
+                .anyMatch(mapping ->
+                        mapping.getMethodsCondition().getMethods()
+                                .contains(method)
+                                && mapping.getPatternValues().contains(path)
+                );
+    }
+
+    private Set<String> componentNames(Class<?> type) {
+        return Arrays.stream(type.getRecordComponents())
+                .map(RecordComponent::getName)
+                .collect(Collectors.toSet());
+    }
+
+    private String json(Object value) throws Exception {
+        return objectMapper.writeValueAsString(value);
+    }
+}

--- a/src/test/java/online/lifeasgame/role/application/RoleEventApplicationTest.java
+++ b/src/test/java/online/lifeasgame/role/application/RoleEventApplicationTest.java
@@ -1,0 +1,360 @@
+package online.lifeasgame.role.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.lifelog.application.record.LifeLogRecordRegistrar;
+import online.lifeasgame.person.application.internal.PersonLookupApi;
+import online.lifeasgame.person.domain.error.PersonError;
+import online.lifeasgame.role.application.command.RoleEventCommand;
+import online.lifeasgame.role.domain.Role;
+import online.lifeasgame.role.domain.RoleEvent;
+import online.lifeasgame.role.domain.RoleEventParticipant;
+import online.lifeasgame.role.domain.RoleType;
+import online.lifeasgame.role.domain.error.RoleError;
+import online.lifeasgame.user.application.internal.UserLookupApi;
+import online.lifeasgame.user.domain.error.UserError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RoleEvent Application")
+class RoleEventApplicationTest {
+
+    private static final Long PLAYER_ID = 252L;
+    private static final Long ROLE_ID = 25L;
+    private static final Long EVENT_ID = 52L;
+    private static final Instant NOW =
+            Instant.parse("2026-08-11T03:00:00Z");
+
+    @Mock
+    private RoleReader roleReader;
+
+    @Mock
+    private RoleEventReader eventReader;
+
+    @Mock
+    private RoleEventWriter eventWriter;
+
+    @Mock
+    private PersonLookupApi personLookupApi;
+
+    @Mock
+    private UserLookupApi userLookupApi;
+
+    @Mock
+    private CurrentPlayerAccessor currentPlayerAccessor;
+
+    @Mock
+    private Clock clock;
+
+    @InjectMocks
+    private RoleEventService service;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(currentPlayerAccessor.currentPlayerIdOrThrow())
+                .thenReturn(PLAYER_ID);
+        lenient().when(eventWriter.saveAndFlush(any()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Nested
+    @DisplayName("RoleEvent를 생성할 때")
+    class Create {
+
+        @Test
+        @DisplayName("현재 Player가 소유한 ACTIVE Role에만 생성한다")
+        void createsForOwnedActiveRole() {
+            given(roleReader.getOwnedForUpdate(ROLE_ID, PLAYER_ID))
+                    .willReturn(role());
+
+            var result = service.create(ROLE_ID, createCommand());
+
+            assertThat(result.roleId()).isEqualTo(ROLE_ID);
+            assertThat(result.status()).isEqualTo("PLANNED");
+            verify(roleReader).getOwnedForUpdate(ROLE_ID, PLAYER_ID);
+        }
+
+        @Test
+        @DisplayName("ARCHIVED Role에는 생성하지 않는다")
+        void rejectsArchivedRole() {
+            Role role = role();
+            role.archive();
+            given(roleReader.getOwnedForUpdate(ROLE_ID, PLAYER_ID))
+                    .willReturn(role);
+
+            assertRoleError(
+                    () -> service.create(ROLE_ID, createCommand()),
+                    RoleError.ROLE_ARCHIVED
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("RoleEvent 상태를 변경할 때")
+    class ChangeStatus {
+
+        @Test
+        @DisplayName("Clock의 명시적 시각으로 완료한다")
+        void completesAtClockInstant() {
+            RoleEvent event = event();
+            given(eventReader.getOwnedForUpdate(
+                    EVENT_ID,
+                    ROLE_ID,
+                    PLAYER_ID
+            )).willReturn(event);
+            given(clock.instant()).willReturn(NOW);
+
+            var result = service.complete(ROLE_ID, EVENT_ID);
+
+            assertThat(result.status()).isEqualTo("COMPLETED");
+            assertThat(result.completedAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("다른 Player의 Event는 not found로 거부한다")
+        void rejectsAnotherPlayersEvent() {
+            given(eventReader.getOwnedForUpdate(
+                    EVENT_ID,
+                    ROLE_ID,
+                    PLAYER_ID
+            )).willThrow(new DomainException(
+                    RoleError.ROLE_EVENT_NOT_FOUND
+            ));
+
+            assertRoleError(
+                    () -> service.cancel(ROLE_ID, EVENT_ID),
+                    RoleError.ROLE_EVENT_NOT_FOUND
+            );
+        }
+
+        @Test
+        @DisplayName("terminal Event의 구조 수정은 거부한다")
+        void rejectsUpdatingTerminalEvent() {
+            RoleEvent event = event();
+            event.complete(NOW);
+            given(eventReader.getOwnedForUpdate(
+                    EVENT_ID,
+                    ROLE_ID,
+                    PLAYER_ID
+            )).willReturn(event);
+
+            assertRoleError(
+                    () -> service.update(
+                            ROLE_ID,
+                            EVENT_ID,
+                            new RoleEventCommand.Update(
+                                    "변경",
+                                    null,
+                                    null,
+                                    null
+                            )
+                    ),
+                    RoleError.ROLE_EVENT_NOT_PLANNED
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("RoleEvent 참여자를 추가할 때")
+    class AddParticipant {
+
+        @Test
+        @DisplayName("linkedUserId가 있어도 PERSON으로 유지한다")
+        void preservesPersonMeaning() {
+            RoleEvent event = eventForUpdate();
+            given(personLookupApi.getOwnedActive(3L, PLAYER_ID))
+                    .willReturn(new PersonLookupApi.PersonReference(
+                            3L,
+                            30L,
+                            "Alice"
+                    ));
+
+            var result = service.addParticipant(
+                    ROLE_ID,
+                    EVENT_ID,
+                    new RoleEventCommand.AddParticipant("PERSON", 3L)
+            );
+
+            assertThat(result.participantType()).isEqualTo("PERSON");
+            assertThat(event.getParticipants()).singleElement()
+                    .extracting(RoleEventParticipant::getParticipantId)
+                    .isEqualTo(3L);
+            verifyNoInteractions(userLookupApi);
+        }
+
+        @Test
+        @DisplayName("다른 Player 또는 archived Person 오류를 그대로 전파한다")
+        void rejectsInvalidPerson() {
+            eventForUpdate();
+            given(personLookupApi.getOwnedActive(3L, PLAYER_ID))
+                    .willThrow(new DomainException(PersonError.PERSON_NOT_FOUND));
+
+            assertThatThrownBy(() -> service.addParticipant(
+                    ROLE_ID,
+                    EVENT_ID,
+                    new RoleEventCommand.AddParticipant("PERSON", 3L)
+            )).isInstanceOfSatisfying(
+                    DomainException.class,
+                    exception -> assertThat(exception.getErrorCode())
+                            .isEqualTo(PersonError.PERSON_NOT_FOUND)
+            );
+        }
+
+        @Test
+        @DisplayName("ACTIVE SERVICE_USER만 별도 type으로 추가한다")
+        void addsActiveServiceUser() {
+            eventForUpdate();
+            given(userLookupApi.getActive(7L)).willReturn(
+                    new UserLookupApi.UserReference(7L, "service-user")
+            );
+
+            var result = service.addParticipant(
+                    ROLE_ID,
+                    EVENT_ID,
+                    new RoleEventCommand.AddParticipant("SERVICE_USER", 7L)
+            );
+
+            assertThat(result.participantType()).isEqualTo("SERVICE_USER");
+            verifyNoInteractions(personLookupApi);
+        }
+
+        @Test
+        @DisplayName("inactive SERVICE_USER 오류를 전파한다")
+        void rejectsInactiveServiceUser() {
+            eventForUpdate();
+            given(userLookupApi.getActive(7L)).willThrow(
+                    new DomainException(UserError.USER_NOT_ACTIVE)
+            );
+
+            assertThatThrownBy(() -> service.addParticipant(
+                    ROLE_ID,
+                    EVENT_ID,
+                    new RoleEventCommand.AddParticipant("SERVICE_USER", 7L)
+            )).isInstanceOfSatisfying(
+                    DomainException.class,
+                    exception -> assertThat(exception.getErrorCode())
+                            .isEqualTo(UserError.USER_NOT_ACTIVE)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("참여자 link를 제거할 때")
+    class RemoveParticipant {
+
+        @Test
+        @DisplayName("path의 owned Event 안에 있는 link만 제거한다")
+        void removesOnlyOwnedEventLink() {
+            RoleEvent event = event();
+            RoleEventParticipant participant = event.addParticipant(
+                    online.lifeasgame.role.domain.RoleEventParticipantType.PERSON,
+                    3L
+            );
+            ReflectionTestUtils.setField(participant, "id", 9L);
+            given(eventReader.getOwnedForUpdate(
+                    EVENT_ID,
+                    ROLE_ID,
+                    PLAYER_ID
+            )).willReturn(event);
+
+            service.removeParticipant(ROLE_ID, EVENT_ID, 9L);
+
+            assertThat(event.getParticipants()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("path의 Event에 속하지 않은 link는 삭제하지 않는다")
+        void rejectsAnotherEventsLink() {
+            eventForUpdate();
+
+            assertRoleError(
+                    () -> service.removeParticipant(
+                            ROLE_ID,
+                            EVENT_ID,
+                            9L
+                    ),
+                    RoleError.ROLE_EVENT_PARTICIPANT_NOT_FOUND
+            );
+        }
+    }
+
+    @Test
+    @DisplayName("RoleEventService는 LifeLog 등록 dependency를 갖지 않는다")
+    void hasNoAutomaticLifeLogDependency() {
+        assertThat(Arrays.stream(RoleEventService.class.getDeclaredFields())
+                .map(field -> field.getType().getName()))
+                .doesNotContain(LifeLogRecordRegistrar.class.getName());
+    }
+
+    private Role role() {
+        Role role = Role.create(
+                PLAYER_ID,
+                RoleType.of("WORK"),
+                "Developer",
+                null
+        );
+        ReflectionTestUtils.setField(role, "id", ROLE_ID);
+        return role;
+    }
+
+    private RoleEvent event() {
+        RoleEvent event = RoleEvent.create(
+                PLAYER_ID,
+                ROLE_ID,
+                "팀 회고",
+                null,
+                null,
+                null
+        );
+        ReflectionTestUtils.setField(event, "id", EVENT_ID);
+        return event;
+    }
+
+    private RoleEvent eventForUpdate() {
+        RoleEvent event = event();
+        given(eventReader.getOwnedForUpdate(
+                EVENT_ID,
+                ROLE_ID,
+                PLAYER_ID
+        )).willReturn(event);
+        return event;
+    }
+
+    private RoleEventCommand.Create createCommand() {
+        return new RoleEventCommand.Create(
+                "팀 회고",
+                null,
+                null,
+                null
+        );
+    }
+
+    private void assertRoleError(Runnable action, RoleError error) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(
+                        DomainException.class,
+                        exception -> assertThat(exception.getErrorCode())
+                                .isEqualTo(error)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/role/application/RoleEventLifeLogIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/role/application/RoleEventLifeLogIntegrationTest.java
@@ -1,0 +1,185 @@
+package online.lifeasgame.role.application;
+
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.lifelog.application.record.LifeLogRecordMetadataCommand;
+import online.lifeasgame.lifelog.application.record.LifeLogRecordRegistrar;
+import online.lifeasgame.lifelog.domain.record.LifeLogEntryMode;
+import online.lifeasgame.lifelog.domain.record.LifeLogRecord;
+import online.lifeasgame.lifelog.domain.record.LifeLogSourceType;
+import online.lifeasgame.role.application.command.RoleEventCommand;
+import online.lifeasgame.role.application.result.RoleEventResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles({"test", "migration-test"})
+@DisplayName("RoleEvent와 explicit LifeLog linkage MySQL 흐름")
+class RoleEventLifeLogIntegrationTest {
+
+    private static final Long PLAYER_ID = 25201L;
+
+    @Container
+    private static final MySQLContainer<?> MYSQL =
+            new MySQLContainer<>("mysql:8.0.39")
+                    .withDatabaseName("lifeasgame_role_event_lifelog")
+                    .withUsername("lifeasgame")
+                    .withPassword("lifeasgame");
+
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add(
+                "spring.datasource.driver-class-name",
+                MYSQL::getDriverClassName
+        );
+        registry.add("app.outbox.enabled", () -> false);
+    }
+
+    @Autowired
+    private RoleEventService roleEventService;
+
+    @Autowired
+    private LifeLogRecordRegistrar registrar;
+
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @MockitoBean
+    private CurrentPlayerAccessor currentPlayerAccessor;
+
+    @BeforeEach
+    void cleanState() {
+        given(currentPlayerAccessor.currentPlayerIdOrThrow())
+                .willReturn(PLAYER_ID);
+        jdbc.update(
+                "DELETE FROM life_log_records WHERE player_id = ?",
+                PLAYER_ID
+        );
+        jdbc.update("DELETE FROM role_event_participants");
+        jdbc.update(
+                "DELETE FROM role_events WHERE player_id = ?",
+                PLAYER_ID
+        );
+        jdbc.update("DELETE FROM roles WHERE player_id = ?", PLAYER_ID);
+    }
+
+    @Nested
+    @DisplayName("RoleEvent lifecycle을 실행하면")
+    class NoAutomaticLifeLog {
+
+        @Test
+        @DisplayName("create와 complete 모두 LifeLogRecord를 자동 생성하지 않는다")
+        void neverCreatesLifeLog() {
+            Long roleId = insertRole();
+
+            RoleEventResult.Detail event = roleEventService.create(
+                    roleId,
+                    new RoleEventCommand.Create(
+                            "팀 회고",
+                            null,
+                            null,
+                            null
+                    )
+            );
+            roleEventService.complete(roleId, event.id());
+
+            assertThat(lifeLogCount()).isZero();
+            assertThat(jdbc.queryForObject(
+                    "SELECT status FROM role_events WHERE id = ?",
+                    String.class,
+                    event.id()
+            )).isEqualTo("COMPLETED");
+        }
+    }
+
+    @Nested
+    @DisplayName("LifeLog를 RoleEvent에 명시적으로 연결하면")
+    class ExplicitLinkage {
+
+        @Test
+        @DisplayName("event의 Role을 derive해 canonical header에 원자적으로 저장한다")
+        void persistsDerivedRoleContext() {
+            Long roleId = insertRole();
+            RoleEventResult.Detail event = roleEventService.create(
+                    roleId,
+                    new RoleEventCommand.Create(
+                            "팀 회고",
+                            null,
+                            null,
+                            null
+                    )
+            );
+
+            LifeLogRecord record = new TransactionTemplate(transactionManager)
+                    .execute(status -> registrar.register(
+                            PLAYER_ID,
+                            LifeLogSourceType.COLLECTION,
+                            252001L,
+                            LifeLogEntryMode.FULL,
+                            new LifeLogRecordMetadataCommand(
+                                    null,
+                                    null,
+                                    null,
+                                    event.id()
+                            )
+                    ));
+
+            Map<String, Object> stored = jdbc.queryForMap("""
+                    SELECT primary_role_id, role_event_id
+                    FROM life_log_records
+                    WHERE id = ?
+                    """, record.getId());
+            assertThat(stored)
+                    .containsEntry("primary_role_id", roleId)
+                    .containsEntry("role_event_id", event.id());
+        }
+    }
+
+    private Long insertRole() {
+        jdbc.update("""
+                INSERT INTO roles (
+                    player_id, role_type, name, description, status,
+                    created_at, updated_at, version
+                ) VALUES (?, 'WORK', 'Developer', NULL, 'ACTIVE',
+                    CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6), 0)
+                """, PLAYER_ID);
+        return jdbc.queryForObject(
+                "SELECT id FROM roles WHERE player_id = ?",
+                Long.class,
+                PLAYER_ID
+        );
+    }
+
+    private long lifeLogCount() {
+        return jdbc.queryForObject(
+                "SELECT COUNT(*) FROM life_log_records WHERE player_id = ?",
+                Long.class,
+                PLAYER_ID
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/role/application/RoleEventTransactionContractTest.java
+++ b/src/test/java/online/lifeasgame/role/application/RoleEventTransactionContractTest.java
@@ -1,0 +1,47 @@
+package online.lifeasgame.role.application;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("RoleEvent transaction contract")
+class RoleEventTransactionContractTest {
+
+    @Nested
+    @DisplayName("RoleEvent runtime을 변경할 때")
+    class WriteBoundary {
+
+        @Test
+        @DisplayName("writer는 기존 transaction을 필수로 요구한다")
+        void writerRequiresTransaction() {
+            Transactional transactional =
+                    RoleEventWriter.class.getAnnotation(Transactional.class);
+
+            assertThat(transactional.propagation())
+                    .isEqualTo(Propagation.MANDATORY);
+        }
+
+        @Test
+        @DisplayName("locking read는 새 transaction을 만들지 않고 기존 write transaction을 요구한다")
+        void lockingReadRequiresExistingTransaction() throws Exception {
+            Method method = RoleEventReader.class.getDeclaredMethod(
+                    "getOwnedForUpdate",
+                    Long.class,
+                    Long.class,
+                    Long.class
+            );
+            Transactional transactional =
+                    method.getAnnotation(Transactional.class);
+
+            assertThat(transactional.propagation())
+                    .isEqualTo(Propagation.MANDATORY);
+            assertThat(transactional.readOnly()).isFalse();
+        }
+    }
+}

--- a/src/test/java/online/lifeasgame/role/application/RolePersonPersistenceIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/role/application/RolePersonPersistenceIntegrationTest.java
@@ -100,7 +100,7 @@ class RolePersonPersistenceIntegrationTest {
 
     @Test
     void persistsOwnerScopedCrudAndKeepsArchivedRows() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("20");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("21");
 
         var role = roleService.create(
                 new RoleCommand.Create("work", "Developer", "Builds")

--- a/src/test/java/online/lifeasgame/role/application/RoleRelationPersistenceIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/role/application/RoleRelationPersistenceIntegrationTest.java
@@ -93,7 +93,7 @@ class RoleRelationPersistenceIntegrationTest {
 
     @Test
     void persistsCrudRejectsActiveDuplicateAndReactivatesArchivedRow() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("20");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("21");
         Long roleId = createRole("Owner role");
         Long personId = createPerson("Alice");
 

--- a/src/test/java/online/lifeasgame/role/domain/RoleEventTest.java
+++ b/src/test/java/online/lifeasgame/role/domain/RoleEventTest.java
@@ -1,0 +1,186 @@
+package online.lifeasgame.role.domain;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.role.domain.error.RoleError;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("RoleEvent domain")
+class RoleEventTest {
+
+    private static final Instant START =
+            Instant.parse("2026-08-11T01:00:00Z");
+    private static final Instant END = START.plusSeconds(3600);
+
+    @Nested
+    @DisplayName("Role 안에 사건 구조를 만들 때")
+    class Create {
+
+        @Test
+        @DisplayName("PLANNED 상태와 명시한 시간 범위를 보존한다")
+        void createsPlannedEvent() {
+            RoleEvent event = event();
+
+            assertThat(event.getPlayerId()).isEqualTo(1L);
+            assertThat(event.getRoleId()).isEqualTo(2L);
+            assertThat(event.getTitle()).isEqualTo("팀 회고");
+            assertThat(event.getStartsAt()).isEqualTo(START);
+            assertThat(event.getEndsAt()).isEqualTo(END);
+            assertThat(event.getStatus()).isEqualTo(RoleEventStatus.PLANNED);
+            assertThat(event.getCompletedAt()).isNull();
+        }
+
+        @Test
+        @DisplayName("blank 또는 120자를 넘는 제목을 거부한다")
+        void rejectsInvalidTitle() {
+            assertError(
+                    () -> create("   ", START, END),
+                    RoleError.INVALID_ROLE_EVENT_TITLE
+            );
+            assertError(
+                    () -> create("x".repeat(121), START, END),
+                    RoleError.INVALID_ROLE_EVENT_TITLE
+            );
+        }
+
+        @Test
+        @DisplayName("종료 시각이 시작 시각보다 빠르면 거부한다")
+        void rejectsInvalidTimeRange() {
+            assertError(
+                    () -> create("팀 회고", END, START),
+                    RoleError.INVALID_ROLE_EVENT_TIME_RANGE
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("PLANNED 사건을 변경할 때")
+    class ChangePlannedEvent {
+
+        @Test
+        @DisplayName("구조를 수정하고 명시적 완료 시각으로 COMPLETED가 된다")
+        void updatesAndCompletes() {
+            RoleEvent event = event();
+            Instant completedAt = END.plusSeconds(10);
+
+            event.update("새 제목", null, null, null);
+            event.complete(completedAt);
+
+            assertThat(event.getTitle()).isEqualTo("새 제목");
+            assertThat(event.getStartsAt()).isNull();
+            assertThat(event.getStatus()).isEqualTo(RoleEventStatus.COMPLETED);
+            assertThat(event.getCompletedAt()).isEqualTo(completedAt);
+        }
+
+        @Test
+        @DisplayName("취소하면 CANCELED가 되고 완료 시각은 생기지 않는다")
+        void cancels() {
+            RoleEvent event = event();
+
+            event.cancel();
+
+            assertThat(event.getStatus()).isEqualTo(RoleEventStatus.CANCELED);
+            assertThat(event.getCompletedAt()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("terminal 사건을 다시 변경할 때")
+    class TerminalTransitions {
+
+        @Test
+        @DisplayName("COMPLETED는 수정·취소·재완료할 수 없다")
+        void rejectsCompletedTransitions() {
+            RoleEvent event = event();
+            event.complete(END);
+
+            assertNotPlanned(() -> event.update("변경", null, null, null));
+            assertNotPlanned(event::cancel);
+            assertNotPlanned(() -> event.complete(END.plusSeconds(1)));
+        }
+
+        @Test
+        @DisplayName("CANCELED는 수정·완료할 수 없다")
+        void rejectsCanceledTransitions() {
+            RoleEvent event = event();
+            event.cancel();
+
+            assertNotPlanned(() -> event.update("변경", null, null, null));
+            assertNotPlanned(() -> event.complete(END));
+        }
+    }
+
+    @Nested
+    @DisplayName("참여자를 구분해 추가할 때")
+    class Participants {
+
+        @Test
+        @DisplayName("같은 ID의 PERSON과 SERVICE_USER를 별도 참여자로 유지한다")
+        void keepsParticipantMeaningsSeparate() {
+            RoleEvent event = event();
+
+            event.addParticipant(RoleEventParticipantType.PERSON, 3L);
+            event.addParticipant(RoleEventParticipantType.SERVICE_USER, 3L);
+
+            assertThat(event.getParticipants())
+                    .extracting(RoleEventParticipant::getParticipantType)
+                    .containsExactly(
+                            RoleEventParticipantType.PERSON,
+                            RoleEventParticipantType.SERVICE_USER
+                    );
+        }
+
+        @Test
+        @DisplayName("동일 type과 ID 중복은 409 domain error로 거부한다")
+        void rejectsDuplicateParticipant() {
+            RoleEvent event = event();
+            event.addParticipant(RoleEventParticipantType.PERSON, 3L);
+
+            assertError(
+                    () -> event.addParticipant(
+                            RoleEventParticipantType.PERSON,
+                            3L
+                    ),
+                    RoleError.ROLE_EVENT_PARTICIPANT_ALREADY_EXISTS
+            );
+        }
+    }
+
+    private RoleEvent event() {
+        return create("  팀 회고  ", START, END);
+    }
+
+    private RoleEvent create(
+            String title,
+            Instant startsAt,
+            Instant endsAt
+    ) {
+        return RoleEvent.create(
+                1L,
+                2L,
+                title,
+                " 회고를 나눈다 ",
+                startsAt,
+                endsAt
+        );
+    }
+
+    private void assertNotPlanned(Runnable action) {
+        assertError(action, RoleError.ROLE_EVENT_NOT_PLANNED);
+    }
+
+    private void assertError(Runnable action, RoleError error) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(
+                        DomainException.class,
+                        exception -> assertThat(exception.getErrorCode())
+                                .isEqualTo(error)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/user/application/UserLookupServiceTest.java
+++ b/src/test/java/online/lifeasgame/user/application/UserLookupServiceTest.java
@@ -1,0 +1,81 @@
+package online.lifeasgame.user.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.user.domain.Email;
+import online.lifeasgame.user.domain.HashedPassword;
+import online.lifeasgame.user.domain.Nickname;
+import online.lifeasgame.user.domain.User;
+import online.lifeasgame.user.domain.UserStatus;
+import online.lifeasgame.user.domain.error.UserError;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserLookupApi provider")
+class UserLookupServiceTest {
+
+    @Mock
+    private UserReader reader;
+
+    @InjectMocks
+    private UserLookupService service;
+
+    @Nested
+    @DisplayName("SERVICE_USER reference를 조회할 때")
+    class GetActive {
+
+        @Test
+        @DisplayName("ACTIVE User의 provider-owned ID와 nickname만 반환한다")
+        void returnsActiveReference() {
+            User user = user();
+            given(reader.findByIdOrElseThrow(7L)).willReturn(user);
+
+            var reference = service.getActive(7L);
+
+            assertThat(reference.id()).isEqualTo(7L);
+            assertThat(reference.nickname()).isEqualTo("service-user");
+        }
+
+        @Test
+        @DisplayName("PENDING/BANNED/DELETED User는 신규 참여자로 제공하지 않는다")
+        void rejectsInactiveStatuses() {
+            for (UserStatus status : new UserStatus[]{
+                    UserStatus.PENDING_EMAIL_VERIFICATION,
+                    UserStatus.BANNED,
+                    UserStatus.DELETED
+            }) {
+                User user = user();
+                ReflectionTestUtils.setField(user, "status", status);
+                given(reader.findByIdOrElseThrow(7L)).willReturn(user);
+
+                assertThatThrownBy(() -> service.getActive(7L))
+                        .isInstanceOfSatisfying(
+                                DomainException.class,
+                                exception -> assertThat(
+                                        exception.getErrorCode()
+                                ).isEqualTo(UserError.USER_NOT_ACTIVE)
+                        );
+            }
+        }
+    }
+
+    private User user() {
+        User user = User.register(
+                Email.of("service@example.com"),
+                HashedPassword.of("h".repeat(20)),
+                Nickname.of("service-user")
+        );
+        ReflectionTestUtils.setField(user, "id", 7L);
+        return user;
+    }
+}


### PR DESCRIPTION
## Purpose

Add the RoleEvent foundation and connect LifeLog canonical records to Role / RoleEvent context without collapsing the two domain concepts.

The binding boundary is:

```text
RoleEvent
= event structure inside a Role

LifeLog
= the player's own experience or record
```

Creating or completing a RoleEvent does not automatically create a LifeLog.

---

## RoleEvent

Added a player-owned RoleEvent runtime under the Role bounded context with explicit:

```text
PLANNED
COMPLETED
CANCELED
```

transitions.

Event creation, update, completion, and cancellation remain explicit application behaviors.

No automatic Quest, Reward, Achievement, or LifeLog side effect is introduced.

---

## Participants

RoleEvent participants preserve two different identities:

```text
PERSON
SERVICE_USER
```

Person participants are validated through `PersonLookupApi`.

Service-user participants use a provider-owned User lookup contract rather than exposing the User aggregate.

A Person with `linkedUserId` is not automatically converted to a Service User participant.

RoleParty remains out of scope.

---

## LifeLog context

Activated the existing reserved:

```text
primaryRoleId
```

on the canonical `LifeLogRecord`.

Added optional:

```text
roleEventId
```

as canonical context metadata.

Physical Collection / Exercise / Media source entities remain unchanged.

When a RoleEvent is supplied, the canonical Role context is derived and validated against the same player and Role.

---

## Cross-context boundaries

LifeLog validates Role context through provider-owned internal APIs.

There is no direct LifeLog dependency on Role repositories/entities.

RoleEvent does not query LifeLog back, avoiding a Role ↔ LifeLog application dependency cycle.

---

## LifeLogRecorded compatibility

`LifeLogRecorded` remains:

```text
eventType = LifeLogRecorded
eventVersion = 1
```

The already-reserved `primaryRoleId` field is now allowed to carry Role context.

`roleEventId` is intentionally not added to the v1 durable fact because there is no current consumer requiring a new event schema.

Existing LifeLog → Quest behavior remains unchanged.

---

## API compatibility

Existing LifeLog creation requests remain backward compatible.

Optional:

```text
primaryRoleId
roleEventId
```

fields extend the existing metadata contract without restructuring current JSON payloads.

RoleEvent self APIs do not accept `playerId`.

---

## Migration

Added:

```text
V21__role_event_lifelog_linkage.sql
```

No V1-V20 migration is modified.

The migration adds:

```text
role_events
role_event_participants
life_log_records.role_event_id
```

with RoleEvent ownership and participant uniqueness constraints.

---

## Test structure

New meaningful domain/application tests use flow-oriented:

```text
@Nested
@DisplayName
```

Related existing flat tests are incrementally reorganized only where they are directly affected.

Ownership, negative cases, durable event compatibility, and Quest regressions remain preserved.

---

## Out of scope

- RoleParty / RolePartyMember
- RoleChat
- legacy Guild/Party migration
- Role-specific Quest
- QuestAcceptance Role scope
- Route → Role binding
- automatic LifeLog creation
- RoleEvent Reward/Achievement
- LifeLog post-hoc relink API
- LifeLogRecorded roleEventId v2
- Home/Timeline projection
- Social/Economy
- frontend

Closes #252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added role event management, including creation, updates, completion, cancellation, and participant management.
  * Added support for linking LifeLog records to roles and role events.
  * Added optional role and event context to quick and detailed record creation.
* **Bug Fixes**
  * Improved validation for role ownership, event relationships, participant eligibility, and invalid metadata combinations.
  * Preserved compatibility with existing requests that omit role context.
* **Data Updates**
  * Added database support for role events, participants, and LifeLog event links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->