### PR TITLE
[Growth] Add canonical current-player Growth overview and EXP history

### DIFF
--- a/src/main/java/online/lifeasgame/character/api/player/PlayerController.java
+++ b/src/main/java/online/lifeasgame/character/api/player/PlayerController.java
@@ -7,9 +7,11 @@ import online.lifeasgame.character.api.player.request.PlayerRequest;
 import online.lifeasgame.character.api.player.response.PlayerResponse;
 import online.lifeasgame.character.api.player.spec.PlayerApiSpecV1;
 import online.lifeasgame.character.application.PlayerFacade;
+import online.lifeasgame.character.application.GrowthQueryService;
 import online.lifeasgame.character.application.PlayerQueryService;
 import online.lifeasgame.character.application.PlayerService;
 import online.lifeasgame.character.application.result.PlayerResult;
+import online.lifeasgame.character.application.result.GrowthResult;
 import online.lifeasgame.core.response.ApiResponse;
 import online.lifeasgame.platform.web.response.ApiResponses;
 import org.springframework.http.ResponseEntity;
@@ -25,12 +27,20 @@ public class PlayerController implements PlayerApiSpecV1 {
     private final PlayerFacade playerFacade;
     private final PlayerQueryService playerQueryService;
     private final PlayerService playerService;
+    private final GrowthQueryService growthQueryService;
 
     @Override
     @GetMapping
     public ResponseEntity<ApiResponse<PlayerResponse.Info>> me() {
         PlayerResult.PlayerInfo result = playerQueryService.getPlayerInfo();
         return ApiResponses.ok(PlayerWebMapper.toPlayerInfo(result));
+    }
+
+    @Override
+    @GetMapping("/growth")
+    public ResponseEntity<ApiResponse<PlayerResponse.Growth>> growth() {
+        GrowthResult.Overview result = growthQueryService.getCurrentGrowth();
+        return ApiResponses.ok(PlayerWebMapper.toGrowth(result));
     }
 
     @Override

--- a/src/main/java/online/lifeasgame/character/api/player/mapper/PlayerWebMapper.java
+++ b/src/main/java/online/lifeasgame/character/api/player/mapper/PlayerWebMapper.java
@@ -1,6 +1,7 @@
 package online.lifeasgame.character.api.player.mapper;
 
 import online.lifeasgame.character.application.command.PlayerCommand;
+import online.lifeasgame.character.application.result.GrowthResult;
 import online.lifeasgame.character.application.result.PlayerResult;
 import online.lifeasgame.character.api.player.request.PlayerRequest;
 import online.lifeasgame.character.api.player.response.PlayerResponse;
@@ -52,5 +53,38 @@ public final class PlayerWebMapper {
 
     public static PlayerResponse.UpdatedTitle toUpdatedTitle(PlayerResult.UpdatedTitle result) {
         return new PlayerResponse.UpdatedTitle(result.titleId());
+    }
+
+    public static PlayerResponse.Growth toGrowth(GrowthResult.Overview result) {
+        GrowthResult.Current current = result.current();
+        return new PlayerResponse.Growth(
+                new PlayerResponse.Growth.Current(
+                        current.level(),
+                        current.exp(),
+                        current.str(),
+                        current.agi(),
+                        current.dex(),
+                        current.intel(),
+                        current.vit(),
+                        current.luc(),
+                        current.extraStats(),
+                        current.representativeTitleId()
+                ),
+                result.recentExpChanges().stream()
+                        .map(change -> new PlayerResponse.Growth.RecentExpChange(
+                                change.changeId(),
+                                change.requestedExp(),
+                                change.appliedExp(),
+                                change.leftoverExp(),
+                                change.beforeLevel(),
+                                change.afterLevel(),
+                                change.beforeTotalExp(),
+                                change.afterTotalExp(),
+                                change.occurredAt(),
+                                change.sourceType(),
+                                change.sourceId()
+                        ))
+                        .toList()
+        );
     }
 }

--- a/src/main/java/online/lifeasgame/character/api/player/response/PlayerResponse.java
+++ b/src/main/java/online/lifeasgame/character/api/player/response/PlayerResponse.java
@@ -1,5 +1,6 @@
 package online.lifeasgame.character.api.player.response;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -32,6 +33,37 @@ public final class PlayerResponse {
     }
 
     public record UpdatedTitle(Long titleId) {
+    }
+
+    public record Growth(Current current, List<RecentExpChange> recentExpChanges) {
+        public record Current(
+                int level,
+                long exp,
+                int str,
+                int agi,
+                int dex,
+                int intel,
+                int vit,
+                int luc,
+                Map<String, Integer> extraStats,
+                Long representativeTitleId
+        ) {
+        }
+
+        public record RecentExpChange(
+                Long changeId,
+                long requestedExp,
+                long appliedExp,
+                long leftoverExp,
+                int beforeLevel,
+                int afterLevel,
+                long beforeTotalExp,
+                long afterTotalExp,
+                Instant occurredAt,
+                String sourceType,
+                Long sourceId
+        ) {
+        }
     }
 
     public record CharacterSheet(

--- a/src/main/java/online/lifeasgame/character/api/player/spec/PlayerApiSpecV1.java
+++ b/src/main/java/online/lifeasgame/character/api/player/spec/PlayerApiSpecV1.java
@@ -16,6 +16,9 @@ public interface PlayerApiSpecV1 {
     @Operation(summary = "내 Player 조회", description = "상태창에 필요한 Player 기본 정보를 조회합니다.")
     ResponseEntity<ApiResponse<PlayerResponse.Info>> me();
 
+    @Operation(summary = "현재 Player 성장 조회", description = "현재 성장 상태와 최근 EXP 변경을 조회합니다.")
+    ResponseEntity<ApiResponse<PlayerResponse.Growth>> growth();
+
     @Operation(summary = "Player 생성(링크 시작)", description = "User 계정 기준으로 Player를 생성합니다.")
     ResponseEntity<ApiResponse<PlayerResponse.CreatedWithToken>> register(
             @Valid @RequestBody PlayerRequest.Register request

--- a/src/main/java/online/lifeasgame/character/application/GrowthQueryService.java
+++ b/src/main/java/online/lifeasgame/character/application/GrowthQueryService.java
@@ -1,0 +1,81 @@
+package online.lifeasgame.character.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.application.query.GrowthQuery;
+import online.lifeasgame.character.application.result.GrowthResult;
+import online.lifeasgame.character.domain.Player;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.reward.application.internal.RewardGrowthSourceReadApi;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GrowthQueryService {
+
+    static final int RECENT_EXP_CHANGE_LIMIT = 20;
+
+    private final CurrentPlayerAccessor currentPlayerAccessor;
+    private final PlayerReader playerReader;
+    private final GrowthQuery growthQuery;
+    private final RewardGrowthSourceReadApi rewardGrowthSourceReadApi;
+
+    public GrowthResult.Overview getCurrentGrowth() {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        Player player = playerReader.getByIdOrThrow(playerId);
+        List<GrowthQuery.RecentExpChange> changes = growthQuery.findRecentExpChanges(
+                playerId,
+                RECENT_EXP_CHANGE_LIMIT
+        );
+        Map<Long, RewardGrowthSourceReadApi.RewardGrowthSource> sources = sources(changes);
+
+        return new GrowthResult.Overview(
+                GrowthResult.Current.from(player),
+                changes.stream()
+                        .map(change -> toResult(change, sources.get(change.rewardLineId())))
+                        .toList()
+        );
+    }
+
+    private Map<Long, RewardGrowthSourceReadApi.RewardGrowthSource> sources(
+            List<GrowthQuery.RecentExpChange> changes
+    ) {
+        if (changes.isEmpty()) {
+            return Map.of();
+        }
+        LinkedHashSet<Long> rewardLineIds = changes.stream()
+                .map(GrowthQuery.RecentExpChange::rewardLineId)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        return rewardGrowthSourceReadApi.findAllByRewardLineIds(rewardLineIds).stream()
+                .collect(Collectors.toMap(
+                        RewardGrowthSourceReadApi.RewardGrowthSource::rewardLineId,
+                        Function.identity()
+                ));
+    }
+
+    private GrowthResult.RecentExpChange toResult(
+            GrowthQuery.RecentExpChange change,
+            RewardGrowthSourceReadApi.RewardGrowthSource source
+    ) {
+        return new GrowthResult.RecentExpChange(
+                change.changeId(),
+                change.requestedExp(),
+                change.appliedExp(),
+                change.leftoverExp(),
+                change.beforeLevel(),
+                change.afterLevel(),
+                change.beforeTotalExp(),
+                change.afterTotalExp(),
+                change.occurredAt(),
+                source == null ? null : source.sourceType(),
+                source == null ? null : source.sourceId()
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/query/GrowthQuery.java
+++ b/src/main/java/online/lifeasgame/character/application/query/GrowthQuery.java
@@ -1,0 +1,23 @@
+package online.lifeasgame.character.application.query;
+
+import java.time.Instant;
+import java.util.List;
+
+public interface GrowthQuery {
+
+    List<RecentExpChange> findRecentExpChanges(Long playerId, int limit);
+
+    record RecentExpChange(
+            Long changeId,
+            Long rewardLineId,
+            long requestedExp,
+            long appliedExp,
+            long leftoverExp,
+            int beforeLevel,
+            int afterLevel,
+            long beforeTotalExp,
+            long afterTotalExp,
+            Instant occurredAt
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/result/GrowthResult.java
+++ b/src/main/java/online/lifeasgame/character/application/result/GrowthResult.java
@@ -1,0 +1,59 @@
+package online.lifeasgame.character.application.result;
+
+import online.lifeasgame.character.domain.Player;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public final class GrowthResult {
+
+    private GrowthResult() {
+    }
+
+    public record Overview(Current current, List<RecentExpChange> recentExpChanges) {
+    }
+
+    public record Current(
+            int level,
+            long exp,
+            int str,
+            int agi,
+            int dex,
+            int intel,
+            int vit,
+            int luc,
+            Map<String, Integer> extraStats,
+            Long representativeTitleId
+    ) {
+        public static Current from(Player player) {
+            return new Current(
+                    player.getLevel().value(),
+                    player.getExp().value(),
+                    player.getStats().str(),
+                    player.getStats().agi(),
+                    player.getStats().dex(),
+                    player.getStats().intel(),
+                    player.getStats().vit(),
+                    player.getStats().luc(),
+                    player.getExtraStats().asMap(),
+                    player.getTitleId()
+            );
+        }
+    }
+
+    public record RecentExpChange(
+            Long changeId,
+            long requestedExp,
+            long appliedExp,
+            long leftoverExp,
+            int beforeLevel,
+            int afterLevel,
+            long beforeTotalExp,
+            long afterTotalExp,
+            Instant occurredAt,
+            String sourceType,
+            Long sourceId
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/character/infra/growth/GrowthQueryAdapter.java
+++ b/src/main/java/online/lifeasgame/character/infra/growth/GrowthQueryAdapter.java
@@ -1,0 +1,44 @@
+package online.lifeasgame.character.infra.growth;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.application.query.GrowthQuery;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static online.lifeasgame.character.domain.growth.QPlayerGrowthChange.playerGrowthChange;
+
+@Repository
+@RequiredArgsConstructor
+public class GrowthQueryAdapter implements GrowthQuery {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<RecentExpChange> findRecentExpChanges(Long playerId, int limit) {
+        return queryFactory
+                .select(Projections.constructor(
+                        RecentExpChange.class,
+                        playerGrowthChange.id,
+                        playerGrowthChange.rewardLineId,
+                        playerGrowthChange.requestedExp,
+                        playerGrowthChange.appliedExp,
+                        playerGrowthChange.leftoverExp,
+                        playerGrowthChange.beforeLevel,
+                        playerGrowthChange.afterLevel,
+                        playerGrowthChange.beforeTotalExp,
+                        playerGrowthChange.afterTotalExp,
+                        playerGrowthChange.createdAt
+                ))
+                .from(playerGrowthChange)
+                .where(playerGrowthChange.playerId.eq(playerId))
+                .orderBy(
+                        playerGrowthChange.createdAt.desc(),
+                        playerGrowthChange.id.desc()
+                )
+                .limit(limit)
+                .fetch();
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/application/internal/RewardGrowthSourceReadApi.java
+++ b/src/main/java/online/lifeasgame/reward/application/internal/RewardGrowthSourceReadApi.java
@@ -1,0 +1,12 @@
+package online.lifeasgame.reward.application.internal;
+
+import java.util.List;
+import java.util.Set;
+
+public interface RewardGrowthSourceReadApi {
+
+    List<RewardGrowthSource> findAllByRewardLineIds(Set<Long> rewardLineIds);
+
+    record RewardGrowthSource(Long rewardLineId, String sourceType, Long sourceId) {
+    }
+}

--- a/src/main/java/online/lifeasgame/reward/infra/RewardGrowthSourceReadAdapter.java
+++ b/src/main/java/online/lifeasgame/reward/infra/RewardGrowthSourceReadAdapter.java
@@ -1,0 +1,38 @@
+package online.lifeasgame.reward.infra;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.reward.application.internal.RewardGrowthSourceReadApi;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Set;
+
+import static online.lifeasgame.reward.domain.QRewardSettlement.rewardSettlement;
+import static online.lifeasgame.reward.domain.QRewardSettlementLine.rewardSettlementLine;
+
+@Repository
+@RequiredArgsConstructor
+public class RewardGrowthSourceReadAdapter implements RewardGrowthSourceReadApi {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<RewardGrowthSource> findAllByRewardLineIds(Set<Long> rewardLineIds) {
+        if (rewardLineIds.isEmpty()) {
+            return List.of();
+        }
+        return queryFactory
+                .select(Projections.constructor(
+                        RewardGrowthSource.class,
+                        rewardSettlementLine.id,
+                        rewardSettlement.sourceType.stringValue(),
+                        rewardSettlement.sourceId
+                ))
+                .from(rewardSettlementLine)
+                .join(rewardSettlementLine.settlement, rewardSettlement)
+                .where(rewardSettlementLine.id.in(rewardLineIds))
+                .fetch();
+    }
+}

--- a/src/main/resources/db/migration/V16__quest_acceptance_fact_context.sql
+++ b/src/main/resources/db/migration/V16__quest_acceptance_fact_context.sql
@@ -1,7 +1,7 @@
 ALTER TABLE quest_acceptances
     ADD COLUMN accepted_at DATETIME(6) NULL
         AFTER period_end,
-    ADD COLUMN period_key VARCHAR(16) NULL
+    ADD COLUMN period_key VARCHAR(20) NULL
         AFTER accepted_at;
 
 UPDATE quest_acceptances

--- a/src/test/java/online/lifeasgame/character/api/player/PlayerGrowthApiContractTest.java
+++ b/src/test/java/online/lifeasgame/character/api/player/PlayerGrowthApiContractTest.java
@@ -1,0 +1,204 @@
+package online.lifeasgame.character.api.player;
+
+import online.lifeasgame.character.application.GrowthQueryService;
+import online.lifeasgame.character.application.PlayerFacade;
+import online.lifeasgame.character.application.PlayerQueryService;
+import online.lifeasgame.character.application.PlayerService;
+import online.lifeasgame.character.application.result.GrowthResult;
+import online.lifeasgame.character.application.result.PlayerResult;
+import online.lifeasgame.platform.security.jwt.JwtPrincipal;
+import online.lifeasgame.platform.security.jwt.JwtProvider;
+import online.lifeasgame.platform.web.error.docs.ErrorDocLinker;
+import online.lifeasgame.support.WebMvcTestConfig;
+import online.lifeasgame.system.bootstrap.error.handler.AppErrorProperties;
+import online.lifeasgame.system.bootstrap.security.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = PlayerController.class)
+@Import({SecurityConfig.class, WebMvcTestConfig.class})
+@DisplayName("Player Growth API contract")
+class PlayerGrowthApiContractTest {
+
+    private static final Instant OCCURRED_AT = Instant.parse("2026-08-13T00:00:00Z");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private GrowthQueryService growthQueryService;
+
+    @MockitoBean
+    private PlayerFacade playerFacade;
+
+    @MockitoBean
+    private PlayerQueryService playerQueryService;
+
+    @MockitoBean
+    private PlayerService playerService;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private AppErrorProperties appErrorProperties;
+
+    @MockitoBean
+    private ErrorDocLinker errorDocLinker;
+
+    @Nested
+    @DisplayName("GET /api/v1/players/growth")
+    class GetGrowth {
+
+        @Test
+        @DisplayName("identity parameter 없이 current Player endpoint를 노출한다")
+        void exposesParameterlessCurrentPlayerEndpoint() throws Exception {
+            assertThat(PlayerController.class.getDeclaredMethod("growth").getParameterCount())
+                    .isZero();
+        }
+
+        @Test
+        @DisplayName("authoritative current와 recent EXP 필드를 정확히 반환하고 rewardLineId는 숨긴다")
+        void returnsPopulatedExactShape() throws Exception {
+            given(growthQueryService.getCurrentGrowth()).willReturn(populatedGrowth());
+
+            mockMvc.perform(get("/api/v1/players/growth")
+                            .with(authentication(playerAuthentication())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result.current.level").value(3))
+                    .andExpect(jsonPath("$.result.current.exp").value(250))
+                    .andExpect(jsonPath("$.result.current.str").value(2))
+                    .andExpect(jsonPath("$.result.current.agi").value(3))
+                    .andExpect(jsonPath("$.result.current.dex").value(4))
+                    .andExpect(jsonPath("$.result.current.intel").value(5))
+                    .andExpect(jsonPath("$.result.current.vit").value(6))
+                    .andExpect(jsonPath("$.result.current.luc").value(7))
+                    .andExpect(jsonPath("$.result.current.extraStats.sociability").value(8))
+                    .andExpect(jsonPath("$.result.current.representativeTitleId").value(9))
+                    .andExpect(jsonPath("$.result.recentExpChanges[0].changeId").value(10))
+                    .andExpect(jsonPath("$.result.recentExpChanges[0].requestedExp").value(100))
+                    .andExpect(jsonPath("$.result.recentExpChanges[0].appliedExp").value(80))
+                    .andExpect(jsonPath("$.result.recentExpChanges[0].leftoverExp").value(20))
+                    .andExpect(jsonPath("$.result.recentExpChanges[0].beforeLevel").value(2))
+                    .andExpect(jsonPath("$.result.recentExpChanges[0].afterLevel").value(3))
+                    .andExpect(jsonPath("$.result.recentExpChanges[0].beforeTotalExp").value(170))
+                    .andExpect(jsonPath("$.result.recentExpChanges[0].afterTotalExp").value(250))
+                    .andExpect(jsonPath("$.result.recentExpChanges[0].occurredAt")
+                            .value("2026-08-13T00:00:00Z"))
+                    .andExpect(jsonPath("$.result.recentExpChanges[0].sourceType")
+                            .value("QUEST_COMPLETION"))
+                    .andExpect(jsonPath("$.result.recentExpChanges[0].sourceId").value(2640))
+                    .andExpect(jsonPath("$.result.recentExpChanges[0].rewardLineId")
+                            .doesNotExist());
+        }
+
+        @Test
+        @DisplayName("history가 없으면 recentExpChanges 빈 배열을 반환한다")
+        void returnsEmptyHistoryArray() throws Exception {
+            given(growthQueryService.getCurrentGrowth()).willReturn(new GrowthResult.Overview(
+                    new GrowthResult.Current(1, 0, 1, 1, 1, 1, 1, 1, Map.of(), null),
+                    List.of()
+            ));
+
+            mockMvc.perform(get("/api/v1/players/growth")
+                            .with(authentication(playerAuthentication())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result.recentExpChanges").isArray())
+                    .andExpect(jsonPath("$.result.recentExpChanges").isEmpty())
+                    .andExpect(jsonPath("$.result.current.representativeTitleId").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("missing provenance는 null 필드로 반환한다")
+        void returnsNullableProvenance() throws Exception {
+            GrowthResult.Overview growth = populatedGrowth();
+            GrowthResult.RecentExpChange change = growth.recentExpChanges().getFirst();
+            given(growthQueryService.getCurrentGrowth()).willReturn(new GrowthResult.Overview(
+                    growth.current(),
+                    List.of(new GrowthResult.RecentExpChange(
+                            change.changeId(), change.requestedExp(), change.appliedExp(),
+                            change.leftoverExp(), change.beforeLevel(), change.afterLevel(),
+                            change.beforeTotalExp(), change.afterTotalExp(), change.occurredAt(),
+                            null, null
+                    ))
+            ));
+
+            mockMvc.perform(get("/api/v1/players/growth")
+                            .with(authentication(playerAuthentication())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result.recentExpChanges[0].sourceType").doesNotExist())
+                    .andExpect(jsonPath("$.result.recentExpChanges[0].sourceId").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("인증이 없으면 401이다")
+        void requiresAuthentication() throws Exception {
+            mockMvc.perform(get("/api/v1/players/growth"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("기존 Player 조회")
+    class ExistingPlayerApi {
+
+        @Test
+        @DisplayName("GET /api/v1/players response shape를 보존한다")
+        void preservesPlayerResponse() throws Exception {
+            given(playerQueryService.getPlayerInfo()).willReturn(new PlayerResult.PlayerInfo(
+                    1L, "player", "MALE", null, 1, 0,
+                    100, 100, 50, 50,
+                    1, 1, 1, 1, 1, 1,
+                    Map.of(), List.of(), null
+            ));
+
+            mockMvc.perform(get("/api/v1/players")
+                            .with(authentication(playerAuthentication())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result.playerId").value(1))
+                    .andExpect(jsonPath("$.result.name").value("player"))
+                    .andExpect(jsonPath("$.result.level").value(1))
+                    .andExpect(jsonPath("$.result.exp").value(0));
+        }
+    }
+
+    private GrowthResult.Overview populatedGrowth() {
+        return new GrowthResult.Overview(
+                new GrowthResult.Current(
+                        3, 250, 2, 3, 4, 5, 6, 7,
+                        Map.of("sociability", 8), 9L
+                ),
+                List.of(new GrowthResult.RecentExpChange(
+                        10L, 100, 80, 20, 2, 3,
+                        170, 250, OCCURRED_AT, "QUEST_COMPLETION", 2640L
+                ))
+        );
+    }
+
+    private UsernamePasswordAuthenticationToken playerAuthentication() {
+        return new UsernamePasswordAuthenticationToken(
+                new JwtPrincipal(264L, 26401L),
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/character/application/GrowthArchitectureTest.java
+++ b/src/test/java/online/lifeasgame/character/application/GrowthArchitectureTest.java
@@ -1,0 +1,74 @@
+package online.lifeasgame.character.application;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import online.lifeasgame.character.application.query.GrowthQuery;
+import online.lifeasgame.character.infra.growth.GrowthQueryAdapter;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.reward.application.internal.RewardGrowthSourceReadApi;
+import online.lifeasgame.reward.infra.RewardGrowthSourceReadAdapter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Growth cross-context architecture")
+class GrowthArchitectureTest {
+
+    @Nested
+    @DisplayName("Character Growth read를 구성할 때")
+    class CharacterBoundary {
+
+        @Test
+        @DisplayName("Reward Internal API만 의존하고 Reward entity/repository/infra를 참조하지 않는다")
+        void dependsOnlyOnRewardInternalApi() {
+            assertThat(fieldTypes(GrowthQueryService.class))
+                    .containsExactlyInAnyOrder(
+                            CurrentPlayerAccessor.class,
+                            PlayerReader.class,
+                            GrowthQuery.class,
+                            RewardGrowthSourceReadApi.class
+                    );
+            Set<Class<?>> rewardDependencies = Arrays.stream(
+                            GrowthQueryService.class.getDeclaredFields()
+                    ).map(Field::getType)
+                    .filter(type -> type.getPackageName().startsWith("online.lifeasgame.reward"))
+                    .collect(Collectors.toSet());
+            assertThat(rewardDependencies).containsExactly(RewardGrowthSourceReadApi.class);
+            assertThat(fieldTypes(GrowthQueryAdapter.class)).containsExactly(JPAQueryFactory.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("Reward provenance provider를 구성할 때")
+    class RewardBoundary {
+
+        @Test
+        @DisplayName("Reward가 provider를 구현하며 Character Growth에 역의존하지 않는다")
+        void remainsRewardOwnedWithoutReadCycle() {
+            assertThat(RewardGrowthSourceReadApi.class
+                    .isAssignableFrom(RewardGrowthSourceReadAdapter.class)).isTrue();
+            assertThat(fieldTypes(RewardGrowthSourceReadAdapter.class))
+                    .containsExactly(JPAQueryFactory.class);
+            assertThat(Arrays.stream(RewardGrowthSourceReadAdapter.class.getDeclaredFields())
+                    .map(Field::getType)
+                    .noneMatch(type -> type.getPackageName().startsWith(
+                            "online.lifeasgame.character"
+                    ))).isTrue();
+        }
+    }
+
+    private static Set<Class<?>> fieldTypes(Class<?> type) {
+        return Arrays.stream(type.getDeclaredFields())
+                .filter(field -> !field.isSynthetic())
+                .filter(field -> !Modifier.isStatic(field.getModifiers()))
+                .map(Field::getType)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/test/java/online/lifeasgame/character/application/GrowthQueryIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/character/application/GrowthQueryIntegrationTest.java
@@ -1,0 +1,173 @@
+package online.lifeasgame.character.application;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import online.lifeasgame.character.application.result.GrowthResult;
+import online.lifeasgame.character.domain.GenderType;
+import online.lifeasgame.character.domain.Name;
+import online.lifeasgame.character.domain.Player;
+import online.lifeasgame.character.domain.growth.PlayerGrowthChange;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest(properties = {
+        "spring.jpa.properties.hibernate.generate_statistics=true",
+        "spring.datasource.url=jdbc:h2:mem:growth-query-264;MODE=MySQL;DB_CLOSE_DELAY=-1"
+})
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("Growth bounded read integration")
+class GrowthQueryIntegrationTest {
+
+    private static final Instant SAME_TIME = Instant.parse("2026-08-13T00:00:00Z");
+
+    @Autowired
+    private GrowthQueryService service;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @MockitoBean
+    private CurrentPlayerAccessor currentPlayerAccessor;
+
+    @Nested
+    @DisplayName("current Player의 history를 읽을 때")
+    class CurrentPlayerHistory {
+
+        @Test
+        @DisplayName("player를 격리하고 같은 timestamp에서는 id DESC로 최근 20개만 반환한다")
+        void isolatesPlayerAndBoundsStableOrdering() {
+            Player current = persistPlayer(26401L, "current");
+            Player other = persistPlayer(26402L, "other");
+            given(currentPlayerAccessor.currentPlayerIdOrThrow()).willReturn(current.getId());
+
+            List<Long> currentIds = new ArrayList<>();
+            for (int index = 0; index < 22; index++) {
+                currentIds.add(persistChange(current.getId(), 10_000L + index, index * 10L).getId());
+            }
+            Long otherChangeId = persistChange(other.getId(), 20_000L, 0).getId();
+            entityManager.flush();
+            jdbcTemplate.update(
+                    "UPDATE player_growth_changes SET created_at = ?",
+                    SAME_TIME
+            );
+            Statistics statistics = statistics();
+            statistics.clear();
+
+            List<GrowthResult.RecentExpChange> result = service
+                    .getCurrentGrowth().recentExpChanges();
+
+            assertThat(result).hasSize(20);
+            assertThat(result).extracting(GrowthResult.RecentExpChange::changeId)
+                    .containsExactlyElementsOf(currentIds.reversed().subList(0, 20))
+                    .doesNotContain(otherChangeId, currentIds.get(0), currentIds.get(1));
+            assertThat(result).extracting(GrowthResult.RecentExpChange::occurredAt)
+                    .containsOnly(SAME_TIME);
+            assertThat(statistics.getPrepareStatementCount()).isLessThanOrEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("Reward source를 한 query로 조합하고 전체 read를 세 query 이내로 유지한다")
+        void composesProvenanceWithinThreeQueries() {
+            Player current = persistPlayer(26403L, "query-budget");
+            given(currentPlayerAccessor.currentPlayerIdOrThrow()).willReturn(current.getId());
+            Long sourcedLineId = insertQuestCompletionRewardLine(current.getId(), 880L);
+            PlayerGrowthChange missing = persistChange(current.getId(), 30_000L, 0);
+            PlayerGrowthChange sourced = persistChange(current.getId(), sourcedLineId, 10);
+            entityManager.flush();
+            Statistics statistics = statistics();
+            statistics.clear();
+
+            List<GrowthResult.RecentExpChange> result = service
+                    .getCurrentGrowth().recentExpChanges();
+
+            assertThat(result).hasSize(2);
+            GrowthResult.RecentExpChange sourcedResult = result.stream()
+                    .filter(change -> change.changeId().equals(sourced.getId()))
+                    .findFirst()
+                    .orElseThrow();
+            GrowthResult.RecentExpChange missingResult = result.stream()
+                    .filter(change -> change.changeId().equals(missing.getId()))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(sourcedResult.sourceType()).isEqualTo("QUEST_COMPLETION");
+            assertThat(sourcedResult.sourceId()).isEqualTo(880L);
+            assertThat(missingResult.sourceType()).isNull();
+            assertThat(missingResult.sourceId()).isNull();
+            assertThat(statistics.getPrepareStatementCount()).isLessThanOrEqualTo(3);
+        }
+    }
+
+    private Player persistPlayer(Long userId, String name) {
+        Player player = Player.linkStart(userId, Name.of(name), GenderType.MALE);
+        entityManager.persist(player);
+        entityManager.flush();
+        return player;
+    }
+
+    private Statistics statistics() {
+        return entityManagerFactory.unwrap(SessionFactory.class).getStatistics();
+    }
+
+    private PlayerGrowthChange persistChange(Long playerId, Long rewardLineId, long beforeExp) {
+        Player.GainResult gain = new Player.GainResult(
+                10, 10, 0, 1, 1, beforeExp, beforeExp + 10,
+                0, 0, 0, 0
+        );
+        PlayerGrowthChange change = PlayerGrowthChange.rewardExp(playerId, rewardLineId, gain);
+        entityManager.persist(change);
+        entityManager.flush();
+        return change;
+    }
+
+    private Long insertQuestCompletionRewardLine(Long playerId, Long acceptanceId) {
+        jdbcTemplate.update("""
+                INSERT INTO reward_settlements (
+                    player_id, source_type, source_id,
+                    reward_profile_id, reward_profile_code, status,
+                    created_at, updated_at
+                ) VALUES (?, 'QUEST_COMPLETION', ?, 1, 'TEST', 'COMPLETED', ?, ?)
+                """, playerId, acceptanceId, SAME_TIME, SAME_TIME);
+        Long settlementId = jdbcTemplate.queryForObject(
+                "SELECT id FROM reward_settlements WHERE player_id = ? AND source_id = ?",
+                Long.class,
+                playerId,
+                acceptanceId
+        );
+        jdbcTemplate.update("""
+                INSERT INTO reward_settlement_lines (
+                    reward_settlement_id, reward_definition_id,
+                    reward_definition_code, reward_type, amount,
+                    sort_order, status, created_at, updated_at
+                ) VALUES (?, 1, 'EXP_TEST', 'EXP', 10, 0, 'SUCCEEDED', ?, ?)
+                """, settlementId, SAME_TIME, SAME_TIME);
+        return jdbcTemplate.queryForObject(
+                "SELECT id FROM reward_settlement_lines WHERE reward_settlement_id = ?",
+                Long.class,
+                settlementId
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/character/application/GrowthQueryServiceTest.java
+++ b/src/test/java/online/lifeasgame/character/application/GrowthQueryServiceTest.java
@@ -1,0 +1,172 @@
+package online.lifeasgame.character.application;
+
+import online.lifeasgame.character.application.query.GrowthQuery;
+import online.lifeasgame.character.application.result.GrowthResult;
+import online.lifeasgame.character.domain.CoreStatDelta;
+import online.lifeasgame.character.domain.GenderType;
+import online.lifeasgame.character.domain.Name;
+import online.lifeasgame.character.domain.Player;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.reward.application.internal.RewardGrowthSourceReadApi;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Growth query composition")
+class GrowthQueryServiceTest {
+
+    private static final Long PLAYER_ID = 264L;
+    private static final Instant OCCURRED_AT = Instant.parse("2026-08-13T00:00:00Z");
+
+    @Mock
+    private CurrentPlayerAccessor currentPlayerAccessor;
+
+    @Mock
+    private PlayerReader playerReader;
+
+    @Mock
+    private GrowthQuery growthQuery;
+
+    @Mock
+    private RewardGrowthSourceReadApi rewardGrowthSourceReadApi;
+
+    @Captor
+    private ArgumentCaptor<Set<Long>> rewardLineIdsCaptor;
+
+    @InjectMocks
+    private GrowthQueryService service;
+
+    @Nested
+    @DisplayName("현재 성장 상태를 조회할 때")
+    class CurrentGrowth {
+
+        @Test
+        @DisplayName("Player의 authoritative EXP와 stats를 그대로 반환한다")
+        void returnsExactCurrentSnapshot() {
+            Player player = player();
+            player.grantCoreStats(new CoreStatDelta(1, 2, 3, 4, 5, 6));
+            player.changeRepresentativeTitle(77L);
+            givenCurrentPlayer(player);
+            given(growthQuery.findRecentExpChanges(PLAYER_ID, 20)).willReturn(List.of());
+
+            GrowthResult.Current current = service.getCurrentGrowth().current();
+
+            assertThat(current).isEqualTo(new GrowthResult.Current(
+                    1, 0, 2, 3, 4, 5, 6, 7, Map.of(), 77L
+            ));
+        }
+
+        @Test
+        @DisplayName("history가 없으면 빈 목록이며 Reward provider를 호출하지 않는다")
+        void returnsEmptyHistoryWithoutProviderQuery() {
+            givenCurrentPlayer(player());
+            given(growthQuery.findRecentExpChanges(PLAYER_ID, 20)).willReturn(List.of());
+
+            assertThat(service.getCurrentGrowth().recentExpChanges()).isEmpty();
+
+            verifyNoInteractions(rewardGrowthSourceReadApi);
+        }
+    }
+
+    @Nested
+    @DisplayName("최근 EXP 변경을 조합할 때")
+    class RecentExpChanges {
+
+        @Test
+        @DisplayName("SQL query boundary에 고정 limit 20을 전달한다")
+        void requestsFixedSqlLimit() {
+            givenCurrentPlayer(player());
+            given(growthQuery.findRecentExpChanges(PLAYER_ID, 20)).willReturn(List.of());
+
+            service.getCurrentGrowth();
+
+            verify(growthQuery).findRecentExpChanges(PLAYER_ID, 20);
+        }
+
+        @Test
+        @DisplayName("중복을 제거한 rewardLineId를 한 번에 조회하고 provenance를 붙인다")
+        void resolvesUniqueRewardLinesOnce() {
+            givenCurrentPlayer(player());
+            List<GrowthQuery.RecentExpChange> changes = List.of(
+                    change(2L, 22L),
+                    change(1L, 22L)
+            );
+            given(growthQuery.findRecentExpChanges(PLAYER_ID, 20)).willReturn(changes);
+            given(rewardGrowthSourceReadApi.findAllByRewardLineIds(Set.of(22L)))
+                    .willReturn(List.of(new RewardGrowthSourceReadApi.RewardGrowthSource(
+                            22L, "QUEST_COMPLETION", 222L
+                    )));
+
+            List<GrowthResult.RecentExpChange> result = service
+                    .getCurrentGrowth().recentExpChanges();
+
+            verify(rewardGrowthSourceReadApi)
+                    .findAllByRewardLineIds(rewardLineIdsCaptor.capture());
+            assertThat(rewardLineIdsCaptor.getValue()).containsExactly(22L);
+            assertThat(result).extracting(GrowthResult.RecentExpChange::changeId)
+                    .containsExactly(2L, 1L);
+            assertThat(result).allSatisfy(change -> {
+                assertThat(change.sourceType()).isEqualTo("QUEST_COMPLETION");
+                assertThat(change.sourceId()).isEqualTo(222L);
+            });
+        }
+
+        @Test
+        @DisplayName("Reward source가 없어도 Growth row를 null provenance로 보존한다")
+        void keepsGrowthWhenSourceIsMissing() {
+            givenCurrentPlayer(player());
+            given(growthQuery.findRecentExpChanges(PLAYER_ID, 20))
+                    .willReturn(List.of(change(1L, 11L)));
+            given(rewardGrowthSourceReadApi.findAllByRewardLineIds(Set.of(11L)))
+                    .willReturn(List.of());
+
+            GrowthResult.RecentExpChange result = service
+                    .getCurrentGrowth().recentExpChanges().getFirst();
+
+            assertThat(result.changeId()).isEqualTo(1L);
+            assertThat(result.sourceType()).isNull();
+            assertThat(result.sourceId()).isNull();
+        }
+    }
+
+    private void givenCurrentPlayer(Player player) {
+        given(currentPlayerAccessor.currentPlayerIdOrThrow()).willReturn(PLAYER_ID);
+        given(playerReader.getByIdOrThrow(PLAYER_ID)).willReturn(player);
+    }
+
+    private Player player() {
+        return Player.linkStart(1L, Name.of("player"), GenderType.MALE);
+    }
+
+    private GrowthQuery.RecentExpChange change(Long changeId, Long rewardLineId) {
+        return new GrowthQuery.RecentExpChange(
+                changeId,
+                rewardLineId,
+                10,
+                10,
+                0,
+                1,
+                1,
+                0,
+                10,
+                OCCURRED_AT
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -197,7 +197,7 @@ class FlywayMigrationTest {
                     new QuestAcceptanceFactContextColumns(
                             "NO",
                             "YES",
-                            16
+                            20
                     )
             );
             assertThat(legacyQuestAcceptedAt()).isEqualTo(


### PR DESCRIPTION
## Purpose

Expose the Current Player's authoritative growth snapshot and a bounded recent EXP-change history.

## Delivered

- `GET /api/v1/players/growth`
- current level / EXP / stat snapshot
- bounded recent EXP changes
- deterministic recent ordering
- Reward-owned source provenance read boundary
- nullable legacy provenance handling
- Current Player isolation
- bounded query behavior

## Growth contract

Current snapshot exposes:

- level
- exp
- core stats
- extra stats
- representativeTitleId

Recent EXP changes expose:

- changeId
- requestedExp
- appliedExp
- leftoverExp
- beforeLevel / afterLevel
- beforeTotalExp / afterTotalExp
- occurredAt
- sourceType / sourceId

Internal `rewardLineId` is not part of the public response.

## Ordering / performance

Recent changes are:

1. `createdAt DESC`
2. `id DESC`

The server applies the fixed recent limit in SQL.

Reward provenance is resolved in batch without N+1 queries.

## Architecture

Character owns the Growth read model.

Reward source information is consumed only through a Reward-owned Internal API.

Character Growth does not depend on Reward entities, repositories, or persistence adapters.

## Product boundaries

- read-only Growth surface
- no Role stats
- no ranking/streak/balance score
- no Quest-title inference
- no Achievement auto-grant logic
- existing EXP grant/replay behavior unchanged

## Existing contracts

Existing Player, Achievement, Title, Equipment, Certification, and Hobby API response shapes remain unchanged.

## Tests

Coverage includes:

- Current Player isolation
- exact current snapshot
- bounded recent history
- deterministic tie-break
- source batch enrichment
- missing provenance
- query budget
- API/auth contract
- cross-context architecture
- EXP/reward regressions

## Validation

- classes/testClasses
- targeted tests
- relevant regressions
- final build

Closes #264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated player growth endpoint.
  * Players can view current level, experience, stats, extra stats, representative title, and recent experience changes.
  * Recent changes include level transitions, experience details, timestamps, and available source information.

* **Bug Fixes**
  * Increased the maximum length of quest acceptance period keys from 16 to 20 characters.

* **Tests**
  * Added coverage for authentication, response data, history limits, ordering, player isolation, and missing source information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->