### PR TITLE
[LifeLog] Add canonical Journal timeline read model

### DIFF
--- a/src/main/java/online/lifeasgame/lifelog/api/player/PlayerLifeLogJournalController.java
+++ b/src/main/java/online/lifeasgame/lifelog/api/player/PlayerLifeLogJournalController.java
@@ -1,0 +1,54 @@
+package online.lifeasgame.lifelog.api.player;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.response.ApiResponse;
+import online.lifeasgame.lifelog.api.player.mapper.PlayerLifeLogJournalWebMapper;
+import online.lifeasgame.lifelog.api.player.response.PlayerLifeLogJournalResponse;
+import online.lifeasgame.lifelog.api.player.spec.PlayerLifeLogJournalSpecV1;
+import online.lifeasgame.lifelog.application.LifeLogJournalQueryService;
+import online.lifeasgame.lifelog.application.result.LifeLogJournalResult;
+import online.lifeasgame.platform.web.response.ApiResponses;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/lifelogs")
+public class PlayerLifeLogJournalController
+        implements PlayerLifeLogJournalSpecV1 {
+
+    private final LifeLogJournalQueryService journalQueryService;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResponse<PlayerLifeLogJournalResponse.Page>> list(
+            @RequestParam(required = false) @Positive Long primaryRoleId,
+            @RequestParam(required = false) String subtype,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size
+    ) {
+        LifeLogJournalResult.Page result = journalQueryService.list(
+                primaryRoleId,
+                subtype,
+                page,
+                size
+        );
+        return ApiResponses.ok(PlayerLifeLogJournalWebMapper.toPage(result));
+    }
+
+    @Override
+    @GetMapping("/{lifeLogId}")
+    public ResponseEntity<ApiResponse<PlayerLifeLogJournalResponse.Detail>>
+    detail(@PathVariable @Positive Long lifeLogId) {
+        return ApiResponses.ok(PlayerLifeLogJournalWebMapper.toDetail(
+                journalQueryService.detail(lifeLogId)
+        ));
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/api/player/PlayerLifeLogJournalController.java
+++ b/src/main/java/online/lifeasgame/lifelog/api/player/PlayerLifeLogJournalController.java
@@ -1,8 +1,5 @@
 package online.lifeasgame.lifelog.api.player;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.core.response.ApiResponse;
 import online.lifeasgame.lifelog.api.player.mapper.PlayerLifeLogJournalWebMapper;
@@ -29,10 +26,10 @@ public class PlayerLifeLogJournalController
     @Override
     @GetMapping
     public ResponseEntity<ApiResponse<PlayerLifeLogJournalResponse.Page>> list(
-            @RequestParam(required = false) @Positive Long primaryRoleId,
+            @RequestParam(required = false) Long primaryRoleId,
             @RequestParam(required = false) String subtype,
-            @RequestParam(defaultValue = "0") @Min(0) int page,
-            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
     ) {
         LifeLogJournalResult.Page result = journalQueryService.list(
                 primaryRoleId,
@@ -46,7 +43,7 @@ public class PlayerLifeLogJournalController
     @Override
     @GetMapping("/{lifeLogId}")
     public ResponseEntity<ApiResponse<PlayerLifeLogJournalResponse.Detail>>
-    detail(@PathVariable @Positive Long lifeLogId) {
+    detail(@PathVariable Long lifeLogId) {
         return ApiResponses.ok(PlayerLifeLogJournalWebMapper.toDetail(
                 journalQueryService.detail(lifeLogId)
         ));

--- a/src/main/java/online/lifeasgame/lifelog/api/player/mapper/PlayerLifeLogJournalWebMapper.java
+++ b/src/main/java/online/lifeasgame/lifelog/api/player/mapper/PlayerLifeLogJournalWebMapper.java
@@ -1,0 +1,137 @@
+package online.lifeasgame.lifelog.api.player.mapper;
+
+import online.lifeasgame.lifelog.api.player.response.PlayerLifeLogJournalResponse;
+import online.lifeasgame.lifelog.application.result.LifeLogJournalResult;
+
+public final class PlayerLifeLogJournalWebMapper {
+
+    private PlayerLifeLogJournalWebMapper() {
+    }
+
+    public static PlayerLifeLogJournalResponse.Page toPage(
+            LifeLogJournalResult.Page result
+    ) {
+        return new PlayerLifeLogJournalResponse.Page(
+                result.content().stream()
+                        .map(PlayerLifeLogJournalWebMapper::toEntry)
+                        .toList(),
+                result.page(),
+                result.size(),
+                result.totalElements(),
+                result.totalPages()
+        );
+    }
+
+    public static PlayerLifeLogJournalResponse.Detail toDetail(
+            LifeLogJournalResult.Detail result
+    ) {
+        return new PlayerLifeLogJournalResponse.Detail(
+                result.lifeLogId(),
+                result.sourceType(),
+                result.sourceId(),
+                result.subtype(),
+                result.entryMode(),
+                result.reflectionScope(),
+                result.periodKey(),
+                result.primaryRoleId(),
+                result.roleEventId(),
+                result.recordedAt(),
+                toSource(result.source())
+        );
+    }
+
+    private static PlayerLifeLogJournalResponse.Entry toEntry(
+            LifeLogJournalResult.Entry result
+    ) {
+        return new PlayerLifeLogJournalResponse.Entry(
+                result.lifeLogId(),
+                result.sourceType(),
+                result.sourceId(),
+                result.subtype(),
+                result.entryMode(),
+                result.reflectionScope(),
+                result.periodKey(),
+                result.primaryRoleId(),
+                result.roleEventId(),
+                result.recordedAt(),
+                toPreview(result.preview())
+        );
+    }
+
+    private static PlayerLifeLogJournalResponse.Preview toPreview(
+            LifeLogJournalResult.Preview preview
+    ) {
+        return switch (preview) {
+            case LifeLogJournalResult.CollectionPreview value ->
+                    new PlayerLifeLogJournalResponse.CollectionPreview(
+                            value.category(),
+                            value.title(),
+                            value.quantity()
+                    );
+            case LifeLogJournalResult.ExercisePreview value ->
+                    new PlayerLifeLogJournalResponse.ExercisePreview(
+                            value.category(),
+                            value.durationMinutes(),
+                            value.distanceKm(),
+                            value.calories(),
+                            value.exercisedOn(),
+                            value.memo()
+                    );
+            case LifeLogJournalResult.MediaPreview value ->
+                    new PlayerLifeLogJournalResponse.MediaPreview(
+                            value.category(),
+                            value.title(),
+                            value.currentEpisode(),
+                            value.totalEpisode(),
+                            value.status(),
+                            value.rating()
+                    );
+        };
+    }
+
+    private static PlayerLifeLogJournalResponse.Source toSource(
+            LifeLogJournalResult.Source source
+    ) {
+        return switch (source) {
+            case LifeLogJournalResult.CollectionSource value ->
+                    new PlayerLifeLogJournalResponse.CollectionSource(
+                            value.category(),
+                            value.title(),
+                            value.originalTitle(),
+                            value.quantity(),
+                            value.conditionNote(),
+                            value.acquiredFrom(),
+                            value.tags(),
+                            value.createdAt(),
+                            value.updatedAt()
+                    );
+            case LifeLogJournalResult.ExerciseSource value ->
+                    new PlayerLifeLogJournalResponse.ExerciseSource(
+                            value.category(),
+                            value.durationMinutes(),
+                            value.distanceKm(),
+                            value.calories(),
+                            value.exercisedOn(),
+                            value.memo(),
+                            value.createdAt(),
+                            value.updatedAt()
+                    );
+            case LifeLogJournalResult.MediaSource value ->
+                    new PlayerLifeLogJournalResponse.MediaSource(
+                            value.category(),
+                            value.title(),
+                            value.originalTitle(),
+                            value.currentEpisode(),
+                            value.totalEpisode(),
+                            value.status(),
+                            value.rating(),
+                            value.tags(),
+                            value.rewatchCount(),
+                            value.startedOn(),
+                            value.finishedOn(),
+                            value.createdAt(),
+                            value.updatedAt()
+                    );
+        };
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/api/player/response/PlayerLifeLogJournalResponse.java
+++ b/src/main/java/online/lifeasgame/lifelog/api/player/response/PlayerLifeLogJournalResponse.java
@@ -1,0 +1,132 @@
+package online.lifeasgame.lifelog.api.player.response;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+public final class PlayerLifeLogJournalResponse {
+
+    private PlayerLifeLogJournalResponse() {
+    }
+
+    public record Page(
+            List<Entry> content,
+            int page,
+            int size,
+            long totalElements,
+            int totalPages
+    ) {
+    }
+
+    public record Entry(
+            Long lifeLogId,
+            String sourceType,
+            Long sourceId,
+            String subtype,
+            String entryMode,
+            String reflectionScope,
+            String periodKey,
+            Long primaryRoleId,
+            Long roleEventId,
+            Instant recordedAt,
+            Preview preview
+    ) {
+    }
+
+    public record Detail(
+            Long lifeLogId,
+            String sourceType,
+            Long sourceId,
+            String subtype,
+            String entryMode,
+            String reflectionScope,
+            String periodKey,
+            Long primaryRoleId,
+            Long roleEventId,
+            Instant recordedAt,
+            Source source
+    ) {
+    }
+
+    public sealed interface Preview permits
+            CollectionPreview,
+            ExercisePreview,
+            MediaPreview {
+    }
+
+    public record CollectionPreview(
+            String category,
+            String title,
+            Integer quantity
+    ) implements Preview {
+    }
+
+    public record ExercisePreview(
+            String category,
+            Integer durationMinutes,
+            Double distanceKm,
+            Integer calories,
+            LocalDate exercisedOn,
+            String memo
+    ) implements Preview {
+    }
+
+    public record MediaPreview(
+            String category,
+            String title,
+            Integer currentEpisode,
+            Integer totalEpisode,
+            String status,
+            Double rating
+    ) implements Preview {
+    }
+
+    public sealed interface Source permits
+            CollectionSource,
+            ExerciseSource,
+            MediaSource {
+    }
+
+    public record CollectionSource(
+            String category,
+            String title,
+            String originalTitle,
+            Integer quantity,
+            String conditionNote,
+            String acquiredFrom,
+            Set<String> tags,
+            Instant createdAt,
+            Instant updatedAt
+    ) implements Source {
+    }
+
+    public record ExerciseSource(
+            String category,
+            Integer durationMinutes,
+            Double distanceKm,
+            Integer calories,
+            LocalDate exercisedOn,
+            String memo,
+            Instant createdAt,
+            Instant updatedAt
+    ) implements Source {
+    }
+
+    public record MediaSource(
+            String category,
+            String title,
+            String originalTitle,
+            Integer currentEpisode,
+            Integer totalEpisode,
+            String status,
+            Double rating,
+            Set<String> tags,
+            int rewatchCount,
+            LocalDate startedOn,
+            LocalDate finishedOn,
+            Instant createdAt,
+            Instant updatedAt
+    ) implements Source {
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/api/player/spec/PlayerLifeLogJournalSpecV1.java
+++ b/src/main/java/online/lifeasgame/lifelog/api/player/spec/PlayerLifeLogJournalSpecV1.java
@@ -1,0 +1,29 @@
+package online.lifeasgame.lifelog.api.player.spec;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
+import online.lifeasgame.core.response.ApiResponse;
+import online.lifeasgame.lifelog.api.player.response.PlayerLifeLogJournalResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "LifeLog Journal API V1 (Player)")
+public interface PlayerLifeLogJournalSpecV1 {
+
+    @Operation(summary = "canonical Journal timeline 조회")
+    ResponseEntity<ApiResponse<PlayerLifeLogJournalResponse.Page>> list(
+            @RequestParam(required = false) @Positive Long primaryRoleId,
+            @RequestParam(required = false) String subtype,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size
+    );
+
+    @Operation(summary = "canonical Journal 상세 조회")
+    ResponseEntity<ApiResponse<PlayerLifeLogJournalResponse.Detail>> detail(
+            @PathVariable @Positive Long lifeLogId
+    );
+}

--- a/src/main/java/online/lifeasgame/lifelog/application/LifeLogJournalQueryService.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/LifeLogJournalQueryService.java
@@ -1,0 +1,87 @@
+package online.lifeasgame.lifelog.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.lifelog.application.query.LifeLogJournalQuery;
+import online.lifeasgame.lifelog.application.result.LifeLogJournalResult;
+import online.lifeasgame.lifelog.domain.error.LifeLogError;
+import online.lifeasgame.lifelog.domain.record.LifeLogSubtype;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LifeLogJournalQueryService {
+
+    private final LifeLogJournalQuery journalQuery;
+    private final CurrentPlayerAccessor currentPlayerAccessor;
+
+    public LifeLogJournalResult.Page list(
+            Long primaryRoleId,
+            String subtype,
+            int page,
+            int size
+    ) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        LifeLogJournalQuery.CanonicalPage canonicalPage =
+                journalQuery.findPage(
+                        playerId,
+                        primaryRoleId,
+                        subtype == null ? null : LifeLogSubtype.parse(subtype),
+                        page,
+                        size
+                );
+        Map<LifeLogJournalQuery.SourceKey, LifeLogJournalResult.Preview>
+                previews = journalQuery.loadPreviews(
+                        playerId,
+                        canonicalPage.content()
+                );
+        return new LifeLogJournalResult.Page(
+                canonicalPage.content().stream()
+                        .map(record -> LifeLogJournalResult.Entry.from(
+                                record,
+                                requirePreview(previews, record)
+                        ))
+                        .toList(),
+                canonicalPage.page(),
+                canonicalPage.size(),
+                canonicalPage.totalElements(),
+                canonicalPage.totalPages()
+        );
+    }
+
+    public LifeLogJournalResult.Detail detail(Long lifeLogId) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        LifeLogJournalQuery.CanonicalRecord record = journalQuery
+                .findOwned(playerId, lifeLogId)
+                .orElseThrow(() -> new DomainException(
+                        LifeLogError.LIFE_LOG_NOT_FOUND
+                ));
+        LifeLogJournalResult.Source source = journalQuery
+                .loadSource(playerId, record)
+                .orElseThrow(LifeLogJournalQueryService::sourceMissing);
+        return LifeLogJournalResult.Detail.from(record, source);
+    }
+
+    private LifeLogJournalResult.Preview requirePreview(
+            Map<LifeLogJournalQuery.SourceKey, LifeLogJournalResult.Preview>
+                    previews,
+            LifeLogJournalQuery.CanonicalRecord record
+    ) {
+        LifeLogJournalResult.Preview preview = previews.get(
+                record.sourceKey()
+        );
+        if (preview == null) {
+            throw sourceMissing();
+        }
+        return preview;
+    }
+
+    private static DomainException sourceMissing() {
+        return new DomainException(LifeLogError.LIFE_LOG_SOURCE_UNAVAILABLE);
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/application/query/LifeLogJournalQuery.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/query/LifeLogJournalQuery.java
@@ -1,0 +1,64 @@
+package online.lifeasgame.lifelog.application.query;
+
+import online.lifeasgame.lifelog.application.result.LifeLogJournalResult;
+import online.lifeasgame.lifelog.domain.record.LifeLogEntryMode;
+import online.lifeasgame.lifelog.domain.record.LifeLogReflectionScope;
+import online.lifeasgame.lifelog.domain.record.LifeLogSourceType;
+import online.lifeasgame.lifelog.domain.record.LifeLogSubtype;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public interface LifeLogJournalQuery {
+
+    CanonicalPage findPage(
+            Long playerId,
+            Long primaryRoleId,
+            LifeLogSubtype subtype,
+            int page,
+            int size
+    );
+
+    Optional<CanonicalRecord> findOwned(Long playerId, Long lifeLogId);
+
+    Map<SourceKey, LifeLogJournalResult.Preview> loadPreviews(
+            Long playerId,
+            List<CanonicalRecord> records
+    );
+
+    Optional<LifeLogJournalResult.Source> loadSource(
+            Long playerId,
+            CanonicalRecord record
+    );
+
+    record CanonicalPage(
+            List<CanonicalRecord> content,
+            int page,
+            int size,
+            long totalElements,
+            int totalPages
+    ) {
+    }
+
+    record CanonicalRecord(
+            Long lifeLogId,
+            LifeLogSourceType sourceType,
+            Long sourceId,
+            LifeLogSubtype subtype,
+            LifeLogEntryMode entryMode,
+            LifeLogReflectionScope reflectionScope,
+            String periodKey,
+            Long primaryRoleId,
+            Long roleEventId,
+            Instant occurredAt
+    ) {
+        public SourceKey sourceKey() {
+            return new SourceKey(sourceType, sourceId);
+        }
+    }
+
+    record SourceKey(LifeLogSourceType sourceType, Long sourceId) {
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/application/result/LifeLogJournalResult.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/result/LifeLogJournalResult.java
@@ -1,0 +1,182 @@
+package online.lifeasgame.lifelog.application.result;
+
+import online.lifeasgame.lifelog.application.query.LifeLogJournalQuery;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+public final class LifeLogJournalResult {
+
+    private LifeLogJournalResult() {
+    }
+
+    public record Page(
+            List<Entry> content,
+            int page,
+            int size,
+            long totalElements,
+            int totalPages
+    ) {
+    }
+
+    public record Entry(
+            Long lifeLogId,
+            String sourceType,
+            Long sourceId,
+            String subtype,
+            String entryMode,
+            String reflectionScope,
+            String periodKey,
+            Long primaryRoleId,
+            Long roleEventId,
+            Instant recordedAt,
+            Preview preview
+    ) {
+        public static Entry from(
+                LifeLogJournalQuery.CanonicalRecord record,
+                Preview preview
+        ) {
+            return new Entry(
+                    record.lifeLogId(),
+                    record.sourceType().name(),
+                    record.sourceId(),
+                    record.subtype() == null
+                            ? null
+                            : record.subtype().name(),
+                    record.entryMode() == null
+                            ? null
+                            : record.entryMode().name(),
+                    record.reflectionScope() == null
+                            ? null
+                            : record.reflectionScope().name(),
+                    record.periodKey(),
+                    record.primaryRoleId(),
+                    record.roleEventId(),
+                    record.occurredAt(),
+                    preview
+            );
+        }
+    }
+
+    public record Detail(
+            Long lifeLogId,
+            String sourceType,
+            Long sourceId,
+            String subtype,
+            String entryMode,
+            String reflectionScope,
+            String periodKey,
+            Long primaryRoleId,
+            Long roleEventId,
+            Instant recordedAt,
+            Source source
+    ) {
+        public static Detail from(
+                LifeLogJournalQuery.CanonicalRecord record,
+                Source source
+        ) {
+            return new Detail(
+                    record.lifeLogId(),
+                    record.sourceType().name(),
+                    record.sourceId(),
+                    record.subtype() == null
+                            ? null
+                            : record.subtype().name(),
+                    record.entryMode() == null
+                            ? null
+                            : record.entryMode().name(),
+                    record.reflectionScope() == null
+                            ? null
+                            : record.reflectionScope().name(),
+                    record.periodKey(),
+                    record.primaryRoleId(),
+                    record.roleEventId(),
+                    record.occurredAt(),
+                    source
+            );
+        }
+    }
+
+    public sealed interface Preview permits
+            CollectionPreview,
+            ExercisePreview,
+            MediaPreview {
+    }
+
+    public record CollectionPreview(
+            String category,
+            String title,
+            Integer quantity
+    ) implements Preview {
+    }
+
+    public record ExercisePreview(
+            String category,
+            Integer durationMinutes,
+            Double distanceKm,
+            Integer calories,
+            LocalDate exercisedOn,
+            String memo
+    ) implements Preview {
+    }
+
+    public record MediaPreview(
+            String category,
+            String title,
+            Integer currentEpisode,
+            Integer totalEpisode,
+            String status,
+            Double rating
+    ) implements Preview {
+    }
+
+    public sealed interface Source permits
+            CollectionSource,
+            ExerciseSource,
+            MediaSource {
+    }
+
+    public record CollectionSource(
+            String category,
+            String title,
+            String originalTitle,
+            Integer quantity,
+            String conditionNote,
+            String acquiredFrom,
+            Set<String> tags,
+            Instant createdAt,
+            Instant updatedAt
+    ) implements Source {
+    }
+
+    public record ExerciseSource(
+            String category,
+            Integer durationMinutes,
+            Double distanceKm,
+            Integer calories,
+            LocalDate exercisedOn,
+            String memo,
+            Instant createdAt,
+            Instant updatedAt
+    ) implements Source {
+    }
+
+    public record MediaSource(
+            String category,
+            String title,
+            String originalTitle,
+            Integer currentEpisode,
+            Integer totalEpisode,
+            String status,
+            Double rating,
+            Set<String> tags,
+            int rewatchCount,
+            LocalDate startedOn,
+            LocalDate finishedOn,
+            Instant createdAt,
+            Instant updatedAt
+    ) implements Source {
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/domain/error/LifeLogError.java
+++ b/src/main/java/online/lifeasgame/lifelog/domain/error/LifeLogError.java
@@ -3,6 +3,8 @@ package online.lifeasgame.lifelog.domain.error;
 import online.lifeasgame.core.error.ErrorCode;
 
 public enum LifeLogError implements ErrorCode {
+    LIFE_LOG_NOT_FOUND("LIF-404-LIFE-LOG-NOT-FOUND", "LifeLog Not Found", 404),
+    LIFE_LOG_SOURCE_UNAVAILABLE("LIF-500-SOURCE-UNAVAILABLE", "LifeLog Source Unavailable", 500),
     MEDIA_NOT_FOUND("LIF-404-MEDIA-NOT-FOUND", "Media Not Found", 404),
     EXERCISE_NOT_FOUND("LIF-404-EXERCISE-NOT-FOUND", "Exercise Not Found", 404),
     COLLECTION_NOT_FOUND("LIF-404-COLLECTION-NOT-FOUND", "Collection Not Found", 404),

--- a/src/main/java/online/lifeasgame/lifelog/infra/LifeLogJournalQueryAdapter.java
+++ b/src/main/java/online/lifeasgame/lifelog/infra/LifeLogJournalQueryAdapter.java
@@ -1,0 +1,371 @@
+package online.lifeasgame.lifelog.infra;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.lifelog.application.query.LifeLogJournalQuery;
+import online.lifeasgame.lifelog.application.result.LifeLogJournalResult;
+import online.lifeasgame.lifelog.domain.CollectionLog;
+import online.lifeasgame.lifelog.domain.ExerciseLog;
+import online.lifeasgame.lifelog.domain.MediaLog;
+import online.lifeasgame.lifelog.domain.record.LifeLogSourceType;
+import online.lifeasgame.lifelog.domain.record.LifeLogSubtype;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static online.lifeasgame.lifelog.domain.QCollectionLog.collectionLog;
+import static online.lifeasgame.lifelog.domain.QExerciseLog.exerciseLog;
+import static online.lifeasgame.lifelog.domain.QMediaLog.mediaLog;
+import static online.lifeasgame.lifelog.domain.record.QLifeLogRecord.lifeLogRecord;
+
+@Repository
+@RequiredArgsConstructor
+public class LifeLogJournalQueryAdapter implements LifeLogJournalQuery {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public CanonicalPage findPage(
+            Long playerId,
+            Long primaryRoleId,
+            LifeLogSubtype subtype,
+            int page,
+            int size
+    ) {
+        List<CanonicalRecord> content = queryFactory
+                .select(Projections.constructor(
+                        CanonicalRecord.class,
+                        lifeLogRecord.id,
+                        lifeLogRecord.sourceType,
+                        lifeLogRecord.sourceId,
+                        lifeLogRecord.subtype,
+                        lifeLogRecord.entryMode,
+                        lifeLogRecord.reflectionScope,
+                        lifeLogRecord.periodKey,
+                        lifeLogRecord.primaryRoleId,
+                        lifeLogRecord.roleEventId,
+                        lifeLogRecord.occurredAt
+                ))
+                .from(lifeLogRecord)
+                .where(
+                        lifeLogRecord.playerId.eq(playerId),
+                        primaryRoleIdEq(primaryRoleId),
+                        subtypeEq(subtype)
+                )
+                .orderBy(
+                        lifeLogRecord.occurredAt.desc(),
+                        lifeLogRecord.id.desc()
+                )
+                .offset((long) page * size)
+                .limit(size)
+                .fetch();
+        Long count = queryFactory
+                .select(lifeLogRecord.count())
+                .from(lifeLogRecord)
+                .where(
+                        lifeLogRecord.playerId.eq(playerId),
+                        primaryRoleIdEq(primaryRoleId),
+                        subtypeEq(subtype)
+                )
+                .fetchOne();
+        long total = count == null ? 0L : count;
+        int totalPages = (int) Math.ceil(total / (double) size);
+        return new CanonicalPage(content, page, size, total, totalPages);
+    }
+
+    @Override
+    public Optional<CanonicalRecord> findOwned(
+            Long playerId,
+            Long lifeLogId
+    ) {
+        return Optional.ofNullable(queryFactory
+                .select(Projections.constructor(
+                        CanonicalRecord.class,
+                        lifeLogRecord.id,
+                        lifeLogRecord.sourceType,
+                        lifeLogRecord.sourceId,
+                        lifeLogRecord.subtype,
+                        lifeLogRecord.entryMode,
+                        lifeLogRecord.reflectionScope,
+                        lifeLogRecord.periodKey,
+                        lifeLogRecord.primaryRoleId,
+                        lifeLogRecord.roleEventId,
+                        lifeLogRecord.occurredAt
+                ))
+                .from(lifeLogRecord)
+                .where(
+                        lifeLogRecord.id.eq(lifeLogId),
+                        lifeLogRecord.playerId.eq(playerId)
+                )
+                .fetchOne());
+    }
+
+    @Override
+    public Map<SourceKey, LifeLogJournalResult.Preview> loadPreviews(
+            Long playerId,
+            List<CanonicalRecord> records
+    ) {
+        Map<SourceKey, LifeLogJournalResult.Preview> previews =
+                new HashMap<>();
+        loadCollectionPreviews(
+                playerId,
+                sourceIds(records, LifeLogSourceType.COLLECTION),
+                previews
+        );
+        loadExercisePreviews(
+                playerId,
+                sourceIds(records, LifeLogSourceType.EXERCISE),
+                previews
+        );
+        loadMediaPreviews(
+                playerId,
+                sourceIds(records, LifeLogSourceType.MEDIA),
+                previews
+        );
+        return previews;
+    }
+
+    @Override
+    public Optional<LifeLogJournalResult.Source> loadSource(
+            Long playerId,
+            CanonicalRecord record
+    ) {
+        return switch (record.sourceType()) {
+            case COLLECTION -> loadCollectionSource(
+                    playerId,
+                    record.sourceId()
+            );
+            case EXERCISE -> loadExerciseSource(
+                    playerId,
+                    record.sourceId()
+            );
+            case MEDIA -> loadMediaSource(playerId, record.sourceId());
+        };
+    }
+
+    private void loadCollectionPreviews(
+            Long playerId,
+            Set<Long> sourceIds,
+            Map<SourceKey, LifeLogJournalResult.Preview> previews
+    ) {
+        if (sourceIds.isEmpty()) {
+            return;
+        }
+        List<Tuple> rows = queryFactory
+                .select(
+                        collectionLog.id,
+                        collectionLog.category,
+                        collectionLog.title.value,
+                        collectionLog.quantity.value
+                )
+                .from(collectionLog)
+                .where(
+                        collectionLog.playerId.eq(playerId),
+                        collectionLog.id.in(sourceIds)
+                )
+                .fetch();
+        rows.forEach(row -> previews.put(
+                new SourceKey(
+                        LifeLogSourceType.COLLECTION,
+                        row.get(collectionLog.id)
+                ),
+                new LifeLogJournalResult.CollectionPreview(
+                        row.get(collectionLog.category).name(),
+                        row.get(collectionLog.title.value),
+                        row.get(collectionLog.quantity.value)
+                )
+        ));
+    }
+
+    private void loadExercisePreviews(
+            Long playerId,
+            Set<Long> sourceIds,
+            Map<SourceKey, LifeLogJournalResult.Preview> previews
+    ) {
+        if (sourceIds.isEmpty()) {
+            return;
+        }
+        List<Tuple> rows = queryFactory
+                .select(
+                        exerciseLog.id,
+                        exerciseLog.category,
+                        exerciseLog.metrics.durationMinutes,
+                        exerciseLog.metrics.distanceKm,
+                        exerciseLog.metrics.calories,
+                        exerciseLog.exercisedOn,
+                        exerciseLog.memo
+                )
+                .from(exerciseLog)
+                .where(
+                        exerciseLog.playerId.eq(playerId),
+                        exerciseLog.id.in(sourceIds)
+                )
+                .fetch();
+        rows.forEach(row -> previews.put(
+                new SourceKey(
+                        LifeLogSourceType.EXERCISE,
+                        row.get(exerciseLog.id)
+                ),
+                new LifeLogJournalResult.ExercisePreview(
+                        row.get(exerciseLog.category).name(),
+                        row.get(exerciseLog.metrics.durationMinutes),
+                        row.get(exerciseLog.metrics.distanceKm),
+                        row.get(exerciseLog.metrics.calories),
+                        row.get(exerciseLog.exercisedOn),
+                        row.get(exerciseLog.memo)
+                )
+        ));
+    }
+
+    private void loadMediaPreviews(
+            Long playerId,
+            Set<Long> sourceIds,
+            Map<SourceKey, LifeLogJournalResult.Preview> previews
+    ) {
+        if (sourceIds.isEmpty()) {
+            return;
+        }
+        List<Tuple> rows = queryFactory
+                .select(
+                        mediaLog.id,
+                        mediaLog.category,
+                        mediaLog.title.value,
+                        mediaLog.progress.current,
+                        mediaLog.progress.total,
+                        mediaLog.status,
+                        mediaLog.rating.score
+                )
+                .from(mediaLog)
+                .where(
+                        mediaLog.playerId.eq(playerId),
+                        mediaLog.id.in(sourceIds)
+                )
+                .fetch();
+        rows.forEach(row -> previews.put(
+                new SourceKey(
+                        LifeLogSourceType.MEDIA,
+                        row.get(mediaLog.id)
+                ),
+                new LifeLogJournalResult.MediaPreview(
+                        row.get(mediaLog.category).name(),
+                        row.get(mediaLog.title.value),
+                        row.get(mediaLog.progress.current),
+                        row.get(mediaLog.progress.total),
+                        row.get(mediaLog.status).name(),
+                        row.get(mediaLog.rating.score)
+                )
+        ));
+    }
+
+    private Optional<LifeLogJournalResult.Source> loadCollectionSource(
+            Long playerId,
+            Long sourceId
+    ) {
+        CollectionLog log = queryFactory
+                .selectFrom(collectionLog)
+                .distinct()
+                .leftJoin(collectionLog.tags.values).fetchJoin()
+                .where(
+                        collectionLog.playerId.eq(playerId),
+                        collectionLog.id.eq(sourceId)
+                )
+                .fetchOne();
+        return Optional.ofNullable(log).map(value ->
+                new LifeLogJournalResult.CollectionSource(
+                        value.getCategory().name(),
+                        value.getTitle().value(),
+                        value.getTitle().original(),
+                        value.getQuantity().value(),
+                        value.getConditionNote(),
+                        value.getAcquiredFrom(),
+                        value.getTags().values(),
+                        value.getCreatedAt(),
+                        value.getUpdatedAt()
+                ));
+    }
+
+    private Optional<LifeLogJournalResult.Source> loadExerciseSource(
+            Long playerId,
+            Long sourceId
+    ) {
+        ExerciseLog log = queryFactory
+                .selectFrom(exerciseLog)
+                .where(
+                        exerciseLog.playerId.eq(playerId),
+                        exerciseLog.id.eq(sourceId)
+                )
+                .fetchOne();
+        return Optional.ofNullable(log).map(value ->
+                new LifeLogJournalResult.ExerciseSource(
+                        value.getCategory().name(),
+                        value.getMetrics().durationMinutes(),
+                        value.getMetrics().distanceKm(),
+                        value.getMetrics().calories(),
+                        value.getExercisedOn(),
+                        value.getMemo(),
+                        value.getCreatedAt(),
+                        value.getUpdatedAt()
+                ));
+    }
+
+    private Optional<LifeLogJournalResult.Source> loadMediaSource(
+            Long playerId,
+            Long sourceId
+    ) {
+        MediaLog log = queryFactory
+                .selectFrom(mediaLog)
+                .distinct()
+                .leftJoin(mediaLog.mediaTags.values).fetchJoin()
+                .where(
+                        mediaLog.playerId.eq(playerId),
+                        mediaLog.id.eq(sourceId)
+                )
+                .fetchOne();
+        return Optional.ofNullable(log).map(value ->
+                new LifeLogJournalResult.MediaSource(
+                        value.getCategory().name(),
+                        value.getTitle().value(),
+                        value.getTitle().original(),
+                        value.getProgress().current(),
+                        value.getProgress().total(),
+                        value.getStatus().name(),
+                        value.getRating().score(),
+                        value.getMediaTags().values(),
+                        value.getRewatchCount(),
+                        value.getStartedOn(),
+                        value.getFinishedOn(),
+                        value.getCreatedAt(),
+                        value.getUpdatedAt()
+                ));
+    }
+
+    private Set<Long> sourceIds(
+            List<CanonicalRecord> records,
+            LifeLogSourceType sourceType
+    ) {
+        Set<Long> ids = new LinkedHashSet<>();
+        records.stream()
+                .filter(record -> record.sourceType() == sourceType)
+                .map(CanonicalRecord::sourceId)
+                .forEach(ids::add);
+        return ids;
+    }
+
+    private BooleanExpression primaryRoleIdEq(Long primaryRoleId) {
+        return primaryRoleId == null
+                ? null
+                : lifeLogRecord.primaryRoleId.eq(primaryRoleId);
+    }
+
+    private BooleanExpression subtypeEq(LifeLogSubtype subtype) {
+        return subtype == null ? null : lifeLogRecord.subtype.eq(subtype);
+    }
+}

--- a/src/main/java/online/lifeasgame/platform/web/error/GlobalExceptionHandler.java
+++ b/src/main/java/online/lifeasgame/platform/web/error/GlobalExceptionHandler.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
@@ -170,6 +171,20 @@ public class GlobalExceptionHandler {
         pd.setProperty(ErrorKeys.ERRORS, violations);
 
         log.warn("400 constraint size={} path={}", violations.size(), pd.getProperties().get(ErrorKeys.PATH));
+
+        return ResponseEntity.status(status).body(pd);
+    }
+
+    @ExceptionHandler(HandlerMethodValidationException.class)
+    public ResponseEntity<ProblemDetail> handleMethodValidation(
+            HandlerMethodValidationException ex,
+            WebRequest req
+    ) {
+        var err = CommonError.REQ_VALIDATION;
+        var status = HttpStatus.valueOf(err.status());
+        var pd = pdf.base(status, err.message(), "Constraint violation", err.code(), req);
+
+        log.warn("400 method-validation path={}", pd.getProperties().get(ErrorKeys.PATH));
 
         return ResponseEntity.status(status).body(pd);
     }

--- a/src/main/resources/db/migration/V22__lifelog_journal_timeline_index.sql
+++ b/src/main/resources/db/migration/V22__lifelog_journal_timeline_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_life_log_record_player_timeline
+    ON life_log_records (player_id, occurred_at DESC, id DESC);

--- a/src/test/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryIntegrationTest.java
@@ -99,7 +99,7 @@ class InventoryRewardDeliveryIntegrationTest {
     @DisplayName("V17 receipt table은 JPA validate와 unique/check/index 계약을 만족한다")
     void validatesMigrationContract() {
         assertThat(flyway.info().current().getVersion().getVersion())
-                .isEqualTo("21");
+                .isEqualTo("22");
         assertThat(environment.getProperty("spring.jpa.hibernate.ddl-auto"))
                 .isEqualTo("validate");
 

--- a/src/test/java/online/lifeasgame/lifelog/api/player/PlayerLifeLogJournalApiContractTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/api/player/PlayerLifeLogJournalApiContractTest.java
@@ -1,0 +1,224 @@
+package online.lifeasgame.lifelog.api.player;
+
+import online.lifeasgame.lifelog.application.LifeLogJournalQueryService;
+import online.lifeasgame.lifelog.application.result.LifeLogJournalResult;
+import online.lifeasgame.platform.security.jwt.JwtPrincipal;
+import online.lifeasgame.platform.security.jwt.JwtProvider;
+import online.lifeasgame.platform.web.error.docs.ErrorDocLinker;
+import online.lifeasgame.support.WebMvcTestConfig;
+import online.lifeasgame.system.bootstrap.error.handler.AppErrorProperties;
+import online.lifeasgame.system.bootstrap.security.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = PlayerLifeLogJournalController.class)
+@Import({
+        SecurityConfig.class,
+        WebMvcTestConfig.class
+})
+@DisplayName("LifeLog Journal player API")
+class PlayerLifeLogJournalApiContractTest {
+
+    private static final Instant RECORDED_AT =
+            Instant.parse("2026-08-11T12:00:00Z");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private RequestMappingHandlerMapping handlerMapping;
+
+    @MockitoBean
+    private LifeLogJournalQueryService queryService;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private AppErrorProperties appErrorProperties;
+
+    @MockitoBean
+    private ErrorDocLinker errorDocLinker;
+
+    @Nested
+    @DisplayName("self Journal endpoint를 노출할 때")
+    class Endpoints {
+
+        @Test
+        @DisplayName("list와 canonical detail GET mapping만 추가한다")
+        void exposesExactReadMappings() {
+            assertMapping(RequestMethod.GET, "/api/v1/lifelogs");
+            assertMapping(
+                    RequestMethod.GET,
+                    "/api/v1/lifelogs/{lifeLogId}"
+            );
+        }
+
+        @Test
+        @DisplayName("인증이 없으면 list와 detail 모두 401이다")
+        void requiresAuthentication() throws Exception {
+            mockMvc.perform(get("/api/v1/lifelogs"))
+                    .andExpect(status().isUnauthorized());
+            mockMvc.perform(get("/api/v1/lifelogs/1"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("Journal 목록을 호출할 때")
+    class ListJournal {
+
+        @Test
+        @DisplayName("self filter와 page만 위임하고 canonical metadata와 preview를 반환한다")
+        void returnsCanonicalPage() throws Exception {
+            given(queryService.list(31L, "MEMORY", 1, 5))
+                    .willReturn(new LifeLogJournalResult.Page(
+                            List.of(new LifeLogJournalResult.Entry(
+                                    101L,
+                                    "COLLECTION",
+                                    201L,
+                                    "MEMORY",
+                                    "QUICK",
+                                    null,
+                                    null,
+                                    31L,
+                                    41L,
+                                    RECORDED_AT,
+                                    new LifeLogJournalResult.CollectionPreview(
+                                            "BOOK",
+                                            "기록",
+                                            2
+                                    )
+                            )),
+                            1,
+                            5,
+                            6,
+                            2
+                    ));
+
+            mockMvc.perform(authenticatedGet(
+                            "/api/v1/lifelogs"
+                                    + "?primaryRoleId=31"
+                                    + "&subtype=MEMORY&page=1&size=5"
+                                    + "&playerId=999"
+                    ))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result.page").value(1))
+                    .andExpect(jsonPath("$.result.totalElements").value(6))
+                    .andExpect(jsonPath("$.result.content[0].lifeLogId")
+                            .value(101))
+                    .andExpect(jsonPath("$.result.content[0].sourceType")
+                            .value("COLLECTION"))
+                    .andExpect(jsonPath("$.result.content[0].primaryRoleId")
+                            .value(31))
+                    .andExpect(jsonPath("$.result.content[0].roleEventId")
+                            .value(41))
+                    .andExpect(jsonPath("$.result.content[0].recordedAt")
+                            .value("2026-08-11T12:00:00Z"))
+                    .andExpect(jsonPath("$.result.content[0].preview.title")
+                            .value("기록"))
+                    .andExpect(jsonPath("$.result.content[0].playerId")
+                            .doesNotExist());
+            verify(queryService).list(31L, "MEMORY", 1, 5);
+        }
+    }
+
+    @Nested
+    @DisplayName("Journal 상세를 호출할 때")
+    class ReadDetail {
+
+        @Test
+        @DisplayName("canonical identity와 Media source detail을 반환한다")
+        void returnsOwnedSourceDetail() throws Exception {
+            given(queryService.detail(101L)).willReturn(
+                    new LifeLogJournalResult.Detail(
+                            101L,
+                            "MEDIA",
+                            301L,
+                            null,
+                            "FULL",
+                            null,
+                            null,
+                            null,
+                            null,
+                            RECORDED_AT,
+                            new LifeLogJournalResult.MediaSource(
+                                    "MOVIE",
+                                    "영화",
+                                    null,
+                                    2,
+                                    10,
+                                    "WATCHING",
+                                    4.5,
+                                    Set.of("journal"),
+                                    0,
+                                    LocalDate.of(2026, 8, 1),
+                                    null,
+                                    RECORDED_AT,
+                                    RECORDED_AT
+                            )
+                    )
+            );
+
+            mockMvc.perform(authenticatedGet("/api/v1/lifelogs/101"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result.lifeLogId").value(101))
+                    .andExpect(jsonPath("$.result.sourceId").value(301))
+                    .andExpect(jsonPath("$.result.subtype").doesNotExist())
+                    .andExpect(jsonPath("$.result.source.title")
+                            .value("영화"))
+                    .andExpect(jsonPath("$.result.source.currentEpisode")
+                            .value(2))
+                    .andExpect(jsonPath("$.result.source.playerId")
+                            .doesNotExist());
+            verify(queryService).detail(101L);
+        }
+    }
+
+    private MockHttpServletRequestBuilder authenticatedGet(String path) {
+        return get(path)
+                .with(authentication(
+                        new UsernamePasswordAuthenticationToken(
+                                new JwtPrincipal(256L, 25601L),
+                                null,
+                                List.of(new SimpleGrantedAuthority(
+                                        "ROLE_USER"
+                                ))
+                        )
+                ))
+                .header("Authorization", "Bearer test-token");
+    }
+
+    private void assertMapping(RequestMethod method, String path) {
+        assertThat(handlerMapping.getHandlerMethods().keySet())
+                .anyMatch(mapping ->
+                        mapping.getMethodsCondition().getMethods()
+                                .contains(method)
+                                && mapping.getPatternValues().contains(path)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/lifelog/api/player/PlayerLifeLogJournalApiContractTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/api/player/PlayerLifeLogJournalApiContractTest.java
@@ -89,6 +89,41 @@ class PlayerLifeLogJournalApiContractTest {
     }
 
     @Nested
+    @DisplayName("인증된 Journal parameter를 검증할 때")
+    class ValidateParameters {
+
+        @Test
+        @DisplayName("primaryRoleId가 0이면 400이다")
+        void rejectsNonPositivePrimaryRoleId() throws Exception {
+            assertBadRequest("/api/v1/lifelogs?primaryRoleId=0");
+        }
+
+        @Test
+        @DisplayName("page가 음수이면 400이다")
+        void rejectsNegativePage() throws Exception {
+            assertBadRequest("/api/v1/lifelogs?page=-1");
+        }
+
+        @Test
+        @DisplayName("size가 0이면 400이다")
+        void rejectsZeroSize() throws Exception {
+            assertBadRequest("/api/v1/lifelogs?size=0");
+        }
+
+        @Test
+        @DisplayName("size가 100보다 크면 400이다")
+        void rejectsOversizedPage() throws Exception {
+            assertBadRequest("/api/v1/lifelogs?size=101");
+        }
+
+        @Test
+        @DisplayName("lifeLogId가 0이면 400이다")
+        void rejectsNonPositiveLifeLogId() throws Exception {
+            assertBadRequest("/api/v1/lifelogs/0");
+        }
+    }
+
+    @Nested
     @DisplayName("Journal 목록을 호출할 때")
     class ListJournal {
 
@@ -211,6 +246,11 @@ class PlayerLifeLogJournalApiContractTest {
                         )
                 ))
                 .header("Authorization", "Bearer test-token");
+    }
+
+    private void assertBadRequest(String path) throws Exception {
+        mockMvc.perform(authenticatedGet(path))
+                .andExpect(status().isBadRequest());
     }
 
     private void assertMapping(RequestMethod method, String path) {

--- a/src/test/java/online/lifeasgame/lifelog/application/LifeLogJournalQueryIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/application/LifeLogJournalQueryIntegrationTest.java
@@ -442,7 +442,8 @@ class LifeLogJournalQueryIntegrationTest {
             );
 
             assertThat(page.content()).hasSize(3);
-            assertThat(statistics.getPrepareStatementCount()).isEqualTo(5);
+            assertThat(statistics.getPrepareStatementCount())
+                    .isLessThanOrEqualTo(5);
         }
     }
 

--- a/src/test/java/online/lifeasgame/lifelog/application/LifeLogJournalQueryIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/application/LifeLogJournalQueryIntegrationTest.java
@@ -1,0 +1,568 @@
+package online.lifeasgame.lifelog.application;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.lifelog.application.result.LifeLogJournalResult;
+import online.lifeasgame.lifelog.domain.CollectionCategory;
+import online.lifeasgame.lifelog.domain.CollectionLog;
+import online.lifeasgame.lifelog.domain.CollectionTags;
+import online.lifeasgame.lifelog.domain.EpisodeProgress;
+import online.lifeasgame.lifelog.domain.ExerciseCategory;
+import online.lifeasgame.lifelog.domain.ExerciseLog;
+import online.lifeasgame.lifelog.domain.ExerciseMetrics;
+import online.lifeasgame.lifelog.domain.MediaCategory;
+import online.lifeasgame.lifelog.domain.MediaLog;
+import online.lifeasgame.lifelog.domain.MediaTags;
+import online.lifeasgame.lifelog.domain.Quantity;
+import online.lifeasgame.lifelog.domain.Title;
+import online.lifeasgame.lifelog.domain.WatchStatus;
+import online.lifeasgame.lifelog.domain.error.LifeLogError;
+import online.lifeasgame.lifelog.domain.record.LifeLogEntryMode;
+import online.lifeasgame.lifelog.domain.record.LifeLogPeriodKey;
+import online.lifeasgame.lifelog.domain.record.LifeLogRecord;
+import online.lifeasgame.lifelog.domain.record.LifeLogReflectionScope;
+import online.lifeasgame.lifelog.domain.record.LifeLogSourceType;
+import online.lifeasgame.lifelog.domain.record.LifeLogSubtype;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest(properties =
+        "spring.jpa.properties.hibernate.generate_statistics=true")
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("LifeLog canonical Journal query")
+class LifeLogJournalQueryIntegrationTest {
+
+    private static final Long PLAYER_ID = 256L;
+    private static final Long OTHER_PLAYER_ID = 257L;
+    private static final Instant NEWEST =
+            Instant.parse("2026-08-11T12:00:00Z");
+    private static final Instant OLDER =
+            Instant.parse("2026-08-10T12:00:00Z");
+
+    @Autowired
+    private LifeLogJournalQueryService queryService;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    @MockitoBean
+    private CurrentPlayerAccessor currentPlayerAccessor;
+
+    @BeforeEach
+    void setUp() {
+        given(currentPlayerAccessor.currentPlayerIdOrThrow())
+                .willReturn(PLAYER_ID);
+    }
+
+    @Nested
+    @DisplayName("Journal 목록을 조회할 때")
+    class ListJournal {
+
+        @Test
+        @DisplayName("canonical record가 없으면 빈 page를 반환한다")
+        void returnsEmptyPage() {
+            LifeLogJournalResult.Page page = queryService.list(
+                    null,
+                    null,
+                    0,
+                    20
+            );
+
+            assertThat(page.content()).isEmpty();
+            assertThat(page.totalElements()).isZero();
+            assertThat(page.totalPages()).isZero();
+        }
+
+        @Test
+        @DisplayName("mixed source를 canonical 시각과 ID 역순으로 enrich한다")
+        void enrichesMixedSourcesInCanonicalOrder() {
+            CollectionLog collection = collection(PLAYER_ID, "책");
+            ExerciseLog exercise = exercise(PLAYER_ID);
+            MediaLog media = media(PLAYER_ID, "영화");
+            LifeLogRecord older = legacy(
+                    PLAYER_ID,
+                    LifeLogSourceType.COLLECTION,
+                    collection.getId(),
+                    LifeLogEntryMode.FULL,
+                    OLDER
+            );
+            LifeLogRecord sameTimeFirst = contentReady(
+                    PLAYER_ID,
+                    LifeLogSourceType.EXERCISE,
+                    exercise.getId(),
+                    LifeLogSubtype.ACTIVITY,
+                    LifeLogEntryMode.FULL,
+                    31L,
+                    41L,
+                    NEWEST
+            );
+            LifeLogRecord sameTimeLast = contentReady(
+                    PLAYER_ID,
+                    LifeLogSourceType.MEDIA,
+                    media.getId(),
+                    LifeLogSubtype.MEMORY,
+                    LifeLogEntryMode.QUICK,
+                    null,
+                    null,
+                    NEWEST
+            );
+            flushAndClear();
+
+            LifeLogJournalResult.Page page = queryService.list(
+                    null,
+                    null,
+                    0,
+                    20
+            );
+
+            assertThat(page.content())
+                    .extracting(LifeLogJournalResult.Entry::lifeLogId)
+                    .containsExactly(
+                            sameTimeLast.getId(),
+                            sameTimeFirst.getId(),
+                            older.getId()
+                    );
+            assertThat(page.content())
+                    .extracting(LifeLogJournalResult.Entry::preview)
+                    .containsExactly(
+                            new LifeLogJournalResult.MediaPreview(
+                                    "MOVIE", "영화", 2, 10,
+                                    "WATCHING", 4.5
+                            ),
+                            new LifeLogJournalResult.ExercisePreview(
+                                    "RUNNING", 30, 5.0, 200,
+                                    LocalDate.of(2026, 8, 11), "아침 달리기"
+                            ),
+                            new LifeLogJournalResult.CollectionPreview(
+                                    "BOOK", "책", 2
+                            )
+                    );
+            LifeLogJournalResult.Entry roleLinked = page.content().get(1);
+            assertThat(roleLinked.primaryRoleId()).isEqualTo(31L);
+            assertThat(roleLinked.roleEventId()).isEqualTo(41L);
+            assertThat(roleLinked.recordedAt()).isEqualTo(NEWEST);
+        }
+
+        @Test
+        @DisplayName("legacy null metadata를 추론하지 않고 null로 유지한다")
+        void preservesLegacyNullMetadata() {
+            CollectionLog collection = collection(PLAYER_ID, "기록");
+            legacy(
+                    PLAYER_ID,
+                    LifeLogSourceType.COLLECTION,
+                    collection.getId(),
+                    LifeLogEntryMode.FULL,
+                    NEWEST
+            );
+            flushAndClear();
+
+            LifeLogJournalResult.Entry entry = queryService.list(
+                    null,
+                    null,
+                    0,
+                    20
+            ).content().getFirst();
+
+            assertThat(entry.subtype()).isNull();
+            assertThat(entry.reflectionScope()).isNull();
+            assertThat(entry.periodKey()).isNull();
+            assertThat(entry.primaryRoleId()).isNull();
+            assertThat(entry.roleEventId()).isNull();
+        }
+
+        @Test
+        @DisplayName("page 경계에서도 canonical stable order를 보존한다")
+        void paginatesDeterministically() {
+            CollectionLog first = collection(PLAYER_ID, "첫 기록");
+            CollectionLog second = collection(PLAYER_ID, "둘째 기록");
+            LifeLogRecord firstRecord = legacy(
+                    PLAYER_ID,
+                    LifeLogSourceType.COLLECTION,
+                    first.getId(),
+                    LifeLogEntryMode.FULL,
+                    NEWEST
+            );
+            LifeLogRecord secondRecord = legacy(
+                    PLAYER_ID,
+                    LifeLogSourceType.COLLECTION,
+                    second.getId(),
+                    LifeLogEntryMode.FULL,
+                    NEWEST
+            );
+            flushAndClear();
+
+            LifeLogJournalResult.Page page = queryService.list(
+                    null,
+                    null,
+                    1,
+                    1
+            );
+
+            assertThat(page.content())
+                    .extracting(LifeLogJournalResult.Entry::lifeLogId)
+                    .containsExactly(firstRecord.getId());
+            assertThat(secondRecord.getId()).isGreaterThan(firstRecord.getId());
+            assertThat(page.totalElements()).isEqualTo(2);
+            assertThat(page.totalPages()).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("Journal filter를 적용할 때")
+    class FilterJournal {
+
+        @Test
+        @DisplayName("primaryRoleId와 subtype을 함께 만족한 own record만 반환한다")
+        void filtersByRoleAndSubtypeWithinOwnership() {
+            CollectionLog matched = collection(PLAYER_ID, "matched");
+            CollectionLog wrongSubtype = collection(PLAYER_ID, "wrong subtype");
+            CollectionLog wrongRole = collection(PLAYER_ID, "wrong role");
+            CollectionLog otherOwner = collection(OTHER_PLAYER_ID, "other");
+            LifeLogRecord expected = contentReady(
+                    PLAYER_ID,
+                    LifeLogSourceType.COLLECTION,
+                    matched.getId(),
+                    LifeLogSubtype.MEMORY,
+                    LifeLogEntryMode.FULL,
+                    10L,
+                    null,
+                    NEWEST
+            );
+            contentReady(
+                    PLAYER_ID,
+                    LifeLogSourceType.COLLECTION,
+                    wrongSubtype.getId(),
+                    LifeLogSubtype.ACTIVITY,
+                    LifeLogEntryMode.FULL,
+                    10L,
+                    null,
+                    NEWEST
+            );
+            contentReady(
+                    PLAYER_ID,
+                    LifeLogSourceType.COLLECTION,
+                    wrongRole.getId(),
+                    LifeLogSubtype.MEMORY,
+                    LifeLogEntryMode.FULL,
+                    20L,
+                    null,
+                    NEWEST
+            );
+            contentReady(
+                    OTHER_PLAYER_ID,
+                    LifeLogSourceType.COLLECTION,
+                    otherOwner.getId(),
+                    LifeLogSubtype.MEMORY,
+                    LifeLogEntryMode.FULL,
+                    10L,
+                    null,
+                    NEWEST
+            );
+            flushAndClear();
+
+            LifeLogJournalResult.Page page = queryService.list(
+                    10L,
+                    "MEMORY",
+                    0,
+                    20
+            );
+
+            assertThat(page.content())
+                    .extracting(LifeLogJournalResult.Entry::lifeLogId)
+                    .containsExactly(expected.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("Journal 상세를 조회할 때")
+    class ReadDetail {
+
+        @Test
+        @DisplayName("Collection Exercise Media와 Quick source를 명시적으로 projection한다")
+        void projectsEverySupportedSource() {
+            CollectionLog collection = collection(PLAYER_ID, "컬렉션");
+            ExerciseLog exercise = exercise(PLAYER_ID);
+            MediaLog media = media(PLAYER_ID, "미디어");
+            CollectionLog quick = collection(PLAYER_ID, "빠른 기록");
+            LifeLogRecord collectionRecord = legacy(
+                    PLAYER_ID,
+                    LifeLogSourceType.COLLECTION,
+                    collection.getId(),
+                    LifeLogEntryMode.FULL,
+                    NEWEST
+            );
+            LifeLogRecord exerciseRecord = legacy(
+                    PLAYER_ID,
+                    LifeLogSourceType.EXERCISE,
+                    exercise.getId(),
+                    LifeLogEntryMode.FULL,
+                    NEWEST
+            );
+            LifeLogRecord mediaRecord = legacy(
+                    PLAYER_ID,
+                    LifeLogSourceType.MEDIA,
+                    media.getId(),
+                    LifeLogEntryMode.FULL,
+                    NEWEST
+            );
+            LifeLogRecord quickRecord = legacy(
+                    PLAYER_ID,
+                    LifeLogSourceType.COLLECTION,
+                    quick.getId(),
+                    LifeLogEntryMode.QUICK,
+                    NEWEST
+            );
+            flushAndClear();
+
+            assertThat(queryService.detail(collectionRecord.getId()).source())
+                    .isInstanceOfSatisfying(
+                            LifeLogJournalResult.CollectionSource.class,
+                            source -> assertThat(source.tags())
+                                    .containsExactly("owned")
+                    );
+            assertThat(queryService.detail(exerciseRecord.getId()).source())
+                    .isInstanceOf(LifeLogJournalResult.ExerciseSource.class);
+            assertThat(queryService.detail(mediaRecord.getId()).source())
+                    .isInstanceOfSatisfying(
+                            LifeLogJournalResult.MediaSource.class,
+                            source -> assertThat(source.tags())
+                                    .containsExactly("journal")
+                    );
+            assertThat(queryService.detail(quickRecord.getId()).entryMode())
+                    .isEqualTo("QUICK");
+        }
+
+        @Test
+        @DisplayName("missing과 cross-owner lifeLog를 같은 404로 닫는다")
+        void hidesCanonicalOwnership() {
+            CollectionLog other = collection(OTHER_PLAYER_ID, "other");
+            LifeLogRecord otherRecord = legacy(
+                    OTHER_PLAYER_ID,
+                    LifeLogSourceType.COLLECTION,
+                    other.getId(),
+                    LifeLogEntryMode.FULL,
+                    NEWEST
+            );
+            flushAndClear();
+
+            assertNotFound(999_999L);
+            assertNotFound(otherRecord.getId());
+        }
+
+        @Test
+        @DisplayName("canonical source가 없거나 다른 owner이면 invariant 500으로 실패한다")
+        void failsClosedForMissingOrCrossOwnerSource() {
+            LifeLogRecord missing = legacy(
+                    PLAYER_ID,
+                    LifeLogSourceType.COLLECTION,
+                    999_991L,
+                    LifeLogEntryMode.FULL,
+                    NEWEST
+            );
+            CollectionLog other = collection(OTHER_PLAYER_ID, "other source");
+            LifeLogRecord crossOwnerSource = legacy(
+                    PLAYER_ID,
+                    LifeLogSourceType.COLLECTION,
+                    other.getId(),
+                    LifeLogEntryMode.FULL,
+                    OLDER
+            );
+            flushAndClear();
+
+            assertSourceUnavailable(missing.getId());
+            assertSourceUnavailable(crossOwnerSource.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("mixed preview를 enrich할 때")
+    class BatchEnrichment {
+
+        @Test
+        @DisplayName("canonical page와 type별 batch를 합쳐 최대 다섯 query만 실행한다")
+        void boundsMixedPageQueryCount() {
+            CollectionLog collection = collection(PLAYER_ID, "collection");
+            ExerciseLog exercise = exercise(PLAYER_ID);
+            MediaLog media = media(PLAYER_ID, "media");
+            legacy(
+                    PLAYER_ID,
+                    LifeLogSourceType.COLLECTION,
+                    collection.getId(),
+                    LifeLogEntryMode.FULL,
+                    OLDER
+            );
+            legacy(
+                    PLAYER_ID,
+                    LifeLogSourceType.EXERCISE,
+                    exercise.getId(),
+                    LifeLogEntryMode.FULL,
+                    NEWEST
+            );
+            legacy(
+                    PLAYER_ID,
+                    LifeLogSourceType.MEDIA,
+                    media.getId(),
+                    LifeLogEntryMode.FULL,
+                    NEWEST
+            );
+            flushAndClear();
+            Statistics statistics = entityManagerFactory
+                    .unwrap(SessionFactory.class)
+                    .getStatistics();
+            statistics.clear();
+
+            LifeLogJournalResult.Page page = queryService.list(
+                    null,
+                    null,
+                    0,
+                    20
+            );
+
+            assertThat(page.content()).hasSize(3);
+            assertThat(statistics.getPrepareStatementCount()).isEqualTo(5);
+        }
+    }
+
+    private CollectionLog collection(Long playerId, String title) {
+        CollectionLog log = CollectionLog.create(
+                playerId,
+                CollectionCategory.BOOK,
+                Title.of(title, "original " + title),
+                Quantity.of(2),
+                "good",
+                "store",
+                CollectionTags.of(Set.of("owned"))
+        );
+        entityManager.persist(log);
+        entityManager.flush();
+        return log;
+    }
+
+    private ExerciseLog exercise(Long playerId) {
+        ExerciseLog log = ExerciseLog.create(
+                playerId,
+                ExerciseCategory.RUNNING,
+                ExerciseMetrics.of(30, 5.0, 200),
+                LocalDate.of(2026, 8, 11),
+                "아침 달리기"
+        );
+        entityManager.persist(log);
+        entityManager.flush();
+        return log;
+    }
+
+    private MediaLog media(Long playerId, String title) {
+        MediaLog log = MediaLog.create(
+                playerId,
+                MediaCategory.MOVIE,
+                Title.of(title, "original " + title),
+                EpisodeProgress.of(2, 10),
+                WatchStatus.WATCHING,
+                MediaTags.of(Set.of("journal"))
+        );
+        log.rate(4.5);
+        entityManager.persist(log);
+        entityManager.flush();
+        return log;
+    }
+
+    private LifeLogRecord legacy(
+            Long playerId,
+            LifeLogSourceType sourceType,
+            Long sourceId,
+            LifeLogEntryMode entryMode,
+            Instant occurredAt
+    ) {
+        LifeLogRecord record = LifeLogRecord.legacy(
+                playerId,
+                sourceType,
+                sourceId,
+                entryMode,
+                occurredAt
+        );
+        entityManager.persist(record);
+        entityManager.flush();
+        return record;
+    }
+
+    private LifeLogRecord contentReady(
+            Long playerId,
+            LifeLogSourceType sourceType,
+            Long sourceId,
+            LifeLogSubtype subtype,
+            LifeLogEntryMode entryMode,
+            Long primaryRoleId,
+            Long roleEventId,
+            Instant occurredAt
+    ) {
+        LifeLogReflectionScope scope = subtype == LifeLogSubtype.REFLECTION
+                ? LifeLogReflectionScope.WEEKLY_LOOKBACK
+                : null;
+        LifeLogPeriodKey periodKey = scope == null
+                ? null
+                : new LifeLogPeriodKey("2026-W33");
+        LifeLogRecord record = LifeLogRecord.contentReady(
+                playerId,
+                sourceType,
+                sourceId,
+                subtype,
+                entryMode,
+                scope,
+                periodKey,
+                primaryRoleId,
+                roleEventId,
+                occurredAt
+        );
+        entityManager.persist(record);
+        entityManager.flush();
+        return record;
+    }
+
+    private void flushAndClear() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    private void assertNotFound(Long lifeLogId) {
+        assertThatThrownBy(() -> queryService.detail(lifeLogId))
+                .isInstanceOfSatisfying(
+                        DomainException.class,
+                        exception -> assertThat(exception.getErrorCode())
+                                .isEqualTo(LifeLogError.LIFE_LOG_NOT_FOUND)
+                );
+    }
+
+    private void assertSourceUnavailable(Long lifeLogId) {
+        assertThatThrownBy(() -> queryService.detail(lifeLogId))
+                .isInstanceOfSatisfying(
+                        DomainException.class,
+                        exception -> assertThat(exception.getErrorCode())
+                                .isEqualTo(
+                                        LifeLogError.LIFE_LOG_SOURCE_UNAVAILABLE
+                                )
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
@@ -63,7 +63,7 @@ class FlywayExplicitBaselineTest {
     class ApplyExplicitBaseline {
 
         @Test
-        @DisplayName("V1을 재실행하지 않고 V2부터 V21까지 적용한 뒤 JPA validate를 통과한다")
+        @DisplayName("V1을 재실행하지 않고 V2부터 V22까지 적용한 뒤 JPA validate를 통과한다")
         void migratesFromVersionTwoAndValidatesJpa() throws Exception {
             String jdbcUrl = createV1EquivalentDatabase();
             Flyway flyway = migrationFlyway(jdbcUrl);
@@ -72,13 +72,13 @@ class FlywayExplicitBaselineTest {
             MigrateResult migrateResult = flyway.migrate();
             List<HistoryRow> history = successfulHistory(jdbcUrl);
 
-            assertThat(migrateResult.migrationsExecuted).isEqualTo(20);
+            assertThat(migrateResult.migrationsExecuted).isEqualTo(21);
             assertThat(history).extracting(HistoryRow::version)
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
                             "14", "15", "16", "17", "18", "19", "20",
-                            "21"
+                            "21", "22"
                     );
             assertThat(history.getFirst().type()).isEqualTo("BASELINE");
             assertThat(history.getFirst().script())
@@ -109,7 +109,8 @@ class FlywayExplicitBaselineTest {
                             "V18__reward_item_code_snapshot.sql",
                             "V19__role_person_persistence_foundation.sql",
                             "V20__quest_route_mvp.sql",
-                            "V21__role_event_lifelog_linkage.sql"
+                            "V21__role_event_lifelog_linkage.sql",
+                            "V22__lifelog_journal_timeline_index.sql"
                     );
             assertThat(history.subList(1, history.size()))
                     .allSatisfy(row -> assertThat(row.checksum()).isNotNull());
@@ -129,7 +130,7 @@ class FlywayExplicitBaselineTest {
                         "spring.jpa.hibernate.ddl-auto"
                 )).isEqualTo("validate");
                 assertThat(context.getBean(Flyway.class).info().current().getVersion().getVersion())
-                        .isEqualTo("21");
+                        .isEqualTo("22");
             }
         }
     }

--- a/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
@@ -33,7 +33,7 @@ class FlywayHistoryChecksumTest {
     class MigrateAgain {
 
         @Test
-        @DisplayName("V1~V20 checksum을 보존하고 V21 이후 두 번째 실행은 no-op이다")
+        @DisplayName("V1~V20 checksum을 보존하고 V22 이후 두 번째 실행은 no-op이다")
         void keepsMigrationHistory() throws Exception {
             Flyway throughV20 = flyway(MigrationVersion.fromVersion("20"));
             MigrateResult legacy = throughV20.migrate();
@@ -47,7 +47,7 @@ class FlywayHistoryChecksumTest {
             List<HistoryRow> secondHistory = successfulHistory();
 
             assertThat(legacy.migrationsExecuted).isEqualTo(20);
-            assertThat(first.migrationsExecuted).isEqualTo(1);
+            assertThat(first.migrationsExecuted).isEqualTo(2);
             assertThat(second.migrationsExecuted).isZero();
             assertThat(secondHistory).isEqualTo(firstHistory);
             assertThat(firstHistory.subList(0, legacyHistory.size()))
@@ -57,7 +57,7 @@ class FlywayHistoryChecksumTest {
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
                             "14", "15", "16", "17", "18", "19", "20",
-                            "21"
+                            "21", "22"
                     );
             assertThat(secondHistory).allSatisfy(history -> {
                 assertThat(history.checksum()).isNotNull();

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -39,7 +39,7 @@ class FlywayMigrationTest {
     class MigrateCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V21까지 적용되고 RoleEvent linkage를 추가한다")
+        @DisplayName("V1부터 V22까지 적용되고 Journal timeline index를 추가한다")
         void migratesSchemaAndSeedsRewardProfiles() throws Exception {
             Flyway throughV10 = flyway(MigrationVersion.fromVersion("10"));
             MigrateResult legacyResult = throughV10.migrate();
@@ -58,13 +58,13 @@ class FlywayMigrationTest {
             assertThat(legacyResult.migrationsExecuted).isEqualTo(10);
             assertThat(semanticResult.migrationsExecuted).isEqualTo(1);
             assertThat(itemResult.migrationsExecuted).isEqualTo(1);
-            assertThat(result.migrationsExecuted).isEqualTo(9);
+            assertThat(result.migrationsExecuted).isEqualTo(10);
             assertThat(appliedVersions())
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
                             "14", "15", "16", "17", "18", "19", "20",
-                            "21"
+                            "21", "22"
                     );
             assertThat(existingTables(
                     "users",
@@ -285,6 +285,10 @@ class FlywayMigrationTest {
                     "life_log_records",
                     "uq_life_log_record_source"
             )).containsExactly("source_type", "source_id");
+            assertThat(indexColumns(
+                    "life_log_records",
+                    "idx_life_log_record_player_timeline"
+            )).containsExactly("player_id", "occurred_at", "id");
             assertThat(lifeLogRecordColumnNames()).containsExactlyInAnyOrder(
                     "id",
                     "player_id",

--- a/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
@@ -149,7 +149,7 @@ class FlywayProfileCutoverTest {
     class StartLocalWithCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V21까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
+        @DisplayName("V1부터 V22까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
         void migratesThenValidates() {
             ConfigurableEnvironment environment =
                     (ConfigurableEnvironment) applicationContext.getEnvironment();
@@ -161,8 +161,8 @@ class FlywayProfileCutoverTest {
             assertThat(environment.getProperty(
                     "spring.flyway.baseline-on-migrate", Boolean.class
             )).isFalse();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("21");
-            assertThat(appliedMigrationCount()).isEqualTo(21);
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("22");
+            assertThat(appliedMigrationCount()).isEqualTo(22);
         }
     }
 

--- a/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 @SpringBootTest
 @ActiveProfiles({"test", "migration-test"})
-@DisplayName("V21 migration 이후 JPA schema validation")
+@DisplayName("V22 migration 이후 JPA schema validation")
 class JpaValidateAfterMigrationTest {
 
     @Container
@@ -79,14 +79,14 @@ class JpaValidateAfterMigrationTest {
     private QuestDefinitionBootstrapper questDefinitionBootstrapper;
 
     @Nested
-    @DisplayName("V1부터 V21까지 적용된 schema로 ApplicationContext를 기동할 때")
+    @DisplayName("V1부터 V22까지 적용된 schema로 ApplicationContext를 기동할 때")
     class LoadApplicationContext {
 
         @Test
         @DisplayName("ddl-auto validate 상태로 정상 기동한다")
         void loadsWithJpaValidation() {
             assertThat(applicationContext).isNotNull();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("21");
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("22");
             assertThat(applicationContext.getEnvironment().getProperty("spring.jpa.hibernate.ddl-auto"))
                     .isEqualTo("validate");
             assertThat(applicationContext.getEnvironment()

--- a/src/test/java/online/lifeasgame/migration/RoleEventLifeLogLinkageFlywayTest.java
+++ b/src/test/java/online/lifeasgame/migration/RoleEventLifeLogLinkageFlywayTest.java
@@ -34,7 +34,7 @@ class RoleEventLifeLogLinkageFlywayTest {
 
     @BeforeEach
     void migrateCleanDatabase() {
-        flyway = flyway(null);
+        flyway = flyway(MigrationVersion.fromVersion("21"));
         flyway.clean();
         flyway.migrate();
         jdbc = new JdbcTemplate(new DriverManagerDataSource(

--- a/src/test/java/online/lifeasgame/migration/RolePersonPersistenceFoundationFlywayTest.java
+++ b/src/test/java/online/lifeasgame/migration/RolePersonPersistenceFoundationFlywayTest.java
@@ -46,9 +46,9 @@ class RolePersonPersistenceFoundationFlywayTest {
     }
 
     @Test
-    @DisplayName("V21까지 적용된 schema에서 V19 Role/Person 계약을 고정한다")
+    @DisplayName("V22까지 적용된 schema에서 V19 Role/Person 계약을 고정한다")
     void createsSchemaContract() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("21");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("22");
         assertThat(tableContracts()).containsExactly(
                 new TableContract("roles", "InnoDB", "utf8mb4_0900_ai_ci"),
                 new TableContract("persons", "InnoDB", "utf8mb4_0900_ai_ci"),

--- a/src/test/java/online/lifeasgame/role/application/RolePersonPersistenceIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/role/application/RolePersonPersistenceIntegrationTest.java
@@ -100,7 +100,7 @@ class RolePersonPersistenceIntegrationTest {
 
     @Test
     void persistsOwnerScopedCrudAndKeepsArchivedRows() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("21");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("22");
 
         var role = roleService.create(
                 new RoleCommand.Create("work", "Developer", "Builds")

--- a/src/test/java/online/lifeasgame/role/application/RoleRelationPersistenceIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/role/application/RoleRelationPersistenceIntegrationTest.java
@@ -93,7 +93,7 @@ class RoleRelationPersistenceIntegrationTest {
 
     @Test
     void persistsCrudRejectsActiveDuplicateAndReactivatesArchivedRow() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("21");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("22");
         Long roleId = createRole("Owner role");
         Long personId = createPerson("Alice");
 


### PR DESCRIPTION

## Purpose

Add the minimum unified player-facing Journal read model on top of the existing canonical LifeLog foundation.

## Delivered

- unified self Journal list from canonical LifeLog records
- unified LifeLog detail by canonical `lifeLogId`
- deterministic Journal ordering/pagination
- Collection / Exercise / Media / Quick source preview projection
- batch source enrichment without N+1
- optional Role filter
- optional semantic subtype filter
- canonical Role / RoleEvent context references
- ownership-safe detail lookup
- legacy nullable semantic metadata preservation

## Architecture

Journal chronology and identity are driven by:

```text
LifeLogRecord
```

Physical source tables remain source-specific write/detail authorities and are used only to enrich the read projection.

No new Journal aggregate/table was introduced.

## Product boundaries preserved

- LifeLog remains the player's own record
- RoleEvent remains event structure
- RoleEvent creation/completion does not create LifeLog
- RoleEvent does not query LifeLog back
- Person and Service User boundaries are unchanged
- no Role Entity/Repository dependency was added to LifeLog for display enrichment

## Compatibility preserved

- existing Collection / Exercise / Media behavior
- Quick Record idempotency/replay
- canonical LifeLogRecord creation
- `LifeLogRecorded` v1
- LifeLog → Quest progress
- Quest acceptedAt/periodKey
- Role / RoleEvent write validation

## Tests

Flow-oriented `@Nested` / `@DisplayName` tests cover:

- empty/mixed Journal lists
- deterministic ordering/pagination
- source projection
- semantic metadata and legacy nullable metadata
- Role filtering
- detail per physical source
- cross-owner protection
- missing-source failure boundary
- bounded source query behavior
- existing LifeLog / Quick Record / Quest / RoleEvent regressions

## Validation

- classes/testClasses
- targeted Journal tests
- LifeLog/Quick Record/RoleEvent/Quest regressions
- final build

Closes #256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a player LifeLog Journal with paginated timeline browsing.
  * Added optional role and subtype filters.
  * Added detailed journal views with collection, exercise, and media information.
  * Added ownership-aware access and clear errors for missing or unavailable journal data.

* **Bug Fixes**
  * Improved handling of invalid pagination and identifier values with clear validation responses.

* **Performance**
  * Improved timeline retrieval performance.

* **Tests**
  * Added API and integration coverage for journal browsing, filtering, details, security, and source data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->