### PR TITLE
[LifeLog] Fix Exercise partial-update contract integrity

### DIFF
--- a/src/main/java/online/lifeasgame/lifelog/application/ExerciseLogService.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/ExerciseLogService.java
@@ -111,16 +111,30 @@ public class ExerciseLogService {
     @Transactional
     public ExerciseResult.Info update(Long playerId, Long exerciseId, ExerciseCommand.Update command) {
         ExerciseLog exerciseLog = exerciseLogReader.getByIdAndPlayerIdOrThrow(exerciseId, playerId);
+        ExerciseMetrics metrics = exerciseLog.getMetrics();
 
-        exerciseLog.changeMetrics(
+        exerciseLog.update(
+                command.category() != null
+                        ? ExerciseCategory.parse(command.category())
+                        : exerciseLog.getCategory(),
                 ExerciseMetrics.of(
-                        command.durationMinutes(),
-                        command.distanceKm(),
-                        command.calories()
-                )
+                        command.durationMinutes() != null
+                                ? command.durationMinutes()
+                                : metrics.durationMinutes(),
+                        command.distanceKm() != null
+                                ? command.distanceKm()
+                                : metrics.distanceKm(),
+                        command.calories() != null
+                                ? command.calories()
+                                : metrics.calories()
+                ),
+                command.exercisedOn() != null
+                        ? command.exercisedOn()
+                        : exerciseLog.getExercisedOn(),
+                command.memo() != null
+                        ? command.memo()
+                        : exerciseLog.getMemo()
         );
-        exerciseLog.changeExercisedOn(command.exercisedOn());
-        exerciseLog.changeMemo(command.memo());
 
         return ExerciseResult.Info.from(exerciseLog);
     }

--- a/src/main/java/online/lifeasgame/lifelog/domain/ExerciseLog.java
+++ b/src/main/java/online/lifeasgame/lifelog/domain/ExerciseLog.java
@@ -72,15 +72,15 @@ public class ExerciseLog extends AbstractTime {
         return new ExerciseLog(playerId, category, metrics, exercisedOn, memo);
     }
 
-    public void changeMetrics(ExerciseMetrics metrics) {
+    public void update(
+            ExerciseCategory category,
+            ExerciseMetrics metrics,
+            LocalDate exercisedOn,
+            String memo
+    ) {
+        this.category = Guard.notNull(category, "category");
         this.metrics = Guard.notNull(metrics, "metrics");
-    }
-
-    public void changeMemo(String memo) {
+        this.exercisedOn = Guard.notNull(exercisedOn, "exercisedOn");
         this.memo = (memo == null || memo.isBlank()) ? null : memo.trim();
-    }
-
-    public void changeExercisedOn(LocalDate when) {
-        this.exercisedOn = Guard.notNull(when, "when");
     }
 }

--- a/src/test/java/online/lifeasgame/lifelog/application/ExerciseLogServiceTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/application/ExerciseLogServiceTest.java
@@ -10,6 +10,7 @@ import online.lifeasgame.lifelog.domain.ExerciseLog;
 import online.lifeasgame.lifelog.domain.ExerciseMetrics;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -23,7 +24,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("Exercise partial update")
+@DisplayName("ExerciseLogService")
 class ExerciseLogServiceTest {
 
     private static final Long PLAYER_ID = 270L;
@@ -64,58 +65,63 @@ class ExerciseLogServiceTest {
         )).willReturn(exerciseLog);
     }
 
-    @Test
-    @DisplayName("category와 duration만 바꾸고 생략한 metrics/date/memo는 보존한다")
-    void appliesSuppliedFieldsAndPreservesOmittedFields() {
-        ExerciseResult.Info result = service.update(
-                EXERCISE_ID,
-                new ExerciseCommand.Update(
-                        "CYCLING",
-                        45,
-                        null,
-                        null,
-                        null,
-                        null
-                )
-        );
+    @Nested
+    @DisplayName("운동 기록을 부분 수정할 때")
+    class UpdateExercise {
 
-        assertThat(result.category()).isEqualTo("CYCLING");
-        assertThat(result.durationMinutes()).isEqualTo(45);
-        assertThat(result.distanceKm()).isEqualTo(5.0);
-        assertThat(result.calories()).isEqualTo(250);
-        assertThat(result.exercisedOn()).isEqualTo(EXERCISED_ON);
-        assertThat(result.memo()).isEqualTo("기존 메모");
-    }
+        @Test
+        @DisplayName("category와 duration만 바꾸고 생략한 metrics/date/memo는 보존한다")
+        void appliesSuppliedFieldsAndPreservesOmittedFields() {
+            ExerciseResult.Info result = service.update(
+                    EXERCISE_ID,
+                    new ExerciseCommand.Update(
+                            "CYCLING",
+                            45,
+                            null,
+                            null,
+                            null,
+                            null
+                    )
+            );
 
-    @Test
-    @DisplayName("null memo는 보존하고 blank memo는 기존 정규화로 지운다")
-    void preservesNullMemoAndClearsBlankMemo() {
-        ExerciseResult.Info preserved = service.update(
-                EXERCISE_ID,
-                new ExerciseCommand.Update(
-                        null, null, null, null, null, null
-                )
-        );
-        ExerciseResult.Info cleared = service.update(
-                EXERCISE_ID,
-                new ExerciseCommand.Update(
-                        null, null, null, null, null, "   "
-                )
-        );
+            assertThat(result.category()).isEqualTo("CYCLING");
+            assertThat(result.durationMinutes()).isEqualTo(45);
+            assertThat(result.distanceKm()).isEqualTo(5.0);
+            assertThat(result.calories()).isEqualTo(250);
+            assertThat(result.exercisedOn()).isEqualTo(EXERCISED_ON);
+            assertThat(result.memo()).isEqualTo("기존 메모");
+        }
 
-        assertThat(preserved.memo()).isEqualTo("기존 메모");
-        assertThat(cleared.memo()).isNull();
-    }
+        @Test
+        @DisplayName("null memo는 보존하고 blank memo는 기존 정규화로 지운다")
+        void preservesNullMemoAndClearsBlankMemo() {
+            ExerciseResult.Info preserved = service.update(
+                    EXERCISE_ID,
+                    new ExerciseCommand.Update(
+                            null, null, null, null, null, null
+                    )
+            );
+            ExerciseResult.Info cleared = service.update(
+                    EXERCISE_ID,
+                    new ExerciseCommand.Update(
+                            null, null, null, null, null, "   "
+                    )
+            );
 
-    @Test
-    @DisplayName("supplied invalid duration은 기존 domain invariant로 거부한다")
-    void rejectsInvalidSuppliedDuration() {
-        assertThatThrownBy(() -> service.update(
-                EXERCISE_ID,
-                new ExerciseCommand.Update(
-                        null, 0, null, null, null, null
-                )
-        )).isInstanceOf(IllegalStateException.class)
-                .hasMessage("durationMinutes >= 1");
+            assertThat(preserved.memo()).isEqualTo("기존 메모");
+            assertThat(cleared.memo()).isNull();
+        }
+
+        @Test
+        @DisplayName("supplied invalid duration은 기존 domain invariant로 거부한다")
+        void rejectsInvalidSuppliedDuration() {
+            assertThatThrownBy(() -> service.update(
+                    EXERCISE_ID,
+                    new ExerciseCommand.Update(
+                            null, 0, null, null, null, null
+                    )
+            )).isInstanceOf(IllegalStateException.class)
+                    .hasMessage("durationMinutes >= 1");
+        }
     }
 }

--- a/src/test/java/online/lifeasgame/lifelog/application/ExerciseLogServiceTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/application/ExerciseLogServiceTest.java
@@ -1,0 +1,121 @@
+package online.lifeasgame.lifelog.application;
+
+import online.lifeasgame.core.event.DomainEventPublisher;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.lifelog.application.command.ExerciseCommand;
+import online.lifeasgame.lifelog.application.record.LifeLogRecordRegistrar;
+import online.lifeasgame.lifelog.application.result.ExerciseResult;
+import online.lifeasgame.lifelog.domain.ExerciseCategory;
+import online.lifeasgame.lifelog.domain.ExerciseLog;
+import online.lifeasgame.lifelog.domain.ExerciseMetrics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Exercise partial update")
+class ExerciseLogServiceTest {
+
+    private static final Long PLAYER_ID = 270L;
+    private static final Long EXERCISE_ID = 2701L;
+    private static final LocalDate EXERCISED_ON =
+            LocalDate.of(2026, 8, 14);
+
+    @Mock
+    private ExerciseLogReader exerciseLogReader;
+
+    @Mock
+    private CurrentPlayerAccessor currentPlayerAccessor;
+
+    private ExerciseLogService service;
+    private ExerciseLog exerciseLog;
+
+    @BeforeEach
+    void setUp() {
+        service = new ExerciseLogService(
+                exerciseLogReader,
+                mock(ExerciseLogWriter.class),
+                mock(LifeLogRecordRegistrar.class),
+                mock(DomainEventPublisher.class),
+                currentPlayerAccessor
+        );
+        exerciseLog = ExerciseLog.create(
+                PLAYER_ID,
+                ExerciseCategory.RUNNING,
+                ExerciseMetrics.of(30, 5.0, 250),
+                EXERCISED_ON,
+                "기존 메모"
+        );
+        given(currentPlayerAccessor.currentPlayerIdOrThrow())
+                .willReturn(PLAYER_ID);
+        given(exerciseLogReader.getByIdAndPlayerIdOrThrow(
+                EXERCISE_ID,
+                PLAYER_ID
+        )).willReturn(exerciseLog);
+    }
+
+    @Test
+    @DisplayName("category와 duration만 바꾸고 생략한 metrics/date/memo는 보존한다")
+    void appliesSuppliedFieldsAndPreservesOmittedFields() {
+        ExerciseResult.Info result = service.update(
+                EXERCISE_ID,
+                new ExerciseCommand.Update(
+                        "CYCLING",
+                        45,
+                        null,
+                        null,
+                        null,
+                        null
+                )
+        );
+
+        assertThat(result.category()).isEqualTo("CYCLING");
+        assertThat(result.durationMinutes()).isEqualTo(45);
+        assertThat(result.distanceKm()).isEqualTo(5.0);
+        assertThat(result.calories()).isEqualTo(250);
+        assertThat(result.exercisedOn()).isEqualTo(EXERCISED_ON);
+        assertThat(result.memo()).isEqualTo("기존 메모");
+    }
+
+    @Test
+    @DisplayName("null memo는 보존하고 blank memo는 기존 정규화로 지운다")
+    void preservesNullMemoAndClearsBlankMemo() {
+        ExerciseResult.Info preserved = service.update(
+                EXERCISE_ID,
+                new ExerciseCommand.Update(
+                        null, null, null, null, null, null
+                )
+        );
+        ExerciseResult.Info cleared = service.update(
+                EXERCISE_ID,
+                new ExerciseCommand.Update(
+                        null, null, null, null, null, "   "
+                )
+        );
+
+        assertThat(preserved.memo()).isEqualTo("기존 메모");
+        assertThat(cleared.memo()).isNull();
+    }
+
+    @Test
+    @DisplayName("supplied invalid duration은 기존 domain invariant로 거부한다")
+    void rejectsInvalidSuppliedDuration() {
+        assertThatThrownBy(() -> service.update(
+                EXERCISE_ID,
+                new ExerciseCommand.Update(
+                        null, 0, null, null, null, null
+                )
+        )).isInstanceOf(IllegalStateException.class)
+                .hasMessage("durationMinutes >= 1");
+    }
+}


### PR DESCRIPTION
## Body

### Purpose

Make the existing optional Exercise update request behave as a coherent partial update instead of forwarding omitted values into required domain invariants or silently ignoring category.

Closes #270

### Delivered

- preserved existing Exercise update endpoint
- applied supplied category instead of ignoring it
- merged omitted metric fields from current persisted values
- preserved exercised date when omitted
- preserved memo when omitted
- retained blank memo as an explicit clear operation
- removed accidental null-driven domain failures

### Partial Update Contract

```text
non-null supplied -> apply
null/omitted      -> preserve
```

For memo:

```text
null  -> preserve
blank -> clear
```

Nullable numeric fields are not explicitly clearable in this PR because the current request model has no tri-state distinction.

### Architecture

Update semantics remain in the application/domain boundary.

No Controller defaulting, duplicate Mapper logic, endpoint redesign, or schema migration was introduced.

### Structural Integrity

The touched Exercise update path was checked for:

- optional-vs-required contradictions
- silently ignored fields
- inconsistent null semantics
- accidental invariant failures

Only direct/local-safe findings were changed.

### Validation

Focused validation only:

- partial update preservation
- category update
- blank memo clear vs null preserve
- existing invalid metric invariant
- final build