### PR TITLE
feat: add Home world summary read model (#258)

### DIFF
--- a/src/main/java/online/lifeasgame/home/api/HomeController.java
+++ b/src/main/java/online/lifeasgame/home/api/HomeController.java
@@ -1,0 +1,29 @@
+package online.lifeasgame.home.api;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.response.ApiResponse;
+import online.lifeasgame.home.api.mapper.HomeWebMapper;
+import online.lifeasgame.home.api.response.HomeResponse;
+import online.lifeasgame.home.api.spec.HomeApiSpecV1;
+import online.lifeasgame.home.application.HomeQueryService;
+import online.lifeasgame.platform.web.response.ApiResponses;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/home")
+public class HomeController implements HomeApiSpecV1 {
+
+    private final HomeQueryService homeQueryService;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResponse<HomeResponse.Summary>> home() {
+        return ApiResponses.ok(HomeWebMapper.toSummary(
+                homeQueryService.home()
+        ));
+    }
+}

--- a/src/main/java/online/lifeasgame/home/api/mapper/HomeWebMapper.java
+++ b/src/main/java/online/lifeasgame/home/api/mapper/HomeWebMapper.java
@@ -1,0 +1,106 @@
+package online.lifeasgame.home.api.mapper;
+
+import online.lifeasgame.home.api.response.HomeResponse;
+import online.lifeasgame.home.application.result.HomeResult;
+import online.lifeasgame.lifelog.application.result.LifeLogJournalResult;
+
+public final class HomeWebMapper {
+
+    private HomeWebMapper() {
+    }
+
+    public static HomeResponse.Summary toSummary(HomeResult.Summary result) {
+        return new HomeResponse.Summary(
+                result.generatedAt(),
+                result.recentJournal().stream()
+                        .map(HomeWebMapper::toJournalEntry)
+                        .toList(),
+                new HomeResponse.Journey(
+                        result.journey().currentQuests().stream()
+                                .map(quest -> new HomeResponse.CurrentQuest(
+                                        quest.acceptanceId(),
+                                        quest.questCode(),
+                                        quest.title(),
+                                        quest.status(),
+                                        quest.progressValue(),
+                                        quest.targetValue(),
+                                        quest.acceptedAt(),
+                                        quest.goalReachedAt()
+                                ))
+                                .toList(),
+                        result.journey().selectedRoutes().stream()
+                                .map(route -> new HomeResponse.SelectedRoute(
+                                        route.routeId(),
+                                        route.routeCode(),
+                                        route.title(),
+                                        route.status(),
+                                        route.currentStepId(),
+                                        route.selectedAt(),
+                                        route.completedAt()
+                                ))
+                                .toList()
+                ),
+                new HomeResponse.RoleActivity(
+                        result.roleActivity30d().windowStart(),
+                        result.roleActivity30d().windowEnd(),
+                        result.roleActivity30d().totalRecords(),
+                        result.roleActivity30d().assignedRecords(),
+                        result.roleActivity30d().unassignedRecords(),
+                        result.roleActivity30d().roles().stream()
+                                .map(role -> new HomeResponse.RoleBucket(
+                                        role.roleId(),
+                                        role.roleName(),
+                                        role.recordCount(),
+                                        role.share()
+                                ))
+                                .toList()
+                )
+        );
+    }
+
+    private static HomeResponse.JournalEntry toJournalEntry(
+            LifeLogJournalResult.Entry entry
+    ) {
+        return new HomeResponse.JournalEntry(
+                entry.lifeLogId(),
+                entry.sourceType(),
+                entry.subtype(),
+                entry.entryMode(),
+                entry.primaryRoleId(),
+                entry.roleEventId(),
+                entry.recordedAt(),
+                toPreview(entry.preview())
+        );
+    }
+
+    private static HomeResponse.Preview toPreview(
+            LifeLogJournalResult.Preview preview
+    ) {
+        return switch (preview) {
+            case LifeLogJournalResult.CollectionPreview value ->
+                    new HomeResponse.CollectionPreview(
+                            value.category(),
+                            value.title(),
+                            value.quantity()
+                    );
+            case LifeLogJournalResult.ExercisePreview value ->
+                    new HomeResponse.ExercisePreview(
+                            value.category(),
+                            value.durationMinutes(),
+                            value.distanceKm(),
+                            value.calories(),
+                            value.exercisedOn(),
+                            value.memo()
+                    );
+            case LifeLogJournalResult.MediaPreview value ->
+                    new HomeResponse.MediaPreview(
+                            value.category(),
+                            value.title(),
+                            value.currentEpisode(),
+                            value.totalEpisode(),
+                            value.status(),
+                            value.rating()
+                    );
+        };
+    }
+}

--- a/src/main/java/online/lifeasgame/home/api/response/HomeResponse.java
+++ b/src/main/java/online/lifeasgame/home/api/response/HomeResponse.java
@@ -1,0 +1,111 @@
+package online.lifeasgame.home.api.response;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+public final class HomeResponse {
+
+    private HomeResponse() {
+    }
+
+    public record Summary(
+            Instant generatedAt,
+            List<JournalEntry> recentJournal,
+            Journey journey,
+            RoleActivity roleActivity30d
+    ) {
+    }
+
+    public record JournalEntry(
+            Long lifeLogId,
+            String sourceType,
+            String subtype,
+            String entryMode,
+            Long primaryRoleId,
+            Long roleEventId,
+            Instant recordedAt,
+            Preview preview
+    ) {
+    }
+
+    public sealed interface Preview permits
+            CollectionPreview,
+            ExercisePreview,
+            MediaPreview {
+    }
+
+    public record CollectionPreview(
+            String category,
+            String title,
+            Integer quantity
+    ) implements Preview {
+    }
+
+    public record ExercisePreview(
+            String category,
+            Integer durationMinutes,
+            Double distanceKm,
+            Integer calories,
+            LocalDate exercisedOn,
+            String memo
+    ) implements Preview {
+    }
+
+    public record MediaPreview(
+            String category,
+            String title,
+            Integer currentEpisode,
+            Integer totalEpisode,
+            String status,
+            Double rating
+    ) implements Preview {
+    }
+
+    public record Journey(
+            List<CurrentQuest> currentQuests,
+            List<SelectedRoute> selectedRoutes
+    ) {
+    }
+
+    public record CurrentQuest(
+            Long acceptanceId,
+            String questCode,
+            String title,
+            String status,
+            int progressValue,
+            int targetValue,
+            Instant acceptedAt,
+            Instant goalReachedAt
+    ) {
+    }
+
+    public record SelectedRoute(
+            Long routeId,
+            String routeCode,
+            String title,
+            String status,
+            Long currentStepId,
+            Instant selectedAt,
+            Instant completedAt
+    ) {
+    }
+
+    public record RoleActivity(
+            Instant windowStart,
+            Instant windowEnd,
+            long totalRecords,
+            long assignedRecords,
+            long unassignedRecords,
+            List<RoleBucket> roles
+    ) {
+    }
+
+    public record RoleBucket(
+            Long roleId,
+            String roleName,
+            long recordCount,
+            double share
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/home/api/spec/HomeApiSpecV1.java
+++ b/src/main/java/online/lifeasgame/home/api/spec/HomeApiSpecV1.java
@@ -1,0 +1,14 @@
+package online.lifeasgame.home.api.spec;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import online.lifeasgame.core.response.ApiResponse;
+import online.lifeasgame.home.api.response.HomeResponse;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Home API V1 (Player)")
+public interface HomeApiSpecV1 {
+
+    @Operation(summary = "현재 Player world summary 조회")
+    ResponseEntity<ApiResponse<HomeResponse.Summary>> home();
+}

--- a/src/main/java/online/lifeasgame/home/application/HomeQueryService.java
+++ b/src/main/java/online/lifeasgame/home/application/HomeQueryService.java
@@ -1,0 +1,102 @@
+package online.lifeasgame.home.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.home.application.result.HomeResult;
+import online.lifeasgame.lifelog.application.internal.LifeLogActivityReadApi;
+import online.lifeasgame.quest.application.internal.QuestProgressReadApi;
+import online.lifeasgame.role.application.internal.RoleDisplayReadApi;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HomeQueryService {
+
+    static final int RECENT_JOURNAL_LIMIT = 5;
+    static final int CURRENT_QUEST_LIMIT = 10;
+    static final int SELECTED_ROUTE_LIMIT = 10;
+    private static final Duration ROLE_ACTIVITY_WINDOW = Duration.ofDays(30);
+
+    private final CurrentPlayerAccessor currentPlayerAccessor;
+    private final Clock clock;
+    private final LifeLogActivityReadApi lifeLogActivityReadApi;
+    private final QuestProgressReadApi questProgressReadApi;
+    private final RoleDisplayReadApi roleDisplayReadApi;
+
+    public HomeResult.Summary home() {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        Instant generatedAt = clock.instant();
+        Instant windowStart = generatedAt.minus(ROLE_ACTIVITY_WINDOW);
+        LifeLogActivityReadApi.RoleActivity activity =
+                lifeLogActivityReadApi.roleActivity(
+                        playerId,
+                        windowStart,
+                        generatedAt
+                );
+        Map<Long, String> roleNames = roleDisplayReadApi.findNames(
+                playerId,
+                activity.roles().stream()
+                        .map(LifeLogActivityReadApi.RoleCount::roleId)
+                        .toList()
+        );
+
+        return new HomeResult.Summary(
+                generatedAt,
+                lifeLogActivityReadApi.recentJournal(
+                        playerId,
+                        RECENT_JOURNAL_LIMIT
+                ),
+                new HomeResult.Journey(
+                        questProgressReadApi.currentQuests(
+                                playerId,
+                                CURRENT_QUEST_LIMIT
+                        ),
+                        questProgressReadApi.selectedRoutes(
+                                playerId,
+                                SELECTED_ROUTE_LIMIT
+                        )
+                ),
+                roleActivity(
+                        windowStart,
+                        generatedAt,
+                        activity,
+                        roleNames
+                )
+        );
+    }
+
+    private HomeResult.RoleActivity roleActivity(
+            Instant windowStart,
+            Instant windowEnd,
+            LifeLogActivityReadApi.RoleActivity activity,
+            Map<Long, String> roleNames
+    ) {
+        List<HomeResult.RoleBucket> roles = activity.assignedRecords() == 0
+                ? List.of()
+                : activity.roles().stream()
+                        .map(role -> new HomeResult.RoleBucket(
+                                role.roleId(),
+                                roleNames.get(role.roleId()),
+                                role.recordCount(),
+                                (double) role.recordCount()
+                                        / activity.assignedRecords()
+                        ))
+                        .toList();
+        return new HomeResult.RoleActivity(
+                windowStart,
+                windowEnd,
+                activity.totalRecords(),
+                activity.assignedRecords(),
+                activity.unassignedRecords(),
+                roles
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/home/application/result/HomeResult.java
+++ b/src/main/java/online/lifeasgame/home/application/result/HomeResult.java
@@ -1,0 +1,55 @@
+package online.lifeasgame.home.application.result;
+
+import online.lifeasgame.lifelog.application.result.LifeLogJournalResult;
+import online.lifeasgame.quest.application.internal.QuestProgressReadApi;
+
+import java.time.Instant;
+import java.util.List;
+
+public final class HomeResult {
+
+    private HomeResult() {
+    }
+
+    public record Summary(
+            Instant generatedAt,
+            List<LifeLogJournalResult.Entry> recentJournal,
+            Journey journey,
+            RoleActivity roleActivity30d
+    ) {
+        public Summary {
+            recentJournal = List.copyOf(recentJournal);
+        }
+    }
+
+    public record Journey(
+            List<QuestProgressReadApi.CurrentQuest> currentQuests,
+            List<QuestProgressReadApi.SelectedRoute> selectedRoutes
+    ) {
+        public Journey {
+            currentQuests = List.copyOf(currentQuests);
+            selectedRoutes = List.copyOf(selectedRoutes);
+        }
+    }
+
+    public record RoleActivity(
+            Instant windowStart,
+            Instant windowEnd,
+            long totalRecords,
+            long assignedRecords,
+            long unassignedRecords,
+            List<RoleBucket> roles
+    ) {
+        public RoleActivity {
+            roles = List.copyOf(roles);
+        }
+    }
+
+    public record RoleBucket(
+            Long roleId,
+            String roleName,
+            long recordCount,
+            double share
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/application/LifeLogJournalQueryService.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/LifeLogJournalQueryService.java
@@ -3,6 +3,7 @@ package online.lifeasgame.lifelog.application;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.lifelog.application.internal.LifeLogActivityReadApi;
 import online.lifeasgame.lifelog.application.query.LifeLogJournalQuery;
 import online.lifeasgame.lifelog.application.result.LifeLogJournalResult;
 import online.lifeasgame.lifelog.domain.error.LifeLogError;
@@ -10,12 +11,14 @@ import online.lifeasgame.lifelog.domain.record.LifeLogSubtype;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class LifeLogJournalQueryService {
+public class LifeLogJournalQueryService implements LifeLogActivityReadApi {
 
     private final LifeLogJournalQuery journalQuery;
     private final CurrentPlayerAccessor currentPlayerAccessor;
@@ -35,18 +38,8 @@ public class LifeLogJournalQueryService {
                         page,
                         size
                 );
-        Map<LifeLogJournalQuery.SourceKey, LifeLogJournalResult.Preview>
-                previews = journalQuery.loadPreviews(
-                        playerId,
-                        canonicalPage.content()
-                );
         return new LifeLogJournalResult.Page(
-                canonicalPage.content().stream()
-                        .map(record -> LifeLogJournalResult.Entry.from(
-                                record,
-                                requirePreview(previews, record)
-                        ))
-                        .toList(),
+                enrich(playerId, canonicalPage.content()),
                 canonicalPage.page(),
                 canonicalPage.size(),
                 canonicalPage.totalElements(),
@@ -65,6 +58,62 @@ public class LifeLogJournalQueryService {
                 .loadSource(playerId, record)
                 .orElseThrow(LifeLogJournalQueryService::sourceMissing);
         return LifeLogJournalResult.Detail.from(record, source);
+    }
+
+    @Override
+    public List<LifeLogJournalResult.Entry> recentJournal(
+            Long playerId,
+            int limit
+    ) {
+        return enrich(playerId, journalQuery.findRecent(playerId, limit));
+    }
+
+    @Override
+    public RoleActivity roleActivity(
+            Long playerId,
+            Instant windowStart,
+            Instant windowEnd
+    ) {
+        List<LifeLogJournalQuery.RoleCount> counts =
+                journalQuery.countByPrimaryRole(
+                        playerId,
+                        windowStart,
+                        windowEnd
+                );
+        long assigned = counts.stream()
+                .filter(count -> count.roleId() != null)
+                .mapToLong(LifeLogJournalQuery.RoleCount::recordCount)
+                .sum();
+        long unassigned = counts.stream()
+                .filter(count -> count.roleId() == null)
+                .mapToLong(LifeLogJournalQuery.RoleCount::recordCount)
+                .sum();
+        return new RoleActivity(
+                assigned + unassigned,
+                assigned,
+                unassigned,
+                counts.stream()
+                        .filter(count -> count.roleId() != null)
+                        .map(count -> new LifeLogActivityReadApi.RoleCount(
+                                count.roleId(),
+                                count.recordCount()
+                        ))
+                        .toList()
+        );
+    }
+
+    private List<LifeLogJournalResult.Entry> enrich(
+            Long playerId,
+            List<LifeLogJournalQuery.CanonicalRecord> records
+    ) {
+        Map<LifeLogJournalQuery.SourceKey, LifeLogJournalResult.Preview>
+                previews = journalQuery.loadPreviews(playerId, records);
+        return records.stream()
+                .map(record -> LifeLogJournalResult.Entry.from(
+                        record,
+                        requirePreview(previews, record)
+                ))
+                .toList();
     }
 
     private LifeLogJournalResult.Preview requirePreview(

--- a/src/main/java/online/lifeasgame/lifelog/application/internal/LifeLogActivityReadApi.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/internal/LifeLogActivityReadApi.java
@@ -1,0 +1,31 @@
+package online.lifeasgame.lifelog.application.internal;
+
+import online.lifeasgame.lifelog.application.result.LifeLogJournalResult;
+
+import java.time.Instant;
+import java.util.List;
+
+public interface LifeLogActivityReadApi {
+
+    List<LifeLogJournalResult.Entry> recentJournal(
+            Long playerId,
+            int limit
+    );
+
+    RoleActivity roleActivity(
+            Long playerId,
+            Instant windowStart,
+            Instant windowEnd
+    );
+
+    record RoleActivity(
+            long totalRecords,
+            long assignedRecords,
+            long unassignedRecords,
+            List<RoleCount> roles
+    ) {
+    }
+
+    record RoleCount(Long roleId, long recordCount) {
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/application/query/LifeLogJournalQuery.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/query/LifeLogJournalQuery.java
@@ -21,6 +21,14 @@ public interface LifeLogJournalQuery {
             int size
     );
 
+    List<CanonicalRecord> findRecent(Long playerId, int limit);
+
+    List<RoleCount> countByPrimaryRole(
+            Long playerId,
+            Instant windowStart,
+            Instant windowEnd
+    );
+
     Optional<CanonicalRecord> findOwned(Long playerId, Long lifeLogId);
 
     Map<SourceKey, LifeLogJournalResult.Preview> loadPreviews(
@@ -60,5 +68,8 @@ public interface LifeLogJournalQuery {
     }
 
     record SourceKey(LifeLogSourceType sourceType, Long sourceId) {
+    }
+
+    record RoleCount(Long roleId, long recordCount) {
     }
 }

--- a/src/main/java/online/lifeasgame/lifelog/infra/LifeLogJournalQueryAdapter.java
+++ b/src/main/java/online/lifeasgame/lifelog/infra/LifeLogJournalQueryAdapter.java
@@ -3,6 +3,7 @@ package online.lifeasgame.lifelog.infra;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.lifelog.application.query.LifeLogJournalQuery;
@@ -14,6 +15,7 @@ import online.lifeasgame.lifelog.domain.record.LifeLogSourceType;
 import online.lifeasgame.lifelog.domain.record.LifeLogSubtype;
 import org.springframework.stereotype.Repository;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -79,6 +81,61 @@ public class LifeLogJournalQueryAdapter implements LifeLogJournalQuery {
         long total = count == null ? 0L : count;
         int totalPages = (int) Math.ceil(total / (double) size);
         return new CanonicalPage(content, page, size, total, totalPages);
+    }
+
+    @Override
+    public List<CanonicalRecord> findRecent(Long playerId, int limit) {
+        return queryFactory
+                .select(Projections.constructor(
+                        CanonicalRecord.class,
+                        lifeLogRecord.id,
+                        lifeLogRecord.sourceType,
+                        lifeLogRecord.sourceId,
+                        lifeLogRecord.subtype,
+                        lifeLogRecord.entryMode,
+                        lifeLogRecord.reflectionScope,
+                        lifeLogRecord.periodKey,
+                        lifeLogRecord.primaryRoleId,
+                        lifeLogRecord.roleEventId,
+                        lifeLogRecord.occurredAt
+                ))
+                .from(lifeLogRecord)
+                .where(lifeLogRecord.playerId.eq(playerId))
+                .orderBy(
+                        lifeLogRecord.occurredAt.desc(),
+                        lifeLogRecord.id.desc()
+                )
+                .limit(limit)
+                .fetch();
+    }
+
+    @Override
+    public List<RoleCount> countByPrimaryRole(
+            Long playerId,
+            Instant windowStart,
+            Instant windowEnd
+    ) {
+        NumberExpression<Long> recordCount = lifeLogRecord.id.count();
+        return queryFactory
+                .select(lifeLogRecord.primaryRoleId, recordCount)
+                .from(lifeLogRecord)
+                .where(
+                        lifeLogRecord.playerId.eq(playerId),
+                        lifeLogRecord.occurredAt.goe(windowStart),
+                        lifeLogRecord.occurredAt.loe(windowEnd)
+                )
+                .groupBy(lifeLogRecord.primaryRoleId)
+                .orderBy(
+                        recordCount.desc(),
+                        lifeLogRecord.primaryRoleId.asc()
+                )
+                .fetch()
+                .stream()
+                .map(row -> new RoleCount(
+                        row.get(lifeLogRecord.primaryRoleId),
+                        row.get(recordCount)
+                ))
+                .toList();
     }
 
     @Override

--- a/src/main/java/online/lifeasgame/quest/application/internal/QuestProgressReadApi.java
+++ b/src/main/java/online/lifeasgame/quest/application/internal/QuestProgressReadApi.java
@@ -1,0 +1,34 @@
+package online.lifeasgame.quest.application.internal;
+
+import java.time.Instant;
+import java.util.List;
+
+public interface QuestProgressReadApi {
+
+    List<CurrentQuest> currentQuests(Long playerId, int limit);
+
+    List<SelectedRoute> selectedRoutes(Long playerId, int limit);
+
+    record CurrentQuest(
+            Long acceptanceId,
+            String questCode,
+            String title,
+            String status,
+            int progressValue,
+            int targetValue,
+            Instant acceptedAt,
+            Instant goalReachedAt
+    ) {
+    }
+
+    record SelectedRoute(
+            Long routeId,
+            String routeCode,
+            String title,
+            String status,
+            Long currentStepId,
+            Instant selectedAt,
+            Instant completedAt
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/quest/infra/QuestProgressReadAdapter.java
+++ b/src/main/java/online/lifeasgame/quest/infra/QuestProgressReadAdapter.java
@@ -1,0 +1,125 @@
+package online.lifeasgame.quest.infra;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.quest.application.internal.QuestProgressReadApi;
+import online.lifeasgame.quest.domain.PlayerQuestRouteStatus;
+import online.lifeasgame.quest.domain.QuestStatus;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static online.lifeasgame.quest.domain.QPlayerQuestRoute.playerQuestRoute;
+import static online.lifeasgame.quest.domain.QQuest.quest;
+import static online.lifeasgame.quest.domain.QQuestAcceptance.questAcceptance;
+import static online.lifeasgame.quest.domain.QQuestRoute.questRoute;
+
+@Repository
+@RequiredArgsConstructor
+public class QuestProgressReadAdapter implements QuestProgressReadApi {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<CurrentQuest> currentQuests(Long playerId, int limit) {
+        NumberExpression<Integer> statusOrder = new CaseBuilder()
+                .when(questAcceptance.status.eq(QuestStatus.GOAL_REACHED))
+                .then(0)
+                .otherwise(1);
+        return queryFactory
+                .select(
+                        questAcceptance.id,
+                        quest.code,
+                        quest.title.value,
+                        questAcceptance.status,
+                        questAcceptance.progressValue,
+                        quest.target.value,
+                        questAcceptance.acceptedAt,
+                        questAcceptance.goalReachedAt
+                )
+                .from(questAcceptance)
+                .join(quest).on(quest.id.eq(questAcceptance.questId))
+                .where(
+                        questAcceptance.playerId.eq(playerId),
+                        questAcceptance.status.in(
+                                QuestStatus.IN_PROGRESS,
+                                QuestStatus.GOAL_REACHED
+                        )
+                )
+                .orderBy(
+                        statusOrder.asc(),
+                        questAcceptance.acceptedAt.desc(),
+                        questAcceptance.id.desc()
+                )
+                .limit(limit)
+                .fetch()
+                .stream()
+                .map(this::currentQuest)
+                .toList();
+    }
+
+    @Override
+    public List<SelectedRoute> selectedRoutes(Long playerId, int limit) {
+        NumberExpression<Integer> statusOrder = new CaseBuilder()
+                .when(playerQuestRoute.status.eq(
+                        PlayerQuestRouteStatus.IN_PROGRESS
+                ))
+                .then(0)
+                .otherwise(1);
+        return queryFactory
+                .select(
+                        questRoute.id,
+                        questRoute.code,
+                        questRoute.title,
+                        playerQuestRoute.status,
+                        playerQuestRoute.currentStepId,
+                        playerQuestRoute.selectedAt,
+                        playerQuestRoute.completedAt
+                )
+                .from(playerQuestRoute)
+                .join(questRoute).on(
+                        questRoute.id.eq(playerQuestRoute.routeId)
+                )
+                .where(playerQuestRoute.playerId.eq(playerId))
+                .orderBy(
+                        statusOrder.asc(),
+                        playerQuestRoute.selectedAt.desc(),
+                        questRoute.id.asc()
+                )
+                .limit(limit)
+                .fetch()
+                .stream()
+                .map(this::selectedRoute)
+                .toList();
+    }
+
+    private CurrentQuest currentQuest(Tuple row) {
+        QuestStatus status = row.get(questAcceptance.status);
+        return new CurrentQuest(
+                row.get(questAcceptance.id),
+                row.get(quest.code),
+                row.get(quest.title.value),
+                status.name(),
+                row.get(questAcceptance.progressValue),
+                row.get(quest.target.value),
+                row.get(questAcceptance.acceptedAt),
+                row.get(questAcceptance.goalReachedAt)
+        );
+    }
+
+    private SelectedRoute selectedRoute(Tuple row) {
+        PlayerQuestRouteStatus status = row.get(playerQuestRoute.status);
+        return new SelectedRoute(
+                row.get(questRoute.id),
+                row.get(questRoute.code),
+                row.get(questRoute.title),
+                status.name(),
+                row.get(playerQuestRoute.currentStepId),
+                row.get(playerQuestRoute.selectedAt),
+                row.get(playerQuestRoute.completedAt)
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/role/application/internal/RoleDisplayReadApi.java
+++ b/src/main/java/online/lifeasgame/role/application/internal/RoleDisplayReadApi.java
@@ -1,0 +1,9 @@
+package online.lifeasgame.role.application.internal;
+
+import java.util.Collection;
+import java.util.Map;
+
+public interface RoleDisplayReadApi {
+
+    Map<Long, String> findNames(Long playerId, Collection<Long> roleIds);
+}

--- a/src/main/java/online/lifeasgame/role/infra/RoleDisplayReadAdapter.java
+++ b/src/main/java/online/lifeasgame/role/infra/RoleDisplayReadAdapter.java
@@ -1,0 +1,42 @@
+package online.lifeasgame.role.infra;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.role.application.internal.RoleDisplayReadApi;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static online.lifeasgame.role.domain.QRole.role;
+
+@Repository
+@RequiredArgsConstructor
+public class RoleDisplayReadAdapter implements RoleDisplayReadApi {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Map<Long, String> findNames(
+            Long playerId,
+            Collection<Long> roleIds
+    ) {
+        if (roleIds.isEmpty()) {
+            return Map.of();
+        }
+        return queryFactory
+                .select(role.id, role.name)
+                .from(role)
+                .where(
+                        role.playerId.eq(playerId),
+                        role.id.in(roleIds)
+                )
+                .fetch()
+                .stream()
+                .collect(Collectors.toUnmodifiableMap(
+                        row -> row.get(role.id),
+                        row -> row.get(role.name)
+                ));
+    }
+}

--- a/src/test/java/online/lifeasgame/home/api/HomeApiContractTest.java
+++ b/src/test/java/online/lifeasgame/home/api/HomeApiContractTest.java
@@ -1,0 +1,245 @@
+package online.lifeasgame.home.api;
+
+import online.lifeasgame.home.application.HomeQueryService;
+import online.lifeasgame.home.application.result.HomeResult;
+import online.lifeasgame.lifelog.application.result.LifeLogJournalResult;
+import online.lifeasgame.platform.security.jwt.JwtPrincipal;
+import online.lifeasgame.platform.security.jwt.JwtProvider;
+import online.lifeasgame.platform.web.error.docs.ErrorDocLinker;
+import online.lifeasgame.quest.application.internal.QuestProgressReadApi;
+import online.lifeasgame.support.WebMvcTestConfig;
+import online.lifeasgame.system.bootstrap.error.handler.AppErrorProperties;
+import online.lifeasgame.system.bootstrap.security.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = HomeController.class)
+@Import({SecurityConfig.class, WebMvcTestConfig.class})
+@DisplayName("Home player API")
+class HomeApiContractTest {
+
+    private static final Instant GENERATED_AT =
+            Instant.parse("2026-08-12T00:00:00Z");
+    private static final Instant WINDOW_START =
+            Instant.parse("2026-07-13T00:00:00Z");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private RequestMappingHandlerMapping handlerMapping;
+
+    @MockitoBean
+    private HomeQueryService homeQueryService;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private AppErrorProperties appErrorProperties;
+
+    @MockitoBean
+    private ErrorDocLinker errorDocLinker;
+
+    @Nested
+    @DisplayName("Home endpoint를 노출할 때")
+    class Endpoint {
+
+        @Test
+        @DisplayName("parameter 없는 GET /api/v1/home만 노출한다")
+        void exposesExactSelfMapping() throws Exception {
+            assertThat(handlerMapping.getHandlerMethods().keySet())
+                    .anyMatch(mapping ->
+                            mapping.getMethodsCondition().getMethods()
+                                    .contains(RequestMethod.GET)
+                                    && mapping.getPatternValues()
+                                    .contains("/api/v1/home")
+                    );
+            assertThat(HomeController.class.getDeclaredMethod("home")
+                    .getParameterCount()).isZero();
+        }
+
+        @Test
+        @DisplayName("인증이 없으면 401이다")
+        void requiresAuthentication() throws Exception {
+            mockMvc.perform(get("/api/v1/home"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("인증된 Player가 Home을 조회할 때")
+    class ReadHome {
+
+        @Test
+        @DisplayName("기록이 없으면 null 없는 빈 world summary를 반환한다")
+        void returnsEmptySummary() throws Exception {
+            given(homeQueryService.home()).willReturn(emptySummary());
+
+            mockMvc.perform(authenticatedGet("/api/v1/home"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result.generatedAt")
+                            .value("2026-08-12T00:00:00Z"))
+                    .andExpect(jsonPath("$.result.recentJournal").isArray())
+                    .andExpect(jsonPath("$.result.recentJournal").isEmpty())
+                    .andExpect(jsonPath("$.result.journey.currentQuests")
+                            .isEmpty())
+                    .andExpect(jsonPath("$.result.journey.selectedRoutes")
+                            .isEmpty())
+                    .andExpect(jsonPath(
+                            "$.result.roleActivity30d.totalRecords"
+                    ).value(0))
+                    .andExpect(jsonPath(
+                            "$.result.roleActivity30d.roles"
+                    ).isEmpty());
+        }
+
+        @Test
+        @DisplayName("playerId query를 받지 않고 composed section을 반환한다")
+        void returnsPopulatedSelfSummary() throws Exception {
+            given(homeQueryService.home()).willReturn(populatedSummary());
+
+            mockMvc.perform(authenticatedGet(
+                            "/api/v1/home?playerId=999&userId=888"
+                    ))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath(
+                            "$.result.recentJournal[0].lifeLogId"
+                    ).value(101))
+                    .andExpect(jsonPath(
+                            "$.result.recentJournal[0].sourceType"
+                    ).value("COLLECTION"))
+                    .andExpect(jsonPath(
+                            "$.result.recentJournal[0].entryMode"
+                    ).value("QUICK"))
+                    .andExpect(jsonPath(
+                            "$.result.recentJournal[0].preview.title"
+                    ).value("기록"))
+                    .andExpect(jsonPath(
+                            "$.result.recentJournal[0].sourceId"
+                    ).doesNotExist())
+                    .andExpect(jsonPath(
+                            "$.result.journey.currentQuests[0].status"
+                    ).value("GOAL_REACHED"))
+                    .andExpect(jsonPath(
+                            "$.result.journey.selectedRoutes[0].routeCode"
+                    ).value("ROUTE_SELF"))
+                    .andExpect(jsonPath(
+                            "$.result.roleActivity30d.roles[0].roleName"
+                    ).value("개발자"))
+                    .andExpect(jsonPath(
+                            "$.result.roleActivity30d.roles[0].share"
+                    ).value(1.0));
+            verify(homeQueryService).home();
+        }
+    }
+
+    private HomeResult.Summary emptySummary() {
+        return new HomeResult.Summary(
+                GENERATED_AT,
+                List.of(),
+                new HomeResult.Journey(List.of(), List.of()),
+                new HomeResult.RoleActivity(
+                        WINDOW_START,
+                        GENERATED_AT,
+                        0,
+                        0,
+                        0,
+                        List.of()
+                )
+        );
+    }
+
+    private HomeResult.Summary populatedSummary() {
+        return new HomeResult.Summary(
+                GENERATED_AT,
+                List.of(new LifeLogJournalResult.Entry(
+                        101L,
+                        "COLLECTION",
+                        201L,
+                        null,
+                        "QUICK",
+                        null,
+                        null,
+                        31L,
+                        null,
+                        GENERATED_AT.minusSeconds(60),
+                        new LifeLogJournalResult.CollectionPreview(
+                                "BOOK",
+                                "기록",
+                                1
+                        )
+                )),
+                new HomeResult.Journey(
+                        List.of(new QuestProgressReadApi.CurrentQuest(
+                                301L,
+                                "Q_SELF",
+                                "현재 퀘스트",
+                                "GOAL_REACHED",
+                                3,
+                                3,
+                                GENERATED_AT.minusSeconds(300),
+                                GENERATED_AT.minusSeconds(60)
+                        )),
+                        List.of(new QuestProgressReadApi.SelectedRoute(
+                                401L,
+                                "ROUTE_SELF",
+                                "나의 경로",
+                                "IN_PROGRESS",
+                                501L,
+                                GENERATED_AT.minusSeconds(600),
+                                null
+                        ))
+                ),
+                new HomeResult.RoleActivity(
+                        WINDOW_START,
+                        GENERATED_AT,
+                        2,
+                        2,
+                        0,
+                        List.of(new HomeResult.RoleBucket(
+                                31L,
+                                "개발자",
+                                2,
+                                1.0
+                        ))
+                )
+        );
+    }
+
+    private org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
+    authenticatedGet(String path) {
+        return get(path)
+                .with(authentication(
+                        new UsernamePasswordAuthenticationToken(
+                                new JwtPrincipal(258L, 25801L),
+                                null,
+                                List.of(new SimpleGrantedAuthority(
+                                        "ROLE_USER"
+                                ))
+                        )
+                ))
+                .header("Authorization", "Bearer test-token");
+    }
+}

--- a/src/test/java/online/lifeasgame/home/application/HomeArchitectureTest.java
+++ b/src/test/java/online/lifeasgame/home/application/HomeArchitectureTest.java
@@ -1,0 +1,66 @@
+package online.lifeasgame.home.application;
+
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.home.api.HomeController;
+import online.lifeasgame.lifelog.application.internal.LifeLogActivityReadApi;
+import online.lifeasgame.quest.application.internal.QuestProgressReadApi;
+import online.lifeasgame.role.application.internal.RoleDisplayReadApi;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.time.Clock;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Home read composition architecture")
+class HomeArchitectureTest {
+
+    @Nested
+    @DisplayName("Home 경계를 구성할 때")
+    class Boundaries {
+
+        @Test
+        @DisplayName("application은 current identity와 provider read API만 의존한다")
+        void dependsOnlyOnReadBoundaries() {
+            assertThat(fieldTypes(HomeQueryService.class))
+                    .containsExactlyInAnyOrder(
+                            CurrentPlayerAccessor.class,
+                            Clock.class,
+                            LifeLogActivityReadApi.class,
+                            QuestProgressReadApi.class,
+                            RoleDisplayReadApi.class
+                    );
+            assertThat(fieldTypes(HomeController.class))
+                    .containsExactly(HomeQueryService.class);
+        }
+
+        @Test
+        @DisplayName("Home persistence와 write model은 존재하지 않는다")
+        void createsNoHomePersistenceOrWriteModel() {
+            for (String className : Set.of(
+                    "online.lifeasgame.home.domain.Home",
+                    "online.lifeasgame.home.domain.HomeEntity",
+                    "online.lifeasgame.home.domain.HomeRepository",
+                    "online.lifeasgame.home.application.HomeWriter"
+            )) {
+                assertThatThrownBy(() -> Class.forName(className))
+                        .isInstanceOf(ClassNotFoundException.class);
+            }
+        }
+    }
+
+    private static Set<Class<?>> fieldTypes(Class<?> type) {
+        return Arrays.stream(type.getDeclaredFields())
+                .filter(field -> !field.isSynthetic())
+                .filter(field -> !Modifier.isStatic(field.getModifiers()))
+                .map(Field::getType)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/test/java/online/lifeasgame/home/application/HomeProviderIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/home/application/HomeProviderIntegrationTest.java
@@ -1,0 +1,525 @@
+package online.lifeasgame.home.application;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.home.application.result.HomeResult;
+import online.lifeasgame.lifelog.domain.CollectionCategory;
+import online.lifeasgame.lifelog.domain.CollectionLog;
+import online.lifeasgame.lifelog.domain.CollectionTags;
+import online.lifeasgame.lifelog.domain.EpisodeProgress;
+import online.lifeasgame.lifelog.domain.ExerciseCategory;
+import online.lifeasgame.lifelog.domain.ExerciseLog;
+import online.lifeasgame.lifelog.domain.ExerciseMetrics;
+import online.lifeasgame.lifelog.domain.MediaCategory;
+import online.lifeasgame.lifelog.domain.MediaLog;
+import online.lifeasgame.lifelog.domain.MediaTags;
+import online.lifeasgame.lifelog.domain.Quantity;
+import online.lifeasgame.lifelog.domain.Title;
+import online.lifeasgame.lifelog.domain.WatchStatus;
+import online.lifeasgame.lifelog.domain.record.LifeLogEntryMode;
+import online.lifeasgame.lifelog.domain.record.LifeLogRecord;
+import online.lifeasgame.lifelog.domain.record.LifeLogSourceType;
+import online.lifeasgame.lifelog.domain.record.LifeLogSubtype;
+import online.lifeasgame.quest.domain.PlayerQuestRoute;
+import online.lifeasgame.quest.domain.Quest;
+import online.lifeasgame.quest.domain.QuestAcceptance;
+import online.lifeasgame.quest.domain.QuestCategory;
+import online.lifeasgame.quest.domain.QuestRepeatRule;
+import online.lifeasgame.quest.domain.QuestReward;
+import online.lifeasgame.quest.domain.QuestTarget;
+import online.lifeasgame.quest.domain.QuestTargetType;
+import online.lifeasgame.quest.domain.QuestTitle;
+import online.lifeasgame.quest.domain.RewardStats;
+import online.lifeasgame.quest.domain.TimePeriod;
+import online.lifeasgame.role.domain.Role;
+import online.lifeasgame.role.domain.RoleType;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest(properties =
+        "spring.jpa.properties.hibernate.generate_statistics=true")
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("Home provider read integration")
+class HomeProviderIntegrationTest {
+
+    private static final Long PLAYER_ID = 258L;
+    private static final Long OTHER_PLAYER_ID = 259L;
+    private static final Instant NOW =
+            Instant.parse("2026-08-12T00:00:00Z");
+    private static final Instant WINDOW_START =
+            Instant.parse("2026-07-13T00:00:00Z");
+
+    @Autowired
+    private HomeQueryService queryService;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @MockitoBean
+    private CurrentPlayerAccessor currentPlayerAccessor;
+
+    @MockitoBean
+    private Clock clock;
+
+    @BeforeEach
+    void setUp() {
+        given(currentPlayerAccessor.currentPlayerIdOrThrow())
+                .willReturn(PLAYER_ID);
+        given(clock.instant()).willReturn(NOW);
+    }
+
+    @Nested
+    @DisplayName("기록이 없을 때")
+    class EmptyWorld {
+
+        @Test
+        @DisplayName("모든 provider가 빈 section을 반환한다")
+        void returnsEmptySections() {
+            HomeResult.Summary result = queryService.home();
+
+            assertThat(result.recentJournal()).isEmpty();
+            assertThat(result.journey().currentQuests()).isEmpty();
+            assertThat(result.journey().selectedRoutes()).isEmpty();
+            assertThat(result.roleActivity30d().totalRecords()).isZero();
+            assertThat(result.roleActivity30d().roles()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("최근 활동이 있을 때")
+    class PopulatedWorld {
+
+        @Test
+        @DisplayName("canonical Journal을 다섯 개로 제한하고 mixed preview와 QUICK/null metadata를 보존한다")
+        void returnsBoundedCanonicalJournal() {
+            CollectionLog collection = collection(PLAYER_ID, "컬렉션");
+            ExerciseLog exercise = exercise(PLAYER_ID);
+            MediaLog media = media(PLAYER_ID, "미디어");
+            CollectionLog oldOne = collection(PLAYER_ID, "오래된 1");
+            CollectionLog oldTwo = collection(PLAYER_ID, "오래된 2");
+            CollectionLog excluded = collection(PLAYER_ID, "제외");
+            LifeLogRecord quick = record(
+                    PLAYER_ID,
+                    LifeLogSourceType.COLLECTION,
+                    collection.getId(),
+                    LifeLogEntryMode.QUICK,
+                    NOW.minusSeconds(1)
+            );
+            LifeLogRecord mediaRecord = record(
+                    PLAYER_ID,
+                    LifeLogSourceType.MEDIA,
+                    media.getId(),
+                    LifeLogEntryMode.FULL,
+                    NOW.minusSeconds(2)
+            );
+            LifeLogRecord exerciseRecord = record(
+                    PLAYER_ID,
+                    LifeLogSourceType.EXERCISE,
+                    exercise.getId(),
+                    LifeLogEntryMode.FULL,
+                    NOW.minusSeconds(2)
+            );
+            LifeLogRecord oldOneRecord = record(
+                    PLAYER_ID,
+                    LifeLogSourceType.COLLECTION,
+                    oldOne.getId(),
+                    LifeLogEntryMode.FULL,
+                    NOW.minusSeconds(4)
+            );
+            LifeLogRecord oldTwoRecord = record(
+                    PLAYER_ID,
+                    LifeLogSourceType.COLLECTION,
+                    oldTwo.getId(),
+                    LifeLogEntryMode.FULL,
+                    NOW.minusSeconds(5)
+            );
+            LifeLogRecord sixth = record(
+                    PLAYER_ID,
+                    LifeLogSourceType.COLLECTION,
+                    excluded.getId(),
+                    LifeLogEntryMode.FULL,
+                    NOW.minusSeconds(6)
+            );
+            flushAndClear();
+
+            List<online.lifeasgame.lifelog.application.result.LifeLogJournalResult.Entry>
+                    entries = queryService.home().recentJournal();
+
+            assertThat(entries).hasSize(5);
+            assertThat(entries).extracting(
+                    online.lifeasgame.lifelog.application.result.LifeLogJournalResult.Entry::lifeLogId
+            ).containsExactly(
+                    quick.getId(),
+                    exerciseRecord.getId(),
+                    mediaRecord.getId(),
+                    oldOneRecord.getId(),
+                    oldTwoRecord.getId()
+            ).doesNotContain(sixth.getId());
+            assertThat(entries.getFirst().entryMode()).isEqualTo("QUICK");
+            assertThat(entries.getFirst().sourceType()).isEqualTo("COLLECTION");
+            assertThat(entries.getFirst().subtype()).isNull();
+            assertThat(entries).extracting(
+                            entry -> entry.preview().getClass().getSimpleName()
+                    )
+                    .contains(
+                            "CollectionPreview",
+                            "ExercisePreview",
+                            "MediaPreview"
+                    );
+        }
+
+        @Test
+        @DisplayName("GOAL_REACHED와 IN_PROGRESS만 status/시간/ID 순으로 반환한다")
+        void returnsOnlyCurrentQuestsInStableOrder() {
+            Quest goalOlder = quest("Q_GOAL_OLDER", "목표 도달 이전");
+            Quest goalNewer = quest("Q_GOAL_NEWER", "목표 도달 최근");
+            Quest inProgress = quest("Q_PROGRESS", "진행 중");
+            Quest completed = quest("Q_COMPLETED", "완료");
+            Quest canceled = quest("Q_CANCELED", "취소");
+            QuestAcceptance olderGoal = acceptance(
+                    goalOlder,
+                    NOW.minusSeconds(300)
+            );
+            olderGoal.reachGoal(NOW.minusSeconds(100));
+            QuestAcceptance newerGoal = acceptance(
+                    goalNewer,
+                    NOW.minusSeconds(200)
+            );
+            newerGoal.reachGoal(NOW.minusSeconds(50));
+            acceptance(inProgress, NOW.minusSeconds(10));
+            QuestAcceptance done = acceptance(completed, NOW.minusSeconds(5));
+            done.reachGoal(NOW.minusSeconds(4));
+            done.complete(NOW.minusSeconds(3));
+            QuestAcceptance stopped = acceptance(canceled, NOW.minusSeconds(1));
+            stopped.cancel();
+            acceptance(quest("Q_OTHER", "다른 사용자"), NOW, OTHER_PLAYER_ID);
+            flushAndClear();
+
+            HomeResult.Journey journey = queryService.home().journey();
+            List<String> statuses = journey
+                    .currentQuests().stream()
+                    .map(online.lifeasgame.quest.application.internal.QuestProgressReadApi.CurrentQuest::status)
+                    .toList();
+            List<String> codes = journey
+                    .currentQuests().stream()
+                    .map(online.lifeasgame.quest.application.internal.QuestProgressReadApi.CurrentQuest::questCode)
+                    .toList();
+
+            assertThat(statuses).containsExactly(
+                    "GOAL_REACHED",
+                    "GOAL_REACHED",
+                    "IN_PROGRESS"
+            );
+            assertThat(codes).containsExactly(
+                    "Q_GOAL_NEWER",
+                    "Q_GOAL_OLDER",
+                    "Q_PROGRESS"
+            );
+        }
+
+        @Test
+        @DisplayName("여러 selected Route를 상태와 선택 시각 순으로 보존한다")
+        void preservesMultipleSelectedRoutes() {
+            Long first = route("ROUTE_FIRST", "첫 경로");
+            Long second = route("ROUTE_SECOND", "둘째 경로");
+            Long completedRoute = route("ROUTE_DONE", "완료 경로");
+            PlayerQuestRoute older = playerRoute(
+                    first,
+                    NOW.minusSeconds(300)
+            );
+            PlayerQuestRoute newer = playerRoute(
+                    second,
+                    NOW.minusSeconds(100)
+            );
+            PlayerQuestRoute done = playerRoute(
+                    completedRoute,
+                    NOW.minusSeconds(10)
+            );
+            done.complete(done.getCurrentStepId(), NOW.minusSeconds(1));
+            flushAndClear();
+
+            List<online.lifeasgame.quest.application.internal.QuestProgressReadApi.SelectedRoute>
+                    routes = queryService.home().journey().selectedRoutes();
+
+            assertThat(routes).extracting(
+                    online.lifeasgame.quest.application.internal.QuestProgressReadApi.SelectedRoute::routeCode
+            ).containsExactly("ROUTE_SECOND", "ROUTE_FIRST", "ROUTE_DONE");
+            assertThat(routes).extracting(
+                    online.lifeasgame.quest.application.internal.QuestProgressReadApi.SelectedRoute::status
+            ).containsExactly("IN_PROGRESS", "IN_PROGRESS", "COMPLETED");
+            assertThat(older.getId()).isNotEqualTo(newer.getId());
+        }
+
+        @Test
+        @DisplayName("[start,end] primaryRoleId만 grouping하고 archived/missing 이름도 count를 보존한다")
+        void aggregatesInclusiveRoleWindow() {
+            Role active = role("활성", false);
+            Role archived = role("보관", true);
+            CollectionLog atStart = collection(PLAYER_ID, "start");
+            CollectionLog atEnd = collection(PLAYER_ID, "end");
+            CollectionLog archivedLog = collection(PLAYER_ID, "archived");
+            CollectionLog missingRole = collection(PLAYER_ID, "missing");
+            CollectionLog unassigned = collection(PLAYER_ID, "none");
+            CollectionLog before = collection(PLAYER_ID, "before");
+            CollectionLog after = collection(PLAYER_ID, "after");
+            roleRecord(atStart, active.getId(), WINDOW_START);
+            roleRecord(atEnd, active.getId(), NOW);
+            roleRecord(archivedLog, archived.getId(), NOW.minusSeconds(1));
+            roleRecord(missingRole, 999_999L, NOW.minusSeconds(2));
+            record(PLAYER_ID, LifeLogSourceType.COLLECTION,
+                    unassigned.getId(), LifeLogEntryMode.FULL,
+                    NOW.minusSeconds(3));
+            roleRecord(before, active.getId(), WINDOW_START.minusSeconds(1));
+            roleRecord(after, active.getId(), NOW.plusSeconds(1));
+            flushAndClear();
+
+            HomeResult.RoleActivity activity =
+                    queryService.home().roleActivity30d();
+
+            assertThat(activity.totalRecords()).isEqualTo(5);
+            assertThat(activity.assignedRecords()).isEqualTo(4);
+            assertThat(activity.unassignedRecords()).isEqualTo(1);
+            assertThat(activity.roles()).containsExactly(
+                    new HomeResult.RoleBucket(
+                            active.getId(), "활성", 2, 0.5
+                    ),
+                    new HomeResult.RoleBucket(
+                            archived.getId(), "보관", 1, 0.25
+                    ),
+                    new HomeResult.RoleBucket(
+                            999_999L, null, 1, 0.25
+                    )
+            );
+        }
+
+        @Test
+        @DisplayName("mixed world summary를 최대 여덟 query로 읽는다")
+        void boundsComposedQueryCount() {
+            Role role = role("역할", false);
+            CollectionLog collection = collection(PLAYER_ID, "컬렉션");
+            ExerciseLog exercise = exercise(PLAYER_ID);
+            MediaLog media = media(PLAYER_ID, "미디어");
+            roleRecord(collection, role.getId(), NOW.minusSeconds(1));
+            record(PLAYER_ID, LifeLogSourceType.EXERCISE, exercise.getId(),
+                    LifeLogEntryMode.FULL, NOW.minusSeconds(2));
+            record(PLAYER_ID, LifeLogSourceType.MEDIA, media.getId(),
+                    LifeLogEntryMode.FULL, NOW.minusSeconds(3));
+            acceptance(quest("Q_QUERY", "쿼리 퀘스트"), NOW.minusSeconds(4));
+            playerRoute(route("ROUTE_QUERY", "쿼리 경로"),
+                    NOW.minusSeconds(5));
+            flushAndClear();
+            Statistics statistics = entityManagerFactory
+                    .unwrap(SessionFactory.class)
+                    .getStatistics();
+            statistics.clear();
+
+            HomeResult.Summary result = queryService.home();
+
+            assertThat(result.recentJournal()).hasSize(3);
+            assertThat(statistics.getPrepareStatementCount())
+                    .isLessThanOrEqualTo(8);
+        }
+    }
+
+    private CollectionLog collection(Long playerId, String title) {
+        CollectionLog log = CollectionLog.create(
+                playerId,
+                CollectionCategory.BOOK,
+                Title.of(title, null),
+                Quantity.of(1),
+                null,
+                null,
+                CollectionTags.of(Set.of())
+        );
+        entityManager.persist(log);
+        entityManager.flush();
+        return log;
+    }
+
+    private ExerciseLog exercise(Long playerId) {
+        ExerciseLog log = ExerciseLog.create(
+                playerId,
+                ExerciseCategory.RUNNING,
+                ExerciseMetrics.of(30, 5.0, 200),
+                LocalDate.of(2026, 8, 12),
+                "운동"
+        );
+        entityManager.persist(log);
+        entityManager.flush();
+        return log;
+    }
+
+    private MediaLog media(Long playerId, String title) {
+        MediaLog log = MediaLog.create(
+                playerId,
+                MediaCategory.MOVIE,
+                Title.of(title, null),
+                EpisodeProgress.of(1, 2),
+                WatchStatus.WATCHING,
+                MediaTags.of(Set.of())
+        );
+        entityManager.persist(log);
+        entityManager.flush();
+        return log;
+    }
+
+    private LifeLogRecord record(
+            Long playerId,
+            LifeLogSourceType sourceType,
+            Long sourceId,
+            LifeLogEntryMode entryMode,
+            Instant occurredAt
+    ) {
+        LifeLogRecord record = LifeLogRecord.legacy(
+                playerId,
+                sourceType,
+                sourceId,
+                entryMode,
+                occurredAt
+        );
+        entityManager.persist(record);
+        entityManager.flush();
+        return record;
+    }
+
+    private LifeLogRecord roleRecord(
+            CollectionLog source,
+            Long roleId,
+            Instant occurredAt
+    ) {
+        LifeLogRecord record = LifeLogRecord.contentReady(
+                PLAYER_ID,
+                LifeLogSourceType.COLLECTION,
+                source.getId(),
+                LifeLogSubtype.ACTIVITY,
+                LifeLogEntryMode.FULL,
+                null,
+                null,
+                roleId,
+                null,
+                occurredAt
+        );
+        entityManager.persist(record);
+        entityManager.flush();
+        return record;
+    }
+
+    private Quest quest(String code, String title) {
+        Quest quest = Quest.create(
+                code,
+                QuestCategory.MAIN,
+                QuestTitle.of(title),
+                null,
+                QuestTarget.of(QuestTargetType.COUNT, 3),
+                QuestReward.of(0, RewardStats.empty()),
+                QuestRepeatRule.NONE,
+                null
+        );
+        entityManager.persist(quest);
+        entityManager.flush();
+        return quest;
+    }
+
+    private QuestAcceptance acceptance(Quest quest, Instant acceptedAt) {
+        return acceptance(quest, acceptedAt, PLAYER_ID);
+    }
+
+    private QuestAcceptance acceptance(
+            Quest quest,
+            Instant acceptedAt,
+            Long playerId
+    ) {
+        QuestAcceptance acceptance = QuestAcceptance.start(
+                quest.getId(),
+                playerId,
+                TimePeriod.forever(),
+                acceptedAt,
+                null
+        );
+        entityManager.persist(acceptance);
+        entityManager.flush();
+        return acceptance;
+    }
+
+    private Long route(String code, String title) {
+        jdbcTemplate.update("""
+                INSERT INTO quest_routes (
+                    code,
+                    definition_version,
+                    title,
+                    description,
+                    primary_role_template_code,
+                    created_at,
+                    updated_at
+                ) VALUES (?, 1, ?, NULL, NULL, ?, ?)
+                """, code, title, NOW, NOW);
+        return jdbcTemplate.queryForObject(
+                "SELECT id FROM quest_routes WHERE code = ?",
+                Long.class,
+                code
+        );
+    }
+
+    private PlayerQuestRoute playerRoute(
+            Long routeId,
+            Instant selectedAt
+    ) {
+        PlayerQuestRoute playerRoute = PlayerQuestRoute.start(
+                PLAYER_ID,
+                routeId,
+                routeId + 10_000,
+                selectedAt
+        );
+        entityManager.persist(playerRoute);
+        entityManager.flush();
+        return playerRoute;
+    }
+
+    private Role role(String name, boolean archived) {
+        Role role = Role.create(
+                PLAYER_ID,
+                RoleType.of("SELF"),
+                name,
+                null
+        );
+        if (archived) {
+            role.archive();
+        }
+        entityManager.persist(role);
+        entityManager.flush();
+        return role;
+    }
+
+    private void flushAndClear() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+}

--- a/src/test/java/online/lifeasgame/home/application/HomeQueryServiceTest.java
+++ b/src/test/java/online/lifeasgame/home/application/HomeQueryServiceTest.java
@@ -1,0 +1,197 @@
+package online.lifeasgame.home.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.home.application.result.HomeResult;
+import online.lifeasgame.lifelog.application.internal.LifeLogActivityReadApi;
+import online.lifeasgame.lifelog.domain.error.LifeLogError;
+import online.lifeasgame.quest.application.internal.QuestProgressReadApi;
+import online.lifeasgame.role.application.internal.RoleDisplayReadApi;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Home world summary composition")
+class HomeQueryServiceTest {
+
+    private static final Long PLAYER_ID = 258L;
+    private static final Instant NOW =
+            Instant.parse("2026-08-12T00:00:00Z");
+    private static final Instant WINDOW_START =
+            Instant.parse("2026-07-13T00:00:00Z");
+
+    @Mock
+    private CurrentPlayerAccessor currentPlayerAccessor;
+
+    @Mock
+    private LifeLogActivityReadApi lifeLogActivityReadApi;
+
+    @Mock
+    private QuestProgressReadApi questProgressReadApi;
+
+    @Mock
+    private RoleDisplayReadApi roleDisplayReadApi;
+
+    private HomeQueryService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new HomeQueryService(
+                currentPlayerAccessor,
+                Clock.fixed(NOW, ZoneOffset.UTC),
+                lifeLogActivityReadApi,
+                questProgressReadApi,
+                roleDisplayReadApi
+        );
+        given(currentPlayerAccessor.currentPlayerIdOrThrow())
+                .willReturn(PLAYER_ID);
+    }
+
+    @Nested
+    @DisplayName("Home을 조회할 때")
+    class ReadHome {
+
+        @Test
+        @DisplayName("기록이 없으면 동일 Clock snapshot의 빈 summary를 반환한다")
+        void returnsEmptyWorldSummary() {
+            givenEmptyProviders();
+
+            HomeResult.Summary result = service.home();
+
+            assertThat(result.generatedAt()).isEqualTo(NOW);
+            assertThat(result.recentJournal()).isEmpty();
+            assertThat(result.journey().currentQuests()).isEmpty();
+            assertThat(result.journey().selectedRoutes()).isEmpty();
+            assertThat(result.roleActivity30d()).isEqualTo(
+                    new HomeResult.RoleActivity(
+                            WINDOW_START,
+                            NOW,
+                            0,
+                            0,
+                            0,
+                            List.of()
+                    )
+            );
+            verify(lifeLogActivityReadApi).recentJournal(
+                    PLAYER_ID,
+                    HomeQueryService.RECENT_JOURNAL_LIMIT
+            );
+            verify(questProgressReadApi).currentQuests(
+                    PLAYER_ID,
+                    HomeQueryService.CURRENT_QUEST_LIMIT
+            );
+            verify(questProgressReadApi).selectedRoutes(
+                    PLAYER_ID,
+                    HomeQueryService.SELECTED_ROUTE_LIMIT
+            );
+        }
+
+        @Test
+        @DisplayName("assigned count를 분모로 role share를 계산하고 missing 이름은 null로 둔다")
+        void calculatesRoleDistribution() {
+            given(lifeLogActivityReadApi.roleActivity(
+                    PLAYER_ID,
+                    WINDOW_START,
+                    NOW
+            )).willReturn(new LifeLogActivityReadApi.RoleActivity(
+                    5,
+                    4,
+                    1,
+                    List.of(
+                            new LifeLogActivityReadApi.RoleCount(10L, 3),
+                            new LifeLogActivityReadApi.RoleCount(20L, 1)
+                    )
+            ));
+            given(roleDisplayReadApi.findNames(
+                    PLAYER_ID,
+                    List.of(10L, 20L)
+            )).willReturn(Map.of(10L, "개발자"));
+            given(lifeLogActivityReadApi.recentJournal(
+                    PLAYER_ID,
+                    HomeQueryService.RECENT_JOURNAL_LIMIT
+            )).willReturn(List.of());
+            given(questProgressReadApi.currentQuests(
+                    PLAYER_ID,
+                    HomeQueryService.CURRENT_QUEST_LIMIT
+            )).willReturn(List.of());
+            given(questProgressReadApi.selectedRoutes(
+                    PLAYER_ID,
+                    HomeQueryService.SELECTED_ROUTE_LIMIT
+            ))
+                    .willReturn(List.of());
+
+            HomeResult.RoleActivity result = service.home().roleActivity30d();
+
+            assertThat(result.windowStart()).isEqualTo(WINDOW_START);
+            assertThat(result.windowEnd()).isEqualTo(NOW);
+            assertThat(result.roles()).containsExactly(
+                    new HomeResult.RoleBucket(10L, "개발자", 3, 0.75),
+                    new HomeResult.RoleBucket(20L, null, 1, 0.25)
+            );
+        }
+
+        @Test
+        @DisplayName("provider invariant failure를 partial success로 숨기지 않는다")
+        void propagatesProviderInvariantFailure() {
+            DomainException failure = new DomainException(
+                    LifeLogError.LIFE_LOG_SOURCE_UNAVAILABLE
+            );
+            given(lifeLogActivityReadApi.roleActivity(
+                    PLAYER_ID,
+                    WINDOW_START,
+                    NOW
+            )).willReturn(new LifeLogActivityReadApi.RoleActivity(
+                    0, 0, 0, List.of()
+            ));
+            given(roleDisplayReadApi.findNames(PLAYER_ID, List.of()))
+                    .willReturn(Map.of());
+            given(lifeLogActivityReadApi.recentJournal(
+                    PLAYER_ID,
+                    HomeQueryService.RECENT_JOURNAL_LIMIT
+            )).willThrow(failure);
+
+            assertThatThrownBy(service::home).isSameAs(failure);
+        }
+    }
+
+    private void givenEmptyProviders() {
+        given(lifeLogActivityReadApi.roleActivity(
+                PLAYER_ID,
+                WINDOW_START,
+                NOW
+        )).willReturn(new LifeLogActivityReadApi.RoleActivity(
+                0, 0, 0, List.of()
+        ));
+        given(roleDisplayReadApi.findNames(PLAYER_ID, List.of()))
+                .willReturn(Map.of());
+        given(lifeLogActivityReadApi.recentJournal(
+                PLAYER_ID,
+                HomeQueryService.RECENT_JOURNAL_LIMIT
+        )).willReturn(List.of());
+        given(questProgressReadApi.currentQuests(
+                PLAYER_ID,
+                HomeQueryService.CURRENT_QUEST_LIMIT
+        )).willReturn(List.of());
+        given(questProgressReadApi.selectedRoutes(
+                PLAYER_ID,
+                HomeQueryService.SELECTED_ROUTE_LIMIT
+        ))
+                .willReturn(List.of());
+    }
+}


### PR DESCRIPTION
## Purpose

Add the minimum current-player Home/world read model that composes recent records, current Journey state, and recent Role activity without introducing a new persisted Home aggregate.

## Delivered

- `GET /api/v1/home`
- bounded recent canonical Journal records
- current actionable Quest summary
- selected QuestRoute summary with multiple-route semantics
- rolling 30-day Role activity distribution
- explicit assigned/unassigned LifeLog counts
- provider-owned cross-context read boundaries
- deterministic section ordering
- stable empty-state behavior
- bounded read/query behavior

## Architecture

Home is a read-only composition layer.

No:

- Home entity
- Home repository
- Home summary table
- scheduled snapshot persistence
- write-side Home events
- Redis/cache dependency

Cross-context reads go through provider-owned read boundaries rather than foreign entities/repositories.

## Product boundaries preserved

- LifeLog remains the player's canonical record
- Journal remains the unified read surface
- Quick remains `entryMode=QUICK`, not a source type
- `GOAL_REACHED` remains distinct from `COMPLETED`
- Quest completion does not advance QuestRoute
- multiple selected QuestRoutes remain valid
- Role activity is a 30-day distribution, not a score
- RoleEvent does not imply LifeLog creation
- Role Stats/radar remains deferred
- Role Chat/RoleParty remain deferred

## Role activity

The 30-day section is derived only from canonical `LifeLogRecord.primaryRoleId`.

It exposes:

- window
- total records
- assigned records
- unassigned records
- deterministic per-Role record distribution

No Role is inferred from RoleEvent, Quest, Person, or source category.

## Tests

Flow-oriented tests cover:

- empty and populated Home
- canonical recent Journal behavior
- Quick entry-mode semantics
- current Quest state boundaries
- multiple QuestRoutes
- deterministic ordering
- 30-day Role aggregation
- assigned/unassigned handling
- zero denominator handling
- architecture boundaries
- bounded query behavior
- Journal/Journey/Role regressions

## Validation

- classes/testClasses
- targeted Home/provider tests
- relevant regression tests
- final build

Closes #258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a home dashboard endpoint providing:
    * Recent journal entries and previews
    * Current quests and selected journey routes
    * 30-day role activity totals and distribution
  * Added support for displaying role names and activity summaries.
  * Home data is available only to authenticated players.

* **Tests**
  * Added coverage for authentication, empty and populated dashboards, ordering, filtering, date ranges, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->