### PR TITLE
[LifeLog] Normalize optional Media episode progress

### DIFF
--- a/src/main/java/online/lifeasgame/lifelog/domain/EpisodeProgress.java
+++ b/src/main/java/online/lifeasgame/lifelog/domain/EpisodeProgress.java
@@ -28,8 +28,12 @@ public class EpisodeProgress {
         this.total = total;
     }
 
-    public static EpisodeProgress of(int current, int total) {
-        return new EpisodeProgress(current, total);
+    public static EpisodeProgress of(Integer current, Integer total) {
+        int normalizedCurrent = current == null ? 0 : current;
+        int normalizedTotal = total == null
+                ? Math.max(1, normalizedCurrent)
+                : total;
+        return new EpisodeProgress(normalizedCurrent, normalizedTotal);
     }
 
     public EpisodeProgress advance(int step) {

--- a/src/test/java/online/lifeasgame/lifelog/application/LifeLogRecordedApplicationServiceTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/application/LifeLogRecordedApplicationServiceTest.java
@@ -36,6 +36,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -175,7 +176,7 @@ class LifeLogRecordedApplicationServiceTest {
     }
 
     @Test
-    @DisplayName("Media content-ready direct create도 Fact를 정확히 한 번 발행한다")
+    @DisplayName("progress를 생략한 Media direct create도 0/1 Source와 Fact를 한 번 만든다")
     void recordsMediaCreateOnce() {
         MediaLogReader reader = mock(MediaLogReader.class);
         MediaLogWriter writer = mock(MediaLogWriter.class);
@@ -211,8 +212,8 @@ class LifeLogRecordedApplicationServiceTest {
                         "MOVIE",
                         "Private media title",
                         "Private original title",
-                        0,
-                        1,
+                        null,
+                        null,
                         "PLANNED",
                         Set.of("private-tag"),
                         new LifeLogRecordMetadataCommand("STUDY", null)
@@ -221,6 +222,10 @@ class LifeLogRecordedApplicationServiceTest {
 
         assertThat(result.id()).isEqualTo(103L);
         assertThat(result.lifeLogId()).isEqualTo(1003L);
+        verify(writer).create(argThat(media ->
+                media.getProgress().current() == 0
+                        && media.getProgress().total() == 1
+        ));
         assertRecorded(
                 publisher.events(),
                 1003L,

--- a/src/test/java/online/lifeasgame/lifelog/domain/EpisodeProgressTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/domain/EpisodeProgressTest.java
@@ -1,0 +1,97 @@
+package online.lifeasgame.lifelog.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("EpisodeProgress optional binding")
+class EpisodeProgressTest {
+
+    @Nested
+    @DisplayName("create 입력을 정규화할 때")
+    class NormalizeCreateInput {
+
+        @Test
+        @DisplayName("current와 total이 모두 없으면 0/1이다")
+        void defaultsBoth() {
+            assertProgress(EpisodeProgress.of(null, null), 0, 1);
+        }
+
+        @Test
+        @DisplayName("total만 있으면 0/T이다")
+        void defaultsCurrent() {
+            assertProgress(EpisodeProgress.of(null, 12), 0, 12);
+        }
+
+        @Test
+        @DisplayName("current 0만 있으면 0/1이다")
+        void defaultsTotalForZeroCurrent() {
+            assertProgress(EpisodeProgress.of(0, null), 0, 1);
+        }
+
+        @Test
+        @DisplayName("양수 current만 있으면 C/C이다")
+        void defaultsTotalToCurrent() {
+            assertProgress(EpisodeProgress.of(7, null), 7, 7);
+        }
+
+        @Test
+        @DisplayName("둘 다 있으면 값을 그대로 보존한다")
+        void preservesExplicitProgress() {
+            assertProgress(EpisodeProgress.of(3, 10), 3, 10);
+        }
+
+        @Test
+        @DisplayName("current가 supplied total보다 크면 기존 invariant 실패다")
+        void rejectsCurrentAboveTotal() {
+            assertThatThrownBy(() -> EpisodeProgress.of(4, 3))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("current > total");
+        }
+    }
+
+    @Nested
+    @DisplayName("기존 Media 동작을 사용할 때")
+    class ExistingMediaBehavior {
+
+        @Test
+        @DisplayName("normal create/update/advance의 명시적 progress 의미를 보존한다")
+        void preservesCreateUpdateAndAdvance() {
+            MediaLog media = MediaLog.create(
+                    266L,
+                    MediaCategory.MOVIE,
+                    Title.of("title", null),
+                    EpisodeProgress.of(1, 4),
+                    WatchStatus.PLANNED,
+                    MediaTags.of(Set.of())
+            );
+            media.update(
+                    MediaCategory.MOVIE,
+                    Title.of("updated", null),
+                    EpisodeProgress.of(2, 5),
+                    WatchStatus.WATCHING,
+                    MediaTags.of(Set.of())
+            );
+
+            media.advanceEpisode(2);
+
+            assertProgress(media.getProgress(), 4, 5);
+            assertThat(media.getStatus()).isEqualTo(WatchStatus.WATCHING);
+            assertThat(media.getTitle().value()).isEqualTo("updated");
+        }
+    }
+
+    private static void assertProgress(
+            EpisodeProgress progress,
+            int current,
+            int total
+    ) {
+        assertThat(progress.current()).isEqualTo(current);
+        assertThat(progress.total()).isEqualTo(total);
+    }
+}

--- a/src/test/java/online/lifeasgame/lifelog/quick/application/QuickRecordServiceIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/quick/application/QuickRecordServiceIntegrationTest.java
@@ -214,6 +214,52 @@ class QuickRecordServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("Media progress 생략은 0/1로 저장하고 같은 요청을 replay한다")
+    void normalizesOmittedMediaProgressAndReplays() {
+        QuickRecordCommand.Create command = mediaCommand(
+                "Omitted progress",
+                null,
+                null
+        );
+
+        QuickRecordResult.Recorded first = quickRecordService.record(
+                PLAYER_ID,
+                "media-omitted-progress",
+                command
+        );
+        QuickRecordResult.Recorded replay = quickRecordService.record(
+                PLAYER_ID,
+                "media-omitted-progress",
+                command
+        );
+
+        assertFirstResult(first, LifeLogType.MEDIA);
+        assertThat(replay.replay()).isTrue();
+        assertSameSnapshot(first, replay);
+        assertThat(mediaProgress(first.sourceId()))
+                .isEqualTo(new StoredMediaProgress(0, 1));
+        assertThat(count("media_logs")).isEqualTo(1);
+        assertThat(count("life_log_records")).isEqualTo(1);
+        assertThat(receiptCount()).isEqualTo(1);
+        assertThat(outboxCount(RECORDED_ALIAS)).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("Media current만 있으면 C/C로 저장한다")
+    void normalizesCurrentOnlyMediaProgress() {
+        QuickRecordResult.Recorded result = quickRecordService.record(
+                PLAYER_ID,
+                "media-current-only",
+                mediaCommand("Current only", 4, null)
+        );
+
+        assertFirstResult(result, LifeLogType.MEDIA);
+        assertThat(mediaProgress(result.sourceId()))
+                .isEqualTo(new StoredMediaProgress(4, 4));
+        assertThat(count("life_log_records")).isEqualTo(1);
+    }
+
+    @Test
     @DisplayName("동일 key와 payload 순차 replay는 subtype create와 Event를 반복하지 않는다")
     void replaysSequentially() {
         QuickRecordCommand.Create command =
@@ -533,6 +579,14 @@ class QuickRecordServiceIntegrationTest {
     }
 
     private QuickRecordCommand.Create mediaCommand(String title) {
+        return mediaCommand(title, 0, 1);
+    }
+
+    private QuickRecordCommand.Create mediaCommand(
+            String title,
+            Integer currentEpisode,
+            Integer totalEpisode
+    ) {
         return new QuickRecordCommand.Create(
                 "MEDIA",
                 null,
@@ -541,11 +595,26 @@ class QuickRecordServiceIntegrationTest {
                         "MOVIE",
                         title,
                         "Private original",
-                        0,
-                        1,
+                        currentEpisode,
+                        totalEpisode,
                         "PLANNED",
                         Set.of("private-tag")
                 )
+        );
+    }
+
+    private StoredMediaProgress mediaProgress(Long mediaId) {
+        return jdbcTemplate.queryForObject(
+                """
+                SELECT progress_current, progress_total
+                FROM media_logs
+                WHERE id = ?
+                """,
+                (resultSet, rowNumber) -> new StoredMediaProgress(
+                        resultSet.getInt("progress_current"),
+                        resultSet.getInt("progress_total")
+                ),
+                mediaId
         );
     }
 
@@ -557,6 +626,9 @@ class QuickRecordServiceIntegrationTest {
         assertThat(result.sourceId()).isPositive();
         assertThat(result.recordedAt()).isEqualTo(RECORDED_AT);
         assertThat(result.replay()).isFalse();
+    }
+
+    private record StoredMediaProgress(int current, int total) {
     }
 
     private void assertSameSnapshot(


### PR DESCRIPTION
## Body

### Purpose

Close the Media create / Quick Record contract-integrity gap where optional episode progress could reach the non-null `EpisodeProgress` model as null.

Closes #266

### Delivered

- normalized optional Media episode progress at one backend semantic boundary
- preserved the existing optional request contract
- removed the valid-request null-unboxing failure path
- applied the same normalization policy to normal Media create and Quick Record
- preserved canonical LifeLog registration and Quick Record idempotency/replay

### Normalization Contract

```text
null / null -> 0 / 1
null / T    -> 0 / T
C / null    -> C / max(1, C)
C / T       -> exact C / T
```

Existing `current <= total` domain validation remains authoritative.

### Architecture

Normalization is owned by one cohesive backend boundary rather than duplicated across Controller, Mapper, and Service layers.

### Scope Boundaries

- no frontend workaround
- no player/user identity changes
- no Quick Record source-type changes
- no unrelated Media CRUD redesign
- no schema migration unless required by the final audited implementation

### Validation

Focused validation only:

- compact normalization matrix
- invalid supplied-pair invariant
- Quick Record MEDIA with omitted progress
- final build

Existing coverage is reused for unrelated idempotency/replay and Media regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Episode progress can now be omitted when recording media.
  * Missing progress defaults to the beginning of an episode: current `0` of total `1`.
  * Providing only part of the progress information is supported with sensible defaults.
* **Bug Fixes**
  * Progress values are normalized consistently when creating, updating, or advancing media entries.
  * Invalid progress, such as a current value greater than the total, continues to be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->