### PR TITLE
[Achievement] Add bounded recent Achievement Home feed

### DIFF
--- a/src/main/java/online/lifeasgame/character/application/internal/AchievementProgressReadApi.java
+++ b/src/main/java/online/lifeasgame/character/application/internal/AchievementProgressReadApi.java
@@ -1,0 +1,19 @@
+package online.lifeasgame.character.application.internal;
+
+import java.time.Instant;
+import java.util.List;
+
+public interface AchievementProgressReadApi {
+
+    List<RecentAchievement> recentAchievements(Long playerId, int limit);
+
+    record RecentAchievement(
+            Long achievementId,
+            String code,
+            String name,
+            String category,
+            String descMd,
+            Instant acquiredAt
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/character/infra/JpaPlayerAchievementRepository.java
+++ b/src/main/java/online/lifeasgame/character/infra/JpaPlayerAchievementRepository.java
@@ -3,6 +3,7 @@ package online.lifeasgame.character.infra;
 import java.util.List;
 import online.lifeasgame.character.application.view.PlayerAchievementView;
 import online.lifeasgame.character.domain.PlayerAchievement;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -19,9 +20,27 @@ public interface JpaPlayerAchievementRepository extends JpaRepository<PlayerAchi
                 FROM PlayerAchievement pa
                 JOIN Achievement t ON t.id = pa.achievementId
                 WHERE pa.playerId = :playerId
-                ORDER BY pa.acquiredAt DESC
+                ORDER BY pa.acquiredAt DESC, pa.id DESC
         """)
     List<PlayerAchievementView> findPlayerAchievementViews(Long playerId);
+
+    @Query(
+            """
+                SELECT t.id AS achievementId,
+                       t.code AS code,
+                       t.name AS name,
+                       t.category AS category,
+                       t.descMd AS descMd,
+                       pa.acquiredAt AS acquiredAt
+                FROM PlayerAchievement pa
+                JOIN Achievement t ON t.id = pa.achievementId
+                WHERE pa.playerId = :playerId
+                ORDER BY pa.acquiredAt DESC, pa.id DESC
+        """)
+    List<PlayerAchievementView> findRecentPlayerAchievementViews(
+            Long playerId,
+            Pageable pageable
+    );
 
     void deleteByPlayerIdAndAchievementId(Long playerId, Long achievementId);
 }

--- a/src/main/java/online/lifeasgame/character/infra/PlayerAchievementRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/character/infra/PlayerAchievementRepositoryAdapter.java
@@ -1,17 +1,22 @@
 package online.lifeasgame.character.infra;
 
 import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.application.internal.AchievementProgressReadApi;
 import online.lifeasgame.character.application.query.PlayerAchievementQuery;
 import online.lifeasgame.character.application.view.PlayerAchievementView;
 import online.lifeasgame.character.domain.PlayerAchievement;
 import online.lifeasgame.character.domain.repository.PlayerAchievementRepository;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
-public class PlayerAchievementRepositoryAdapter implements PlayerAchievementRepository, PlayerAchievementQuery {
+public class PlayerAchievementRepositoryAdapter implements
+        PlayerAchievementRepository,
+        PlayerAchievementQuery,
+        AchievementProgressReadApi {
 
     private final JpaPlayerAchievementRepository jpaRepository;
 
@@ -28,5 +33,25 @@ public class PlayerAchievementRepositoryAdapter implements PlayerAchievementRepo
     @Override
     public List<PlayerAchievementView> findViewsByPlayerId(Long playerId) {
         return jpaRepository.findPlayerAchievementViews(playerId);
+    }
+
+    @Override
+    public List<RecentAchievement> recentAchievements(
+            Long playerId,
+            int limit
+    ) {
+        return jpaRepository.findRecentPlayerAchievementViews(
+                        playerId,
+                        PageRequest.of(0, limit)
+                ).stream()
+                .map(view -> new RecentAchievement(
+                        view.getAchievementId(),
+                        view.getCode(),
+                        view.getName(),
+                        view.getCategory().name(),
+                        view.getDescMd(),
+                        view.getAcquiredAt()
+                ))
+                .toList();
     }
 }

--- a/src/main/java/online/lifeasgame/home/api/mapper/HomeWebMapper.java
+++ b/src/main/java/online/lifeasgame/home/api/mapper/HomeWebMapper.java
@@ -15,6 +15,16 @@ public final class HomeWebMapper {
                 result.recentJournal().stream()
                         .map(HomeWebMapper::toJournalEntry)
                         .toList(),
+                result.recentAchievements().stream()
+                        .map(achievement -> new HomeResponse.RecentAchievement(
+                                achievement.achievementId(),
+                                achievement.code(),
+                                achievement.name(),
+                                achievement.category(),
+                                achievement.descMd(),
+                                achievement.acquiredAt()
+                        ))
+                        .toList(),
                 new HomeResponse.Journey(
                         result.journey().currentQuests().stream()
                                 .map(quest -> new HomeResponse.CurrentQuest(

--- a/src/main/java/online/lifeasgame/home/api/response/HomeResponse.java
+++ b/src/main/java/online/lifeasgame/home/api/response/HomeResponse.java
@@ -12,6 +12,7 @@ public final class HomeResponse {
     public record Summary(
             Instant generatedAt,
             List<JournalEntry> recentJournal,
+            List<RecentAchievement> recentAchievements,
             Journey journey,
             RoleActivity roleActivity30d
     ) {
@@ -26,6 +27,16 @@ public final class HomeResponse {
             Long roleEventId,
             Instant recordedAt,
             Preview preview
+    ) {
+    }
+
+    public record RecentAchievement(
+            Long achievementId,
+            String code,
+            String name,
+            String category,
+            String descMd,
+            Instant acquiredAt
     ) {
     }
 

--- a/src/main/java/online/lifeasgame/home/application/HomeQueryService.java
+++ b/src/main/java/online/lifeasgame/home/application/HomeQueryService.java
@@ -1,6 +1,7 @@
 package online.lifeasgame.home.application;
 
 import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.application.internal.AchievementProgressReadApi;
 import online.lifeasgame.core.security.CurrentPlayerAccessor;
 import online.lifeasgame.home.application.result.HomeResult;
 import online.lifeasgame.lifelog.application.internal.LifeLogActivityReadApi;
@@ -21,12 +22,14 @@ import java.util.Map;
 public class HomeQueryService {
 
     static final int RECENT_JOURNAL_LIMIT = 5;
+    static final int RECENT_ACHIEVEMENT_LIMIT = 5;
     static final int CURRENT_QUEST_LIMIT = 10;
     static final int SELECTED_ROUTE_LIMIT = 10;
     private static final Duration ROLE_ACTIVITY_WINDOW = Duration.ofDays(30);
 
     private final CurrentPlayerAccessor currentPlayerAccessor;
     private final Clock clock;
+    private final AchievementProgressReadApi achievementProgressReadApi;
     private final LifeLogActivityReadApi lifeLogActivityReadApi;
     private final QuestProgressReadApi questProgressReadApi;
     private final RoleDisplayReadApi roleDisplayReadApi;
@@ -53,6 +56,10 @@ public class HomeQueryService {
                 lifeLogActivityReadApi.recentJournal(
                         playerId,
                         RECENT_JOURNAL_LIMIT
+                ),
+                achievementProgressReadApi.recentAchievements(
+                        playerId,
+                        RECENT_ACHIEVEMENT_LIMIT
                 ),
                 new HomeResult.Journey(
                         questProgressReadApi.currentQuests(

--- a/src/main/java/online/lifeasgame/home/application/result/HomeResult.java
+++ b/src/main/java/online/lifeasgame/home/application/result/HomeResult.java
@@ -1,5 +1,6 @@
 package online.lifeasgame.home.application.result;
 
+import online.lifeasgame.character.application.internal.AchievementProgressReadApi;
 import online.lifeasgame.lifelog.application.result.LifeLogJournalResult;
 import online.lifeasgame.quest.application.internal.QuestProgressReadApi;
 
@@ -14,11 +15,13 @@ public final class HomeResult {
     public record Summary(
             Instant generatedAt,
             List<LifeLogJournalResult.Entry> recentJournal,
+            List<AchievementProgressReadApi.RecentAchievement> recentAchievements,
             Journey journey,
             RoleActivity roleActivity30d
     ) {
         public Summary {
             recentJournal = List.copyOf(recentJournal);
+            recentAchievements = List.copyOf(recentAchievements);
         }
     }
 

--- a/src/test/java/online/lifeasgame/character/api/player/PlayerAchievementApiContractTest.java
+++ b/src/test/java/online/lifeasgame/character/api/player/PlayerAchievementApiContractTest.java
@@ -1,0 +1,112 @@
+package online.lifeasgame.character.api.player;
+
+import online.lifeasgame.character.application.PlayerAchievementService;
+import online.lifeasgame.character.application.result.PlayerAchievementResult;
+import online.lifeasgame.platform.security.jwt.JwtPrincipal;
+import online.lifeasgame.platform.security.jwt.JwtProvider;
+import online.lifeasgame.platform.web.error.docs.ErrorDocLinker;
+import online.lifeasgame.support.WebMvcTestConfig;
+import online.lifeasgame.system.bootstrap.error.handler.AppErrorProperties;
+import online.lifeasgame.system.bootstrap.security.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = PlayerAchievementController.class)
+@Import({SecurityConfig.class, WebMvcTestConfig.class})
+@DisplayName("Player Achievement API contract")
+class PlayerAchievementApiContractTest {
+
+    private static final Instant ACQUIRED_AT =
+            Instant.parse("2026-08-12T00:00:00Z");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PlayerAchievementService playerAchievementService;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private AppErrorProperties appErrorProperties;
+
+    @MockitoBean
+    private ErrorDocLinker errorDocLinker;
+
+    @Nested
+    @DisplayName("현재 Player의 획득 업적을 조회할 때")
+    class ReadAchievements {
+
+        @Test
+        @DisplayName("playerId 없이 현재 Player endpoint를 노출한다")
+        void exposesCurrentPlayerEndpoint() throws Exception {
+            assertThat(PlayerAchievementController.class
+                    .getDeclaredMethod("playerAchievementInfos")
+                    .getParameterCount()).isZero();
+        }
+
+        @Test
+        @DisplayName("기존 infos 항목의 여섯 필드를 그대로 반환한다")
+        void preservesResponseShape() throws Exception {
+            given(playerAchievementService.getPlayerAchievementInfos())
+                    .willReturn(List.of(new PlayerAchievementResult.Info(
+                            260L,
+                            "HOME_FIRST",
+                            "첫 Home",
+                            "STORY",
+                            "Home feed 업적",
+                            ACQUIRED_AT
+                    )));
+
+            mockMvc.perform(get("/api/v1/players/achievements")
+                            .with(authentication(playerAuthentication())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result.infos[0].achievementId")
+                            .value(260))
+                    .andExpect(jsonPath("$.result.infos[0].code")
+                            .value("HOME_FIRST"))
+                    .andExpect(jsonPath("$.result.infos[0].name")
+                            .value("첫 Home"))
+                    .andExpect(jsonPath("$.result.infos[0].category")
+                            .value("STORY"))
+                    .andExpect(jsonPath("$.result.infos[0].descMd")
+                            .value("Home feed 업적"))
+                    .andExpect(jsonPath("$.result.infos[0].acquiredAt")
+                            .value("2026-08-12T00:00:00Z"));
+        }
+
+        @Test
+        @DisplayName("인증이 없으면 401이다")
+        void requiresAuthentication() throws Exception {
+            mockMvc.perform(get("/api/v1/players/achievements"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    private UsernamePasswordAuthenticationToken playerAuthentication() {
+        return new UsernamePasswordAuthenticationToken(
+                new JwtPrincipal(260L, 26001L),
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/character/application/AchievementProgressReadIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/character/application/AchievementProgressReadIntegrationTest.java
@@ -1,0 +1,204 @@
+package online.lifeasgame.character.application;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import online.lifeasgame.character.application.internal.AchievementProgressReadApi;
+import online.lifeasgame.character.application.query.PlayerAchievementQuery;
+import online.lifeasgame.character.application.view.PlayerAchievementView;
+import online.lifeasgame.character.domain.Achievement;
+import online.lifeasgame.character.domain.AchievementCategory;
+import online.lifeasgame.character.domain.PlayerAchievement;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties =
+        "spring.jpa.properties.hibernate.generate_statistics=true")
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("Achievement recent read provider")
+class AchievementProgressReadIntegrationTest {
+
+    private static final Long PLAYER_ID = 260L;
+    private static final Long OTHER_PLAYER_ID = 261L;
+    private static final Instant ACQUIRED_AT =
+            Instant.parse("2026-08-12T00:00:00Z");
+
+    @Autowired
+    private AchievementProgressReadApi achievementProgressReadApi;
+
+    @Autowired
+    private PlayerAchievementQuery playerAchievementQuery;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Nested
+    @DisplayName("획득 업적이 없을 때")
+    class NoAchievements {
+
+        @Test
+        @DisplayName("한 번의 bounded query로 빈 목록을 반환한다")
+        void returnsEmptyList() {
+            Statistics statistics = statistics();
+            statistics.clear();
+
+            List<AchievementProgressReadApi.RecentAchievement> result =
+                    achievementProgressReadApi.recentAchievements(
+                            PLAYER_ID,
+                            5
+                    );
+
+            assertThat(result).isEmpty();
+            assertThat(statistics.getPrepareStatementCount()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("여러 Player가 업적을 획득했을 때")
+    class AcquiredAchievements {
+
+        @Test
+        @DisplayName("현재 Player의 최근 다섯 건을 시각과 획득 ID 역순으로 한 query에 반환한다")
+        void returnsBoundedOwnedAchievementsInStableOrder() {
+            Acquisition recent = acquire(
+                    PLAYER_ID, "RECENT", "최근", ACQUIRED_AT.minusSeconds(1)
+            );
+            Acquisition firstTie = acquire(
+                    PLAYER_ID, "TIE_FIRST", "동시 첫째", ACQUIRED_AT
+            );
+            Acquisition secondTie = acquire(
+                    PLAYER_ID, "TIE_SECOND", "동시 둘째", ACQUIRED_AT
+            );
+            Acquisition older = acquire(
+                    PLAYER_ID, "OLDER", "이전", ACQUIRED_AT.minusSeconds(2)
+            );
+            Acquisition oldestIncluded = acquire(
+                    PLAYER_ID, "OLDEST_INCLUDED", "포함 마지막",
+                    ACQUIRED_AT.minusSeconds(3)
+            );
+            Acquisition excluded = acquire(
+                    PLAYER_ID, "EXCLUDED", "제외",
+                    ACQUIRED_AT.minusSeconds(4)
+            );
+            acquire(
+                    OTHER_PLAYER_ID, "OTHER_PLAYER", "다른 Player",
+                    ACQUIRED_AT.plusSeconds(100)
+            );
+            flushAndClear();
+            Statistics statistics = statistics();
+            statistics.clear();
+
+            List<AchievementProgressReadApi.RecentAchievement> result =
+                    achievementProgressReadApi.recentAchievements(
+                            PLAYER_ID,
+                            5
+                    );
+
+            assertThat(secondTie.playerAchievementId())
+                    .isGreaterThan(firstTie.playerAchievementId());
+            assertThat(result).extracting(
+                    AchievementProgressReadApi.RecentAchievement::achievementId
+            ).containsExactly(
+                    secondTie.achievementId(),
+                    firstTie.achievementId(),
+                    recent.achievementId(),
+                    older.achievementId(),
+                    oldestIncluded.achievementId()
+            ).doesNotContain(excluded.achievementId());
+            assertThat(result.getFirst()).isEqualTo(
+                    new AchievementProgressReadApi.RecentAchievement(
+                            secondTie.achievementId(),
+                            "TIE_SECOND",
+                            "동시 둘째",
+                            "STORY",
+                            "TIE_SECOND 설명",
+                            ACQUIRED_AT
+                    )
+            );
+            assertThat(statistics.getPrepareStatementCount()).isEqualTo(1);
+
+            List<PlayerAchievementView> existingList =
+                    playerAchievementQuery.findViewsByPlayerId(PLAYER_ID);
+
+            assertThat(existingList).hasSize(6);
+            assertThat(existingList).extracting(
+                    PlayerAchievementView::getAchievementId
+            ).containsExactly(
+                    secondTie.achievementId(),
+                    firstTie.achievementId(),
+                    recent.achievementId(),
+                    older.achievementId(),
+                    oldestIncluded.achievementId(),
+                    excluded.achievementId()
+            );
+        }
+    }
+
+    private Acquisition acquire(
+            Long playerId,
+            String code,
+            String name,
+            Instant acquiredAt
+    ) {
+        Achievement achievement = Achievement.create(
+                code,
+                name,
+                AchievementCategory.STORY,
+                code + " 설명"
+        );
+        entityManager.persist(achievement);
+        entityManager.flush();
+        PlayerAchievement playerAchievement = PlayerAchievement.create(
+                playerId,
+                achievement.getId()
+        );
+        entityManager.persist(playerAchievement);
+        entityManager.flush();
+        jdbcTemplate.update(
+                "UPDATE player_achievements SET acquired_at = ? WHERE id = ?",
+                Timestamp.from(acquiredAt),
+                playerAchievement.getId()
+        );
+        return new Acquisition(
+                playerAchievement.getId(),
+                achievement.getId()
+        );
+    }
+
+    private Statistics statistics() {
+        return entityManagerFactory
+                .unwrap(SessionFactory.class)
+                .getStatistics();
+    }
+
+    private void flushAndClear() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    private record Acquisition(
+            Long playerAchievementId,
+            Long achievementId
+    ) {
+    }
+}

--- a/src/test/java/online/lifeasgame/character/application/PlayerAchievementServiceTest.java
+++ b/src/test/java/online/lifeasgame/character/application/PlayerAchievementServiceTest.java
@@ -1,0 +1,111 @@
+package online.lifeasgame.character.application;
+
+import online.lifeasgame.character.domain.Achievement;
+import online.lifeasgame.character.domain.AchievementCategory;
+import online.lifeasgame.character.domain.PlayerAchievement;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Player Achievement service")
+class PlayerAchievementServiceTest {
+
+    private static final Long PLAYER_ID = 260L;
+    private static final Long ACHIEVEMENT_ID = 2601L;
+
+    @Mock
+    private PlayerAchievementReader playerAchievementReader;
+
+    @Mock
+    private PlayerAchievementWriter playerAchievementWriter;
+
+    @Mock
+    private AchievementReader achievementReader;
+
+    @Mock
+    private PlayerReader playerReader;
+
+    @Mock
+    private CurrentPlayerAccessor currentPlayerAccessor;
+
+    private PlayerAchievementService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PlayerAchievementService(
+                playerAchievementReader,
+                playerAchievementWriter,
+                achievementReader,
+                playerReader,
+                currentPlayerAccessor
+        );
+    }
+
+    @Nested
+    @DisplayName("업적을 지급할 때")
+    class GrantAchievement {
+
+        @Test
+        @DisplayName("Player와 Achievement 확인 후 기존 획득 의미를 보존한다")
+        void grantsExistingAchievement() {
+            Achievement achievement = Achievement.create(
+                    "HOME_FIRST",
+                    "첫 Home",
+                    AchievementCategory.STORY,
+                    "Home feed 업적"
+            );
+            given(achievementReader.getByIdOrThrow(ACHIEVEMENT_ID))
+                    .willReturn(achievement);
+            given(playerAchievementWriter.create(any(PlayerAchievement.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            var result = service.grantAchievement(
+                    PLAYER_ID,
+                    ACHIEVEMENT_ID
+            );
+
+            assertThat(result.playerId()).isEqualTo(PLAYER_ID);
+            assertThat(result.achievementId()).isEqualTo(ACHIEVEMENT_ID);
+            assertThat(result.code()).isEqualTo("HOME_FIRST");
+            assertThat(result.name()).isEqualTo("첫 Home");
+            assertThat(result.category()).isEqualTo("STORY");
+            assertThat(result.acquiredAt()).isNotNull();
+            verify(playerReader).assertExistsById(PLAYER_ID);
+            verify(achievementReader).getByIdOrThrow(ACHIEVEMENT_ID);
+        }
+    }
+
+    @Nested
+    @DisplayName("업적을 회수할 때")
+    class RevokeAchievement {
+
+        @Test
+        @DisplayName("Player와 Achievement 확인 후 기존 ownership key로 삭제한다")
+        void revokesExistingAchievement() {
+            var result = service.revokeAchievement(
+                    PLAYER_ID,
+                    ACHIEVEMENT_ID
+            );
+
+            assertThat(result.playerId()).isEqualTo(PLAYER_ID);
+            assertThat(result.achievementId()).isEqualTo(ACHIEVEMENT_ID);
+            verify(playerReader).assertExistsById(PLAYER_ID);
+            verify(achievementReader).assertExistsById(ACHIEVEMENT_ID);
+            verify(playerAchievementWriter).revoke(
+                    PLAYER_ID,
+                    ACHIEVEMENT_ID
+            );
+        }
+    }
+}

--- a/src/test/java/online/lifeasgame/home/api/HomeApiContractTest.java
+++ b/src/test/java/online/lifeasgame/home/api/HomeApiContractTest.java
@@ -1,5 +1,6 @@
 package online.lifeasgame.home.api;
 
+import online.lifeasgame.character.application.internal.AchievementProgressReadApi;
 import online.lifeasgame.home.application.HomeQueryService;
 import online.lifeasgame.home.application.result.HomeResult;
 import online.lifeasgame.lifelog.application.result.LifeLogJournalResult;
@@ -103,6 +104,10 @@ class HomeApiContractTest {
                             .value("2026-08-12T00:00:00Z"))
                     .andExpect(jsonPath("$.result.recentJournal").isArray())
                     .andExpect(jsonPath("$.result.recentJournal").isEmpty())
+                    .andExpect(jsonPath("$.result.recentAchievements")
+                            .isArray())
+                    .andExpect(jsonPath("$.result.recentAchievements")
+                            .isEmpty())
                     .andExpect(jsonPath("$.result.journey.currentQuests")
                             .isEmpty())
                     .andExpect(jsonPath("$.result.journey.selectedRoutes")
@@ -140,6 +145,24 @@ class HomeApiContractTest {
                             "$.result.recentJournal[0].sourceId"
                     ).doesNotExist())
                     .andExpect(jsonPath(
+                            "$.result.recentAchievements[0].achievementId"
+                    ).value(601))
+                    .andExpect(jsonPath(
+                            "$.result.recentAchievements[0].code"
+                    ).value("HOME_FIRST"))
+                    .andExpect(jsonPath(
+                            "$.result.recentAchievements[0].name"
+                    ).value("첫 Home"))
+                    .andExpect(jsonPath(
+                            "$.result.recentAchievements[0].category"
+                    ).value("STORY"))
+                    .andExpect(jsonPath(
+                            "$.result.recentAchievements[0].descMd"
+                    ).value("Home feed 업적"))
+                    .andExpect(jsonPath(
+                            "$.result.recentAchievements[0].acquiredAt"
+                    ).value("2026-08-11T23:59:30Z"))
+                    .andExpect(jsonPath(
                             "$.result.journey.currentQuests[0].status"
                     ).value("GOAL_REACHED"))
                     .andExpect(jsonPath(
@@ -158,6 +181,7 @@ class HomeApiContractTest {
     private HomeResult.Summary emptySummary() {
         return new HomeResult.Summary(
                 GENERATED_AT,
+                List.of(),
                 List.of(),
                 new HomeResult.Journey(List.of(), List.of()),
                 new HomeResult.RoleActivity(
@@ -190,6 +214,14 @@ class HomeApiContractTest {
                                 "기록",
                                 1
                         )
+                )),
+                List.of(new AchievementProgressReadApi.RecentAchievement(
+                        601L,
+                        "HOME_FIRST",
+                        "첫 Home",
+                        "STORY",
+                        "Home feed 업적",
+                        GENERATED_AT.minusSeconds(30)
                 )),
                 new HomeResult.Journey(
                         List.of(new QuestProgressReadApi.CurrentQuest(

--- a/src/test/java/online/lifeasgame/home/application/HomeArchitectureTest.java
+++ b/src/test/java/online/lifeasgame/home/application/HomeArchitectureTest.java
@@ -1,5 +1,6 @@
 package online.lifeasgame.home.application;
 
+import online.lifeasgame.character.application.internal.AchievementProgressReadApi;
 import online.lifeasgame.core.security.CurrentPlayerAccessor;
 import online.lifeasgame.home.api.HomeController;
 import online.lifeasgame.lifelog.application.internal.LifeLogActivityReadApi;
@@ -33,6 +34,7 @@ class HomeArchitectureTest {
                     .containsExactlyInAnyOrder(
                             CurrentPlayerAccessor.class,
                             Clock.class,
+                            AchievementProgressReadApi.class,
                             LifeLogActivityReadApi.class,
                             QuestProgressReadApi.class,
                             RoleDisplayReadApi.class

--- a/src/test/java/online/lifeasgame/home/application/HomeProviderIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/home/application/HomeProviderIntegrationTest.java
@@ -105,6 +105,7 @@ class HomeProviderIntegrationTest {
             HomeResult.Summary result = queryService.home();
 
             assertThat(result.recentJournal()).isEmpty();
+            assertThat(result.recentAchievements()).isEmpty();
             assertThat(result.journey().currentQuests()).isEmpty();
             assertThat(result.journey().selectedRoutes()).isEmpty();
             assertThat(result.roleActivity30d().totalRecords()).isZero();
@@ -320,7 +321,7 @@ class HomeProviderIntegrationTest {
         }
 
         @Test
-        @DisplayName("mixed world summary를 최대 여덟 query로 읽는다")
+        @DisplayName("Achievement를 포함한 mixed world summary를 최대 아홉 query로 읽는다")
         void boundsComposedQueryCount() {
             Role role = role("역할", false);
             CollectionLog collection = collection(PLAYER_ID, "컬렉션");
@@ -334,6 +335,7 @@ class HomeProviderIntegrationTest {
             acceptance(quest("Q_QUERY", "쿼리 퀘스트"), NOW.minusSeconds(4));
             playerRoute(route("ROUTE_QUERY", "쿼리 경로"),
                     NOW.minusSeconds(5));
+            acquire("HOME_QUERY", "Home 조회", PLAYER_ID);
             flushAndClear();
             Statistics statistics = entityManagerFactory
                     .unwrap(SessionFactory.class)
@@ -343,8 +345,9 @@ class HomeProviderIntegrationTest {
             HomeResult.Summary result = queryService.home();
 
             assertThat(result.recentJournal()).hasSize(3);
+            assertThat(result.recentAchievements()).hasSize(1);
             assertThat(statistics.getPrepareStatementCount())
-                    .isLessThanOrEqualTo(8);
+                    .isLessThanOrEqualTo(9);
         }
     }
 
@@ -445,6 +448,43 @@ class HomeProviderIntegrationTest {
         entityManager.persist(quest);
         entityManager.flush();
         return quest;
+    }
+
+    private void acquire(
+            String code,
+            String name,
+            Long playerId
+    ) {
+        jdbcTemplate.update("""
+                INSERT INTO achievements (
+                    created_at,
+                    updated_at,
+                    code,
+                    name,
+                    category,
+                    desc_md
+                ) VALUES (?, ?, ?, ?, 'STORY', ?)
+                """, NOW, NOW, code, name, "Home feed");
+        Long achievementId = jdbcTemplate.queryForObject(
+                "SELECT id FROM achievements WHERE code = ?",
+                Long.class,
+                code
+        );
+        jdbcTemplate.update("""
+                INSERT INTO player_achievements (
+                    achievement_id,
+                    acquired_at,
+                    created_at,
+                    player_id,
+                    updated_at
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                achievementId,
+                NOW,
+                NOW,
+                playerId,
+                NOW
+        );
     }
 
     private QuestAcceptance acceptance(Quest quest, Instant acceptedAt) {

--- a/src/test/java/online/lifeasgame/home/application/HomeQueryServiceTest.java
+++ b/src/test/java/online/lifeasgame/home/application/HomeQueryServiceTest.java
@@ -1,5 +1,6 @@
 package online.lifeasgame.home.application;
 
+import online.lifeasgame.character.application.internal.AchievementProgressReadApi;
 import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.core.security.CurrentPlayerAccessor;
 import online.lifeasgame.home.application.result.HomeResult;
@@ -40,6 +41,9 @@ class HomeQueryServiceTest {
     private CurrentPlayerAccessor currentPlayerAccessor;
 
     @Mock
+    private AchievementProgressReadApi achievementProgressReadApi;
+
+    @Mock
     private LifeLogActivityReadApi lifeLogActivityReadApi;
 
     @Mock
@@ -55,6 +59,7 @@ class HomeQueryServiceTest {
         service = new HomeQueryService(
                 currentPlayerAccessor,
                 Clock.fixed(NOW, ZoneOffset.UTC),
+                achievementProgressReadApi,
                 lifeLogActivityReadApi,
                 questProgressReadApi,
                 roleDisplayReadApi
@@ -76,6 +81,7 @@ class HomeQueryServiceTest {
 
             assertThat(result.generatedAt()).isEqualTo(NOW);
             assertThat(result.recentJournal()).isEmpty();
+            assertThat(result.recentAchievements()).isEmpty();
             assertThat(result.journey().currentQuests()).isEmpty();
             assertThat(result.journey().selectedRoutes()).isEmpty();
             assertThat(result.roleActivity30d()).isEqualTo(
@@ -88,9 +94,14 @@ class HomeQueryServiceTest {
                             List.of()
                     )
             );
+            verify(currentPlayerAccessor).currentPlayerIdOrThrow();
             verify(lifeLogActivityReadApi).recentJournal(
                     PLAYER_ID,
                     HomeQueryService.RECENT_JOURNAL_LIMIT
+            );
+            verify(achievementProgressReadApi).recentAchievements(
+                    PLAYER_ID,
+                    HomeQueryService.RECENT_ACHIEVEMENT_LIMIT
             );
             verify(questProgressReadApi).currentQuests(
                     PLAYER_ID,
@@ -100,6 +111,34 @@ class HomeQueryServiceTest {
                     PLAYER_ID,
                     HomeQueryService.SELECTED_ROUTE_LIMIT
             );
+        }
+
+        @Test
+        @DisplayName("현재 Player와 limit 5로 최근 획득 업적을 합성한다")
+        void composesRecentAchievements() {
+            givenEmptyProviders();
+            AchievementProgressReadApi.RecentAchievement achievement =
+                    new AchievementProgressReadApi.RecentAchievement(
+                            260L,
+                            "FIRST_HOME",
+                            "첫 Home",
+                            "STORY",
+                            "Home feed 업적",
+                            NOW.minusSeconds(60)
+                    );
+            given(achievementProgressReadApi.recentAchievements(
+                    PLAYER_ID,
+                    HomeQueryService.RECENT_ACHIEVEMENT_LIMIT
+            )).willReturn(List.of(achievement));
+
+            HomeResult.Summary result = service.home();
+
+            assertThat(result.recentAchievements())
+                    .containsExactly(achievement);
+            assertThat(result.recentJournal()).isEmpty();
+            assertThat(result.journey().currentQuests()).isEmpty();
+            assertThat(result.journey().selectedRoutes()).isEmpty();
+            assertThat(result.roleActivity30d().totalRecords()).isZero();
         }
 
         @Test
@@ -168,6 +207,33 @@ class HomeQueryServiceTest {
 
             assertThatThrownBy(service::home).isSameAs(failure);
         }
+
+        @Test
+        @DisplayName("Achievement provider 실패를 빈 목록으로 위조하지 않는다")
+        void propagatesAchievementProviderFailure() {
+            given(lifeLogActivityReadApi.roleActivity(
+                    PLAYER_ID,
+                    WINDOW_START,
+                    NOW
+            )).willReturn(new LifeLogActivityReadApi.RoleActivity(
+                    0, 0, 0, List.of()
+            ));
+            given(roleDisplayReadApi.findNames(PLAYER_ID, List.of()))
+                    .willReturn(Map.of());
+            given(lifeLogActivityReadApi.recentJournal(
+                    PLAYER_ID,
+                    HomeQueryService.RECENT_JOURNAL_LIMIT
+            )).willReturn(List.of());
+            RuntimeException failure = new RuntimeException(
+                    "achievement provider unavailable"
+            );
+            given(achievementProgressReadApi.recentAchievements(
+                    PLAYER_ID,
+                    HomeQueryService.RECENT_ACHIEVEMENT_LIMIT
+            )).willThrow(failure);
+
+            assertThatThrownBy(service::home).isSameAs(failure);
+        }
     }
 
     private void givenEmptyProviders() {
@@ -183,6 +249,10 @@ class HomeQueryServiceTest {
         given(lifeLogActivityReadApi.recentJournal(
                 PLAYER_ID,
                 HomeQueryService.RECENT_JOURNAL_LIMIT
+        )).willReturn(List.of());
+        given(achievementProgressReadApi.recentAchievements(
+                PLAYER_ID,
+                HomeQueryService.RECENT_ACHIEVEMENT_LIMIT
         )).willReturn(List.of());
         given(questProgressReadApi.currentQuests(
                 PLAYER_ID,


### PR DESCRIPTION
## Purpose

Add a provider-owned bounded recent Achievement read projection and compose it into the current-player Home/world summary.

## Delivered

- bounded recent player Achievement read boundary
- deterministic recent acquisition ordering
- `recentAchievements` in `GET /api/v1/home`
- current-player isolation
- compact Achievement Home projection
- stable empty-state behavior
- bounded query behavior
- existing player Achievement API compatibility

## Home contract

`recentAchievements` exposes:

- `achievementId`
- `code`
- `name`
- `category`
- `descMd`
- `acquiredAt`

The section is read-only.

## Architecture

Character/Achievement remains the data owner.

Home consumes a provider-owned read API and does not depend on:

- Achievement entities
- PlayerAchievement entities
- Character repositories
- persistence adapters

No Home persistence or cache was introduced.

## Product boundaries preserved

- no automatic Achievement grant rules
- no Quest/Route/RoleEvent/LifeLog grant inference
- no ranking/score/streak pressure
- existing grant/revoke semantics unchanged
- existing `/api/v1/players/achievements` contract preserved

## Performance

- bounded SQL recent read
- deterministic ordering
- no N+1
- Home query budget remains bounded

## Tests

Coverage includes:

- bounded recent ordering
- equal-time deterministic tie-break
- current-player isolation
- empty/populated Home feed
- architecture boundaries
- query behavior
- existing Achievement/Home regressions

## Validation

- classes/testClasses
- targeted tests
- relevant regressions
- final build

Closes #260