### PR TITLE
[Achievement] Add Current Player acquired Achievement detail

### DIFF
--- a/src/main/java/online/lifeasgame/character/api/player/PlayerAchievementController.java
+++ b/src/main/java/online/lifeasgame/character/api/player/PlayerAchievementController.java
@@ -10,6 +10,7 @@ import online.lifeasgame.core.response.ApiResponse;
 import online.lifeasgame.platform.web.response.ApiResponses;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,5 +28,14 @@ public class PlayerAchievementController implements PlayerAchievementApiSpecV1 {
     public ResponseEntity<ApiResponse<PlayerAchievementResponse.Infos>> playerAchievementInfos() {
         List<PlayerAchievementResult.Info> results = playerAchievementService.getPlayerAchievementInfos();
         return ApiResponses.ok(PlayerAchievementWebMapper.toInfos(results));
+    }
+
+    @Override
+    @GetMapping("/achievements/{achievementId}")
+    public ResponseEntity<ApiResponse<PlayerAchievementResponse.Info>> playerAchievementInfo(
+            @PathVariable Long achievementId
+    ) {
+        PlayerAchievementResult.Info result = playerAchievementService.getPlayerAchievementInfo(achievementId);
+        return ApiResponses.ok(PlayerAchievementWebMapper.toInfo(result));
     }
 }

--- a/src/main/java/online/lifeasgame/character/api/player/spec/PlayerAchievementApiSpecV1.java
+++ b/src/main/java/online/lifeasgame/character/api/player/spec/PlayerAchievementApiSpecV1.java
@@ -11,4 +11,7 @@ public interface PlayerAchievementApiSpecV1 {
 
     @Operation(summary = "Player 보유 업적 목록", description = "사용자가 보유한 업적 목록을 출력합니다.")
     ResponseEntity<ApiResponse<PlayerAchievementResponse.Infos>> playerAchievementInfos();
+
+    @Operation(summary = "Player 보유 업적 상세", description = "사용자가 보유한 업적 상세를 출력합니다.")
+    ResponseEntity<ApiResponse<PlayerAchievementResponse.Info>> playerAchievementInfo(Long achievementId);
 }

--- a/src/main/java/online/lifeasgame/character/application/PlayerAchievementReader.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerAchievementReader.java
@@ -3,6 +3,8 @@ package online.lifeasgame.character.application;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.character.application.query.PlayerAchievementQuery;
 import online.lifeasgame.character.application.view.PlayerAchievementView;
+import online.lifeasgame.character.domain.error.AchievementError;
+import online.lifeasgame.core.error.DomainException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,7 +22,11 @@ class PlayerAchievementReader {
         return query.findViewsByPlayerId(playerId);
     }
 
-    public void getByPlayerId(Long playerId) {
-
+    public PlayerAchievementView getViewByPlayerIdAndAchievementIdOrThrow(
+            Long playerId,
+            Long achievementId
+    ) {
+        return query.findViewByPlayerIdAndAchievementId(playerId, achievementId)
+                .orElseThrow(() -> new DomainException(AchievementError.ACHIEVEMENT_NOT_FOUND));
     }
 }

--- a/src/main/java/online/lifeasgame/character/application/PlayerAchievementService.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerAchievementService.java
@@ -32,6 +32,17 @@ public class PlayerAchievementService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
+    public PlayerAchievementResult.Info getPlayerAchievementInfo(Long achievementId) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        return PlayerAchievementResult.Info.from(
+                playerAchievementReader.getViewByPlayerIdAndAchievementIdOrThrow(
+                        playerId,
+                        achievementId
+                )
+        );
+    }
+
     @Transactional
     public PlayerAchievementResult.Granted grantAchievement(Long playerId, Long achievementId) {
         playerReader.assertExistsById(playerId);

--- a/src/main/java/online/lifeasgame/character/application/query/PlayerAchievementQuery.java
+++ b/src/main/java/online/lifeasgame/character/application/query/PlayerAchievementQuery.java
@@ -3,7 +3,10 @@ package online.lifeasgame.character.application.query;
 import online.lifeasgame.character.application.view.PlayerAchievementView;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PlayerAchievementQuery {
     List<PlayerAchievementView> findViewsByPlayerId(Long playerId);
+
+    Optional<PlayerAchievementView> findViewByPlayerIdAndAchievementId(Long playerId, Long achievementId);
 }

--- a/src/main/java/online/lifeasgame/character/infra/JpaPlayerAchievementRepository.java
+++ b/src/main/java/online/lifeasgame/character/infra/JpaPlayerAchievementRepository.java
@@ -1,6 +1,7 @@
 package online.lifeasgame.character.infra;
 
 import java.util.List;
+import java.util.Optional;
 import online.lifeasgame.character.application.view.PlayerAchievementView;
 import online.lifeasgame.character.domain.PlayerAchievement;
 import org.springframework.data.domain.Pageable;
@@ -23,6 +24,24 @@ public interface JpaPlayerAchievementRepository extends JpaRepository<PlayerAchi
                 ORDER BY pa.acquiredAt DESC, pa.id DESC
         """)
     List<PlayerAchievementView> findPlayerAchievementViews(Long playerId);
+
+    @Query(
+            """
+                SELECT t.id AS achievementId,
+                       t.code AS code,
+                       t.name AS name,
+                       t.category AS category,
+                       t.descMd AS descMd,
+                       pa.acquiredAt AS acquiredAt
+                FROM PlayerAchievement pa
+                JOIN Achievement t ON t.id = pa.achievementId
+                WHERE pa.playerId = :playerId
+                  AND pa.achievementId = :achievementId
+        """)
+    Optional<PlayerAchievementView> findViewByPlayerIdAndAchievementId(
+            Long playerId,
+            Long achievementId
+    );
 
     @Query(
             """

--- a/src/main/java/online/lifeasgame/character/infra/PlayerAchievementRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/character/infra/PlayerAchievementRepositoryAdapter.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -33,6 +34,17 @@ public class PlayerAchievementRepositoryAdapter implements
     @Override
     public List<PlayerAchievementView> findViewsByPlayerId(Long playerId) {
         return jpaRepository.findPlayerAchievementViews(playerId);
+    }
+
+    @Override
+    public Optional<PlayerAchievementView> findViewByPlayerIdAndAchievementId(
+            Long playerId,
+            Long achievementId
+    ) {
+        return jpaRepository.findViewByPlayerIdAndAchievementId(
+                playerId,
+                achievementId
+        );
     }
 
     @Override

--- a/src/test/java/online/lifeasgame/character/api/player/PlayerAchievementApiContractTest.java
+++ b/src/test/java/online/lifeasgame/character/api/player/PlayerAchievementApiContractTest.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -99,6 +100,41 @@ class PlayerAchievementApiContractTest {
         void requiresAuthentication() throws Exception {
             mockMvc.perform(get("/api/v1/players/achievements"))
                     .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("현재 Player의 획득 업적 상세를 조회할 때")
+    class ReadAchievement {
+
+        @Test
+        @DisplayName("인증된 exact path에서 caller identity 없이 기존 여섯 필드만 반환한다")
+        void returnsExactOwnedDetailContract() throws Exception {
+            given(playerAchievementService.getPlayerAchievementInfo(260L))
+                    .willReturn(new PlayerAchievementResult.Info(
+                            260L,
+                            "HOME_FIRST",
+                            "첫 Home",
+                            "STORY",
+                            "Home feed 업적",
+                            ACQUIRED_AT
+                    ));
+
+            assertThat(PlayerAchievementController.class
+                    .getDeclaredMethod("playerAchievementInfo", Long.class)
+                    .getParameterCount()).isEqualTo(1);
+
+            mockMvc.perform(get("/api/v1/players/achievements/{achievementId}", 260L)
+                            .with(authentication(playerAuthentication())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result.*", hasSize(6)))
+                    .andExpect(jsonPath("$.result.achievementId").value(260))
+                    .andExpect(jsonPath("$.result.code").value("HOME_FIRST"))
+                    .andExpect(jsonPath("$.result.name").value("첫 Home"))
+                    .andExpect(jsonPath("$.result.category").value("STORY"))
+                    .andExpect(jsonPath("$.result.descMd").value("Home feed 업적"))
+                    .andExpect(jsonPath("$.result.acquiredAt")
+                            .value("2026-08-12T00:00:00Z"));
         }
     }
 

--- a/src/test/java/online/lifeasgame/character/application/AchievementProgressReadIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/character/application/AchievementProgressReadIntegrationTest.java
@@ -4,10 +4,14 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import online.lifeasgame.character.application.internal.AchievementProgressReadApi;
 import online.lifeasgame.character.application.query.PlayerAchievementQuery;
+import online.lifeasgame.character.application.result.PlayerAchievementResult;
 import online.lifeasgame.character.application.view.PlayerAchievementView;
 import online.lifeasgame.character.domain.Achievement;
 import online.lifeasgame.character.domain.AchievementCategory;
 import online.lifeasgame.character.domain.PlayerAchievement;
+import online.lifeasgame.character.domain.error.AchievementError;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
 import org.hibernate.SessionFactory;
 import org.hibernate.stat.Statistics;
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Timestamp;
@@ -24,6 +29,8 @@ import java.time.Instant;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
 
 @SpringBootTest(properties =
         "spring.jpa.properties.hibernate.generate_statistics=true")
@@ -44,6 +51,9 @@ class AchievementProgressReadIntegrationTest {
     private PlayerAchievementQuery playerAchievementQuery;
 
     @Autowired
+    private PlayerAchievementService playerAchievementService;
+
+    @Autowired
     private EntityManager entityManager;
 
     @Autowired
@@ -51,6 +61,54 @@ class AchievementProgressReadIntegrationTest {
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
+
+    @MockitoBean
+    private CurrentPlayerAccessor currentPlayerAccessor;
+
+    @Nested
+    @DisplayName("현재 Player의 획득 업적 상세를 조회할 때")
+    class OwnedDetail {
+
+        @Test
+        @DisplayName("보유 상세만 한 query로 반환하고 다른 Player 및 미획득 catalog 업적은 숨긴다")
+        void returnsOnlyOwnedAchievementInOneQuery() {
+            Acquisition owned = acquire(
+                    PLAYER_ID, "OWNED", "보유", ACQUIRED_AT
+            );
+            Acquisition otherOwned = acquire(
+                    OTHER_PLAYER_ID, "OTHER_OWNED", "다른 Player 보유", ACQUIRED_AT
+            );
+            Achievement notAcquired = Achievement.create(
+                    "NOT_ACQUIRED",
+                    "미획득",
+                    AchievementCategory.STORY,
+                    "미획득 설명"
+            );
+            entityManager.persist(notAcquired);
+            flushAndClear();
+            given(currentPlayerAccessor.currentPlayerIdOrThrow())
+                    .willReturn(PLAYER_ID);
+            Statistics statistics = statistics();
+            statistics.clear();
+
+            PlayerAchievementResult.Info result =
+                    playerAchievementService.getPlayerAchievementInfo(
+                            owned.achievementId()
+                    );
+
+            assertThat(result).isEqualTo(new PlayerAchievementResult.Info(
+                    owned.achievementId(),
+                    "OWNED",
+                    "보유",
+                    "STORY",
+                    "OWNED 설명",
+                    ACQUIRED_AT
+            ));
+            assertThat(statistics.getPrepareStatementCount()).isEqualTo(1);
+            assertOwnedDetailNotFound(otherOwned.achievementId());
+            assertOwnedDetailNotFound(notAcquired.getId());
+        }
+    }
 
     @Nested
     @DisplayName("획득 업적이 없을 때")
@@ -189,6 +247,20 @@ class AchievementProgressReadIntegrationTest {
         return entityManagerFactory
                 .unwrap(SessionFactory.class)
                 .getStatistics();
+    }
+
+    private void assertOwnedDetailNotFound(Long achievementId) {
+        Statistics statistics = statistics();
+        statistics.clear();
+
+        assertThatThrownBy(() -> playerAchievementService
+                .getPlayerAchievementInfo(achievementId))
+                .isInstanceOfSatisfying(
+                        DomainException.class,
+                        exception -> assertThat(exception.getErrorCode())
+                                .isEqualTo(AchievementError.ACHIEVEMENT_NOT_FOUND)
+                );
+        assertThat(statistics.getPrepareStatementCount()).isEqualTo(1);
     }
 
     private void flushAndClear() {


### PR DESCRIPTION
### Purpose

Add a canonical Current Player detail boundary for an Achievement the player has actually acquired.

Closes #268

### Delivered

- `GET /api/v1/players/achievements/{achievementId}`
- Current Player ownership-aware acquired detail
- single acquired Achievement read projection
- exact parity with the existing acquired-list item shape
- local Achievement Reader cleanup

### Response

```text
{
  achievementId,
  code,
  name,
  category,
  descMd,
  acquiredAt
}
```

### Ownership

The endpoint does not accept player/user identity.

A catalog Achievement that the Current Player has not acquired is not returned as an acquired success.

Another player's acquisition cannot satisfy the lookup.

### Provenance

The current persistence model does not contain an authoritative acquisition source beyond `acquiredAt`.

This PR does not invent Quest/Reward provenance, speculative nullable fields, or schema solely for future compatibility.

### Structural Integrity

The touched Achievement boundary was checked for:

- catalog vs acquired semantic confusion
- Current Player identity leakage
- empty/pass-through Reader methods
- duplicate detail queries

Only local-safe findings were changed.

### Validation

Focused validation only:

- Current Player acquired detail
- cross-player isolation
- non-acquired behavior
- exact API contract
- final build