### PR TITLE
[Character] Harden PlayerHobby partial updates and mutation responsibilities

### DIFF
--- a/src/main/java/online/lifeasgame/character/application/PlayerHobbyReader.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerHobbyReader.java
@@ -3,10 +3,6 @@ package online.lifeasgame.character.application;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.character.application.query.PlayerHobbyQuery;
 import online.lifeasgame.character.application.view.PlayerHobbyView;
-import online.lifeasgame.character.domain.PlayerHobby;
-import online.lifeasgame.character.domain.error.PlayerHobbyError;
-import online.lifeasgame.character.domain.repository.PlayerHobbyRepository;
-import online.lifeasgame.core.error.DomainException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,14 +15,8 @@ import java.util.List;
 class PlayerHobbyReader {
 
     private final PlayerHobbyQuery query;
-    private final PlayerHobbyRepository repository;
 
     public List<PlayerHobbyView> getViewsByPlayerId(Long playerId) {
         return query.findViewsByPlayerId(playerId);
-    }
-
-    public PlayerHobby getByPlayerIdAndHobbyId(Long playerId, Long hobbyId) {
-        return repository.findByPlayerIdAndHobbyId(playerId, hobbyId)
-                .orElseThrow(() -> new DomainException(PlayerHobbyError.PLAYER_HOBBY_NOT_FOUND));
     }
 }

--- a/src/main/java/online/lifeasgame/character/application/PlayerHobbyRegistrar.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerHobbyRegistrar.java
@@ -1,0 +1,20 @@
+package online.lifeasgame.character.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.domain.PlayerHobby;
+import online.lifeasgame.character.domain.repository.PlayerHobbyRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.MANDATORY)
+class PlayerHobbyRegistrar {
+
+    private final PlayerHobbyRepository repository;
+
+    public PlayerHobby register(PlayerHobby playerHobby) {
+        return repository.save(playerHobby);
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/PlayerHobbyRevoker.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerHobbyRevoker.java
@@ -1,7 +1,6 @@
 package online.lifeasgame.character.application;
 
 import lombok.RequiredArgsConstructor;
-import online.lifeasgame.character.domain.PlayerHobby;
 import online.lifeasgame.character.domain.error.PlayerHobbyError;
 import online.lifeasgame.character.domain.repository.PlayerHobbyRepository;
 import online.lifeasgame.core.error.DomainException;
@@ -12,15 +11,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @RequiredArgsConstructor
 @Transactional(propagation = Propagation.MANDATORY)
-class PlayerHobbyWriter {
+class PlayerHobbyRevoker {
 
     private final PlayerHobbyRepository repository;
 
-    public PlayerHobby create(PlayerHobby playerHobby) {
-        return repository.save(playerHobby);
-    }
-
-    public void deleteByPlayerIdAndHobbyId(Long playerId, Long hobbyId) {
+    public void revoke(Long playerId, Long hobbyId) {
         if (!repository.existsByPlayerIdAndHobbyId(playerId, hobbyId)) {
             throw new DomainException(PlayerHobbyError.PLAYER_HOBBY_NOT_FOUND);
         }

--- a/src/main/java/online/lifeasgame/character/application/PlayerHobbyService.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerHobbyService.java
@@ -19,7 +19,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PlayerHobbyService {
 
-    private final PlayerHobbyWriter playerHobbyWriter;
+    private final PlayerHobbyRegistrar playerHobbyRegistrar;
+    private final PlayerHobbyUpdater playerHobbyUpdater;
+    private final PlayerHobbyRevoker playerHobbyRevoker;
     private final PlayerHobbyReader playerHobbyReader;
 
     private final HobbyReader hobbyReader;
@@ -37,7 +39,7 @@ public class PlayerHobbyService {
 
         Hobby hobby = hobbyReader.getByIdOrThrow(command.hobbyId());
 
-        PlayerHobby playerHobby = playerHobbyWriter.create(
+        PlayerHobby playerHobby = playerHobbyRegistrar.register(
                 PlayerHobby.create(
                         playerId,
                         command.hobbyId(),
@@ -68,15 +70,7 @@ public class PlayerHobbyService {
 
     @Transactional
     public PlayerHobbyResult.Changed changePlayerHobby(Long playerId, PlayerHobbyCommand.Change command) {
-        PlayerHobby playerHobby = playerHobbyReader.getByPlayerIdAndHobbyId(playerId, command.hobbyId());
-
-        playerHobby.changeHobby(
-                command.name(),
-                command.detail(),
-                command.proficiency(),
-                PlayerHobbyStatus.parse(command.status()),
-                command.startedOn()
-        );
+        PlayerHobby playerHobby = playerHobbyUpdater.update(playerId, command);
 
         return PlayerHobbyResult.Changed.from(playerHobby);
     }
@@ -88,12 +82,12 @@ public class PlayerHobbyService {
 
     @Transactional
     public void deletePlayerHobby(Long playerId, Long hobbyId) {
-        playerHobbyWriter.deleteByPlayerIdAndHobbyId(playerId, hobbyId);
+        playerHobbyRevoker.revoke(playerId, hobbyId);
     }
 
     @Transactional
     public PlayerHobbyResult.Revoked revokeHobby(Long playerId, Long hobbyId) {
-        playerHobbyWriter.deleteByPlayerIdAndHobbyId(playerId, hobbyId);
+        playerHobbyRevoker.revoke(playerId, hobbyId);
         return new PlayerHobbyResult.Revoked(playerId, hobbyId);
     }
 }

--- a/src/main/java/online/lifeasgame/character/application/PlayerHobbyUpdater.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerHobbyUpdater.java
@@ -1,0 +1,53 @@
+package online.lifeasgame.character.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.application.command.PlayerHobbyCommand;
+import online.lifeasgame.character.domain.PlayerHobby;
+import online.lifeasgame.character.domain.PlayerHobbyStatus;
+import online.lifeasgame.character.domain.error.PlayerHobbyError;
+import online.lifeasgame.character.domain.repository.PlayerHobbyRepository;
+import online.lifeasgame.core.error.DomainException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.MANDATORY)
+class PlayerHobbyUpdater {
+
+    private final PlayerHobbyRepository repository;
+
+    public PlayerHobby update(
+            Long playerId,
+            PlayerHobbyCommand.Change command
+    ) {
+        PlayerHobby playerHobby = repository.findByPlayerIdAndHobbyId(
+                        playerId,
+                        command.hobbyId()
+                )
+                .orElseThrow(() -> new DomainException(
+                        PlayerHobbyError.PLAYER_HOBBY_NOT_FOUND
+                ));
+
+        playerHobby.changeHobby(
+                command.name() != null
+                        ? command.name()
+                        : playerHobby.getCustomName(),
+                command.detail() != null
+                        ? command.detail()
+                        : playerHobby.getDetail(),
+                command.proficiency() != null
+                        ? command.proficiency()
+                        : playerHobby.getProficiency(),
+                command.status() != null
+                        ? PlayerHobbyStatus.parse(command.status())
+                        : playerHobby.getStatus(),
+                command.startedOn() != null
+                        ? command.startedOn()
+                        : playerHobby.getStartedOn()
+        );
+
+        return playerHobby;
+    }
+}

--- a/src/main/java/online/lifeasgame/character/domain/PlayerHobby.java
+++ b/src/main/java/online/lifeasgame/character/domain/PlayerHobby.java
@@ -15,6 +15,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import online.lifeasgame.core.annotation.AggregateRoot;
+import online.lifeasgame.core.guard.Guard;
 
 @Getter
 @Entity
@@ -44,7 +45,7 @@ public class PlayerHobby {
     private String detail;
 
     @Column(name = "proficiency", nullable = false)
-    private int proficiency = 0; // 0~100 규약
+    private int proficiency = 0;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", length = 20, nullable = false)
@@ -69,7 +70,7 @@ public class PlayerHobby {
         this.hobbyId = hobbyId;
         this.customName = customName;
         this.detail = detail;
-        this.proficiency = proficiency;
+        this.proficiency = validateProficiency(proficiency);
         this.status = status;
         this.startedOn = startedOn;
         this.xp = 0;
@@ -99,14 +100,19 @@ public class PlayerHobby {
     public void changeHobby(
             String name,
             String detail,
-            Integer proficiency,
+            int proficiency,
             PlayerHobbyStatus status,
             LocalDate startedOn
     ) {
+        int validatedProficiency = validateProficiency(proficiency);
         this.customName = name;
         this.detail = detail;
-        this.proficiency = proficiency;
+        this.proficiency = validatedProficiency;
         this.status = status;
         this.startedOn = startedOn;
+    }
+
+    private static int validateProficiency(int proficiency) {
+        return Guard.inRange(proficiency, 0, 100, "proficiency");
     }
 }

--- a/src/test/java/online/lifeasgame/character/application/PlayerHobbyUpdaterTest.java
+++ b/src/test/java/online/lifeasgame/character/application/PlayerHobbyUpdaterTest.java
@@ -1,0 +1,129 @@
+package online.lifeasgame.character.application;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import online.lifeasgame.character.application.command.PlayerHobbyCommand;
+import online.lifeasgame.character.domain.PlayerHobby;
+import online.lifeasgame.character.domain.PlayerHobbyStatus;
+import online.lifeasgame.character.domain.error.PlayerHobbyError;
+import online.lifeasgame.character.domain.repository.PlayerHobbyRepository;
+import online.lifeasgame.core.error.DomainException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PlayerHobbyUpdater")
+class PlayerHobbyUpdaterTest {
+
+    private static final Long PLAYER_ID = 274L;
+    private static final Long HOBBY_ID = 27401L;
+    private static final LocalDate STARTED_ON = LocalDate.of(2025, 1, 10);
+
+    @Mock
+    private PlayerHobbyRepository repository;
+
+    @Nested
+    @DisplayName("보유 취미를 부분 수정할 때")
+    class PartialUpdate {
+
+        @Test
+        @DisplayName("customName만 바꾸고 null proficiency/status를 포함한 생략 값은 보존한다")
+        void changesSubsetAndPreservesOmittedValues() {
+            PlayerHobby playerHobby = playerHobby();
+            givenOwnedHobby(playerHobby);
+
+            updater().update(
+                    PLAYER_ID,
+                    new PlayerHobbyCommand.Change(
+                            HOBBY_ID,
+                            "변경 이름",
+                            null,
+                            null,
+                            null,
+                            null
+                    )
+            );
+
+            assertThat(playerHobby.getCustomName()).isEqualTo("변경 이름");
+            assertThat(playerHobby.getDetail()).isEqualTo("기존 상세");
+            assertThat(playerHobby.getProficiency()).isEqualTo(60);
+            assertThat(playerHobby.getStatus()).isEqualTo(PlayerHobbyStatus.ACTIVE);
+            assertThat(playerHobby.getStartedOn()).isEqualTo(STARTED_ON);
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 supplied status는 기존 domain error로 거부한다")
+        void rejectsInvalidSuppliedStatus() {
+            PlayerHobby playerHobby = playerHobby();
+            givenOwnedHobby(playerHobby);
+
+            assertThatThrownBy(() -> updater().update(
+                    PLAYER_ID,
+                    new PlayerHobbyCommand.Change(
+                            HOBBY_ID,
+                            null,
+                            null,
+                            null,
+                            "INVALID",
+                            null
+                    )
+            )).isInstanceOfSatisfying(
+                    DomainException.class,
+                    exception -> assertThat(exception.getErrorCode())
+                            .isEqualTo(PlayerHobbyError.INVALID_PLAYER_HOBBY_STATUS)
+            );
+            assertThat(playerHobby.getStatus()).isEqualTo(PlayerHobbyStatus.ACTIVE);
+        }
+
+        @Test
+        @DisplayName("범위를 벗어난 supplied proficiency는 aggregate 변경 전에 거부한다")
+        void rejectsInvalidSuppliedProficiencyBeforeMutation() {
+            PlayerHobby playerHobby = playerHobby();
+            givenOwnedHobby(playerHobby);
+
+            assertThatThrownBy(() -> updater().update(
+                    PLAYER_ID,
+                    new PlayerHobbyCommand.Change(
+                            HOBBY_ID,
+                            "변경되면 안 됨",
+                            null,
+                            101,
+                            null,
+                            null
+                    )
+            )).isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("proficiency must be between 0 and 100");
+            assertThat(playerHobby.getCustomName()).isEqualTo("기존 이름");
+            assertThat(playerHobby.getProficiency()).isEqualTo(60);
+        }
+    }
+
+    private PlayerHobbyUpdater updater() {
+        return new PlayerHobbyUpdater(repository);
+    }
+
+    private PlayerHobby playerHobby() {
+        return PlayerHobby.create(
+                PLAYER_ID,
+                HOBBY_ID,
+                "기존 이름",
+                "기존 상세",
+                60,
+                PlayerHobbyStatus.ACTIVE,
+                STARTED_ON
+        );
+    }
+
+    private void givenOwnedHobby(PlayerHobby playerHobby) {
+        given(repository.findByPlayerIdAndHobbyId(PLAYER_ID, HOBBY_ID))
+                .willReturn(Optional.of(playerHobby));
+    }
+}


### PR DESCRIPTION
### Purpose

Make the existing Current Player Hobby PATCH contract behave as a coherent partial update and replace the directly touched generic mutation boundary with responsibility-specific components.

Closes #274

### Delivered

- coherent partial Hobby update semantics
- omitted fields preserve persisted values
- null-safe proficiency handling
- status parsing only for supplied values
- responsibility-driven Hobby mutation components
- read/write responsibility separation
- focused readable regression coverage

### PATCH Contract

Existing endpoint remains:

```text
PATCH /api/v1/players/hobbies/{hobbyId}
```

Semantics:

```text
non-null supplied -> apply
null / omitted    -> preserve
```

The current request type has no tri-state null distinction, so explicit clearing is intentionally not introduced.

### Responsibility Naming

The touched mutation path uses behavior-specific registration/update/revocation responsibilities.

The Reader remains limited to genuine read/query behavior.

### Current Player Boundary

Current Player identity remains authentication-owned.

No player/user identity fields are added to the request contract.

Existing admin explicit-player flows remain supported.

### Scope

No:

- endpoint redesign
- schema migration
- explicit-null clearing protocol
- unrelated Certification/Title refactor
- repository-wide Reader/Writer rename

### Validation

Focused coverage verifies:

- partial update preservation
- null proficiency preservation
- omitted status preservation
- invalid supplied status controlled failure
- final build