### PR TITLE
[Equipment] Enforce authoritative equip invariants

### DIFF
--- a/src/main/java/online/lifeasgame/character/application/EquipmentCompatibilityPolicy.java
+++ b/src/main/java/online/lifeasgame/character/application/EquipmentCompatibilityPolicy.java
@@ -1,0 +1,35 @@
+package online.lifeasgame.character.application;
+
+import online.lifeasgame.character.domain.EquipmentSlotCategory;
+import online.lifeasgame.character.domain.error.PlayerEquipmentError;
+import online.lifeasgame.core.error.DomainException;
+
+final class EquipmentCompatibilityPolicy {
+
+    private EquipmentCompatibilityPolicy() {
+    }
+
+    static void validate(
+            EquipmentSlotCategory slot,
+            String itemCategory,
+            String itemType
+    ) {
+        boolean compatible = switch (slot) {
+            case WEAPON -> itemCategory.equals("WEAPON");
+            case HEAD -> itemCategory.equals("ARMOR")
+                    && itemType.equals("HELMET");
+            case CHEST -> itemCategory.equals("ARMOR")
+                    && itemType.equals("CHEST");
+            case RING -> itemCategory.equals("ACCESSORY")
+                    && itemType.equals("RING");
+            case LEGS, HANDS, FEET, NECK, TRINKET -> throw new DomainException(
+                    PlayerEquipmentError.UNSUPPORTED_EQUIPMENT_SLOT
+            );
+        };
+        if (!compatible) {
+            throw new DomainException(
+                    PlayerEquipmentError.ITEM_NOT_COMPATIBLE_WITH_SLOT
+            );
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/PlayerEquipmentReader.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerEquipmentReader.java
@@ -24,8 +24,11 @@ class PlayerEquipmentReader {
         return repository.findByPlayerId(playerId);
     }
 
-    public void assertNotEquipped(Long playerId, Long slotId, Long instanceId) {
-        if (repository.existsByPlayerIdAndSlotIdAndItemInstanceId(playerId, slotId, instanceId)) {
+    public void assertNotEquipped(Long playerId, Long instanceId) {
+        if (repository.existsByPlayerIdAndItemInstanceId(
+                playerId,
+                instanceId
+        )) {
             throw new DomainException(PlayerEquipmentError.ALREADY_EQUIPPED_ITEM);
         }
     }

--- a/src/main/java/online/lifeasgame/character/application/PlayerEquipmentService.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerEquipmentService.java
@@ -3,8 +3,10 @@ package online.lifeasgame.character.application;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.character.application.command.PlayerEquipmentCommand.Equip;
 import online.lifeasgame.character.application.result.PlayerEquipmentResult;
+import online.lifeasgame.character.domain.EquipmentSlot;
 import online.lifeasgame.character.domain.PlayerEquipment;
 import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.inventory.application.internal.InventoryEquipmentReadApi;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,12 +18,30 @@ public class PlayerEquipmentService {
 
     private final PlayerEquipmentWriter playerEquipmentWriter;
     private final PlayerEquipmentReader playerEquipmentReader;
+    private final EquipmentSlotReader equipmentSlotReader;
+    private final InventoryEquipmentReadApi inventoryEquipmentReadApi;
     private final CurrentPlayerAccessor currentPlayerAccessor;
 
     @Transactional
     public PlayerEquipmentResult.Equipped equip(Equip command) {
         Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
-        playerEquipmentReader.assertNotEquipped(playerId, command.slotId(), command.itemInstanceId());
+        EquipmentSlot slot = equipmentSlotReader.getByIdOrThrow(
+                command.slotId()
+        );
+        InventoryEquipmentReadApi.OwnedEquipmentItem item =
+                inventoryEquipmentReadApi.getOwnedItem(
+                        playerId,
+                        command.itemInstanceId()
+                );
+        EquipmentCompatibilityPolicy.validate(
+                slot.getCategory(),
+                item.category(),
+                item.type()
+        );
+        playerEquipmentReader.assertNotEquipped(
+                playerId,
+                command.itemInstanceId()
+        );
 
         PlayerEquipment playerEquipment = playerEquipmentWriter.equip(
                 playerId,

--- a/src/main/java/online/lifeasgame/character/application/PlayerEquipmentWriter.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerEquipmentWriter.java
@@ -5,6 +5,7 @@ import online.lifeasgame.character.domain.PlayerEquipment;
 import online.lifeasgame.character.domain.error.PlayerEquipmentError;
 import online.lifeasgame.character.domain.repository.PlayerEquipmentRepository;
 import online.lifeasgame.core.error.DomainException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,6 +14,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(propagation = Propagation.MANDATORY)
 class PlayerEquipmentWriter {
+
+    private static final String EQUIPPED_ITEM_UNIQUE =
+            "uq_player_equipment_item";
 
     private final PlayerEquipmentRepository repository;
 
@@ -24,7 +28,18 @@ class PlayerEquipmentWriter {
     public PlayerEquipment equip(Long playerId, Long slotId, Long itemInstanceId) {
         PlayerEquipment playerEquipment = getByPlayerIdAndSlotIdForUpdate(playerId, slotId);
         playerEquipment.equip(itemInstanceId);
-        return playerEquipment;
+        try {
+            return repository.saveAndFlush(playerEquipment);
+        } catch (DataIntegrityViolationException exception) {
+            if (isEquippedItemConflict(exception)) {
+                throw new DomainException(
+                        PlayerEquipmentError.ALREADY_EQUIPPED_ITEM,
+                        null,
+                        exception
+                );
+            }
+            throw exception;
+        }
     }
 
     public void unEquip(Long playerId, Long slotId) {
@@ -35,5 +50,23 @@ class PlayerEquipmentWriter {
     private PlayerEquipment getByPlayerIdAndSlotIdForUpdate(Long playerId, Long slotId) {
         return repository.findByPlayerIdAndSlotIdForUpdate(playerId, slotId)
                 .orElseThrow(() -> new DomainException(PlayerEquipmentError.PLAYER_EQUIPMENT_NOT_FOUND));
+    }
+
+    private boolean isEquippedItemConflict(Throwable failure) {
+        for (Throwable cause = failure; cause != null;
+             cause = cause.getCause()) {
+            if (cause instanceof org.hibernate.exception.ConstraintViolationException violation
+                    && EQUIPPED_ITEM_UNIQUE.equalsIgnoreCase(
+                    violation.getConstraintName()
+            )) {
+                return true;
+            }
+            String message = cause.getMessage();
+            if (message != null && message.toLowerCase()
+                    .contains(EQUIPPED_ITEM_UNIQUE)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/online/lifeasgame/character/domain/PlayerEquipment.java
+++ b/src/main/java/online/lifeasgame/character/domain/PlayerEquipment.java
@@ -15,7 +15,16 @@ import java.time.Instant;
 @AggregateRoot
 @Table(
         name = "player_equipment",
-        uniqueConstraints = @UniqueConstraint(name = "uq_player_slot", columnNames = {"player_id", "slot_id"})
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_player_slot",
+                        columnNames = {"player_id", "slot_id"}
+                ),
+                @UniqueConstraint(
+                        name = "uq_player_equipment_item",
+                        columnNames = {"player_id", "item_inst_id"}
+                )
+        }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PlayerEquipment extends AbstractTime {

--- a/src/main/java/online/lifeasgame/character/domain/error/PlayerEquipmentError.java
+++ b/src/main/java/online/lifeasgame/character/domain/error/PlayerEquipmentError.java
@@ -7,7 +7,8 @@ public enum PlayerEquipmentError implements ErrorCode {
     ALREADY_EQUIPPED_ITEM("PEQ-409-ALREADY-EQUIPPED", "Item is already equipped", 409),
     INVALID_ITEM_INSTANCE_ID("PEQ-400-INVALID-ITEM-INSTANCE", "Item instance id is required", 400),
     ITEM_NOT_OWNED_BY_PLAYER("PEQ-403-NOT-OWNER", "Item is not owned by the player", 403),
-    ITEM_NOT_COMPATIBLE_WITH_SLOT("PEQ-422-NOT-COMPATIBLE", "Item is not compatible with the slot", 422);
+    ITEM_NOT_COMPATIBLE_WITH_SLOT("PEQ-422-NOT-COMPATIBLE", "Item is not compatible with the slot", 422),
+    UNSUPPORTED_EQUIPMENT_SLOT("PEQ-422-UNSUPPORTED-SLOT", "Equipment slot is not supported", 422);
 
     private final String code;
     private final String message;

--- a/src/main/java/online/lifeasgame/character/domain/repository/PlayerEquipmentRepository.java
+++ b/src/main/java/online/lifeasgame/character/domain/repository/PlayerEquipmentRepository.java
@@ -10,7 +10,12 @@ public interface PlayerEquipmentRepository {
 
     List<PlayerEquipment> findByPlayerId(Long playerId);
 
-    boolean existsByPlayerIdAndSlotIdAndItemInstanceId(Long playerId, Long slotId, Long instanceId);
+    boolean existsByPlayerIdAndItemInstanceId(
+            Long playerId,
+            Long instanceId
+    );
 
     PlayerEquipment save(PlayerEquipment playerEquipment);
+
+    PlayerEquipment saveAndFlush(PlayerEquipment playerEquipment);
 }

--- a/src/main/java/online/lifeasgame/character/infra/JpaPlayerEquipmentRepository.java
+++ b/src/main/java/online/lifeasgame/character/infra/JpaPlayerEquipmentRepository.java
@@ -19,7 +19,10 @@ public interface JpaPlayerEquipmentRepository extends JpaRepository<PlayerEquipm
     @Query("SELECT pe FROM PlayerEquipment pe WHERE pe.playerId = :playerId AND pe.slotId = :slotId")
     Optional<PlayerEquipment> findByPlayerIdAndSlotIdForUpdate(Long playerId, Long slotId);
 
-    boolean existsByPlayerIdAndSlotIdAndItemInstanceId(Long playerId, Long slotId, Long instanceId);
+    boolean existsByPlayerIdAndItemInstanceId(
+            Long playerId,
+            Long instanceId
+    );
 
     List<PlayerEquipment> findByPlayerId(Long playerId);
 }

--- a/src/main/java/online/lifeasgame/character/infra/PlayerEquipmentRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/character/infra/PlayerEquipmentRepositoryAdapter.java
@@ -20,13 +20,24 @@ public class PlayerEquipmentRepositoryAdapter implements PlayerEquipmentReposito
     }
 
     @Override
-    public boolean existsByPlayerIdAndSlotIdAndItemInstanceId(Long playerId, Long slotId, Long instanceId) {
-        return jpaRepository.existsByPlayerIdAndSlotIdAndItemInstanceId(playerId, slotId, instanceId);
+    public boolean existsByPlayerIdAndItemInstanceId(
+            Long playerId,
+            Long instanceId
+    ) {
+        return jpaRepository.existsByPlayerIdAndItemInstanceId(
+                playerId,
+                instanceId
+        );
     }
 
     @Override
     public PlayerEquipment save(PlayerEquipment playerEquipment) {
         return jpaRepository.save(playerEquipment);
+    }
+
+    @Override
+    public PlayerEquipment saveAndFlush(PlayerEquipment playerEquipment) {
+        return jpaRepository.saveAndFlush(playerEquipment);
     }
 
     @Override

--- a/src/main/java/online/lifeasgame/inventory/application/InventoryQueryService.java
+++ b/src/main/java/online/lifeasgame/inventory/application/InventoryQueryService.java
@@ -3,8 +3,10 @@ package online.lifeasgame.inventory.application;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.inventory.application.internal.InventoryEquipmentReadApi;
 import online.lifeasgame.inventory.application.query.InventoryEntryView;
 import online.lifeasgame.inventory.application.query.InventoryQuery;
+import online.lifeasgame.inventory.application.query.OwnedEquipmentItemView;
 import online.lifeasgame.inventory.application.result.InventoryResult;
 import online.lifeasgame.inventory.domain.error.InventoryError;
 import org.springframework.stereotype.Service;
@@ -15,7 +17,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class InventoryQueryService {
+public class InventoryQueryService implements InventoryEquipmentReadApi {
 
     private final InventoryQuery inventoryQuery;
     private final CurrentPlayerAccessor currentPlayerAccessor;
@@ -47,5 +49,23 @@ public class InventoryQueryService {
                         InventoryError.INVENTORY_ENTRY_NOT_FOUND
                 ));
         return InventoryResult.Entry.fromView(entryView);
+    }
+
+    @Override
+    public OwnedEquipmentItem getOwnedItem(
+            Long playerId,
+            Long itemInstanceId
+    ) {
+        OwnedEquipmentItemView item = inventoryQuery
+                .findOwnedEquipmentItem(playerId, itemInstanceId)
+                .orElseThrow(() -> new DomainException(
+                        InventoryError.INVENTORY_ENTRY_NOT_FOUND
+                ));
+        return new OwnedEquipmentItem(
+                item.itemInstanceId(),
+                item.itemId(),
+                item.category().name(),
+                item.type().name()
+        );
     }
 }

--- a/src/main/java/online/lifeasgame/inventory/application/internal/InventoryEquipmentReadApi.java
+++ b/src/main/java/online/lifeasgame/inventory/application/internal/InventoryEquipmentReadApi.java
@@ -1,0 +1,14 @@
+package online.lifeasgame.inventory.application.internal;
+
+public interface InventoryEquipmentReadApi {
+
+    OwnedEquipmentItem getOwnedItem(Long playerId, Long itemInstanceId);
+
+    record OwnedEquipmentItem(
+            Long itemInstanceId,
+            Long itemId,
+            String category,
+            String type
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/inventory/application/query/InventoryQuery.java
+++ b/src/main/java/online/lifeasgame/inventory/application/query/InventoryQuery.java
@@ -8,4 +8,6 @@ public interface InventoryQuery {
     List<InventoryEntryView> findInventoryEntries(Long playerId);
 
     Optional<InventoryEntryView> findInventoryEntryByInstanceId(Long playerId, Long itemInstanceId);
+
+    Optional<OwnedEquipmentItemView> findOwnedEquipmentItem(Long playerId, Long itemInstanceId);
 }

--- a/src/main/java/online/lifeasgame/inventory/application/query/OwnedEquipmentItemView.java
+++ b/src/main/java/online/lifeasgame/inventory/application/query/OwnedEquipmentItemView.java
@@ -1,0 +1,12 @@
+package online.lifeasgame.inventory.application.query;
+
+import online.lifeasgame.inventory.domain.ItemCategory;
+import online.lifeasgame.inventory.domain.ItemType;
+
+public record OwnedEquipmentItemView(
+        Long itemInstanceId,
+        Long itemId,
+        ItemCategory category,
+        ItemType type
+) {
+}

--- a/src/main/java/online/lifeasgame/inventory/infra/PlayerInventoryQueryAdapter.java
+++ b/src/main/java/online/lifeasgame/inventory/infra/PlayerInventoryQueryAdapter.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.inventory.application.query.InventoryEntryView;
 import online.lifeasgame.inventory.application.query.InventoryQuery;
+import online.lifeasgame.inventory.application.query.OwnedEquipmentItemView;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -66,6 +67,26 @@ public class PlayerInventoryQueryAdapter implements InventoryQuery {
             JOIN Item i ON i.id = e.itemId
             WHERE inv.playerId = :playerId AND e.id = :itemInstanceId
         """, InventoryEntryView.class)
+                .setParameter("playerId", playerId)
+                .setParameter("itemInstanceId", itemInstanceId)
+                .getResultStream()
+                .findFirst();
+    }
+
+    @Override
+    public Optional<OwnedEquipmentItemView> findOwnedEquipmentItem(Long playerId, Long itemInstanceId) {
+        return em.createQuery("""
+            SELECT new online.lifeasgame.inventory.application.query.OwnedEquipmentItemView(
+                e.id,
+                i.id,
+                i.category,
+                i.type
+            )
+            FROM InventoryEntry e
+            JOIN e.inventory inv
+            JOIN Item i ON i.id = e.itemId
+            WHERE inv.playerId = :playerId AND e.id = :itemInstanceId
+        """, OwnedEquipmentItemView.class)
                 .setParameter("playerId", playerId)
                 .setParameter("itemInstanceId", itemInstanceId)
                 .getResultStream()

--- a/src/main/resources/db/migration/V23__player_equipment_item_uniqueness.sql
+++ b/src/main/resources/db/migration/V23__player_equipment_item_uniqueness.sql
@@ -1,0 +1,3 @@
+ALTER TABLE player_equipment
+    ADD CONSTRAINT uq_player_equipment_item
+    UNIQUE (player_id, item_inst_id);

--- a/src/test/java/online/lifeasgame/character/api/player/PlayerEquipmentApiContractTest.java
+++ b/src/test/java/online/lifeasgame/character/api/player/PlayerEquipmentApiContractTest.java
@@ -1,0 +1,194 @@
+package online.lifeasgame.character.api.player;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import online.lifeasgame.character.application.PlayerEquipmentService;
+import online.lifeasgame.character.application.command.PlayerEquipmentCommand;
+import online.lifeasgame.character.application.result.PlayerEquipmentResult;
+import online.lifeasgame.character.domain.error.PlayerEquipmentError;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.inventory.domain.error.InventoryError;
+import online.lifeasgame.platform.security.jwt.JwtPrincipal;
+import online.lifeasgame.platform.security.jwt.JwtProvider;
+import online.lifeasgame.platform.web.error.docs.ErrorDocLinker;
+import online.lifeasgame.support.WebMvcTestConfig;
+import online.lifeasgame.system.bootstrap.error.handler.AppErrorProperties;
+import online.lifeasgame.system.bootstrap.security.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.lang.reflect.RecordComponent;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = PlayerEquipmentController.class)
+@Import({SecurityConfig.class, WebMvcTestConfig.class})
+@DisplayName("Player equipment API contract")
+class PlayerEquipmentApiContractTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private PlayerEquipmentService playerEquipmentService;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private AppErrorProperties appErrorProperties;
+
+    @MockitoBean
+    private ErrorDocLinker errorDocLinker;
+
+    @Nested
+    @DisplayName("기존 equipment endpoint를 호출할 때")
+    class ExistingContract {
+
+        @Test
+        @DisplayName("GET, PUT, DELETE shape와 current-player 요청을 그대로 유지한다")
+        void preservesExistingSuccessShapes() throws Exception {
+            given(playerEquipmentService.getPlayerEquipmentInfos())
+                    .willReturn(List.of(new PlayerEquipmentResult.Info(
+                            1L,
+                            "WEAPON_MAIN",
+                            "주무기",
+                            "WEAPON",
+                            "MAIN",
+                            101L
+                    )));
+            given(playerEquipmentService.equip(any()))
+                    .willReturn(new PlayerEquipmentResult.Equipped(1L, 102L));
+
+            mockMvc.perform(get("/api/v1/players/equipment")
+                            .with(authentication(playerAuthentication())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result.infos[0].slotId")
+                            .value(1))
+                    .andExpect(jsonPath("$.result.infos[0].slotCode")
+                            .value("WEAPON_MAIN"))
+                    .andExpect(jsonPath("$.result.infos[0].slotName")
+                            .value("주무기"))
+                    .andExpect(jsonPath("$.result.infos[0].slotCategory")
+                            .value("WEAPON"))
+                    .andExpect(jsonPath("$.result.infos[0].slotRole")
+                            .value("MAIN"))
+                    .andExpect(jsonPath("$.result.infos[0].itemInstanceId")
+                            .value(101));
+
+            mockMvc.perform(put("/api/v1/players/equipment/1")
+                            .with(authentication(playerAuthentication()))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(json(new online.lifeasgame.character.api.player.request.PlayerEquipmentRequest.Equip(
+                                    102L
+                            ))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result.slotId").value(1))
+                    .andExpect(jsonPath("$.result.itemInstanceId")
+                            .value(102));
+
+            mockMvc.perform(delete("/api/v1/players/equipment/1")
+                            .with(authentication(playerAuthentication())))
+                    .andExpect(status().isNoContent());
+
+            assertThat(Arrays.stream(PlayerEquipmentCommand.Equip.class
+                            .getRecordComponents())
+                    .map(RecordComponent::getName))
+                    .containsExactly("slotId", "itemInstanceId")
+                    .doesNotContain("playerId", "userId");
+            verify(playerEquipmentService).unEquip(1L);
+        }
+
+        @Test
+        @DisplayName("인증이 없으면 모든 write가 401이다")
+        void requiresAuthentication() throws Exception {
+            mockMvc.perform(put("/api/v1/players/equipment/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"itemInstanceId\":102}"))
+                    .andExpect(status().isUnauthorized());
+            mockMvc.perform(delete("/api/v1/players/equipment/1"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("authoritative invariant를 위반하면")
+    class InvariantFailure {
+
+        @Test
+        @DisplayName("foreign과 nonexistent item은 같은 ownership-safe code다")
+        void returnsOwnershipSafeNotFound() throws Exception {
+            given(playerEquipmentService.equip(any())).willThrow(
+                    new DomainException(
+                            InventoryError.INVENTORY_ENTRY_NOT_FOUND
+                    )
+            );
+
+            mockMvc.perform(equipRequest())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value(
+                            InventoryError.INVENTORY_ENTRY_NOT_FOUND.code()
+                    ));
+        }
+
+        @Test
+        @DisplayName("precheck와 DB race는 같은 already-equipped code다")
+        void returnsStableDuplicateConflict() throws Exception {
+            given(playerEquipmentService.equip(any())).willThrow(
+                    new DomainException(
+                            PlayerEquipmentError.ALREADY_EQUIPPED_ITEM
+                    )
+            );
+
+            mockMvc.perform(equipRequest())
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value(
+                            PlayerEquipmentError.ALREADY_EQUIPPED_ITEM.code()
+                    ));
+        }
+    }
+
+    private org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
+    equipRequest() throws Exception {
+        return put("/api/v1/players/equipment/1")
+                .with(authentication(playerAuthentication()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json(new online.lifeasgame.character.api.player.request.PlayerEquipmentRequest.Equip(
+                        102L
+                )));
+    }
+
+    private UsernamePasswordAuthenticationToken playerAuthentication() {
+        return new UsernamePasswordAuthenticationToken(
+                new JwtPrincipal(262L, 26201L),
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+
+    private String json(Object value) throws Exception {
+        return objectMapper.writeValueAsString(value);
+    }
+}

--- a/src/test/java/online/lifeasgame/character/application/EquipmentArchitectureTest.java
+++ b/src/test/java/online/lifeasgame/character/application/EquipmentArchitectureTest.java
@@ -1,0 +1,73 @@
+package online.lifeasgame.character.application;
+
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.inventory.application.InventoryQueryService;
+import online.lifeasgame.inventory.application.internal.InventoryEquipmentReadApi;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Equipment cross-context architecture")
+class EquipmentArchitectureTest {
+
+    @Nested
+    @DisplayName("Character equipment write를 구성할 때")
+    class CharacterBoundary {
+
+        @Test
+        @DisplayName("Inventory provider Internal API만 의존한다")
+        void dependsOnlyOnInventoryProviderBoundary() {
+            assertThat(fieldTypes(PlayerEquipmentService.class))
+                    .containsExactlyInAnyOrder(
+                            PlayerEquipmentWriter.class,
+                            PlayerEquipmentReader.class,
+                            EquipmentSlotReader.class,
+                            InventoryEquipmentReadApi.class,
+                            CurrentPlayerAccessor.class
+                    );
+            Set<Class<?>> inventoryDependencies = Arrays.stream(
+                            PlayerEquipmentService.class.getDeclaredFields()
+                    ).map(Field::getType)
+                    .filter(type -> type.getPackageName().startsWith(
+                            "online.lifeasgame.inventory"
+                    ))
+                    .collect(Collectors.toSet());
+            assertThat(inventoryDependencies)
+                    .containsExactlyInAnyOrder(InventoryEquipmentReadApi.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("Inventory equipment provider를 구성할 때")
+    class InventoryBoundary {
+
+        @Test
+        @DisplayName("기존 Inventory query service가 Character 의존 없이 구현한다")
+        void remainsProviderOwnedWithoutCycle() {
+            assertThat(InventoryEquipmentReadApi.class
+                    .isAssignableFrom(InventoryQueryService.class)).isTrue();
+            assertThat(Arrays.stream(
+                            InventoryQueryService.class.getDeclaredFields()
+                    ).map(Field::getType)
+                    .noneMatch(type -> type.getPackageName().startsWith(
+                            "online.lifeasgame.character"
+                    ))).isTrue();
+        }
+    }
+
+    private static Set<Class<?>> fieldTypes(Class<?> type) {
+        return Arrays.stream(type.getDeclaredFields())
+                .filter(field -> !field.isSynthetic())
+                .filter(field -> !Modifier.isStatic(field.getModifiers()))
+                .map(Field::getType)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/test/java/online/lifeasgame/character/application/EquipmentCompatibilityPolicyTest.java
+++ b/src/test/java/online/lifeasgame/character/application/EquipmentCompatibilityPolicyTest.java
@@ -1,0 +1,124 @@
+package online.lifeasgame.character.application;
+
+import online.lifeasgame.character.domain.EquipmentSlotCategory;
+import online.lifeasgame.character.domain.error.PlayerEquipmentError;
+import online.lifeasgame.core.error.DomainException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Equipment compatibility policy")
+class EquipmentCompatibilityPolicyTest {
+
+    @Nested
+    @DisplayName("검증된 슬롯과 item 조합이면")
+    class SupportedPair {
+
+        @Test
+        @DisplayName("WEAPON, HEAD, CHEST, RING 조합만 허용한다")
+        void allowsVerifiedPairs() {
+            assertThatCode(() -> validate(
+                    EquipmentSlotCategory.WEAPON,
+                    "WEAPON",
+                    "SWORD"
+            )).doesNotThrowAnyException();
+            assertThatCode(() -> validate(
+                    EquipmentSlotCategory.HEAD,
+                    "ARMOR",
+                    "HELMET"
+            )).doesNotThrowAnyException();
+            assertThatCode(() -> validate(
+                    EquipmentSlotCategory.CHEST,
+                    "ARMOR",
+                    "CHEST"
+            )).doesNotThrowAnyException();
+            assertThatCode(() -> validate(
+                    EquipmentSlotCategory.RING,
+                    "ACCESSORY",
+                    "RING"
+            )).doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("검증된 슬롯에 다른 item 조합이면")
+    class IncompatiblePair {
+
+        @Test
+        @DisplayName("category와 type을 정확히 비교해 incompatible로 거부한다")
+        void rejectsIncompatiblePairs() {
+            assertError(
+                    EquipmentSlotCategory.WEAPON,
+                    "ARMOR",
+                    "HELMET",
+                    PlayerEquipmentError.ITEM_NOT_COMPATIBLE_WITH_SLOT
+            );
+            assertError(
+                    EquipmentSlotCategory.HEAD,
+                    "ARMOR",
+                    "CHEST",
+                    PlayerEquipmentError.ITEM_NOT_COMPATIBLE_WITH_SLOT
+            );
+            assertError(
+                    EquipmentSlotCategory.CHEST,
+                    "ARMOR",
+                    "HELMET",
+                    PlayerEquipmentError.ITEM_NOT_COMPATIBLE_WITH_SLOT
+            );
+            assertError(
+                    EquipmentSlotCategory.RING,
+                    "ACCESSORY",
+                    "ETC",
+                    PlayerEquipmentError.ITEM_NOT_COMPATIBLE_WITH_SLOT
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("아직 검증되지 않은 슬롯이면")
+    class UnsupportedSlot {
+
+        @Test
+        @DisplayName("LEGS, HANDS, FEET, NECK, TRINKET을 distinct error로 거부한다")
+        void rejectsUnsupportedSlots() {
+            for (EquipmentSlotCategory slot : new EquipmentSlotCategory[]{
+                    EquipmentSlotCategory.LEGS,
+                    EquipmentSlotCategory.HANDS,
+                    EquipmentSlotCategory.FEET,
+                    EquipmentSlotCategory.NECK,
+                    EquipmentSlotCategory.TRINKET
+            }) {
+                assertError(
+                        slot,
+                        "MISC",
+                        "ETC",
+                        PlayerEquipmentError.UNSUPPORTED_EQUIPMENT_SLOT
+                );
+            }
+        }
+    }
+
+    private void validate(
+            EquipmentSlotCategory slot,
+            String category,
+            String type
+    ) {
+        EquipmentCompatibilityPolicy.validate(slot, category, type);
+    }
+
+    private void assertError(
+            EquipmentSlotCategory slot,
+            String category,
+            String type,
+            PlayerEquipmentError error
+    ) {
+        assertThatThrownBy(() -> validate(slot, category, type))
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(error)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/character/application/PlayerEquipmentConcurrencyIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/character/application/PlayerEquipmentConcurrencyIntegrationTest.java
@@ -1,0 +1,235 @@
+package online.lifeasgame.character.application;
+
+import online.lifeasgame.character.application.command.PlayerEquipmentCommand;
+import online.lifeasgame.character.domain.error.PlayerEquipmentError;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles({"test", "migration-test"})
+@DisplayName("Player equipment concurrency MySQL integration")
+class PlayerEquipmentConcurrencyIntegrationTest {
+
+    private static final Long PLAYER_ID = 262001L;
+    private static final MySQLContainer<?> MYSQL =
+            new MySQLContainer<>("mysql:8.0.39")
+                    .withDatabaseName("lifeasgame_equipment_concurrency")
+                    .withUsername("lifeasgame")
+                    .withPassword("lifeasgame");
+
+    static {
+        MYSQL.start();
+    }
+
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add(
+                "spring.datasource.driver-class-name",
+                MYSQL::getDriverClassName
+        );
+    }
+
+    @Autowired
+    private PlayerEquipmentService playerEquipmentService;
+
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    @MockitoBean
+    private CurrentPlayerAccessor currentPlayerAccessor;
+
+    private Long firstSlotId;
+    private Long secondSlotId;
+    private Long itemInstanceId;
+
+    @BeforeEach
+    void setUp() {
+        given(currentPlayerAccessor.currentPlayerIdOrThrow())
+                .willReturn(PLAYER_ID);
+        jdbc.update("DELETE FROM player_equipment");
+        jdbc.update("DELETE FROM inventory_entries");
+        jdbc.update("DELETE FROM player_inventory");
+        jdbc.update("DELETE FROM equipment_slots");
+        jdbc.update("DELETE FROM items");
+        firstSlotId = insertSlot("WEAPON_MAIN", "주무기", "MAIN");
+        secondSlotId = insertSlot("WEAPON_OFF", "보조무기", "OFFHAND");
+        itemInstanceId = insertOwnedWeapon();
+        insertEmptyEquipment(firstSlotId);
+        insertEmptyEquipment(secondSlotId);
+    }
+
+    @Nested
+    @DisplayName("같은 item을 서로 다른 슬롯에 동시에 장착하면")
+    class EquipSameItemAcrossSlots {
+
+        @Test
+        @DisplayName("정확히 하나만 성공하고 하나는 stable semantic conflict다")
+        void allowsOneWinnerAndMapsOneConflict() throws Exception {
+            List<Throwable> outcomes = race(
+                    () -> equip(firstSlotId),
+                    () -> equip(secondSlotId)
+            );
+
+            assertThat(outcomes.stream().filter(Objects::isNull).count())
+                    .isEqualTo(1);
+            Throwable failure = outcomes.stream()
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(failure).isInstanceOfSatisfying(
+                    DomainException.class,
+                    exception -> assertThat(exception.getErrorCode())
+                            .isEqualTo(
+                                    PlayerEquipmentError.ALREADY_EQUIPPED_ITEM
+                            )
+            );
+            assertThat(jdbc.queryForObject("""
+                    SELECT COUNT(*)
+                    FROM player_equipment
+                    WHERE player_id = ?
+                      AND item_inst_id = ?
+                    """, Integer.class, PLAYER_ID, itemInstanceId))
+                    .isEqualTo(1);
+        }
+    }
+
+    private void equip(Long slotId) {
+        playerEquipmentService.equip(new PlayerEquipmentCommand.Equip(
+                slotId,
+                itemInstanceId
+        ));
+    }
+
+    private List<Throwable> race(
+            Runnable first,
+            Runnable second
+    ) throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<Throwable>> futures = new ArrayList<>();
+        try {
+            for (Runnable action : List.of(first, second)) {
+                futures.add(executor.submit(() -> {
+                    ready.countDown();
+                    start.await();
+                    try {
+                        action.run();
+                        return null;
+                    } catch (Throwable failure) {
+                        return failure;
+                    }
+                }));
+            }
+            assertThat(ready.await(10, TimeUnit.SECONDS)).isTrue();
+            start.countDown();
+            List<Throwable> outcomes = new ArrayList<>();
+            for (Future<Throwable> future : futures) {
+                outcomes.add(future.get(30, TimeUnit.SECONDS));
+            }
+            return outcomes;
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private Long insertSlot(String code, String name, String role) {
+        jdbc.update("""
+                INSERT INTO equipment_slots (
+                    created_at, updated_at, code, name, category, role
+                ) VALUES (
+                    CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6),
+                    ?, ?, 'WEAPON', ?
+                )
+                """, code, name, role);
+        return jdbc.queryForObject(
+                "SELECT id FROM equipment_slots WHERE code = ?",
+                Long.class,
+                code
+        );
+    }
+
+    private Long insertOwnedWeapon() {
+        jdbc.update("""
+                INSERT INTO items (
+                    code, name, category, type, rarity, base_attrs,
+                    stackable, max_stack, max_durability,
+                    created_at, updated_at
+                ) VALUES (
+                    'IT_262_WEAPON', 'Issue 262 weapon',
+                    'WEAPON', 'SWORD', 'COMMON', JSON_OBJECT(),
+                    FALSE, 1, NULL,
+                    CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
+                )
+                """);
+        Long itemId = jdbc.queryForObject(
+                "SELECT id FROM items WHERE code = 'IT_262_WEAPON'",
+                Long.class
+        );
+        jdbc.update("""
+                INSERT INTO player_inventory (
+                    player_id, capacity_slots, version,
+                    created_at, updated_at
+                ) VALUES (
+                    ?, 10, 0, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
+                )
+                """, PLAYER_ID);
+        jdbc.update("""
+                INSERT INTO inventory_entries (
+                    bound, durability, quantity, slot_index,
+                    created_at, item_id, player_id, updated_at,
+                    inst_attrs, rarity
+                ) VALUES (
+                    FALSE, NULL, 1, 0,
+                    CURRENT_TIMESTAMP(6), ?, ?, CURRENT_TIMESTAMP(6),
+                    JSON_OBJECT(), 'COMMON'
+                )
+                """, itemId, PLAYER_ID);
+        return jdbc.queryForObject("""
+                SELECT id
+                FROM inventory_entries
+                WHERE player_id = ? AND item_id = ?
+                """, Long.class, PLAYER_ID, itemId);
+    }
+
+    private void insertEmptyEquipment(Long slotId) {
+        jdbc.update("""
+                INSERT INTO player_equipment (
+                    created_at, equipped_at, item_inst_id,
+                    player_id, slot_id, updated_at
+                ) VALUES (
+                    CURRENT_TIMESTAMP(6), NULL, NULL,
+                    ?, ?, CURRENT_TIMESTAMP(6)
+                )
+                """, PLAYER_ID, slotId);
+    }
+}

--- a/src/test/java/online/lifeasgame/character/application/PlayerEquipmentServiceTest.java
+++ b/src/test/java/online/lifeasgame/character/application/PlayerEquipmentServiceTest.java
@@ -1,0 +1,265 @@
+package online.lifeasgame.character.application;
+
+import online.lifeasgame.character.application.command.PlayerEquipmentCommand;
+import online.lifeasgame.character.domain.EquipmentSlot;
+import online.lifeasgame.character.domain.EquipmentSlotCategory;
+import online.lifeasgame.character.domain.PlayerEquipment;
+import online.lifeasgame.character.domain.error.PlayerEquipmentError;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.inventory.application.internal.InventoryEquipmentReadApi;
+import online.lifeasgame.inventory.domain.error.InventoryError;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Player equipment write")
+class PlayerEquipmentServiceTest {
+
+    private static final Long PLAYER_ID = 262L;
+    private static final Long SLOT_ID = 21L;
+    private static final Long ITEM_INSTANCE_ID = 31L;
+
+    @Mock
+    private PlayerEquipmentWriter writer;
+
+    @Mock
+    private PlayerEquipmentReader reader;
+
+    @Mock
+    private EquipmentSlotReader slotReader;
+
+    @Mock
+    private InventoryEquipmentReadApi inventoryEquipmentReadApi;
+
+    @Mock
+    private CurrentPlayerAccessor currentPlayerAccessor;
+
+    private PlayerEquipmentService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PlayerEquipmentService(
+                writer,
+                reader,
+                slotReader,
+                inventoryEquipmentReadApi,
+                currentPlayerAccessor
+        );
+        given(currentPlayerAccessor.currentPlayerIdOrThrow())
+                .willReturn(PLAYER_ID);
+    }
+
+    @Nested
+    @DisplayName("소유한 item을 장착할 때")
+    class EquipOwnedItem {
+
+        @Test
+        @DisplayName("slot, ownership, compatibility, uniqueness 검증 후 target row를 갱신한다")
+        void equipsVerifiedOwnedItemInOrder() {
+            EquipmentSlot slot = slot(EquipmentSlotCategory.WEAPON);
+            InventoryEquipmentReadApi.OwnedEquipmentItem item = item(
+                    ITEM_INSTANCE_ID,
+                    "WEAPON",
+                    "SWORD"
+            );
+            PlayerEquipment equipment = PlayerEquipment.create(
+                    PLAYER_ID,
+                    SLOT_ID,
+                    ITEM_INSTANCE_ID
+            );
+            given(slotReader.getByIdOrThrow(SLOT_ID)).willReturn(slot);
+            given(inventoryEquipmentReadApi.getOwnedItem(
+                    PLAYER_ID,
+                    ITEM_INSTANCE_ID
+            )).willReturn(item);
+            given(writer.equip(PLAYER_ID, SLOT_ID, ITEM_INSTANCE_ID))
+                    .willReturn(equipment);
+
+            var result = service.equip(command(SLOT_ID, ITEM_INSTANCE_ID));
+
+            assertThat(result.slotId()).isEqualTo(SLOT_ID);
+            assertThat(result.itemInstanceId()).isEqualTo(ITEM_INSTANCE_ID);
+            InOrder order = inOrder(
+                    currentPlayerAccessor,
+                    slotReader,
+                    inventoryEquipmentReadApi,
+                    reader,
+                    writer
+            );
+            order.verify(currentPlayerAccessor).currentPlayerIdOrThrow();
+            order.verify(slotReader).getByIdOrThrow(SLOT_ID);
+            order.verify(inventoryEquipmentReadApi).getOwnedItem(
+                    PLAYER_ID,
+                    ITEM_INSTANCE_ID
+            );
+            order.verify(reader).assertNotEquipped(
+                    PLAYER_ID,
+                    ITEM_INSTANCE_ID
+            );
+            order.verify(writer).equip(
+                    PLAYER_ID,
+                    SLOT_ID,
+                    ITEM_INSTANCE_ID
+            );
+        }
+
+        @Test
+        @DisplayName("서로 다른 item은 서로 다른 슬롯에 각각 장착할 수 있다")
+        void equipsDifferentItemsInDifferentSlots() {
+            Long secondSlotId = 22L;
+            Long secondItemId = 32L;
+            given(slotReader.getByIdOrThrow(SLOT_ID))
+                    .willReturn(slot(EquipmentSlotCategory.WEAPON));
+            given(slotReader.getByIdOrThrow(secondSlotId))
+                    .willReturn(slot(EquipmentSlotCategory.HEAD));
+            given(inventoryEquipmentReadApi.getOwnedItem(
+                    PLAYER_ID,
+                    ITEM_INSTANCE_ID
+            )).willReturn(item(ITEM_INSTANCE_ID, "WEAPON", "SWORD"));
+            given(inventoryEquipmentReadApi.getOwnedItem(
+                    PLAYER_ID,
+                    secondItemId
+            )).willReturn(item(secondItemId, "ARMOR", "HELMET"));
+            given(writer.equip(PLAYER_ID, SLOT_ID, ITEM_INSTANCE_ID))
+                    .willReturn(PlayerEquipment.create(
+                            PLAYER_ID,
+                            SLOT_ID,
+                            ITEM_INSTANCE_ID
+                    ));
+            given(writer.equip(PLAYER_ID, secondSlotId, secondItemId))
+                    .willReturn(PlayerEquipment.create(
+                            PLAYER_ID,
+                            secondSlotId,
+                            secondItemId
+                    ));
+
+            service.equip(command(SLOT_ID, ITEM_INSTANCE_ID));
+            service.equip(command(secondSlotId, secondItemId));
+
+            verify(writer).equip(PLAYER_ID, SLOT_ID, ITEM_INSTANCE_ID);
+            verify(writer).equip(PLAYER_ID, secondSlotId, secondItemId);
+        }
+    }
+
+    @Nested
+    @DisplayName("소유하지 않은 item을 장착할 때")
+    class EquipUnavailableItem {
+
+        @Test
+        @DisplayName("foreign과 nonexistent instance를 같은 Inventory not-found로 거부한다")
+        void rejectsForeignAndMissingItemsWithoutDisclosure() {
+            given(slotReader.getByIdOrThrow(SLOT_ID))
+                    .willReturn(slot(EquipmentSlotCategory.WEAPON));
+            given(inventoryEquipmentReadApi.getOwnedItem(
+                    PLAYER_ID,
+                    ITEM_INSTANCE_ID
+            )).willThrow(new DomainException(
+                    InventoryError.INVENTORY_ENTRY_NOT_FOUND
+            ));
+
+            assertThatThrownBy(() -> service.equip(command(
+                    SLOT_ID,
+                    ITEM_INSTANCE_ID
+            ))).isInstanceOfSatisfying(DomainException.class, exception ->
+                    assertThat(exception.getErrorCode()).isEqualTo(
+                            InventoryError.INVENTORY_ENTRY_NOT_FOUND
+                    )
+            );
+            verify(reader, never()).assertNotEquipped(
+                    PLAYER_ID,
+                    ITEM_INSTANCE_ID
+            );
+            verifyNoInteractions(writer);
+        }
+    }
+
+    @Nested
+    @DisplayName("이미 다른 슬롯에 장착한 item이면")
+    class EquipDuplicateItem {
+
+        @Test
+        @DisplayName("player-wide conflict로 거부하고 implicit move하지 않는다")
+        void rejectsAlreadyEquippedItemAcrossSlots() {
+            given(slotReader.getByIdOrThrow(SLOT_ID))
+                    .willReturn(slot(EquipmentSlotCategory.RING));
+            given(inventoryEquipmentReadApi.getOwnedItem(
+                    PLAYER_ID,
+                    ITEM_INSTANCE_ID
+            )).willReturn(item(
+                    ITEM_INSTANCE_ID,
+                    "ACCESSORY",
+                    "RING"
+            ));
+            willThrow(new DomainException(
+                    PlayerEquipmentError.ALREADY_EQUIPPED_ITEM
+            )).given(reader).assertNotEquipped(
+                    PLAYER_ID,
+                    ITEM_INSTANCE_ID
+            );
+
+            assertThatThrownBy(() -> service.equip(command(
+                    SLOT_ID,
+                    ITEM_INSTANCE_ID
+            ))).isInstanceOfSatisfying(DomainException.class, exception ->
+                    assertThat(exception.getErrorCode()).isEqualTo(
+                            PlayerEquipmentError.ALREADY_EQUIPPED_ITEM
+                    )
+            );
+            verifyNoInteractions(writer);
+        }
+    }
+
+    @Nested
+    @DisplayName("legacy 장착을 해제할 때")
+    class UnequipLegacyItem {
+
+        @Test
+        @DisplayName("slot compatibility나 Inventory ownership을 다시 검증하지 않는다")
+        void unequipsWithoutNewValidation() {
+            service.unEquip(SLOT_ID);
+
+            verify(writer).unEquip(PLAYER_ID, SLOT_ID);
+            verifyNoInteractions(slotReader, inventoryEquipmentReadApi, reader);
+        }
+    }
+
+    private PlayerEquipmentCommand.Equip command(
+            Long slotId,
+            Long itemInstanceId
+    ) {
+        return new PlayerEquipmentCommand.Equip(slotId, itemInstanceId);
+    }
+
+    private EquipmentSlot slot(EquipmentSlotCategory category) {
+        return EquipmentSlot.of("SLOT_" + category, "slot", category);
+    }
+
+    private InventoryEquipmentReadApi.OwnedEquipmentItem item(
+            Long itemInstanceId,
+            String category,
+            String type
+    ) {
+        return new InventoryEquipmentReadApi.OwnedEquipmentItem(
+                itemInstanceId,
+                itemInstanceId + 1_000,
+                category,
+                type
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/character/application/PlayerEquipmentWriterTest.java
+++ b/src/test/java/online/lifeasgame/character/application/PlayerEquipmentWriterTest.java
@@ -1,0 +1,91 @@
+package online.lifeasgame.character.application;
+
+import online.lifeasgame.character.domain.PlayerEquipment;
+import online.lifeasgame.character.domain.error.PlayerEquipmentError;
+import online.lifeasgame.character.domain.repository.PlayerEquipmentRepository;
+import online.lifeasgame.core.error.DomainException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Player equipment writer")
+class PlayerEquipmentWriterTest {
+
+    private static final Long PLAYER_ID = 262L;
+    private static final Long SLOT_ID = 1L;
+    private static final Long ITEM_INSTANCE_ID = 26201L;
+
+    @Mock
+    private PlayerEquipmentRepository repository;
+
+    @Nested
+    @DisplayName("DB unique conflict가 발생하면")
+    class UniqueConflict {
+
+        @Test
+        @DisplayName("equipped-item constraint만 stable semantic conflict로 매핑한다")
+        void mapsOnlyEquippedItemConstraint() {
+            PlayerEquipment equipment = emptyEquipment();
+            DataIntegrityViolationException conflict =
+                    new DataIntegrityViolationException(
+                            "Duplicate entry for key 'uq_player_equipment_item'"
+                    );
+            given(repository.findByPlayerIdAndSlotIdForUpdate(
+                    PLAYER_ID,
+                    SLOT_ID
+            )).willReturn(Optional.of(equipment));
+            given(repository.saveAndFlush(equipment)).willThrow(conflict);
+
+            assertThatThrownBy(() -> writer().equip(
+                    PLAYER_ID,
+                    SLOT_ID,
+                    ITEM_INSTANCE_ID
+            )).isInstanceOfSatisfying(DomainException.class, exception -> {
+                assertThat(exception.getErrorCode()).isEqualTo(
+                        PlayerEquipmentError.ALREADY_EQUIPPED_ITEM
+                );
+                assertThat(exception.getCause()).isSameAs(conflict);
+            });
+        }
+
+        @Test
+        @DisplayName("다른 constraint violation은 원래 예외를 유지한다")
+        void preservesUnrelatedConstraintFailure() {
+            PlayerEquipment equipment = emptyEquipment();
+            DataIntegrityViolationException unrelated =
+                    new DataIntegrityViolationException(
+                            "Duplicate entry for key 'uq_player_slot'"
+                    );
+            given(repository.findByPlayerIdAndSlotIdForUpdate(
+                    PLAYER_ID,
+                    SLOT_ID
+            )).willReturn(Optional.of(equipment));
+            given(repository.saveAndFlush(equipment)).willThrow(unrelated);
+
+            assertThatThrownBy(() -> writer().equip(
+                    PLAYER_ID,
+                    SLOT_ID,
+                    ITEM_INSTANCE_ID
+            )).isSameAs(unrelated);
+        }
+    }
+
+    private PlayerEquipmentWriter writer() {
+        return new PlayerEquipmentWriter(repository);
+    }
+
+    private PlayerEquipment emptyEquipment() {
+        return PlayerEquipment.create(PLAYER_ID, SLOT_ID, null);
+    }
+}

--- a/src/test/java/online/lifeasgame/character/infra/PlayerEquipmentRepositoryIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/character/infra/PlayerEquipmentRepositoryIntegrationTest.java
@@ -1,0 +1,103 @@
+package online.lifeasgame.character.infra;
+
+import online.lifeasgame.character.domain.PlayerEquipment;
+import online.lifeasgame.character.domain.repository.PlayerEquipmentRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("Player equipment repository invariants")
+class PlayerEquipmentRepositoryIntegrationTest {
+
+    private static final Long PLAYER_ID = 262L;
+    private static final Long ITEM_INSTANCE_ID = 26201L;
+
+    @Autowired
+    private PlayerEquipmentRepository repository;
+
+    @Nested
+    @DisplayName("장착 item을 조회할 때")
+    class FindEquippedItem {
+
+        @Test
+        @DisplayName("slot과 무관하게 같은 Player 전체에서 찾고 다른 Player와 격리한다")
+        void checksPlayerWideItemIdentity() {
+            repository.saveAndFlush(PlayerEquipment.create(
+                    PLAYER_ID,
+                    1L,
+                    ITEM_INSTANCE_ID
+            ));
+
+            assertThat(repository.existsByPlayerIdAndItemInstanceId(
+                    PLAYER_ID,
+                    ITEM_INSTANCE_ID
+            )).isTrue();
+            assertThat(repository.existsByPlayerIdAndItemInstanceId(
+                    PLAYER_ID + 1,
+                    ITEM_INSTANCE_ID
+            )).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("장착 상태를 저장할 때")
+    class PersistEquipment {
+
+        @Test
+        @DisplayName("같은 Player의 동일 item은 다른 slot에도 중복 저장할 수 없다")
+        void rejectsDuplicateItemAcrossSlots() {
+            repository.saveAndFlush(PlayerEquipment.create(
+                    PLAYER_ID,
+                    1L,
+                    ITEM_INSTANCE_ID
+            ));
+
+            assertThatThrownBy(() -> repository.saveAndFlush(
+                    PlayerEquipment.create(
+                            PLAYER_ID,
+                            2L,
+                            ITEM_INSTANCE_ID
+                    )
+            )).isInstanceOf(DataIntegrityViolationException.class);
+        }
+
+        @Test
+        @DisplayName("nullable empty slot과 다른 Player의 동일 item은 허용한다")
+        void preservesNullableAndPlayerScopedSemantics() {
+            repository.saveAndFlush(PlayerEquipment.create(
+                    PLAYER_ID,
+                    1L,
+                    null
+            ));
+            assertThatCode(() -> repository.saveAndFlush(
+                    PlayerEquipment.create(PLAYER_ID, 2L, null)
+            )).doesNotThrowAnyException();
+            assertThatCode(() -> repository.saveAndFlush(
+                    PlayerEquipment.create(
+                            PLAYER_ID + 1,
+                            1L,
+                            ITEM_INSTANCE_ID
+                    )
+            )).doesNotThrowAnyException();
+            assertThatCode(() -> repository.saveAndFlush(
+                    PlayerEquipment.create(
+                            PLAYER_ID + 2,
+                            1L,
+                            ITEM_INSTANCE_ID
+                    )
+            )).doesNotThrowAnyException();
+        }
+    }
+}

--- a/src/test/java/online/lifeasgame/inventory/application/InventoryEquipmentReadIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/inventory/application/InventoryEquipmentReadIntegrationTest.java
@@ -1,0 +1,150 @@
+package online.lifeasgame.inventory.application;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.inventory.application.internal.InventoryEquipmentReadApi;
+import online.lifeasgame.inventory.domain.BaseAttrs;
+import online.lifeasgame.inventory.domain.InstanceAttrs;
+import online.lifeasgame.inventory.domain.Item;
+import online.lifeasgame.inventory.domain.ItemCarryPolicy;
+import online.lifeasgame.inventory.domain.ItemCategory;
+import online.lifeasgame.inventory.domain.ItemName;
+import online.lifeasgame.inventory.domain.ItemType;
+import online.lifeasgame.inventory.domain.PlayerInventory;
+import online.lifeasgame.inventory.domain.Rarity;
+import online.lifeasgame.inventory.domain.error.InventoryError;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest(properties =
+        "spring.jpa.properties.hibernate.generate_statistics=true")
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("Inventory equipment read provider")
+class InventoryEquipmentReadIntegrationTest {
+
+    private static final Long PLAYER_ID = 262L;
+    private static final Long OTHER_PLAYER_ID = 263L;
+
+    @Autowired
+    private InventoryEquipmentReadApi inventoryEquipmentReadApi;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    @Nested
+    @DisplayName("Player가 item instance를 소유하면")
+    class OwnedItem {
+
+        @Test
+        @DisplayName("한 번의 direct query로 exact category와 type을 반환한다")
+        void returnsCompactOwnedProjectionWithoutNPlusOne() {
+            Long itemInstanceId = entry(
+                    PLAYER_ID,
+                    "소유한 투구",
+                    ItemCategory.ARMOR,
+                    ItemType.HELMET
+            );
+            flushAndClear();
+            Statistics statistics = statistics();
+            statistics.clear();
+
+            InventoryEquipmentReadApi.OwnedEquipmentItem result =
+                    inventoryEquipmentReadApi.getOwnedItem(
+                            PLAYER_ID,
+                            itemInstanceId
+                    );
+
+            assertThat(result.itemInstanceId()).isEqualTo(itemInstanceId);
+            assertThat(result.itemId()).isPositive();
+            assertThat(result.category()).isEqualTo("ARMOR");
+            assertThat(result.type()).isEqualTo("HELMET");
+            assertThat(statistics.getPrepareStatementCount()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("item instance를 소유하지 않으면")
+    class UnavailableItem {
+
+        @Test
+        @DisplayName("foreign과 nonexistent를 같은 ownership-safe not-found로 반환한다")
+        void hidesForeignOwnershipAndMissingIdentity() {
+            Long foreignItemInstanceId = entry(
+                    OTHER_PLAYER_ID,
+                    "다른 Player 검",
+                    ItemCategory.WEAPON,
+                    ItemType.SWORD
+            );
+            flushAndClear();
+
+            assertNotFound(foreignItemInstanceId);
+            assertNotFound(foreignItemInstanceId + 100_000);
+        }
+    }
+
+    private Long entry(
+            Long playerId,
+            String name,
+            ItemCategory category,
+            ItemType type
+    ) {
+        Item item = Item.create(
+                ItemName.of(name),
+                category,
+                type,
+                Rarity.COMMON,
+                BaseAttrs.empty(),
+                false,
+                null,
+                null
+        );
+        entityManager.persist(item);
+        entityManager.flush();
+        PlayerInventory inventory = PlayerInventory.of(playerId, 10);
+        inventory.add(
+                ItemCarryPolicy.from(item),
+                1,
+                InstanceAttrs.empty(),
+                false
+        );
+        entityManager.persist(inventory);
+        entityManager.flush();
+        return inventory.getEntries().getFirst().getId();
+    }
+
+    private void assertNotFound(Long itemInstanceId) {
+        assertThatThrownBy(() -> inventoryEquipmentReadApi.getOwnedItem(
+                PLAYER_ID,
+                itemInstanceId
+        )).isInstanceOfSatisfying(DomainException.class, exception ->
+                assertThat(exception.getErrorCode()).isEqualTo(
+                        InventoryError.INVENTORY_ENTRY_NOT_FOUND
+                )
+        );
+    }
+
+    private Statistics statistics() {
+        return entityManagerFactory.unwrap(SessionFactory.class)
+                .getStatistics();
+    }
+
+    private void flushAndClear() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+}

--- a/src/test/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryIntegrationTest.java
@@ -99,7 +99,7 @@ class InventoryRewardDeliveryIntegrationTest {
     @DisplayName("V17 receipt table은 JPA validate와 unique/check/index 계약을 만족한다")
     void validatesMigrationContract() {
         assertThat(flyway.info().current().getVersion().getVersion())
-                .isEqualTo("22");
+                .isEqualTo("23");
         assertThat(environment.getProperty("spring.jpa.hibernate.ddl-auto"))
                 .isEqualTo("validate");
 

--- a/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
@@ -63,7 +63,7 @@ class FlywayExplicitBaselineTest {
     class ApplyExplicitBaseline {
 
         @Test
-        @DisplayName("V1을 재실행하지 않고 V2부터 V22까지 적용한 뒤 JPA validate를 통과한다")
+        @DisplayName("V1을 재실행하지 않고 V2부터 V23까지 적용한 뒤 JPA validate를 통과한다")
         void migratesFromVersionTwoAndValidatesJpa() throws Exception {
             String jdbcUrl = createV1EquivalentDatabase();
             Flyway flyway = migrationFlyway(jdbcUrl);
@@ -72,13 +72,13 @@ class FlywayExplicitBaselineTest {
             MigrateResult migrateResult = flyway.migrate();
             List<HistoryRow> history = successfulHistory(jdbcUrl);
 
-            assertThat(migrateResult.migrationsExecuted).isEqualTo(21);
+            assertThat(migrateResult.migrationsExecuted).isEqualTo(22);
             assertThat(history).extracting(HistoryRow::version)
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
                             "14", "15", "16", "17", "18", "19", "20",
-                            "21", "22"
+                            "21", "22", "23"
                     );
             assertThat(history.getFirst().type()).isEqualTo("BASELINE");
             assertThat(history.getFirst().script())
@@ -110,7 +110,8 @@ class FlywayExplicitBaselineTest {
                             "V19__role_person_persistence_foundation.sql",
                             "V20__quest_route_mvp.sql",
                             "V21__role_event_lifelog_linkage.sql",
-                            "V22__lifelog_journal_timeline_index.sql"
+                            "V22__lifelog_journal_timeline_index.sql",
+                            "V23__player_equipment_item_uniqueness.sql"
                     );
             assertThat(history.subList(1, history.size()))
                     .allSatisfy(row -> assertThat(row.checksum()).isNotNull());
@@ -130,7 +131,7 @@ class FlywayExplicitBaselineTest {
                         "spring.jpa.hibernate.ddl-auto"
                 )).isEqualTo("validate");
                 assertThat(context.getBean(Flyway.class).info().current().getVersion().getVersion())
-                        .isEqualTo("22");
+                        .isEqualTo("23");
             }
         }
     }

--- a/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
@@ -33,7 +33,7 @@ class FlywayHistoryChecksumTest {
     class MigrateAgain {
 
         @Test
-        @DisplayName("V1~V20 checksum을 보존하고 V22 이후 두 번째 실행은 no-op이다")
+        @DisplayName("V1~V20 checksum을 보존하고 V23 이후 두 번째 실행은 no-op이다")
         void keepsMigrationHistory() throws Exception {
             Flyway throughV20 = flyway(MigrationVersion.fromVersion("20"));
             MigrateResult legacy = throughV20.migrate();
@@ -47,7 +47,7 @@ class FlywayHistoryChecksumTest {
             List<HistoryRow> secondHistory = successfulHistory();
 
             assertThat(legacy.migrationsExecuted).isEqualTo(20);
-            assertThat(first.migrationsExecuted).isEqualTo(2);
+            assertThat(first.migrationsExecuted).isEqualTo(3);
             assertThat(second.migrationsExecuted).isZero();
             assertThat(secondHistory).isEqualTo(firstHistory);
             assertThat(firstHistory.subList(0, legacyHistory.size()))
@@ -57,7 +57,7 @@ class FlywayHistoryChecksumTest {
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
                             "14", "15", "16", "17", "18", "19", "20",
-                            "21", "22"
+                            "21", "22", "23"
                     );
             assertThat(secondHistory).allSatisfy(history -> {
                 assertThat(history.checksum()).isNotNull();

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -39,7 +39,7 @@ class FlywayMigrationTest {
     class MigrateCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V22까지 적용되고 Journal timeline index를 추가한다")
+        @DisplayName("V1부터 V23까지 적용되고 equipment item uniqueness를 추가한다")
         void migratesSchemaAndSeedsRewardProfiles() throws Exception {
             Flyway throughV10 = flyway(MigrationVersion.fromVersion("10"));
             MigrateResult legacyResult = throughV10.migrate();
@@ -58,13 +58,13 @@ class FlywayMigrationTest {
             assertThat(legacyResult.migrationsExecuted).isEqualTo(10);
             assertThat(semanticResult.migrationsExecuted).isEqualTo(1);
             assertThat(itemResult.migrationsExecuted).isEqualTo(1);
-            assertThat(result.migrationsExecuted).isEqualTo(10);
+            assertThat(result.migrationsExecuted).isEqualTo(11);
             assertThat(appliedVersions())
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
                             "14", "15", "16", "17", "18", "19", "20",
-                            "21", "22"
+                            "21", "22", "23"
                     );
             assertThat(existingTables(
                     "users",

--- a/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
@@ -149,7 +149,7 @@ class FlywayProfileCutoverTest {
     class StartLocalWithCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V22까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
+        @DisplayName("V1부터 V23까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
         void migratesThenValidates() {
             ConfigurableEnvironment environment =
                     (ConfigurableEnvironment) applicationContext.getEnvironment();
@@ -161,8 +161,8 @@ class FlywayProfileCutoverTest {
             assertThat(environment.getProperty(
                     "spring.flyway.baseline-on-migrate", Boolean.class
             )).isFalse();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("22");
-            assertThat(appliedMigrationCount()).isEqualTo(22);
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("23");
+            assertThat(appliedMigrationCount()).isEqualTo(23);
         }
     }
 

--- a/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 @SpringBootTest
 @ActiveProfiles({"test", "migration-test"})
-@DisplayName("V22 migration 이후 JPA schema validation")
+@DisplayName("V23 migration 이후 JPA schema validation")
 class JpaValidateAfterMigrationTest {
 
     @Container
@@ -79,14 +79,14 @@ class JpaValidateAfterMigrationTest {
     private QuestDefinitionBootstrapper questDefinitionBootstrapper;
 
     @Nested
-    @DisplayName("V1부터 V22까지 적용된 schema로 ApplicationContext를 기동할 때")
+    @DisplayName("V1부터 V23까지 적용된 schema로 ApplicationContext를 기동할 때")
     class LoadApplicationContext {
 
         @Test
         @DisplayName("ddl-auto validate 상태로 정상 기동한다")
         void loadsWithJpaValidation() {
             assertThat(applicationContext).isNotNull();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("22");
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("23");
             assertThat(applicationContext.getEnvironment().getProperty("spring.jpa.hibernate.ddl-auto"))
                     .isEqualTo("validate");
             assertThat(applicationContext.getEnvironment()

--- a/src/test/java/online/lifeasgame/migration/PlayerEquipmentUniquenessFlywayTest.java
+++ b/src/test/java/online/lifeasgame/migration/PlayerEquipmentUniquenessFlywayTest.java
@@ -1,0 +1,156 @@
+package online.lifeasgame.migration;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.FlywayException;
+import org.flywaydb.core.api.MigrationVersion;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+@DisplayName("V23 Player equipment item uniqueness migration")
+class PlayerEquipmentUniquenessFlywayTest {
+
+    @Container
+    private static final MySQLContainer<?> MYSQL =
+            new MySQLContainer<>("mysql:8.0.39")
+                    .withDatabaseName("lifeasgame_equipment_uniqueness")
+                    .withUsername("lifeasgame")
+                    .withPassword("lifeasgame");
+
+    private JdbcTemplate jdbc;
+
+    @BeforeEach
+    void migrateThroughV22() {
+        Flyway throughV22 = flyway(MigrationVersion.fromVersion("22"));
+        throughV22.clean();
+        throughV22.migrate();
+        jdbc = new JdbcTemplate(new DriverManagerDataSource(
+                MYSQL.getJdbcUrl(),
+                MYSQL.getUsername(),
+                MYSQL.getPassword()
+        ));
+    }
+
+    @Nested
+    @DisplayName("중복 장착 데이터가 없으면")
+    class CompatibleExistingData {
+
+        @Test
+        @DisplayName("player/item unique를 추가하고 nullable empty slot은 유지한다")
+        void addsPlayerItemUniquenessWithNullableSlots() {
+            var result = flyway(null).migrate();
+
+            assertThat(result.migrationsExecuted).isEqualTo(1);
+            assertThat(indexColumns()).containsExactly(
+                    "player_id",
+                    "item_inst_id"
+            );
+            assertThatCode(() -> {
+                insertEquipment(262L, 1L, null);
+                insertEquipment(262L, 2L, null);
+                insertEquipment(262L, 3L, 26201L);
+                insertEquipment(263L, 1L, 26201L);
+            }).doesNotThrowAnyException();
+            assertThatThrownBy(() -> insertEquipment(
+                    262L,
+                    4L,
+                    26201L
+            )).isInstanceOf(DataIntegrityViolationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("기존 Player에 non-null duplicate item이 있으면")
+    class ConflictingExistingData {
+
+        @Test
+        @DisplayName("cleanup 없이 migration을 실패시키고 원본 두 행을 보존한다")
+        void failsClosedWithoutDeletingUnknownData() {
+            insertEquipment(262L, 1L, 26201L);
+            insertEquipment(262L, 2L, 26201L);
+
+            assertThatThrownBy(() -> flyway(null).migrate())
+                    .isInstanceOf(FlywayException.class);
+
+            assertThat(jdbc.queryForObject("""
+                    SELECT COUNT(*)
+                    FROM player_equipment
+                    WHERE player_id = 262
+                      AND item_inst_id = 26201
+                    """, Integer.class)).isEqualTo(2);
+            assertThat(indexColumns()).isEmpty();
+            assertThat(jdbc.queryForObject("""
+                    SELECT success
+                    FROM flyway_schema_history
+                    WHERE version = '23'
+                    """, Boolean.class)).isFalse();
+        }
+    }
+
+    private Flyway flyway(MigrationVersion target) {
+        var configuration = Flyway.configure()
+                .dataSource(
+                        MYSQL.getJdbcUrl(),
+                        MYSQL.getUsername(),
+                        MYSQL.getPassword()
+                )
+                .locations("classpath:db/migration")
+                .baselineOnMigrate(false)
+                .cleanDisabled(false);
+        if (target != null) {
+            configuration.target(target);
+        }
+        return configuration.load();
+    }
+
+    private List<String> indexColumns() {
+        return jdbc.queryForList("""
+                SELECT column_name
+                FROM information_schema.statistics
+                WHERE table_schema = DATABASE()
+                  AND table_name = 'player_equipment'
+                  AND index_name = 'uq_player_equipment_item'
+                ORDER BY seq_in_index
+                """, String.class);
+    }
+
+    private void insertEquipment(
+            Long playerId,
+            Long slotId,
+            Long itemInstanceId
+    ) {
+        jdbc.update("""
+                INSERT INTO player_equipment (
+                    created_at,
+                    equipped_at,
+                    item_inst_id,
+                    player_id,
+                    slot_id,
+                    updated_at
+                ) VALUES (
+                    CURRENT_TIMESTAMP(6),
+                    CASE WHEN ? IS NULL THEN NULL ELSE CURRENT_TIMESTAMP(6) END,
+                    ?, ?, ?, CURRENT_TIMESTAMP(6)
+                )
+                """,
+                itemInstanceId,
+                itemInstanceId,
+                playerId,
+                slotId
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/migration/RolePersonPersistenceFoundationFlywayTest.java
+++ b/src/test/java/online/lifeasgame/migration/RolePersonPersistenceFoundationFlywayTest.java
@@ -46,9 +46,9 @@ class RolePersonPersistenceFoundationFlywayTest {
     }
 
     @Test
-    @DisplayName("V22까지 적용된 schema에서 V19 Role/Person 계약을 고정한다")
+    @DisplayName("V23까지 적용된 schema에서 V19 Role/Person 계약을 고정한다")
     void createsSchemaContract() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("22");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("23");
         assertThat(tableContracts()).containsExactly(
                 new TableContract("roles", "InnoDB", "utf8mb4_0900_ai_ci"),
                 new TableContract("persons", "InnoDB", "utf8mb4_0900_ai_ci"),

--- a/src/test/java/online/lifeasgame/role/application/RolePersonPersistenceIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/role/application/RolePersonPersistenceIntegrationTest.java
@@ -100,7 +100,7 @@ class RolePersonPersistenceIntegrationTest {
 
     @Test
     void persistsOwnerScopedCrudAndKeepsArchivedRows() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("22");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("23");
 
         var role = roleService.create(
                 new RoleCommand.Create("work", "Developer", "Builds")

--- a/src/test/java/online/lifeasgame/role/application/RoleRelationPersistenceIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/role/application/RoleRelationPersistenceIntegrationTest.java
@@ -93,7 +93,7 @@ class RoleRelationPersistenceIntegrationTest {
 
     @Test
     void persistsCrudRejectsActiveDuplicateAndReactivatesArchivedRow() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("22");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("23");
         Long roleId = createRole("Owner role");
         Long personId = createPerson("Alice");
 


### PR DESCRIPTION
## Purpose

Make equipment writes authoritative for item ownership, slot compatibility, and per-player item-instance uniqueness.

## Delivered

- Inventory provider-owned owned-item read boundary
- Current Player item ownership validation
- Character-owned target slot validation
- centralized safe compatibility policy
- player-wide already-equipped invariant
- DB uniqueness for concurrent same-item equip
- stable race-conflict mapping
- legacy-safe unequip behavior

## Safe compatibility v1

New equip is allowed only for combinations provable by the current item contract:

- WEAPON + WEAPON
- HEAD + ARMOR/HELMET
- CHEST + ARMOR/CHEST
- RING + ACCESSORY/RING

Current unverifiable slots fail safely until item taxonomy is expanded:

- LEGS
- HANDS
- FEET
- NECK
- TRINKET

No item-name inference is used.

## Architecture

Character does not access Inventory entities or repositories.

Inventory exposes a provider-owned internal projection for the owned item instance.

## Concurrency

A DB-level unique invariant prevents one item instance from occupying multiple slots for the same player, including concurrent different-slot requests.

Empty nullable slots remain supported.

## API compatibility

Preserved:

- `GET /api/v1/players/equipment`
- `PUT /api/v1/players/equipment/{slotId}`
- `DELETE /api/v1/players/equipment/{slotId}`

Equipment GET remains slot identity only and is not enriched with Inventory display metadata.

## Legacy behavior

Existing unsupported legacy equipment remains readable and can be unequipped.

No destructive cleanup or auto-migration is performed.

## Tests

Coverage includes:

- owned/foreign/nonexistent items
- verified/incompatible/unsupported slot pairs
- player-wide duplicate item
- concurrent same-item equip
- DB uniqueness
- architecture boundaries
- API/regression behavior

## Validation

- classes/testClasses
- targeted tests
- concurrency/schema tests
- relevant regressions
- final build

Closes #262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Equipment slots now validate item compatibility before equipping.
  - Supported combinations include weapons, helmets, chest armor, and rings.
  - Items must be owned by the player to be equipped.
- **Bug Fixes**
  - Prevented the same item from being equipped in multiple slots.
  - Concurrent equip attempts now produce a consistent duplicate-equipment error.
  - Added a clear error for unsupported equipment slots.
- **Database**
  - Added safeguards to preserve equipment uniqueness across slots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->