### PR TITLE
[Social] Harden Follow lifecycle and mutual-friend semantics

### DIFF
--- a/src/main/java/online/lifeasgame/social/application/ChatService.java
+++ b/src/main/java/online/lifeasgame/social/application/ChatService.java
@@ -20,7 +20,7 @@ public class ChatService {
     private final ChatWriter chatWriter;
     private final GuildReader guildReader;
     private final PartyReader partyReader;
-    private final FollowReader followReader;
+    private final FriendshipVerifier friendshipVerifier;
 
     @Transactional
     public ChatResult.Channel openGlobal(Long playerId, ChatCommand.OpenGlobal command) {
@@ -69,7 +69,7 @@ public class ChatService {
 
     @Transactional
     public ChatResult.Channel openFriend(Long playerId, Long friendId, ChatCommand.OpenFriend command) {
-        followReader.assertExistsFriend(playerId, friendId);
+        friendshipVerifier.verify(playerId, friendId);
 
         ChatSpec.OpenFriend spec = ChatSpec.OpenFriend.from(playerId, friendId, command);
         ChatChannel channel = chatWriter.ensureFriendChannel(spec.playerId(), spec.friendId(), spec.name());

--- a/src/main/java/online/lifeasgame/social/application/FollowReader.java
+++ b/src/main/java/online/lifeasgame/social/application/FollowReader.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -21,6 +22,10 @@ public class FollowReader {
     public Follow getByFollowIdAndPlayerId(Long followId, Long playerId) {
         return repository.findByIdAndPlayerId(followId, playerId).orElseThrow(() -> new DomainException(
                 SocialError.FOLLOW_NOT_FOUND));
+    }
+
+    public Optional<Follow> findByPlayerIdAndTargetPlayerId(Long playerId, Long targetPlayerId) {
+        return repository.findByPlayerIdAndTargetPlayerId(playerId, targetPlayerId);
     }
 
     public List<Follow> getFollowingsByPlayerId(Long playerId, int page, int size) {
@@ -47,10 +52,4 @@ public class FollowReader {
         return repository.recentFollowers(playerId, limit);
     }
 
-    public void assertExistsFriend(Long friendId, Long playerId) {
-        if (repository.existsByPlayerIdAndTargetId(playerId, friendId)
-                && repository.existsByPlayerIdAndTargetId(friendId, playerId)) {
-            throw new DomainException(SocialError.NOT_FRIEND);
-        }
-    }
 }

--- a/src/main/java/online/lifeasgame/social/application/FollowRegistrar.java
+++ b/src/main/java/online/lifeasgame/social/application/FollowRegistrar.java
@@ -10,11 +10,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @RequiredArgsConstructor
 @Transactional(propagation = Propagation.MANDATORY)
-public class FollowWriter {
+public class FollowRegistrar {
 
     private final FollowRepository repository;
 
-    public Follow create(Follow follow) {
+    public Follow register(Follow follow) {
         return repository.save(follow);
     }
 }

--- a/src/main/java/online/lifeasgame/social/application/FollowService.java
+++ b/src/main/java/online/lifeasgame/social/application/FollowService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import online.lifeasgame.social.application.command.FollowCommand;
 import online.lifeasgame.social.application.result.FollowResult;
 import online.lifeasgame.social.domain.Follow;
+import online.lifeasgame.social.domain.FollowState;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,16 +17,22 @@ import java.util.List;
 public class FollowService {
 
     private final FollowReader followReader;
-    private final FollowWriter followWriter;
+    private final FollowRegistrar followRegistrar;
 
     @Transactional
     public FollowResult.Info follow(Long playerId, FollowCommand.Create command) {
-        Follow follow = followWriter.create(
+        Follow follow = followReader.findByPlayerIdAndTargetPlayerId(
+                playerId,
+                command.targetPlayerId()
+        ).orElseGet(() -> followRegistrar.register(
                 Follow.create(
                         playerId,
                         command.targetPlayerId()
                 )
-        );
+        ));
+        if (follow.getState() == FollowState.STOPPED) {
+            follow.followAgain();
+        }
         
         return FollowResult.Info.from(follow);
     }

--- a/src/main/java/online/lifeasgame/social/application/FriendshipVerifier.java
+++ b/src/main/java/online/lifeasgame/social/application/FriendshipVerifier.java
@@ -1,0 +1,24 @@
+package online.lifeasgame.social.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.social.domain.error.SocialError;
+import online.lifeasgame.social.domain.repository.FollowRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+public class FriendshipVerifier {
+
+    private final FollowRepository repository;
+
+    public void verify(Long playerId, Long friendId) {
+        if (!repository.existsActiveFollow(playerId, friendId)
+                || !repository.existsActiveFollow(friendId, playerId)) {
+            throw new DomainException(SocialError.NOT_FRIEND);
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/social/domain/Follow.java
+++ b/src/main/java/online/lifeasgame/social/domain/Follow.java
@@ -77,6 +77,12 @@ public class Follow extends AbstractTime {
         this.muted = false;
     }
 
+    public void followAgain() {
+        Guard.checkState(this.state == FollowState.STOPPED, "already following");
+        this.state = FollowState.FOLLOWING;
+        this.muted = false;
+    }
+
     public void mute() {
         Guard.checkState(this.state == FollowState.FOLLOWING, "mute only when following");
         this.muted = true;

--- a/src/main/java/online/lifeasgame/social/domain/repository/FollowRepository.java
+++ b/src/main/java/online/lifeasgame/social/domain/repository/FollowRepository.java
@@ -12,7 +12,9 @@ public interface FollowRepository {
 
     Optional<Follow> findByIdAndPlayerId(Long id, Long playerId);
 
-    boolean existsByPlayerIdAndTargetId(Long playerId, Long friendId);
+    Optional<Follow> findByPlayerIdAndTargetPlayerId(Long playerId, Long targetPlayerId);
+
+    boolean existsActiveFollow(Long playerId, Long targetPlayerId);
 
     List<Follow> findFollowings(Long playerId, int page, int size);
 

--- a/src/main/java/online/lifeasgame/social/infra/FollowJpaRepository.java
+++ b/src/main/java/online/lifeasgame/social/infra/FollowJpaRepository.java
@@ -1,6 +1,7 @@
 package online.lifeasgame.social.infra;
 
 import online.lifeasgame.social.domain.Follow;
+import online.lifeasgame.social.domain.FollowState;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,56 +17,88 @@ public interface FollowJpaRepository extends JpaRepository<Follow, Long> {
 
     Optional<Follow> findByIdAndPlayerId(Long id, Long playerId);
 
+    Optional<Follow> findByPlayerIdAndTargetPlayerId(Long playerId, Long targetPlayerId);
+
     @Query(
         """
             SELECT f.id
             FROM Follow f
             WHERE f.playerId = :playerId
+              AND f.state = :state
             ORDER BY f.id DESC
         """
     )
-    Page<Long> findFollowingIds(@Param("playerId") Long playerId, Pageable pageable);
+    Page<Long> findFollowingIds(
+            @Param("playerId") Long playerId,
+            @Param("state") FollowState state,
+            Pageable pageable
+    );
 
     @Query(
         """
             SELECT f.id
             FROM Follow f
             WHERE f.targetPlayerId = :playerId
+              AND f.state = :state
             ORDER BY f.id DESC
         """
     )
-    Page<Long> findFollowerIds(@Param("playerId") Long playerId, Pageable pageable);
+    Page<Long> findFollowerIds(
+            @Param("playerId") Long playerId,
+            @Param("state") FollowState state,
+            Pageable pageable
+    );
 
     @Query(
         """
             SELECT f
             FROM Follow f
             WHERE f.id IN :ids
+              AND f.state = :state
         """
     )
-    List<Follow> findAllByIdIn(@Param("ids") List<Long> ids);
+    List<Follow> findAllByIdInAndState(
+            @Param("ids") List<Long> ids,
+            @Param("state") FollowState state
+    );
 
     @Query(
         """
             SELECT f
             FROM Follow f
             WHERE f.playerId = :playerId
+              AND f.state = :state
             ORDER BY f.id DESC
         """
     )
-    List<Follow> findRecentFollowings(@Param("playerId") Long playerId, Pageable pageable);
+    List<Follow> findRecentFollowings(
+            @Param("playerId") Long playerId,
+            @Param("state") FollowState state,
+            Pageable pageable
+    );
 
     @Query(
         """
             SELECT f
             FROM Follow f
             WHERE f.targetPlayerId = :playerId
+              AND f.state = :state
             ORDER BY f.id DESC
         """
     )
-    List<Follow> findRecentFollowers(@Param("playerId") Long playerId, Pageable pageable);
+    List<Follow> findRecentFollowers(
+            @Param("playerId") Long playerId,
+            @Param("state") FollowState state,
+            Pageable pageable
+    );
 
-    long countByPlayerId(Long playerId);
+    long countByPlayerIdAndState(Long playerId, FollowState state);
 
-    boolean existsByPlayerIdAndTargetPlayerId(Long playerId, Long targetPlayerId);
+    long countByTargetPlayerIdAndState(Long targetPlayerId, FollowState state);
+
+    boolean existsByPlayerIdAndTargetPlayerIdAndState(
+            Long playerId,
+            Long targetPlayerId,
+            FollowState state
+    );
 }

--- a/src/main/java/online/lifeasgame/social/infra/FollowRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/social/infra/FollowRepositoryAdapter.java
@@ -2,6 +2,7 @@ package online.lifeasgame.social.infra;
 
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.social.domain.Follow;
+import online.lifeasgame.social.domain.FollowState;
 import online.lifeasgame.social.domain.repository.FollowRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -31,19 +32,29 @@ public class FollowRepositoryAdapter implements FollowRepository {
     }
 
     @Override
-    public boolean existsByPlayerIdAndTargetId(Long playerId, Long friendId) {
-        return followJpaRepository.existsByPlayerIdAndTargetPlayerId(playerId, friendId);
+    public Optional<Follow> findByPlayerIdAndTargetPlayerId(Long playerId, Long targetPlayerId) {
+        return followJpaRepository.findByPlayerIdAndTargetPlayerId(playerId, targetPlayerId);
+    }
+
+    @Override
+    public boolean existsActiveFollow(Long playerId, Long targetPlayerId) {
+        return followJpaRepository.existsByPlayerIdAndTargetPlayerIdAndState(
+                playerId,
+                targetPlayerId,
+                FollowState.FOLLOWING
+        );
     }
 
     @Override
     public List<Follow> findFollowings(Long playerId, int page, int size) {
         Page<Long> idPage = followJpaRepository.findFollowingIds(
                 playerId,
+                FollowState.FOLLOWING,
                 PageRequest.of(Math.max(page, 0), Math.min(Math.max(size, 1), 100))
         );
         if (idPage.isEmpty()) return List.of();
         List<Long> ids = idPage.getContent();
-        List<Follow> list = followJpaRepository.findAllByIdIn(ids);
+        List<Follow> list = followJpaRepository.findAllByIdInAndState(ids, FollowState.FOLLOWING);
         Map<Long, Integer> order = new HashMap<>();
         for (int i = 0; i < ids.size(); i++) order.put(ids.get(i), i);
         list.sort(Comparator.comparingInt(f -> order.getOrDefault(f.getId(), Integer.MAX_VALUE)));
@@ -52,18 +63,19 @@ public class FollowRepositoryAdapter implements FollowRepository {
 
     @Override
     public long countFollowings(Long playerId) {
-        return followJpaRepository.findFollowingIds(playerId, PageRequest.of(0, 1)).getTotalElements();
+        return followJpaRepository.countByPlayerIdAndState(playerId, FollowState.FOLLOWING);
     }
 
     @Override
     public List<Follow> findFollowers(Long playerId, int page, int size) {
         Page<Long> idPage = followJpaRepository.findFollowerIds(
                 playerId,
+                FollowState.FOLLOWING,
                 PageRequest.of(Math.max(page, 0), Math.min(Math.max(size, 1), 100))
         );
         if (idPage.isEmpty()) return List.of();
         List<Long> ids = idPage.getContent();
-        List<Follow> list = followJpaRepository.findAllByIdIn(ids);
+        List<Follow> list = followJpaRepository.findAllByIdInAndState(ids, FollowState.FOLLOWING);
         Map<Long, Integer> order = new HashMap<>();
         for (int i = 0; i < ids.size(); i++) order.put(ids.get(i), i);
         list.sort(Comparator.comparingInt(f -> order.getOrDefault(f.getId(), Integer.MAX_VALUE)));
@@ -72,16 +84,24 @@ public class FollowRepositoryAdapter implements FollowRepository {
 
     @Override
     public long countFollowers(Long playerId) {
-        return followJpaRepository.countByPlayerId(playerId);
+        return followJpaRepository.countByTargetPlayerIdAndState(playerId, FollowState.FOLLOWING);
     }
 
     @Override
     public List<Follow> recentFollowings(Long playerId, int limit) {
-        return followJpaRepository.findRecentFollowings(playerId, PageRequest.of(0, Math.min(Math.max(limit, 1), 100)));
+        return followJpaRepository.findRecentFollowings(
+                playerId,
+                FollowState.FOLLOWING,
+                PageRequest.of(0, Math.min(Math.max(limit, 1), 100))
+        );
     }
 
     @Override
     public List<Follow> recentFollowers(Long playerId, int limit) {
-        return followJpaRepository.findRecentFollowers(playerId, PageRequest.of(0, Math.min(Math.max(limit, 1), 100)));
+        return followJpaRepository.findRecentFollowers(
+                playerId,
+                FollowState.FOLLOWING,
+                PageRequest.of(0, Math.min(Math.max(limit, 1), 100))
+        );
     }
 }

--- a/src/test/java/online/lifeasgame/social/application/FollowLifecycleIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/social/application/FollowLifecycleIntegrationTest.java
@@ -1,0 +1,157 @@
+package online.lifeasgame.social.application;
+
+import jakarta.persistence.EntityManager;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.social.application.command.FollowCommand;
+import online.lifeasgame.social.application.result.FollowResult;
+import online.lifeasgame.social.domain.Follow;
+import online.lifeasgame.social.domain.FollowState;
+import online.lifeasgame.social.domain.error.SocialError;
+import online.lifeasgame.social.domain.repository.FollowRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("Follow lifecycle와 friendship contract")
+class FollowLifecycleIntegrationTest {
+
+    private static final Long PLAYER_ID = 282L;
+    private static final Long FRIEND_ID = 283L;
+
+    @Autowired
+    private FollowService followService;
+
+    @Autowired
+    private FollowRepository followRepository;
+
+    @Autowired
+    private FriendshipVerifier friendshipVerifier;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Nested
+    @DisplayName("같은 pair를 다시 follow할 때")
+    class Refollow {
+
+        @Test
+        @DisplayName("기존 row를 재사용하고 STOPPED 상태와 mute만 복구한다")
+        void reusesExistingRow() {
+            FollowResult.Info first = follow(PLAYER_ID, FRIEND_ID);
+            FollowResult.Info alreadyFollowing = follow(PLAYER_ID, FRIEND_ID);
+            followService.block(PLAYER_ID, first.id());
+            followService.mute(PLAYER_ID, first.id());
+            followService.unfollow(PLAYER_ID, first.id());
+
+            FollowResult.Info followedAgain = follow(PLAYER_ID, FRIEND_ID);
+            entityManager.flush();
+            Follow persisted = followRepository.findByPlayerIdAndTargetPlayerId(
+                    PLAYER_ID,
+                    FRIEND_ID
+            ).orElseThrow();
+
+            assertThat(alreadyFollowing.id()).isEqualTo(first.id());
+            assertThat(followedAgain.id()).isEqualTo(first.id());
+            assertThat(pairRowCount(PLAYER_ID, FRIEND_ID)).isEqualTo(1);
+            assertThat(persisted.getState()).isEqualTo(FollowState.FOLLOWING);
+            assertThat(persisted.isMuted()).isFalse();
+            assertThat(persisted.isBlocked()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("follow 목록과 집계를 조회할 때")
+    class ActiveQueries {
+
+        @Test
+        @DisplayName("양방향 모두 FOLLOWING만 반환하고 follower는 inbound로 집계한다")
+        void returnsOnlyActiveRelationships() {
+            FollowResult.Info activeFollowing = follow(PLAYER_ID, FRIEND_ID);
+            FollowResult.Info stoppedFollowing = follow(PLAYER_ID, FRIEND_ID + 1);
+            FollowResult.Info activeFollower = follow(FRIEND_ID + 2, PLAYER_ID);
+            FollowResult.Info stoppedFollower = follow(FRIEND_ID + 3, PLAYER_ID);
+            followService.unfollow(PLAYER_ID, stoppedFollowing.id());
+            followService.unfollow(FRIEND_ID + 3, stoppedFollower.id());
+
+            FollowResult.Page<FollowResult.Summary> followings =
+                    followService.listFollowings(PLAYER_ID, 0, 20);
+            FollowResult.Page<FollowResult.Summary> followers =
+                    followService.listFollowers(PLAYER_ID, 0, 20);
+
+            assertThat(followings.contents()).extracting(FollowResult.Summary::id)
+                    .containsExactly(activeFollowing.id());
+            assertThat(followings.totalElements()).isEqualTo(1);
+            assertThat(followers.contents()).extracting(FollowResult.Summary::id)
+                    .containsExactly(activeFollower.id());
+            assertThat(followers.totalElements()).isEqualTo(1);
+            assertThat(followService.recentFollowings(PLAYER_ID, 20))
+                    .extracting(FollowResult.Summary::id)
+                    .containsExactly(activeFollowing.id());
+            assertThat(followService.recentFollowers(PLAYER_ID, 20))
+                    .extracting(FollowResult.Summary::id)
+                    .containsExactly(activeFollower.id());
+        }
+    }
+
+    @Nested
+    @DisplayName("friendship을 검증할 때")
+    class Friendship {
+
+        @Test
+        @DisplayName("양방향 active follow이면 허용한다")
+        void allowsMutualActiveFollow() {
+            follow(PLAYER_ID, FRIEND_ID);
+            follow(FRIEND_ID, PLAYER_ID);
+
+            assertThatCode(() -> friendshipVerifier.verify(PLAYER_ID, FRIEND_ID))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("반대 방향이 없거나 STOPPED이면 NOT_FRIEND로 거부한다")
+        void rejectsMissingOrStoppedDirection() {
+            follow(PLAYER_ID, FRIEND_ID);
+
+            assertNotFriend();
+
+            FollowResult.Info reverse = follow(FRIEND_ID, PLAYER_ID);
+            followService.unfollow(FRIEND_ID, reverse.id());
+
+            assertNotFriend();
+        }
+    }
+
+    private FollowResult.Info follow(Long playerId, Long targetPlayerId) {
+        return followService.follow(playerId, new FollowCommand.Create(targetPlayerId));
+    }
+
+    private long pairRowCount(Long playerId, Long targetPlayerId) {
+        return entityManager.createQuery("""
+                SELECT COUNT(f)
+                FROM Follow f
+                WHERE f.playerId = :playerId
+                  AND f.targetPlayerId = :targetPlayerId
+                """, Long.class)
+                .setParameter("playerId", playerId)
+                .setParameter("targetPlayerId", targetPlayerId)
+                .getSingleResult();
+    }
+
+    private void assertNotFriend() {
+        assertThatThrownBy(() -> friendshipVerifier.verify(PLAYER_ID, FRIEND_ID))
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(SocialError.NOT_FRIEND)
+                );
+    }
+}


### PR DESCRIPTION
### Purpose

Make Follow a coherent foundation for real Connections and Friend Chat.

Closes #282

### Delivered

- single-row directed Follow lifecycle
- refollow reactivation
- no sequential duplicate pair insert
- active-only following/follower reads
- corrected follower count direction
- active-only recent connections
- semantic mutual-friend verification
- Friend Chat verification fix
- responsibility-specific Follow registration
- focused lifecycle/query coverage

### Lifecycle

```text
first follow -> create FOLLOWING row
already FOLLOWING -> reuse existing row
STOPPED -> reactivate same row
```

Refollow keeps the same followId.

### Active Connections

Only:

```text
state = FOLLOWING
```

appears in followings, followers, counts, and recent lists.

### Friendship

Friend Chat friendship means:

```text
A -> B FOLLOWING
AND
B -> A FOLLOWING
```

Otherwise the existing:

```text
NOT_FRIEND
```

is returned.

### Ownership

Current Player identity remains authentication-owned.

No player/user identity is added to requests.

### Scope

No:

- Follow HTTP redesign
- block policy redesign
- Character repository dependency
- schema migration
- distributed locking
- Party/Guild refactor
- RoleParty work

### Validation

Focused coverage verifies refollow row reuse, active-only reads/counts, correct directionality, mutual-follow friendship, and final build.