### PR TITLE
[LifeLog] Fix Media partial-update contract integrity

### DIFF
--- a/src/main/java/online/lifeasgame/lifelog/application/MediaLogService.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/MediaLogService.java
@@ -24,6 +24,7 @@ import java.time.Instant;
 public class MediaLogService {
 
     private final MediaLogReader mediaLogReader;
+    private final MediaLogUpdater mediaLogUpdater;
     private final MediaLogWriter mediaLogWriter;
     private final LifeLogRecordRegistrar lifeLogRecordRegistrar;
     private final DomainEventPublisher domainEventPublisher;
@@ -160,23 +161,7 @@ public class MediaLogService {
 
     @Transactional
     public MediaLogResult.Info update(Long playerId, Long mediaId, MediaLogCommand.Update command) {
-        MediaCategory mediaCategory = MediaCategory.parse(command.category());
-        Title title = Title.of(command.title(), command.originalTitle());
-        EpisodeProgress episodeProgress = EpisodeProgress.of(command.currentEpisode(), command.totalEpisode());
-        WatchStatus watchStatus = WatchStatus.parse(command.status());
-        MediaTags tags = MediaTags.of(command.tags());
-
-        MediaLog mediaLog = mediaLogReader.getByPlayerIdAndIdOrThrow(playerId, mediaId);
-
-        mediaLog.update(
-                mediaCategory,
-                title,
-                episodeProgress,
-                watchStatus,
-                tags
-        );
-
-        return MediaLogResult.Info.from(mediaLog);
+        return MediaLogResult.Info.from(mediaLogUpdater.update(playerId, mediaId, command));
     }
 
     @Transactional

--- a/src/main/java/online/lifeasgame/lifelog/application/MediaLogUpdater.java
+++ b/src/main/java/online/lifeasgame/lifelog/application/MediaLogUpdater.java
@@ -1,0 +1,50 @@
+package online.lifeasgame.lifelog.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.lifelog.application.command.MediaLogCommand;
+import online.lifeasgame.lifelog.domain.EpisodeProgress;
+import online.lifeasgame.lifelog.domain.MediaCategory;
+import online.lifeasgame.lifelog.domain.MediaLog;
+import online.lifeasgame.lifelog.domain.MediaTags;
+import online.lifeasgame.lifelog.domain.Title;
+import online.lifeasgame.lifelog.domain.WatchStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.MANDATORY)
+class MediaLogUpdater {
+
+    private final MediaLogReader mediaLogReader;
+
+    public MediaLog update(Long playerId, Long mediaId, MediaLogCommand.Update command) {
+        MediaLog mediaLog = mediaLogReader.getByPlayerIdAndIdOrThrow(playerId, mediaId);
+
+        MediaCategory category = command.category() != null
+                ? MediaCategory.parse(command.category())
+                : mediaLog.getCategory();
+        Title title = Title.of(
+                command.title() != null ? command.title() : mediaLog.getTitle().value(),
+                command.originalTitle() != null ? command.originalTitle() : mediaLog.getTitle().original()
+        );
+        EpisodeProgress progress = EpisodeProgress.of(
+                command.currentEpisode() != null
+                        ? command.currentEpisode()
+                        : mediaLog.getProgress().current(),
+                command.totalEpisode() != null
+                        ? command.totalEpisode()
+                        : mediaLog.getProgress().total()
+        );
+        WatchStatus status = command.status() != null
+                ? WatchStatus.parse(command.status())
+                : mediaLog.getStatus();
+        MediaTags tags = command.tags() != null
+                ? MediaTags.of(command.tags())
+                : mediaLog.getMediaTags();
+
+        mediaLog.update(category, title, progress, status, tags);
+        return mediaLog;
+    }
+}

--- a/src/main/java/online/lifeasgame/lifelog/domain/MediaLog.java
+++ b/src/main/java/online/lifeasgame/lifelog/domain/MediaLog.java
@@ -153,6 +153,12 @@ public class MediaLog extends AbstractTime {
             WatchStatus watchStatus,
             MediaTags tags
     ) {
+        Guard.notNull(mediaCategory, "mediaCategory");
+        Guard.notNull(title, "title");
+        Guard.notNull(episodeProgress, "episodeProgress");
+        Guard.notNull(watchStatus, "watchStatus");
+        Guard.notNull(tags, "tags");
+
         this.category = mediaCategory;
         this.title = title;
         this.progress = episodeProgress;

--- a/src/test/java/online/lifeasgame/lifelog/application/LifeLogRecordedApplicationServiceTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/application/LifeLogRecordedApplicationServiceTest.java
@@ -200,6 +200,7 @@ class LifeLogRecordedApplicationServiceTest {
         )).thenReturn(canonical);
         MediaLogService service = new MediaLogService(
                 reader,
+                mock(MediaLogUpdater.class),
                 writer,
                 recordRegistrar,
                 publisher,

--- a/src/test/java/online/lifeasgame/lifelog/application/MediaLogUpdaterTest.java
+++ b/src/test/java/online/lifeasgame/lifelog/application/MediaLogUpdaterTest.java
@@ -1,0 +1,141 @@
+package online.lifeasgame.lifelog.application;
+
+import online.lifeasgame.lifelog.application.command.MediaLogCommand;
+import online.lifeasgame.lifelog.domain.EpisodeProgress;
+import online.lifeasgame.lifelog.domain.MediaCategory;
+import online.lifeasgame.lifelog.domain.MediaLog;
+import online.lifeasgame.lifelog.domain.MediaTags;
+import online.lifeasgame.lifelog.domain.Title;
+import online.lifeasgame.lifelog.domain.WatchStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MediaLogUpdater")
+class MediaLogUpdaterTest {
+
+    private static final Long PLAYER_ID = 276L;
+    private static final Long MEDIA_ID = 2761L;
+
+    @Mock
+    private MediaLogReader mediaLogReader;
+
+    private MediaLogUpdater updater;
+    private MediaLog mediaLog;
+
+    @BeforeEach
+    void setUp() {
+        updater = new MediaLogUpdater(mediaLogReader);
+        mediaLog = MediaLog.create(
+                PLAYER_ID,
+                MediaCategory.SERIES,
+                Title.of("기존 제목", "기존 원제"),
+                EpisodeProgress.of(3, 12),
+                WatchStatus.WATCHING,
+                MediaTags.of(Set.of("drama", "favorite"))
+        );
+        given(mediaLogReader.getByPlayerIdAndIdOrThrow(PLAYER_ID, MEDIA_ID))
+                .willReturn(mediaLog);
+    }
+
+    @Nested
+    @DisplayName("미디어 기록을 부분 수정할 때")
+    class UpdateMediaLog {
+
+        @Test
+        @DisplayName("전달한 category만 바꾸고 생략한 title/progress/status/tags는 보존한다")
+        void appliesSubsetAndPreservesOmittedFields() {
+            updater.update(
+                    PLAYER_ID,
+                    MEDIA_ID,
+                    new MediaLogCommand.Update("MOVIE", null, null, null, null, null, null)
+            );
+
+            assertThat(mediaLog.getCategory()).isEqualTo(MediaCategory.MOVIE);
+            assertThat(mediaLog.getTitle()).isEqualTo(Title.of("기존 제목", "기존 원제"));
+            assertThat(mediaLog.getProgress()).isEqualTo(EpisodeProgress.of(3, 12));
+            assertThat(mediaLog.getStatus()).isEqualTo(WatchStatus.WATCHING);
+            assertThat(mediaLog.getMediaTags().values()).containsExactlyInAnyOrder("drama", "favorite");
+        }
+
+        @Test
+        @DisplayName("currentEpisode만 전달하면 totalEpisode는 보존한다")
+        void mergesProgressAgainstPersistedValues() {
+            updater.update(
+                    PLAYER_ID,
+                    MEDIA_ID,
+                    new MediaLogCommand.Update(null, null, null, 5, null, null, null)
+            );
+
+            assertThat(mediaLog.getProgress()).isEqualTo(EpisodeProgress.of(5, 12));
+        }
+
+        @Test
+        @DisplayName("null tags는 보존하고 빈 tags는 지운다")
+        void preservesNullTagsAndClearsEmptyTags() {
+            updater.update(
+                    PLAYER_ID,
+                    MEDIA_ID,
+                    new MediaLogCommand.Update(null, null, null, null, null, null, null)
+            );
+
+            assertThat(mediaLog.getMediaTags().values()).containsExactlyInAnyOrder("drama", "favorite");
+
+            updater.update(
+                    PLAYER_ID,
+                    MEDIA_ID,
+                    new MediaLogCommand.Update(null, null, null, null, null, null, Set.of())
+            );
+
+            assertThat(mediaLog.getMediaTags().values()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("null originalTitle은 보존하고 blank originalTitle은 지운다")
+        void preservesNullOriginalTitleAndClearsBlankOriginalTitle() {
+            updater.update(
+                    PLAYER_ID,
+                    MEDIA_ID,
+                    new MediaLogCommand.Update(null, null, null, null, null, null, null)
+            );
+
+            assertThat(mediaLog.getTitle().original()).isEqualTo("기존 원제");
+
+            updater.update(
+                    PLAYER_ID,
+                    MEDIA_ID,
+                    new MediaLogCommand.Update(null, null, "   ", null, null, null, null)
+            );
+
+            assertThat(mediaLog.getTitle().original()).isNull();
+        }
+
+        @Test
+        @DisplayName("병합한 progress가 유효하지 않으면 다른 필드도 변경하지 않는다")
+        void rejectsInvalidProgressWithoutPartialMutation() {
+            assertThatThrownBy(() -> updater.update(
+                    PLAYER_ID,
+                    MEDIA_ID,
+                    new MediaLogCommand.Update("MOVIE", "변경 제목", null, 13, null, "COMPLETED", Set.of())
+            )).isInstanceOf(IllegalStateException.class)
+                    .hasMessage("current > total");
+
+            assertThat(mediaLog.getCategory()).isEqualTo(MediaCategory.SERIES);
+            assertThat(mediaLog.getTitle()).isEqualTo(Title.of("기존 제목", "기존 원제"));
+            assertThat(mediaLog.getProgress()).isEqualTo(EpisodeProgress.of(3, 12));
+            assertThat(mediaLog.getStatus()).isEqualTo(WatchStatus.WATCHING);
+            assertThat(mediaLog.getMediaTags().values()).containsExactlyInAnyOrder("drama", "favorite");
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

Make the existing Current Player Media PATCH endpoint behave as a coherent partial update and unblock the real frontend Media management surface.

Closes #276

### Delivered

- omitted Media fields preserve persisted values
- one-sided episode progress updates preserve the other side
- null-safe category/status handling
- originalTitle preserve/clear semantics
- tags preserve/clear semantics
- responsibility-specific MediaLogUpdater
- atomic effective-value validation before aggregate mutation
- focused readable regression coverage

### PATCH Contract

Existing endpoint remains:

```text
PATCH /api/v1/players/media/{mediaId}
```

Normal semantics:

```text
non-null supplied -> apply
null / omitted    -> preserve
```

Special semantics:

```text
originalTitle null  -> preserve
originalTitle blank -> clear

tags null -> preserve
tags []   -> clear
```

### Episode Progress

PATCH progress is merged against the persisted pair before validation.

Backend #266 create/Quick Record normalization remains unchanged and is not reused as PATCH omission behavior.

### Architecture

`MediaLogUpdater` owns:

- owned Media lookup
- partial merge
- domain parsing/value construction
- one aggregate mutation boundary

`MediaLogService.update(...)` remains the application use-case entry.

### Current Player Boundary

Current Player identity remains authentication-owned.

No player/user identity fields were added.

### Scope

No:

- endpoint redesign
- response change
- schema migration
- create/Quick Record change
- rate/advance/status/rewatch redesign
- broader status/progress lifecycle redesign
- unrelated Reader/Writer rename

### Validation

Focused coverage verifies:

- omitted-field preservation
- one-sided progress merge
- tags null vs empty semantics
- originalTitle null vs blank semantics
- invalid effective progress rejection without partial mutation
- final build