### PR TITLE
[Character] Harden PlayerCertification partial date updates and mutation responsibilities

### DIFF
--- a/src/main/java/online/lifeasgame/character/application/PlayerCertificationDateUpdater.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerCertificationDateUpdater.java
@@ -1,0 +1,35 @@
+package online.lifeasgame.character.application;
+
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.domain.PlayerCertification;
+import online.lifeasgame.character.domain.error.PlayerCertificationError;
+import online.lifeasgame.character.domain.repository.PlayerCertificationRepository;
+import online.lifeasgame.core.error.DomainException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.MANDATORY)
+class PlayerCertificationDateUpdater {
+
+    private final PlayerCertificationRepository repository;
+
+    public PlayerCertification update(
+            Long playerId,
+            Long certificationId,
+            LocalDate acquiredDate,
+            LocalDate expiresDate
+    ) {
+        PlayerCertification playerCertification = repository.findByPlayerIdAndCertificationId(playerId, certificationId)
+                .orElseThrow(() -> new DomainException(PlayerCertificationError.PLAYER_CERTIFICATION_NOT_FOUND));
+
+        LocalDate effectiveAcquiredDate = acquiredDate != null ? acquiredDate : playerCertification.getAcquiredDate();
+        LocalDate effectiveExpiresDate = expiresDate != null ? expiresDate : playerCertification.getExpiresDate();
+        playerCertification.changeDates(effectiveAcquiredDate, effectiveExpiresDate);
+
+        return playerCertification;
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/PlayerCertificationRegistrar.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerCertificationRegistrar.java
@@ -1,0 +1,20 @@
+package online.lifeasgame.character.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.domain.PlayerCertification;
+import online.lifeasgame.character.domain.repository.PlayerCertificationRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.MANDATORY)
+class PlayerCertificationRegistrar {
+
+    private final PlayerCertificationRepository repository;
+
+    public PlayerCertification register(PlayerCertification playerCertification) {
+        return repository.save(playerCertification);
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/PlayerCertificationRevoker.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerCertificationRevoker.java
@@ -1,7 +1,6 @@
 package online.lifeasgame.character.application;
 
 import lombok.RequiredArgsConstructor;
-import online.lifeasgame.character.domain.PlayerCertification;
 import online.lifeasgame.character.domain.error.PlayerCertificationError;
 import online.lifeasgame.character.domain.repository.PlayerCertificationRepository;
 import online.lifeasgame.core.error.DomainException;
@@ -9,34 +8,14 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-
 @Component
 @RequiredArgsConstructor
 @Transactional(propagation = Propagation.MANDATORY)
-class PlayerCertificationWriter {
+class PlayerCertificationRevoker {
 
     private final PlayerCertificationRepository repository;
 
-    public PlayerCertification create(PlayerCertification playerCertification) {
-        return repository.save(playerCertification);
-    }
-
-    public PlayerCertification changeDates(
-            Long playerId,
-            Long certificationId,
-            LocalDate acquiredDate,
-            LocalDate expiresDate
-    ) {
-        PlayerCertification playerCertification = repository.findByPlayerIdAndCertificationId(playerId, certificationId)
-                .orElseThrow(() -> new DomainException(PlayerCertificationError.PLAYER_CERTIFICATION_NOT_FOUND));
-
-        playerCertification.changeDate(acquiredDate, expiresDate);
-
-        return playerCertification;
-    }
-
-    public void deletePlayerCertification(Long playerId, Long certificationId) {
+    public void revoke(Long playerId, Long certificationId) {
         if (!repository.existsByPlayerIdAndCertificationId(playerId, certificationId)) {
             throw new DomainException(PlayerCertificationError.PLAYER_CERTIFICATION_NOT_FOUND);
         }

--- a/src/main/java/online/lifeasgame/character/application/PlayerCertificationService.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerCertificationService.java
@@ -16,7 +16,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PlayerCertificationService {
 
-    private final PlayerCertificationWriter playerCertificationWriter;
+    private final PlayerCertificationRegistrar playerCertificationRegistrar;
+    private final PlayerCertificationDateUpdater playerCertificationDateUpdater;
+    private final PlayerCertificationRevoker playerCertificationRevoker;
     private final PlayerCertificationReader playerCertificationReader;
 
     private final CertificationReader certificationReader;
@@ -34,7 +36,7 @@ public class PlayerCertificationService {
 
         Certification certification = certificationReader.getByIdOrThrow(command.certificationId());
 
-        PlayerCertification playerCertification = playerCertificationWriter.create(
+        PlayerCertification playerCertification = playerCertificationRegistrar.register(
                 PlayerCertification.create(
                         playerId,
                         command.certificationId(),
@@ -62,7 +64,7 @@ public class PlayerCertificationService {
 
     @Transactional
     public PlayerCertificationResult.Changed changePlayerCertification(Long playerId, PlayerCertificationCommand.Change command) {
-        PlayerCertification playerCertification = playerCertificationWriter.changeDates(
+        PlayerCertification playerCertification = playerCertificationDateUpdater.update(
                 playerId,
                 command.certificationId(),
                 command.acquiredDate(),
@@ -79,12 +81,12 @@ public class PlayerCertificationService {
 
     @Transactional
     public void deletePlayerCertification(Long playerId, Long certificationId) {
-        playerCertificationWriter.deletePlayerCertification(playerId, certificationId);
+        playerCertificationRevoker.revoke(playerId, certificationId);
     }
 
     @Transactional
     public PlayerCertificationResult.Revoked revokeCertification(Long playerId, Long certificationId) {
-        playerCertificationWriter.deletePlayerCertification(playerId, certificationId);
+        playerCertificationRevoker.revoke(playerId, certificationId);
         return new PlayerCertificationResult.Revoked(playerId, certificationId);
     }
 }

--- a/src/main/java/online/lifeasgame/character/domain/PlayerCertification.java
+++ b/src/main/java/online/lifeasgame/character/domain/PlayerCertification.java
@@ -72,21 +72,19 @@ public class PlayerCertification extends AbstractTime {
             LocalDate acquiredDate,
             LocalDate expiresDate
     ) {
+        validateDateOrder(acquiredDate, expiresDate);
+        return new PlayerCertification(playerId, certificationId, acquiredDate, expiresDate);
+    }
+
+    public void changeDates(LocalDate acquiredDate, LocalDate expiresDate) {
+        validateDateOrder(acquiredDate, expiresDate);
+        this.acquiredDate = acquiredDate;
+        this.expiresDate = expiresDate;
+    }
+
+    private static void validateDateOrder(LocalDate acquiredDate, LocalDate expiresDate) {
         if (acquiredDate != null && expiresDate != null && expiresDate.isBefore(acquiredDate)) {
             throw new DomainException(PlayerCertificationError.EXPIRES_BEFORE_ACQUIRED);
         }
-        return new PlayerCertification(playerId, certificationId, acquiredDate, expiresDate);
-    }
-
-    public static PlayerCertification of(Long playerId, Long certificationId, LocalDate acquiredDate, LocalDate expiresDate) {
-        return new PlayerCertification(playerId, certificationId, acquiredDate, expiresDate);
-    }
-
-    public void changeDate(LocalDate acquiredDate, LocalDate expiresDate) {
-        if (expiresDate.isBefore(acquiredDate)) {
-            throw new DomainException(PlayerCertificationError.EXPIRES_BEFORE_ACQUIRED);
-        }
-        this.acquiredDate = acquiredDate;
-        this.expiresDate = expiresDate;
     }
 }

--- a/src/test/java/online/lifeasgame/character/application/PlayerCertificationDateUpdaterTest.java
+++ b/src/test/java/online/lifeasgame/character/application/PlayerCertificationDateUpdaterTest.java
@@ -1,0 +1,107 @@
+package online.lifeasgame.character.application;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import online.lifeasgame.character.domain.PlayerCertification;
+import online.lifeasgame.character.domain.error.PlayerCertificationError;
+import online.lifeasgame.character.domain.repository.PlayerCertificationRepository;
+import online.lifeasgame.core.error.DomainException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Player certification date updater")
+class PlayerCertificationDateUpdaterTest {
+
+    private static final Long PLAYER_ID = 272L;
+    private static final Long CERTIFICATION_ID = 27201L;
+    private static final LocalDate ACQUIRED_DATE = LocalDate.of(2025, 1, 10);
+    private static final LocalDate EXPIRES_DATE = LocalDate.of(2026, 1, 10);
+
+    @Mock
+    private PlayerCertificationRepository repository;
+
+    @Nested
+    @DisplayName("자격증 날짜를 부분 수정할 때")
+    class PartialDateUpdate {
+
+        @Test
+        @DisplayName("취득일만 전달하면 만료일은 기존 값을 유지한다")
+        void changesOnlyAcquiredDate() {
+            PlayerCertification certification = certification();
+            givenOwnedCertification(certification);
+            LocalDate changedAcquiredDate = LocalDate.of(2025, 2, 10);
+
+            updater().update(PLAYER_ID, CERTIFICATION_ID, changedAcquiredDate, null);
+
+            assertThat(certification.getAcquiredDate()).isEqualTo(changedAcquiredDate);
+            assertThat(certification.getExpiresDate()).isEqualTo(EXPIRES_DATE);
+        }
+
+        @Test
+        @DisplayName("만료일만 전달하면 취득일은 기존 값을 유지한다")
+        void changesOnlyExpiresDate() {
+            PlayerCertification certification = certification();
+            givenOwnedCertification(certification);
+            LocalDate changedExpiresDate = LocalDate.of(2026, 2, 10);
+
+            updater().update(PLAYER_ID, CERTIFICATION_ID, null, changedExpiresDate);
+
+            assertThat(certification.getAcquiredDate()).isEqualTo(ACQUIRED_DATE);
+            assertThat(certification.getExpiresDate()).isEqualTo(changedExpiresDate);
+        }
+
+        @Test
+        @DisplayName("두 날짜가 모두 null이면 기존 값을 유지한다")
+        void preservesBothDates() {
+            PlayerCertification certification = certification();
+            givenOwnedCertification(certification);
+
+            updater().update(PLAYER_ID, CERTIFICATION_ID, null, null);
+
+            assertThat(certification.getAcquiredDate()).isEqualTo(ACQUIRED_DATE);
+            assertThat(certification.getExpiresDate()).isEqualTo(EXPIRES_DATE);
+        }
+
+        @Test
+        @DisplayName("최종 날짜 순서가 잘못되면 기존 도메인 오류를 반환한다")
+        void rejectsInvalidEffectiveDateOrder() {
+            PlayerCertification certification = certification();
+            givenOwnedCertification(certification);
+            LocalDate invalidExpiresDate = ACQUIRED_DATE.minusDays(1);
+
+            assertThatThrownBy(() -> updater().update(
+                    PLAYER_ID,
+                    CERTIFICATION_ID,
+                    null,
+                    invalidExpiresDate
+            )).isInstanceOfSatisfying(DomainException.class, exception ->
+                    assertThat(exception.getErrorCode())
+                            .isEqualTo(PlayerCertificationError.EXPIRES_BEFORE_ACQUIRED)
+            );
+            assertThat(certification.getAcquiredDate()).isEqualTo(ACQUIRED_DATE);
+            assertThat(certification.getExpiresDate()).isEqualTo(EXPIRES_DATE);
+        }
+    }
+
+    private PlayerCertificationDateUpdater updater() {
+        return new PlayerCertificationDateUpdater(repository);
+    }
+
+    private PlayerCertification certification() {
+        return PlayerCertification.create(PLAYER_ID, CERTIFICATION_ID, ACQUIRED_DATE, EXPIRES_DATE);
+    }
+
+    private void givenOwnedCertification(PlayerCertification certification) {
+        given(repository.findByPlayerIdAndCertificationId(PLAYER_ID, CERTIFICATION_ID))
+                .willReturn(Optional.of(certification));
+    }
+}


### PR DESCRIPTION
### Purpose

Make the existing Current Player Certification PATCH contract null-safe and coherent, while replacing the directly touched generic mutation `Writer` with behavior-specific responsibilities.

Closes #272

### Delivered

- coherent partial date update semantics
- omitted/null dates preserve persisted values
- null-safe Certification date invariant
- controlled expiry-before-acquisition failure
- responsibility-driven Certification mutation components
- generic mixed-responsibility `PlayerCertificationWriter` removal
- invariant-bypass factory cleanup where applicable
- focused readable regression coverage

### PATCH Contract

Existing endpoint remains:

```text
PATCH /api/v1/players/certifications/{certificationId}
```

Semantics:

```text
non-null supplied -> apply
null / omitted    -> preserve
```

The current request contract does not expose tri-state null handling, so explicit date clearing is intentionally not introduced.

### Domain Invariant

Ordering is checked only when both dates exist:

```text
expiresDate >= acquiredDate
```

Invalid ordering continues to use:

```text
EXPIRES_BEFORE_ACQUIRED
```

No accidental null-driven runtime failure remains.

### Responsibility Naming

The touched mutation path no longer uses a generic `Writer` for unrelated mutation responsibilities.

Responsibilities are expressed through behavior-specific components such as registration, date updating and revocation.

The pure read boundary remains a Reader where that name accurately reflects its responsibility.

### Current Player Boundary

Current Player identity remains authentication-owned.

No player/user identity fields were added to the request contract.

Existing admin explicit-player flows remain supported.

### Scope

No:

- endpoint redesign
- schema migration
- explicit date-clear protocol
- unrelated Hobby/Title refactor
- repository-wide Reader/Writer rename

### Validation

Focused coverage verifies:

- acquired-only update
- expiry-only update
- omitted-date preservation
- invalid final date ordering
- final build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated workflows for registering, updating, and revoking player certifications.
  * Certification date updates can change either date while preserving the other when omitted.
* **Bug Fixes**
  * Prevented invalid acquisition and expiration date combinations from being saved.
  * Revocation now reports an error when the specified player certification does not exist.
  * Failed date updates leave existing certification data unchanged.
* **Tests**
  * Added coverage for partial updates, date validation, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->