### PR TITLE
[Platform] Add production web CORS and frontend integration policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,9 +294,9 @@ LIFEASGAME_WEB_ALLOWED_ORIGINS=<frontend production origin>
 ```
 
 여러 origin은 공백 없는 쉼표 구분 형식으로 설정합니다.
-예: `https://frontend.example,https://admin.example`. 각 값은 scheme과 host를 포함한 정확한
-origin이어야 하며 wildcard는 허용하지 않습니다. 로컬 기본 origin은
-`http://localhost:3000`입니다.
+예: `https://frontend.example,https://admin.example`. 각 값은 path, trailing slash, query,
+fragment가 없는 정확한 `http(s)://host[:port]` origin이어야 합니다. 빈 값, malformed URI,
+wildcard는 application startup에서 거부합니다. 로컬 기본 origin은 `http://localhost:3000`입니다.
 
 ### API 문서와 테스트
 
@@ -630,8 +630,9 @@ LIFEASGAME_WEB_ALLOWED_ORIGINS=<frontend production origin>
 ```
 
 For multiple origins, use a comma-separated list without spaces, for example
-`https://frontend.example,https://admin.example`. Each value must be an exact origin including
-scheme and host; wildcards are rejected. The local default origin is
+`https://frontend.example,https://admin.example`. Each value must be an exact
+`http(s)://host[:port]` origin without a path, trailing slash, query, or fragment. Empty values,
+malformed URIs, and wildcards are rejected at application startup. The local default origin is
 `http://localhost:3000`.
 
 ### API documentation and tests

--- a/README.md
+++ b/README.md
@@ -278,6 +278,26 @@ export DB_PASSWORD=root
 
 Local profile은 기본값이며 Flyway migration을 실행합니다.
 
+### 프로덕션 웹 연동
+
+프론트엔드 배포 환경:
+
+```bash
+NEXT_PUBLIC_USE_MOCK=false
+NEXT_PUBLIC_API_URL=<backend URL>
+```
+
+백엔드 `prod` profile은 허용할 프론트엔드 origin을 필수 환경변수로 받습니다.
+
+```bash
+LIFEASGAME_WEB_ALLOWED_ORIGINS=<frontend production origin>
+```
+
+여러 origin은 공백 없는 쉼표 구분 형식으로 설정합니다.
+예: `https://frontend.example,https://admin.example`. 각 값은 scheme과 host를 포함한 정확한
+origin이어야 하며 wildcard는 허용하지 않습니다. 로컬 기본 origin은
+`http://localhost:3000`입니다.
+
 ### API 문서와 테스트
 
 애플리케이션 실행 후:
@@ -593,6 +613,26 @@ export DB_PASSWORD=root
 ```
 
 The local profile is the default and runs Flyway migrations.
+
+### Production web integration
+
+Frontend deployment environment:
+
+```bash
+NEXT_PUBLIC_USE_MOCK=false
+NEXT_PUBLIC_API_URL=<backend URL>
+```
+
+The backend `prod` profile requires the frontend origin through an environment variable.
+
+```bash
+LIFEASGAME_WEB_ALLOWED_ORIGINS=<frontend production origin>
+```
+
+For multiple origins, use a comma-separated list without spaces, for example
+`https://frontend.example,https://admin.example`. Each value must be an exact origin including
+scheme and host; wildcards are rejected. The local default origin is
+`http://localhost:3000`.
 
 ### API documentation and tests
 

--- a/src/main/java/online/lifeasgame/LifeasgameApplication.java
+++ b/src/main/java/online/lifeasgame/LifeasgameApplication.java
@@ -1,9 +1,12 @@
 package online.lifeasgame;
 
+import online.lifeasgame.system.bootstrap.security.WebCorsProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties(WebCorsProperties.class)
 public class LifeasgameApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/online/lifeasgame/social/api/config/ChatWebSocketConfig.java
+++ b/src/main/java/online/lifeasgame/social/api/config/ChatWebSocketConfig.java
@@ -1,5 +1,7 @@
 package online.lifeasgame.social.api.config;
 
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.system.bootstrap.security.WebCorsProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -8,12 +10,15 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class ChatWebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final WebCorsProperties webCorsProperties;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
-                .setAllowedOriginPatterns("*")
+                .setAllowedOrigins(webCorsProperties.allowedOrigins().toArray(String[]::new))
                 .withSockJS();
     }
 

--- a/src/main/java/online/lifeasgame/system/bootstrap/security/SecurityConfig.java
+++ b/src/main/java/online/lifeasgame/system/bootstrap/security/SecurityConfig.java
@@ -4,10 +4,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.platform.security.jwt.JwtAuthenticationFilter;
 import online.lifeasgame.platform.security.jwt.JwtProvider;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -22,7 +20,6 @@ import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
-@EnableConfigurationProperties(WebCorsProperties.class)
 public class SecurityConfig {
 
     private final JwtProvider jwtProvider;
@@ -71,7 +68,6 @@ public class SecurityConfig {
         cfg.setAllowedOrigins(webCorsProperties.allowedOrigins());
         cfg.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         cfg.setAllowedHeaders(List.of("Authorization", "Content-Type", "Accept"));
-        cfg.setExposedHeaders(List.of(HttpHeaders.LOCATION));
         cfg.setAllowCredentials(true);
         cfg.validateAllowCredentials();
         cfg.setMaxAge(3600L);

--- a/src/main/java/online/lifeasgame/system/bootstrap/security/SecurityConfig.java
+++ b/src/main/java/online/lifeasgame/system/bootstrap/security/SecurityConfig.java
@@ -4,8 +4,10 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.platform.security.jwt.JwtAuthenticationFilter;
 import online.lifeasgame.platform.security.jwt.JwtProvider;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -20,9 +22,11 @@ import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
+@EnableConfigurationProperties(WebCorsProperties.class)
 public class SecurityConfig {
 
     private final JwtProvider jwtProvider;
+    private final WebCorsProperties webCorsProperties;
 
     @Bean
     SecurityFilterChain security(HttpSecurity http) throws Exception {
@@ -64,14 +68,12 @@ public class SecurityConfig {
     @Bean
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration cfg = new CorsConfiguration();
-        cfg.setAllowedOriginPatterns(List.of(
-                "http://localhost:3000",
-                "https://*.vercel.app",
-                "https://lifeasgame.online"
-        ));
-        cfg.setAllowedMethods(List.of("GET","POST","PUT","DELETE","PATCH","OPTIONS"));
-        cfg.setAllowedHeaders(List.of("*"));
+        cfg.setAllowedOrigins(webCorsProperties.allowedOrigins());
+        cfg.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        cfg.setAllowedHeaders(List.of("Authorization", "Content-Type", "Accept"));
+        cfg.setExposedHeaders(List.of(HttpHeaders.LOCATION));
         cfg.setAllowCredentials(true);
+        cfg.validateAllowCredentials();
         cfg.setMaxAge(3600L);
         UrlBasedCorsConfigurationSource src = new UrlBasedCorsConfigurationSource();
         src.registerCorsConfiguration("/**", cfg);

--- a/src/main/java/online/lifeasgame/system/bootstrap/security/WebCorsProperties.java
+++ b/src/main/java/online/lifeasgame/system/bootstrap/security/WebCorsProperties.java
@@ -1,0 +1,22 @@
+package online.lifeasgame.system.bootstrap.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "lifeasgame.web.cors")
+public record WebCorsProperties(List<String> allowedOrigins) {
+
+    public WebCorsProperties {
+        allowedOrigins = allowedOrigins == null
+                ? List.of()
+                : allowedOrigins.stream().map(String::trim).toList();
+
+        if (allowedOrigins.isEmpty()
+                || allowedOrigins.stream().anyMatch(origin -> origin.isEmpty() || origin.contains("*"))) {
+            throw new IllegalArgumentException(
+                    "lifeasgame.web.cors.allowed-origins requires explicit origins without wildcards"
+            );
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/system/bootstrap/security/WebCorsProperties.java
+++ b/src/main/java/online/lifeasgame/system/bootstrap/security/WebCorsProperties.java
@@ -2,6 +2,7 @@ package online.lifeasgame.system.bootstrap.security;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.net.URI;
 import java.util.List;
 
 @ConfigurationProperties(prefix = "lifeasgame.web.cors")
@@ -12,11 +13,28 @@ public record WebCorsProperties(List<String> allowedOrigins) {
                 ? List.of()
                 : allowedOrigins.stream().map(String::trim).toList();
 
-        if (allowedOrigins.isEmpty()
-                || allowedOrigins.stream().anyMatch(origin -> origin.isEmpty() || origin.contains("*"))) {
+        if (allowedOrigins.isEmpty() || allowedOrigins.stream().anyMatch(origin ->
+                origin.isEmpty() || origin.contains("*") || !isExactOrigin(origin))) {
             throw new IllegalArgumentException(
-                    "lifeasgame.web.cors.allowed-origins requires explicit origins without wildcards"
+                    "lifeasgame.web.cors.allowed-origins requires exact "
+                            + "http(s)://host[:port] origins"
             );
+        }
+    }
+
+    private static boolean isExactOrigin(String origin) {
+        try {
+            URI uri = URI.create(origin);
+            return ("http".equalsIgnoreCase(uri.getScheme())
+                    || "https".equalsIgnoreCase(uri.getScheme()))
+                    && uri.getHost() != null
+                    && uri.getRawUserInfo() == null
+                    && (uri.getRawPath() == null || uri.getRawPath().isEmpty())
+                    && uri.getRawQuery() == null
+                    && uri.getRawFragment() == null
+                    && uri.getPort() <= 65_535;
+        } catch (IllegalArgumentException ignored) {
+            return false;
         }
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -22,6 +22,9 @@ logging:
     org.hibernate.SQL: INFO
 
 lifeasgame:
+  web:
+    cors:
+      allowed-origins: ${LIFEASGAME_WEB_ALLOWED_ORIGINS}
   jwt:
     secret: ${JWT_SECRET}
     access-token-expiry-ms: 3600000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,6 +71,11 @@ logging:
     org.hibernate.orm.jdbc.extract: OFF
     org.hibernate.type.descriptor.sql: WARN
 
+lifeasgame:
+  web:
+    cors:
+      allowed-origins: ${LIFEASGAME_WEB_ALLOWED_ORIGINS:http://localhost:3000}
+
 app:
   error:
     docs:

--- a/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
@@ -183,6 +183,7 @@ class FlywayProfileCutoverTest {
                     .run(
                             "--spring.profiles.active=prod",
                             "--FLYWAY_ENABLED=false",
+                            "--LIFEASGAME_WEB_ALLOWED_ORIGINS=https://app.example.com",
                             "--spring.datasource.url=" + jdbcUrl,
                             "--spring.datasource.username=" + FLYWAY_DISABLED_MYSQL.getUsername(),
                             "--spring.datasource.password=" + FLYWAY_DISABLED_MYSQL.getPassword(),

--- a/src/test/java/online/lifeasgame/system/bootstrap/security/ChatWebSocketOriginContractTest.java
+++ b/src/test/java/online/lifeasgame/system/bootstrap/security/ChatWebSocketOriginContractTest.java
@@ -1,0 +1,54 @@
+package online.lifeasgame.system.bootstrap.security;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties =
+        "lifeasgame.web.cors.allowed-origins=http://localhost:3000")
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+@DisplayName("Realtime origin을 검증할 때")
+class ChatWebSocketOriginContractTest {
+
+    private static final String LOCAL_ORIGIN = "http://localhost:3000";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Nested
+    @DisplayName("SockJS /ws Origin을 확인하면")
+    class SockJsOrigin {
+
+        @Test
+        @DisplayName("설정된 Origin의 info 요청을 허용한다")
+        void allowsConfiguredOrigin() throws Exception {
+            mockMvc.perform(get("/ws/info")
+                            .header(HttpHeaders.ORIGIN, LOCAL_ORIGIN))
+                    .andExpect(status().isOk())
+                    .andExpect(header().string(
+                            HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
+                            LOCAL_ORIGIN
+                    ));
+        }
+
+        @Test
+        @DisplayName("설정되지 않은 Origin의 info 요청을 거부한다")
+        void rejectsUnknownOrigin() throws Exception {
+            mockMvc.perform(get("/ws/info")
+                            .header(HttpHeaders.ORIGIN, "https://unknown.example.com"))
+                    .andExpect(status().isForbidden())
+                    .andExpect(header().doesNotExist(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN));
+        }
+    }
+}

--- a/src/test/java/online/lifeasgame/system/bootstrap/security/ChatWebSocketOriginContractTest.java
+++ b/src/test/java/online/lifeasgame/system/bootstrap/security/ChatWebSocketOriginContractTest.java
@@ -10,13 +10,14 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest(properties =
         "lifeasgame.web.cors.allowed-origins=http://localhost:3000")
-@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureMockMvc
 @ActiveProfiles("test")
 @DisplayName("Realtime origin을 검증할 때")
 class ChatWebSocketOriginContractTest {
@@ -31,9 +32,10 @@ class ChatWebSocketOriginContractTest {
     class SockJsOrigin {
 
         @Test
-        @DisplayName("설정된 Origin의 info 요청을 허용한다")
+        @DisplayName("설정된 Origin의 인증된 info 요청을 허용한다")
         void allowsConfiguredOrigin() throws Exception {
             mockMvc.perform(get("/ws/info")
+                            .with(user("user").roles("USER"))
                             .header(HttpHeaders.ORIGIN, LOCAL_ORIGIN))
                     .andExpect(status().isOk())
                     .andExpect(header().string(
@@ -43,9 +45,22 @@ class ChatWebSocketOriginContractTest {
         }
 
         @Test
-        @DisplayName("설정되지 않은 Origin의 info 요청을 거부한다")
+        @DisplayName("설정된 Origin이어도 인증되지 않은 info 요청은 거부한다")
+        void rejectsAnonymousRequest() throws Exception {
+            mockMvc.perform(get("/ws/info")
+                            .header(HttpHeaders.ORIGIN, LOCAL_ORIGIN))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(header().string(
+                            HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
+                            LOCAL_ORIGIN
+                    ));
+        }
+
+        @Test
+        @DisplayName("설정되지 않은 Origin의 인증된 info 요청을 거부한다")
         void rejectsUnknownOrigin() throws Exception {
             mockMvc.perform(get("/ws/info")
+                            .with(user("user").roles("USER"))
                             .header(HttpHeaders.ORIGIN, "https://unknown.example.com"))
                     .andExpect(status().isForbidden())
                     .andExpect(header().doesNotExist(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN));

--- a/src/test/java/online/lifeasgame/system/bootstrap/security/CorsSecurityContractTest.java
+++ b/src/test/java/online/lifeasgame/system/bootstrap/security/CorsSecurityContractTest.java
@@ -15,7 +15,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -23,15 +22,16 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -48,7 +48,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         SecurityConfig.class,
         WebMvcTestConfig.class
 })
-@DisplayName("Web CORS and security contract")
+@DisplayName("CORS 요청을 처리할 때")
 class CorsSecurityContractTest {
 
     private static final String PROTECTED_PATH = "/api/v1/security-contract/ping";
@@ -68,11 +68,11 @@ class CorsSecurityContractTest {
     private ErrorDocLinker errorDocLinker;
 
     @Nested
-    @DisplayName("Configured origin flow")
-    class ConfiguredOriginFlow {
+    @DisplayName("허용된 Origin이면")
+    class AllowedOrigin {
 
         @Test
-        @DisplayName("localhost:3000 preflight is allowed with credentials")
+        @DisplayName("localhost:3000의 protected preflight를 credentials와 함께 허용한다")
         void allowsLocalhostPreflight() throws Exception {
             preflight(LOCAL_ORIGIN, HttpMethod.GET, "Authorization")
                     .andExpect(status().isOk())
@@ -81,7 +81,7 @@ class CorsSecurityContractTest {
         }
 
         @Test
-        @DisplayName("a second configured production origin is allowed")
+        @DisplayName("쉼표로 설정한 두 번째 production Origin도 허용한다")
         void allowsMultipleConfiguredOrigins() throws Exception {
             preflight(PRODUCTION_ORIGIN, HttpMethod.POST, "Content-Type")
                     .andExpect(status().isOk())
@@ -89,7 +89,7 @@ class CorsSecurityContractTest {
         }
 
         @Test
-        @DisplayName("preflight advertises the required methods and headers")
+        @DisplayName("preflight에 필요한 method와 header만 알린다")
         void advertisesRequiredMethodsAndHeaders() throws Exception {
             preflight(PRODUCTION_ORIGIN, HttpMethod.PATCH,
                     "Authorization", "Content-Type", "Accept")
@@ -118,43 +118,9 @@ class CorsSecurityContractTest {
                             containsString("Accept")
                     ));
         }
-    }
-
-    @Nested
-    @DisplayName("Rejected origin flow")
-    class RejectedOriginFlow {
 
         @Test
-        @DisplayName("an unknown origin is rejected")
-        void rejectsUnknownOrigin() throws Exception {
-            preflight("https://unknown.example.com", HttpMethod.GET, "Authorization")
-                    .andExpect(status().isForbidden())
-                    .andExpect(header().doesNotExist(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN));
-        }
-
-        @ParameterizedTest
-        @ValueSource(strings = {"*", "https://*.example.com"})
-        @DisplayName("credentialed policy rejects wildcard origins")
-        void rejectsWildcardOrigins(String origin) {
-            assertThatThrownBy(() -> new WebCorsProperties(List.of(origin)))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("without wildcards");
-        }
-    }
-
-    @Nested
-    @DisplayName("Protected API flow")
-    class ProtectedApiFlow {
-
-        @Test
-        @DisplayName("a configured preflight reaches CORS without JWT")
-        void allowsProtectedPreflightWithoutJwt() throws Exception {
-            preflight(LOCAL_ORIGIN, HttpMethod.GET, "Authorization")
-                    .andExpect(status().isOk());
-        }
-
-        @Test
-        @DisplayName("the actual protected request still requires JWT")
+        @DisplayName("actual protected request는 계속 JWT를 요구한다")
         void rejectsActualRequestWithoutJwt() throws Exception {
             mockMvc.perform(get(PROTECTED_PATH)
                             .header(HttpHeaders.ORIGIN, LOCAL_ORIGIN))
@@ -164,8 +130,8 @@ class CorsSecurityContractTest {
         }
 
         @Test
-        @DisplayName("a valid JWT keeps the protected API and Location header available")
-        void allowsActualRequestWithJwtAndExposesLocation() throws Exception {
+        @DisplayName("유효한 JWT의 actual protected request를 허용하고 불필요한 header는 expose하지 않는다")
+        void allowsActualRequestWithJwt() throws Exception {
             Claims claims = mock(Claims.class);
             given(jwtProvider.parse("valid-access-token")).willReturn(Optional.of(claims));
             given(claims.getSubject()).willReturn("1");
@@ -176,10 +142,79 @@ class CorsSecurityContractTest {
                             .header(HttpHeaders.AUTHORIZATION, "Bearer valid-access-token"))
                     .andExpect(status().isOk())
                     .andExpect(header().string(
-                            HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS,
-                            containsString(HttpHeaders.LOCATION)
+                            HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
+                            PRODUCTION_ORIGIN
                     ))
-                    .andExpect(header().string(HttpHeaders.LOCATION, PROTECTED_PATH));
+                    .andExpect(header().doesNotExist(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS));
+        }
+    }
+
+    @Nested
+    @DisplayName("허용되지 않은 Origin이면")
+    class UnknownOrigin {
+
+        @Test
+        @DisplayName("preflight를 permissive header 없이 거부한다")
+        void rejectsUnknownOriginPreflight() throws Exception {
+            preflight("https://unknown.example.com", HttpMethod.GET, "Authorization")
+                    .andExpect(status().isForbidden())
+                    .andExpect(header().doesNotExist(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN));
+        }
+
+        @Test
+        @DisplayName("actual request도 permissive header 없이 거부한다")
+        void rejectsUnknownOriginActualRequest() throws Exception {
+            mockMvc.perform(get(PROTECTED_PATH)
+                            .with(user("user").roles("USER"))
+                            .header(HttpHeaders.ORIGIN, "https://unknown.example.com"))
+                    .andExpect(status().isForbidden())
+                    .andExpect(header().doesNotExist(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN));
+        }
+    }
+
+    @Nested
+    @DisplayName("Origin 설정 계약을 검증할 때")
+    class OriginConfiguration {
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "http://localhost:3000",
+                "https://app.example.com",
+                "https://app.example.com:8443"
+        })
+        @DisplayName("exact HTTP Origin은 허용한다")
+        void acceptsExactOrigins(String origin) {
+            assertThat(new WebCorsProperties(List.of(origin)).allowedOrigins())
+                    .containsExactly(origin);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "",
+                "*",
+                "https://*.example.com",
+                "app.example.com",
+                "ftp://app.example.com",
+                "https://app.example.com/",
+                "https://app.example.com/api",
+                "https://app.example.com?tenant=1",
+                "https://app.example.com#fragment",
+                "https://exa mple.com"
+        })
+        @DisplayName("exact HTTP Origin이 아니면 startup에서 거부한다")
+        void rejectsInvalidOrigins(String origin) {
+            assertThatThrownBy(() -> new WebCorsProperties(List.of(origin)))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("exact http(s)://host[:port]");
+        }
+
+        @Test
+        @DisplayName("Origin 목록이 없거나 비어 있으면 startup에서 거부한다")
+        void rejectsMissingOrigins() {
+            assertThatThrownBy(() -> new WebCorsProperties(null))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> new WebCorsProperties(List.of()))
+                    .isInstanceOf(IllegalArgumentException.class);
         }
     }
 
@@ -195,10 +230,8 @@ class CorsSecurityContractTest {
     static class ContractController {
 
         @GetMapping(PROTECTED_PATH)
-        ResponseEntity<Void> ping() {
-            return ResponseEntity.ok()
-                    .location(URI.create(PROTECTED_PATH))
-                    .build();
+        String ping() {
+            return "ok";
         }
     }
 }

--- a/src/test/java/online/lifeasgame/system/bootstrap/security/CorsSecurityContractTest.java
+++ b/src/test/java/online/lifeasgame/system/bootstrap/security/CorsSecurityContractTest.java
@@ -1,0 +1,204 @@
+package online.lifeasgame.system.bootstrap.security;
+
+import io.jsonwebtoken.Claims;
+import online.lifeasgame.platform.security.jwt.JwtProvider;
+import online.lifeasgame.platform.web.error.docs.ErrorDocLinker;
+import online.lifeasgame.support.WebMvcTestConfig;
+import online.lifeasgame.system.bootstrap.error.handler.AppErrorProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = CorsSecurityContractTest.ContractController.class,
+        properties = "lifeasgame.web.cors.allowed-origins="
+                + "http://localhost:3000,https://app.example.com"
+)
+@ActiveProfiles("test")
+@Import({
+        CorsSecurityContractTest.ContractController.class,
+        SecurityConfig.class,
+        WebMvcTestConfig.class
+})
+@DisplayName("Web CORS and security contract")
+class CorsSecurityContractTest {
+
+    private static final String PROTECTED_PATH = "/api/v1/security-contract/ping";
+    private static final String LOCAL_ORIGIN = "http://localhost:3000";
+    private static final String PRODUCTION_ORIGIN = "https://app.example.com";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private AppErrorProperties appErrorProperties;
+
+    @MockitoBean
+    private ErrorDocLinker errorDocLinker;
+
+    @Nested
+    @DisplayName("Configured origin flow")
+    class ConfiguredOriginFlow {
+
+        @Test
+        @DisplayName("localhost:3000 preflight is allowed with credentials")
+        void allowsLocalhostPreflight() throws Exception {
+            preflight(LOCAL_ORIGIN, HttpMethod.GET, "Authorization")
+                    .andExpect(status().isOk())
+                    .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, LOCAL_ORIGIN))
+                    .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true"));
+        }
+
+        @Test
+        @DisplayName("a second configured production origin is allowed")
+        void allowsMultipleConfiguredOrigins() throws Exception {
+            preflight(PRODUCTION_ORIGIN, HttpMethod.POST, "Content-Type")
+                    .andExpect(status().isOk())
+                    .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, PRODUCTION_ORIGIN));
+        }
+
+        @Test
+        @DisplayName("preflight advertises the required methods and headers")
+        void advertisesRequiredMethodsAndHeaders() throws Exception {
+            preflight(PRODUCTION_ORIGIN, HttpMethod.PATCH,
+                    "Authorization", "Content-Type", "Accept")
+                    .andExpect(status().isOk())
+                    .andExpect(header().string(
+                            HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,
+                            allOf(
+                                    containsString("GET"),
+                                    containsString("POST"),
+                                    containsString("PUT"),
+                                    containsString("PATCH"),
+                                    containsString("DELETE"),
+                                    containsString("OPTIONS")
+                            )
+                    ))
+                    .andExpect(header().string(
+                            HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS,
+                            containsString("Authorization")
+                    ))
+                    .andExpect(header().string(
+                            HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS,
+                            containsString("Content-Type")
+                    ))
+                    .andExpect(header().string(
+                            HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS,
+                            containsString("Accept")
+                    ));
+        }
+    }
+
+    @Nested
+    @DisplayName("Rejected origin flow")
+    class RejectedOriginFlow {
+
+        @Test
+        @DisplayName("an unknown origin is rejected")
+        void rejectsUnknownOrigin() throws Exception {
+            preflight("https://unknown.example.com", HttpMethod.GET, "Authorization")
+                    .andExpect(status().isForbidden())
+                    .andExpect(header().doesNotExist(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"*", "https://*.example.com"})
+        @DisplayName("credentialed policy rejects wildcard origins")
+        void rejectsWildcardOrigins(String origin) {
+            assertThatThrownBy(() -> new WebCorsProperties(List.of(origin)))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("without wildcards");
+        }
+    }
+
+    @Nested
+    @DisplayName("Protected API flow")
+    class ProtectedApiFlow {
+
+        @Test
+        @DisplayName("a configured preflight reaches CORS without JWT")
+        void allowsProtectedPreflightWithoutJwt() throws Exception {
+            preflight(LOCAL_ORIGIN, HttpMethod.GET, "Authorization")
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("the actual protected request still requires JWT")
+        void rejectsActualRequestWithoutJwt() throws Exception {
+            mockMvc.perform(get(PROTECTED_PATH)
+                            .header(HttpHeaders.ORIGIN, LOCAL_ORIGIN))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, LOCAL_ORIGIN))
+                    .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true"));
+        }
+
+        @Test
+        @DisplayName("a valid JWT keeps the protected API and Location header available")
+        void allowsActualRequestWithJwtAndExposesLocation() throws Exception {
+            Claims claims = mock(Claims.class);
+            given(jwtProvider.parse("valid-access-token")).willReturn(Optional.of(claims));
+            given(claims.getSubject()).willReturn("1");
+            given(claims.get("pid", Long.class)).willReturn(2L);
+
+            mockMvc.perform(get(PROTECTED_PATH)
+                            .header(HttpHeaders.ORIGIN, PRODUCTION_ORIGIN)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer valid-access-token"))
+                    .andExpect(status().isOk())
+                    .andExpect(header().string(
+                            HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS,
+                            containsString(HttpHeaders.LOCATION)
+                    ))
+                    .andExpect(header().string(HttpHeaders.LOCATION, PROTECTED_PATH));
+        }
+    }
+
+    private ResultActions preflight(String origin, HttpMethod method, String... requestedHeaders)
+            throws Exception {
+        return mockMvc.perform(options(PROTECTED_PATH)
+                .header(HttpHeaders.ORIGIN, origin)
+                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, method.name())
+                .header(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS, String.join(",", requestedHeaders)));
+    }
+
+    @RestController
+    static class ContractController {
+
+        @GetMapping(PROTECTED_PATH)
+        ResponseEntity<Void> ping() {
+            return ResponseEntity.ok()
+                    .location(URI.create(PROTECTED_PATH))
+                    .build();
+        }
+    }
+}

--- a/src/test/java/online/lifeasgame/system/bootstrap/security/CorsSecurityContractTest.java
+++ b/src/test/java/online/lifeasgame/system/bootstrap/security/CorsSecurityContractTest.java
@@ -173,6 +173,27 @@ class CorsSecurityContractTest {
     }
 
     @Nested
+    @DisplayName("허용되지 않은 method/header이면")
+    class UnapprovedRequestContract {
+
+        @Test
+        @DisplayName("TRACE preflight를 403으로 거부한다")
+        void rejectsTraceMethod() throws Exception {
+            preflight(PRODUCTION_ORIGIN, HttpMethod.TRACE, "Authorization")
+                    .andExpect(status().isForbidden())
+                    .andExpect(header().doesNotExist(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS));
+        }
+
+        @Test
+        @DisplayName("X-Unapproved-Header preflight를 403으로 거부한다")
+        void rejectsUnapprovedHeader() throws Exception {
+            preflight(PRODUCTION_ORIGIN, HttpMethod.GET, "X-Unapproved-Header")
+                    .andExpect(status().isForbidden())
+                    .andExpect(header().doesNotExist(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS));
+        }
+    }
+
+    @Nested
     @DisplayName("Origin 설정 계약을 검증할 때")
     class OriginConfiguration {
 


### PR DESCRIPTION
## Purpose
Prepare the backend for browser integration with the Vercel-hosted frontend through an explicit environment-driven CORS policy.

## Policy
- explicit allowed origins
- no wildcard production origin
- localhost development support
- GET/POST/PUT/PATCH/DELETE/OPTIONS
- Authorization/Content-Type/Accept browser headers
- credentials policy consistent with the merged frontend client

## Security
CORS is integrated with the active Spring Security filter chain so configured preflight requests work without weakening JWT authorization.

## Deployment contract
Frontend Production:
NEXT_PUBLIC_USE_MOCK=false
NEXT_PUBLIC_API_URL=<backend URL>

Backend:
LIFEASGAME_WEB_ALLOWED_ORIGINS=<frontend production origin>

No generated Vercel URL is hard-coded in Java.

## Tests
Added CORS/security regression coverage using readable nested JUnit flows.

## Out of scope
- product domain changes
- content delivery
- OAuth
- JWT cookie migration
- Social/Economy refactor
- Vercel dashboard configuration

Closes #254


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable web access controls for approved frontend origins.
  - Applied origin restrictions to REST requests and chat WebSocket connections.
  - Added support for credentials, standard methods and headers, and exposed redirect location headers.
  - Production deployments can configure approved origins through an environment variable.

- **Bug Fixes**
  - Unknown, wildcard, blank, or invalid origins are now rejected.

- **Documentation**
  - Added Korean and English setup instructions for frontend and production web integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->