### PR TITLE
[Character] Align PlayerTitle ownership and mutation responsibilities

### DIFF
--- a/src/main/java/online/lifeasgame/character/application/PlayerService.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerService.java
@@ -15,7 +15,7 @@ public class PlayerService {
 
     private final PlayerWriter playerWriter;
     private final PlayerReader playerReader;
-    private final PlayerTitleReader playerTitleReader;
+    private final PlayerTitleOwnershipVerifier playerTitleOwnershipVerifier;
     private final PlayerExpGrantService playerExpGrantService;
     private final DomainEventPublisher domainEventPublisher;
     private final CurrentPlayerAccessor currentPlayerAccessor;
@@ -45,7 +45,7 @@ public class PlayerService {
     @Transactional
     public PlayerResult.UpdatedTitle changeRepresentativeTitle(Long playerId, Long titleId) {
         Player player = playerReader.getByIdForUpdateOrThrow(playerId);
-        playerTitleReader.assertHasTitle(playerId, titleId);
+        playerTitleOwnershipVerifier.verifyOwned(playerId, titleId);
         player.changeRepresentativeTitle(titleId);
 
         return new PlayerResult.UpdatedTitle(player.getTitleId());

--- a/src/main/java/online/lifeasgame/character/application/PlayerTitleOwnershipVerifier.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerTitleOwnershipVerifier.java
@@ -1,0 +1,23 @@
+package online.lifeasgame.character.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.domain.error.PlayerTitleError;
+import online.lifeasgame.character.domain.repository.PlayerTitleRepository;
+import online.lifeasgame.core.error.DomainException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.MANDATORY)
+class PlayerTitleOwnershipVerifier {
+
+    private final PlayerTitleRepository repository;
+
+    public void verifyOwned(Long playerId, Long titleId) {
+        if (!repository.existsByPlayerIdAndTitleId(playerId, titleId)) {
+            throw new DomainException(PlayerTitleError.PLAYER_TITLE_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/PlayerTitleReader.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerTitleReader.java
@@ -3,9 +3,6 @@ package online.lifeasgame.character.application;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.character.application.query.PlayerTitleQuery;
 import online.lifeasgame.character.application.view.PlayerTitleView;
-import online.lifeasgame.character.domain.error.PlayerTitleError;
-import online.lifeasgame.character.domain.repository.PlayerTitleRepository;
-import online.lifeasgame.core.error.DomainException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,15 +15,8 @@ import java.util.List;
 class PlayerTitleReader {
 
     private final PlayerTitleQuery query;
-    private final PlayerTitleRepository repository;
 
     public List<PlayerTitleView> getViewsByPlayerId(Long playerId) {
         return query.findViewsByPlayerId(playerId);
-    }
-
-    public void assertHasTitle(Long playerId, Long titleId) {
-        if (!repository.existsByPlayerIdAndTitleId(playerId, titleId)) {
-            throw new DomainException(PlayerTitleError.PLAYER_TITLE_NOT_FOUND);
-        }
     }
 }

--- a/src/main/java/online/lifeasgame/character/application/PlayerTitleRegistrar.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerTitleRegistrar.java
@@ -1,0 +1,20 @@
+package online.lifeasgame.character.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.domain.PlayerTitle;
+import online.lifeasgame.character.domain.repository.PlayerTitleRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.MANDATORY)
+class PlayerTitleRegistrar {
+
+    private final PlayerTitleRepository repository;
+
+    public PlayerTitle register(PlayerTitle playerTitle) {
+        return repository.save(playerTitle);
+    }
+}

--- a/src/main/java/online/lifeasgame/character/application/PlayerTitleRevoker.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerTitleRevoker.java
@@ -1,8 +1,9 @@
 package online.lifeasgame.character.application;
 
 import lombok.RequiredArgsConstructor;
-import online.lifeasgame.character.domain.PlayerTitle;
+import online.lifeasgame.character.domain.error.PlayerTitleError;
 import online.lifeasgame.character.domain.repository.PlayerTitleRepository;
+import online.lifeasgame.core.error.DomainException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,15 +11,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @RequiredArgsConstructor
 @Transactional(propagation = Propagation.MANDATORY)
-class PlayerTitleWriter {
+class PlayerTitleRevoker {
 
     private final PlayerTitleRepository repository;
 
-    public PlayerTitle create(PlayerTitle playerTitle) {
-        return repository.save(playerTitle);
-    }
-
     public void revoke(Long playerId, Long titleId) {
-        repository.deleteByPlayerIdAndTitleId(playerId, titleId);
+        if (repository.deleteByPlayerIdAndTitleId(playerId, titleId) == 0) {
+            throw new DomainException(PlayerTitleError.PLAYER_TITLE_NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/online/lifeasgame/character/application/PlayerTitleService.java
+++ b/src/main/java/online/lifeasgame/character/application/PlayerTitleService.java
@@ -18,7 +18,9 @@ import java.util.List;
 public class PlayerTitleService {
 
     private final PlayerTitleReader playerTitleReader;
-    private final PlayerTitleWriter playerTitleWriter;
+    private final PlayerTitleOwnershipVerifier playerTitleOwnershipVerifier;
+    private final PlayerTitleRegistrar playerTitleRegistrar;
+    private final PlayerTitleRevoker playerTitleRevoker;
     private final TitleReader titleReader;
     private final PlayerReader playerReader;
     private final CurrentPlayerAccessor currentPlayerAccessor;
@@ -34,9 +36,11 @@ public class PlayerTitleService {
 
     @Transactional
     public PlayerTitleResult.Created createTitle(Long playerId, Long titleId) {
+        playerReader.assertExistsById(playerId);
+
         Title title = titleReader.getByIdOrThrow(titleId);
 
-        PlayerTitle playerTitle = playerTitleWriter.create(
+        PlayerTitle playerTitle = playerTitleRegistrar.register(
                 PlayerTitle.create(playerId, titleId)
         );
 
@@ -46,9 +50,9 @@ public class PlayerTitleService {
     @Transactional
     public PlayerTitleResult.Revoked revokeTitle(Long playerId, Long titleId) {
         var player = playerReader.getByIdForUpdateOrThrow(playerId);
-        playerTitleReader.assertHasTitle(playerId, titleId);
+        playerTitleOwnershipVerifier.verifyOwned(playerId, titleId);
         player.clearRepresentativeTitleIfMatches(titleId);
-        playerTitleWriter.revoke(playerId, titleId);
+        playerTitleRevoker.revoke(playerId, titleId);
         return new PlayerTitleResult.Revoked(playerId, titleId);
     }
 }

--- a/src/main/java/online/lifeasgame/character/domain/repository/PlayerTitleRepository.java
+++ b/src/main/java/online/lifeasgame/character/domain/repository/PlayerTitleRepository.java
@@ -7,5 +7,5 @@ public interface PlayerTitleRepository {
 
     boolean existsByPlayerIdAndTitleId(Long playerId, Long titleId);
 
-    void deleteByPlayerIdAndTitleId(Long playerId, Long titleId);
+    long deleteByPlayerIdAndTitleId(Long playerId, Long titleId);
 }

--- a/src/main/java/online/lifeasgame/character/infra/JpaPlayerTitleRepository.java
+++ b/src/main/java/online/lifeasgame/character/infra/JpaPlayerTitleRepository.java
@@ -26,5 +26,5 @@ public interface JpaPlayerTitleRepository extends JpaRepository<PlayerTitle, Lon
 
     boolean existsByPlayerIdAndTitleId(Long playerId, Long titleId);
 
-    void deleteByPlayerIdAndTitleId(Long playerId, Long titleId);
+    long deleteByPlayerIdAndTitleId(Long playerId, Long titleId);
 }

--- a/src/main/java/online/lifeasgame/character/infra/PlayerTitleRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/character/infra/PlayerTitleRepositoryAdapter.java
@@ -25,8 +25,8 @@ public class PlayerTitleRepositoryAdapter implements PlayerTitleRepository, Play
     }
 
     @Override
-    public void deleteByPlayerIdAndTitleId(Long playerId, Long titleId) {
-        jpaRepository.deleteByPlayerIdAndTitleId(playerId, titleId);
+    public long deleteByPlayerIdAndTitleId(Long playerId, Long titleId) {
+        return jpaRepository.deleteByPlayerIdAndTitleId(playerId, titleId);
     }
 
     @Override

--- a/src/test/java/online/lifeasgame/character/application/CharacterApplicationBoundaryTest.java
+++ b/src/test/java/online/lifeasgame/character/application/CharacterApplicationBoundaryTest.java
@@ -1,6 +1,5 @@
 package online.lifeasgame.character.application;
 
-import online.lifeasgame.character.application.query.PlayerTitleQuery;
 import online.lifeasgame.character.domain.GenderType;
 import online.lifeasgame.character.domain.Name;
 import online.lifeasgame.character.domain.Player;
@@ -10,6 +9,8 @@ import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.core.event.DomainEventPublisher;
 import online.lifeasgame.core.security.CurrentPlayerAccessor;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
@@ -17,19 +18,18 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayName("Character application boundary")
 class CharacterApplicationBoundaryTest {
 
     private static final Long PLAYER_ID = 230L;
     private static final Long TITLE_ID = 231L;
-
-    @Mock
-    private PlayerTitleQuery playerTitleQuery;
 
     @Mock
     private PlayerTitleRepository playerTitleRepository;
@@ -41,7 +41,7 @@ class CharacterApplicationBoundaryTest {
     private PlayerTitleReader playerTitleReader;
 
     @Mock
-    private PlayerTitleWriter playerTitleWriter;
+    private PlayerTitleRegistrar playerTitleRegistrar;
 
     @Mock
     private TitleReader titleReader;
@@ -67,95 +67,100 @@ class CharacterApplicationBoundaryTest {
     @Mock
     private CurrentPlayerAccessor currentPlayerAccessor;
 
-    private PlayerTitleReader actualPlayerTitleReader;
+    private PlayerTitleOwnershipVerifier playerTitleOwnershipVerifier;
+    private PlayerTitleRevoker playerTitleRevoker;
 
     @BeforeEach
     void setUp() {
-        actualPlayerTitleReader = new PlayerTitleReader(
-                playerTitleQuery,
-                playerTitleRepository
-        );
+        playerTitleOwnershipVerifier = new PlayerTitleOwnershipVerifier(playerTitleRepository);
+        playerTitleRevoker = new PlayerTitleRevoker(playerTitleRepository);
     }
 
-    @Test
-    void acceptsOwnedTitle() {
-        given(playerTitleRepository.existsByPlayerIdAndTitleId(
-                PLAYER_ID,
-                TITLE_ID
-        )).willReturn(true);
+    @Nested
+    @DisplayName("대표 칭호를 선택할 때")
+    class ChangeRepresentativeTitle {
 
-        assertThatCode(() -> actualPlayerTitleReader.assertHasTitle(
-                PLAYER_ID,
-                TITLE_ID
-        )).doesNotThrowAnyException();
+        @Test
+        @DisplayName("Player를 잠근 뒤 보유한 칭호를 대표 칭호로 변경한다")
+        void changesToOwnedTitleAfterLock() {
+            Player player = player();
+            given(playerReader.getByIdForUpdateOrThrow(PLAYER_ID)).willReturn(player);
+            given(playerTitleRepository.existsByPlayerIdAndTitleId(PLAYER_ID, TITLE_ID))
+                    .willReturn(true);
+            PlayerService service = playerService();
+
+            var result = service.changeRepresentativeTitle(PLAYER_ID, TITLE_ID);
+
+            InOrder order = inOrder(playerReader, playerTitleRepository);
+            order.verify(playerReader).getByIdForUpdateOrThrow(PLAYER_ID);
+            order.verify(playerTitleRepository).existsByPlayerIdAndTitleId(PLAYER_ID, TITLE_ID);
+            assertThat(result.titleId()).isEqualTo(TITLE_ID);
+            assertThat(player.getTitleId()).isEqualTo(TITLE_ID);
+        }
+
+        @Test
+        @DisplayName("보유하지 않은 칭호는 거부하고 기존 대표 칭호를 유지한다")
+        void rejectsUnownedTitleWithoutChangingState() {
+            Player player = player();
+            player.changeRepresentativeTitle(232L);
+            given(playerReader.getByIdForUpdateOrThrow(PLAYER_ID)).willReturn(player);
+            given(playerTitleRepository.existsByPlayerIdAndTitleId(PLAYER_ID, TITLE_ID))
+                    .willReturn(false);
+
+            assertPlayerTitleNotFound(() -> playerService()
+                    .changeRepresentativeTitle(PLAYER_ID, TITLE_ID));
+
+            InOrder order = inOrder(playerReader, playerTitleRepository);
+            order.verify(playerReader).getByIdForUpdateOrThrow(PLAYER_ID);
+            order.verify(playerTitleRepository).existsByPlayerIdAndTitleId(PLAYER_ID, TITLE_ID);
+            assertThat(player.getTitleId()).isEqualTo(232L);
+        }
     }
 
-    @Test
-    void rejectsMissingTitle() {
-        given(playerTitleRepository.existsByPlayerIdAndTitleId(
-                PLAYER_ID,
-                TITLE_ID
-        )).willReturn(false);
+    @Nested
+    @DisplayName("보유 칭호를 회수할 때")
+    class RevokeTitle {
 
-        assertThatThrownBy(() -> actualPlayerTitleReader.assertHasTitle(
-                PLAYER_ID,
-                TITLE_ID
-        )).isInstanceOfSatisfying(DomainException.class, exception ->
-                assertThat(exception.getErrorCode())
-                        .isEqualTo(PlayerTitleError.PLAYER_TITLE_NOT_FOUND)
-        );
-    }
+        @Test
+        @DisplayName("Player를 잠그고 소유권을 확인한 뒤 대표 칭호를 지우고 소유권을 회수한다")
+        void clearsCurrentRepresentativeBeforeRevokingOwnership() {
+            Player player = player();
+            player.changeRepresentativeTitle(TITLE_ID);
+            given(playerReader.getByIdForUpdateOrThrow(PLAYER_ID)).willReturn(player);
+            given(playerTitleRepository.existsByPlayerIdAndTitleId(PLAYER_ID, TITLE_ID))
+                    .willReturn(true);
+            given(playerTitleRepository.deleteByPlayerIdAndTitleId(PLAYER_ID, TITLE_ID))
+                    .willAnswer(invocation -> {
+                        assertThat(player.getTitleId()).isNull();
+                        return 1L;
+                    });
 
-    @Test
-    void locksPlayerBeforeChangingRepresentativeTitle() {
-        Player player = player();
-        given(playerReader.getByIdForUpdateOrThrow(PLAYER_ID))
-                .willReturn(player);
-        PlayerService service = new PlayerService(
-                playerWriter,
-                playerReader,
-                playerTitleReader,
-                playerExpGrantService,
-                domainEventPublisher,
-                currentPlayerAccessor
-        );
+            var result = playerTitleService().revokeTitle(PLAYER_ID, TITLE_ID);
 
-        var result = service.changeRepresentativeTitle(PLAYER_ID, TITLE_ID);
+            InOrder order = inOrder(playerReader, playerTitleRepository);
+            order.verify(playerReader).getByIdForUpdateOrThrow(PLAYER_ID);
+            order.verify(playerTitleRepository).existsByPlayerIdAndTitleId(PLAYER_ID, TITLE_ID);
+            order.verify(playerTitleRepository).deleteByPlayerIdAndTitleId(PLAYER_ID, TITLE_ID);
+            assertThat(result.playerId()).isEqualTo(PLAYER_ID);
+            assertThat(result.titleId()).isEqualTo(TITLE_ID);
+        }
 
-        InOrder locks = inOrder(playerReader, playerTitleReader);
-        locks.verify(playerReader).getByIdForUpdateOrThrow(PLAYER_ID);
-        locks.verify(playerTitleReader).assertHasTitle(PLAYER_ID, TITLE_ID);
-        assertThat(result.titleId()).isEqualTo(TITLE_ID);
-        assertThat(player.getTitleId()).isEqualTo(TITLE_ID);
-    }
+        @Test
+        @DisplayName("소유권이 없으면 대표 칭호를 유지하고 PLAYER_TITLE_NOT_FOUND로 거부한다")
+        void rejectsMissingOwnershipWithoutChangingState() {
+            Player player = player();
+            player.changeRepresentativeTitle(TITLE_ID);
+            given(playerReader.getByIdForUpdateOrThrow(PLAYER_ID)).willReturn(player);
+            given(playerTitleRepository.existsByPlayerIdAndTitleId(PLAYER_ID, TITLE_ID))
+                    .willReturn(false);
 
-    @Test
-    void locksPlayerAndClearsRepresentativeTitleBeforeRevoke() {
-        Player player = player();
-        player.changeRepresentativeTitle(TITLE_ID);
-        given(playerReader.getByIdForUpdateOrThrow(PLAYER_ID))
-                .willReturn(player);
-        PlayerTitleService service = new PlayerTitleService(
-                playerTitleReader,
-                playerTitleWriter,
-                titleReader,
-                playerReader,
-                currentPlayerAccessor
-        );
+            assertPlayerTitleNotFound(() -> playerTitleService().revokeTitle(PLAYER_ID, TITLE_ID));
 
-        var result = service.revokeTitle(PLAYER_ID, TITLE_ID);
+            assertThat(player.getTitleId()).isEqualTo(TITLE_ID);
+            verify(playerTitleRepository, never()).deleteByPlayerIdAndTitleId(PLAYER_ID, TITLE_ID);
 
-        InOrder order = inOrder(
-                playerReader,
-                playerTitleReader,
-                playerTitleWriter
-        );
-        order.verify(playerReader).getByIdForUpdateOrThrow(PLAYER_ID);
-        order.verify(playerTitleReader).assertHasTitle(PLAYER_ID, TITLE_ID);
-        order.verify(playerTitleWriter).revoke(PLAYER_ID, TITLE_ID);
-        assertThat(player.getTitleId()).isNull();
-        assertThat(result.playerId()).isEqualTo(PLAYER_ID);
-        assertThat(result.titleId()).isEqualTo(TITLE_ID);
+            assertPlayerTitleNotFound(() -> playerTitleRevoker.revoke(PLAYER_ID, TITLE_ID));
+        }
     }
 
     @Test
@@ -176,5 +181,41 @@ class CharacterApplicationBoundaryTest {
 
     private Player player() {
         return Player.linkStart(1L, Name.of("player"), GenderType.MALE);
+    }
+
+    private PlayerService playerService() {
+        return new PlayerService(
+                playerWriter,
+                playerReader,
+                playerTitleOwnershipVerifier,
+                playerExpGrantService,
+                domainEventPublisher,
+                currentPlayerAccessor
+        );
+    }
+
+    private PlayerTitleService playerTitleService() {
+        return new PlayerTitleService(
+                playerTitleReader,
+                playerTitleOwnershipVerifier,
+                playerTitleRegistrar,
+                playerTitleRevoker,
+                titleReader,
+                playerReader,
+                currentPlayerAccessor
+        );
+    }
+
+    private void assertPlayerTitleNotFound(ThrowingAction action) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode())
+                                .isEqualTo(PlayerTitleError.PLAYER_TITLE_NOT_FOUND)
+                );
+    }
+
+    @FunctionalInterface
+    private interface ThrowingAction {
+        void run();
     }
 }

--- a/src/test/java/online/lifeasgame/character/application/PlayerServiceExpGrantTest.java
+++ b/src/test/java/online/lifeasgame/character/application/PlayerServiceExpGrantTest.java
@@ -26,7 +26,7 @@ class PlayerServiceExpGrantTest {
     private PlayerReader playerReader;
 
     @Mock
-    private PlayerTitleReader playerTitleReader;
+    private PlayerTitleOwnershipVerifier playerTitleOwnershipVerifier;
 
     @Mock
     private PlayerExpGrantService playerExpGrantService;
@@ -44,7 +44,7 @@ class PlayerServiceExpGrantTest {
         service = new PlayerService(
                 playerWriter,
                 playerReader,
-                playerTitleReader,
+                playerTitleOwnershipVerifier,
                 playerExpGrantService,
                 domainEventPublisher,
                 currentPlayerAccessor


### PR DESCRIPTION
### Purpose

Align the PlayerTitle application boundary with responsibility-driven naming while preserving acquired-title, representative-title and admin grant/revoke behavior.

Closes #278

### Delivered

- pure PlayerTitle read boundary
- explicit PlayerTitle ownership verification
- responsibility-specific PlayerTitle registration
- responsibility-specific PlayerTitle revocation
- representative-title ownership contract preservation
- representative clearing on revoke preservation
- controlled missing-ownership behavior
- focused readable regression coverage

### Responsibility Structure

The touched boundary separates:

```text
read projection
ownership verification
registration
revocation
```

The generic mixed-purpose PlayerTitleWriter is removed.

### Representative Title

Representative selection still requires an owned Title and preserves the existing Player locking/transaction boundary.

### Revoke

Revoking a currently representative Title clears the representative field and removes the ownership association in the same application transaction.

Missing ownership continues to use:

```text
PLAYER_TITLE_NOT_FOUND
```

### Current Player Boundary

Current Player identity remains authentication-owned.

No caller player/user identity fields are added.

### Scope

No:

- endpoint change
- response change
- schema migration
- Current Player acquire/revoke API
- representative clear API
- Title catalog redesign
- repository-wide Reader/Writer refactor

### Validation

Focused coverage verifies:

- owned representative selection
- unowned selection rejection
- representative clearing on revoke
- missing ownership revoke rejection
- final build