### PR TITLE
[Social] Add canonical Current Player Connections read model

### DIFF
--- a/src/main/java/online/lifeasgame/character/application/internal/PlayerConnectionReadApi.java
+++ b/src/main/java/online/lifeasgame/character/application/internal/PlayerConnectionReadApi.java
@@ -1,0 +1,17 @@
+package online.lifeasgame.character.application.internal;
+
+import java.util.Map;
+import java.util.Set;
+
+public interface PlayerConnectionReadApi {
+
+    Map<Long, PlayerSummary> findAllByPlayerIds(Set<Long> playerIds);
+
+    record PlayerSummary(
+            Long playerId,
+            String name,
+            String job,
+            int level
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/character/infra/PlayerConnectionReadAdapter.java
+++ b/src/main/java/online/lifeasgame/character/infra/PlayerConnectionReadAdapter.java
@@ -1,0 +1,48 @@
+package online.lifeasgame.character.infra;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.application.internal.PlayerConnectionReadApi;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static online.lifeasgame.character.domain.QPlayer.player;
+
+@Repository
+@RequiredArgsConstructor
+public class PlayerConnectionReadAdapter implements PlayerConnectionReadApi {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Map<Long, PlayerSummary> findAllByPlayerIds(Set<Long> playerIds) {
+        if (playerIds.isEmpty()) {
+            return Map.of();
+        }
+        return queryFactory
+                .select(
+                        player.id,
+                        player.name.value,
+                        player.job,
+                        player.level.value
+                )
+                .from(player)
+                .where(player.id.in(playerIds))
+                .fetch()
+                .stream()
+                .map(row -> new PlayerSummary(
+                        row.get(player.id),
+                        row.get(player.name.value),
+                        row.get(player.job),
+                        row.get(player.level.value)
+                ))
+                .collect(Collectors.toUnmodifiableMap(
+                        PlayerSummary::playerId,
+                        Function.identity()
+                ));
+    }
+}

--- a/src/main/java/online/lifeasgame/social/api/player/PlayerConnectionController.java
+++ b/src/main/java/online/lifeasgame/social/api/player/PlayerConnectionController.java
@@ -1,0 +1,50 @@
+package online.lifeasgame.social.api.player;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.response.ApiResponse;
+import online.lifeasgame.platform.web.response.ApiResponses;
+import online.lifeasgame.social.api.player.mapper.PlayerConnectionWebMapper;
+import online.lifeasgame.social.api.player.response.PlayerConnectionResponse;
+import online.lifeasgame.social.api.player.spec.PlayerConnectionApiSpecV1;
+import online.lifeasgame.social.application.ConnectionQueryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/connections")
+public class PlayerConnectionController implements PlayerConnectionApiSpecV1 {
+
+    private final ConnectionQueryService connectionQueryService;
+
+    @Override
+    @GetMapping("/followings")
+    public ResponseEntity<ApiResponse<PlayerConnectionResponse.Page<PlayerConnectionResponse.Following>>> followings(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return ApiResponses.ok(PlayerConnectionWebMapper.toFollowingPage(
+                connectionQueryService.followings(
+                        Math.max(page, 0),
+                        Math.min(Math.max(size, 1), 100)
+                )
+        ));
+    }
+
+    @Override
+    @GetMapping("/followers")
+    public ResponseEntity<ApiResponse<PlayerConnectionResponse.Page<PlayerConnectionResponse.Follower>>> followers(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return ApiResponses.ok(PlayerConnectionWebMapper.toFollowerPage(
+                connectionQueryService.followers(
+                        Math.max(page, 0),
+                        Math.min(Math.max(size, 1), 100)
+                )
+        ));
+    }
+}

--- a/src/main/java/online/lifeasgame/social/api/player/mapper/PlayerConnectionWebMapper.java
+++ b/src/main/java/online/lifeasgame/social/api/player/mapper/PlayerConnectionWebMapper.java
@@ -1,0 +1,56 @@
+package online.lifeasgame.social.api.player.mapper;
+
+import online.lifeasgame.social.api.player.response.PlayerConnectionResponse;
+import online.lifeasgame.social.application.result.ConnectionResult;
+
+public final class PlayerConnectionWebMapper {
+
+    private PlayerConnectionWebMapper() {
+    }
+
+    public static PlayerConnectionResponse.Page<PlayerConnectionResponse.Following> toFollowingPage(
+            ConnectionResult.Page<ConnectionResult.Following> result
+    ) {
+        return new PlayerConnectionResponse.Page<>(
+                result.contents().stream()
+                        .map(item -> new PlayerConnectionResponse.Following(
+                                item.followId(),
+                                peer(item.peer()),
+                                item.muted(),
+                                item.blocked()
+                        ))
+                        .toList(),
+                result.page(),
+                result.size(),
+                result.totalElements(),
+                result.totalPages()
+        );
+    }
+
+    public static PlayerConnectionResponse.Page<PlayerConnectionResponse.Follower> toFollowerPage(
+            ConnectionResult.Page<ConnectionResult.Follower> result
+    ) {
+        return new PlayerConnectionResponse.Page<>(
+                result.contents().stream()
+                        .map(item -> new PlayerConnectionResponse.Follower(
+                                peer(item.peer()),
+                                item.followedBack(),
+                                item.outboundFollowId()
+                        ))
+                        .toList(),
+                result.page(),
+                result.size(),
+                result.totalElements(),
+                result.totalPages()
+        );
+    }
+
+    private static PlayerConnectionResponse.Peer peer(ConnectionResult.Peer peer) {
+        return new PlayerConnectionResponse.Peer(
+                peer.playerId(),
+                peer.name(),
+                peer.job(),
+                peer.level()
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/social/api/player/response/PlayerConnectionResponse.java
+++ b/src/main/java/online/lifeasgame/social/api/player/response/PlayerConnectionResponse.java
@@ -1,0 +1,41 @@
+package online.lifeasgame.social.api.player.response;
+
+import java.util.List;
+
+public final class PlayerConnectionResponse {
+
+    private PlayerConnectionResponse() {
+    }
+
+    public record Page<T>(
+            List<T> contents,
+            int page,
+            int size,
+            long totalElements,
+            int totalPages
+    ) {
+    }
+
+    public record Peer(
+            Long playerId,
+            String name,
+            String job,
+            int level
+    ) {
+    }
+
+    public record Following(
+            Long followId,
+            Peer peer,
+            boolean muted,
+            boolean blocked
+    ) {
+    }
+
+    public record Follower(
+            Peer peer,
+            boolean followedBack,
+            Long outboundFollowId
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/social/api/player/spec/PlayerConnectionApiSpecV1.java
+++ b/src/main/java/online/lifeasgame/social/api/player/spec/PlayerConnectionApiSpecV1.java
@@ -1,0 +1,24 @@
+package online.lifeasgame.social.api.player.spec;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import online.lifeasgame.core.response.ApiResponse;
+import online.lifeasgame.social.api.player.response.PlayerConnectionResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Social Connections API V1 (Player)")
+public interface PlayerConnectionApiSpecV1 {
+
+    @Operation(summary = "현재 Player의 팔로잉 연결 목록")
+    ResponseEntity<ApiResponse<PlayerConnectionResponse.Page<PlayerConnectionResponse.Following>>> followings(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    );
+
+    @Operation(summary = "현재 Player의 팔로워 연결 목록")
+    ResponseEntity<ApiResponse<PlayerConnectionResponse.Page<PlayerConnectionResponse.Follower>>> followers(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    );
+}

--- a/src/main/java/online/lifeasgame/social/application/ConnectionQueryService.java
+++ b/src/main/java/online/lifeasgame/social/application/ConnectionQueryService.java
@@ -1,0 +1,117 @@
+package online.lifeasgame.social.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.application.internal.PlayerConnectionReadApi;
+import online.lifeasgame.character.application.internal.PlayerConnectionReadApi.PlayerSummary;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.social.application.result.ConnectionResult;
+import online.lifeasgame.social.domain.Follow;
+import online.lifeasgame.social.domain.error.SocialError;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ConnectionQueryService {
+
+    private final CurrentPlayerAccessor currentPlayerAccessor;
+    private final FollowReader followReader;
+    private final PlayerConnectionReadApi playerConnectionReadApi;
+
+    public ConnectionResult.Page<ConnectionResult.Following> followings(
+            int page,
+            int size
+    ) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        List<Follow> followings = followReader.getFollowingsByPlayerId(
+                playerId,
+                page,
+                size
+        );
+        Map<Long, PlayerSummary> peers = playerConnectionReadApi.findAllByPlayerIds(followings.stream()
+                .map(Follow::getTargetPlayerId)
+                .collect(Collectors.toUnmodifiableSet()));
+        List<ConnectionResult.Following> contents = followings.stream()
+                .map(follow -> new ConnectionResult.Following(
+                        follow.getId(),
+                        peer(requirePeer(peers, follow.getTargetPlayerId())),
+                        follow.isMuted(),
+                        follow.isBlocked()
+                ))
+                .toList();
+        return ConnectionResult.Page.of(
+                contents,
+                page,
+                size,
+                followReader.countFollowings(playerId)
+        );
+    }
+
+    public ConnectionResult.Page<ConnectionResult.Follower> followers(
+            int page,
+            int size
+    ) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        List<Follow> followers = followReader.getFollowersByPlayerId(
+                playerId,
+                page,
+                size
+        );
+        Set<Long> peerIds = followers.stream()
+                .map(Follow::getPlayerId)
+                .collect(Collectors.toUnmodifiableSet());
+        Map<Long, PlayerSummary> peers = playerConnectionReadApi.findAllByPlayerIds(peerIds);
+        Map<Long, Follow> outboundByPeerId = followReader
+                .findActiveFollowings(playerId, peerIds)
+                .stream()
+                .collect(Collectors.toUnmodifiableMap(
+                        Follow::getTargetPlayerId,
+                        Function.identity()
+                ));
+        List<ConnectionResult.Follower> contents = followers.stream()
+                .map(follow -> {
+                    Long peerId = follow.getPlayerId();
+                    Follow outbound = outboundByPeerId.get(peerId);
+                    return new ConnectionResult.Follower(
+                            peer(requirePeer(peers, peerId)),
+                            outbound != null,
+                            outbound == null ? null : outbound.getId()
+                    );
+                })
+                .toList();
+        return ConnectionResult.Page.of(
+                contents,
+                page,
+                size,
+                followReader.countFollowers(playerId)
+        );
+    }
+
+    private static PlayerSummary requirePeer(
+            Map<Long, PlayerSummary> peers,
+            Long playerId
+    ) {
+        PlayerSummary peer = peers.get(playerId);
+        if (peer == null) {
+            throw new DomainException(SocialError.CONNECTION_PEER_NOT_FOUND);
+        }
+        return peer;
+    }
+
+    private static ConnectionResult.Peer peer(PlayerSummary peer) {
+        return new ConnectionResult.Peer(
+                peer.playerId(),
+                peer.name(),
+                peer.job(),
+                peer.level()
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/social/application/FollowReader.java
+++ b/src/main/java/online/lifeasgame/social/application/FollowReader.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
@@ -26,6 +27,10 @@ public class FollowReader {
 
     public Optional<Follow> findByPlayerIdAndTargetPlayerId(Long playerId, Long targetPlayerId) {
         return repository.findByPlayerIdAndTargetPlayerId(playerId, targetPlayerId);
+    }
+
+    public List<Follow> findActiveFollowings(Long playerId, Set<Long> targetPlayerIds) {
+        return repository.findActiveFollowings(playerId, targetPlayerIds);
     }
 
     public List<Follow> getFollowingsByPlayerId(Long playerId, int page, int size) {

--- a/src/main/java/online/lifeasgame/social/application/result/ConnectionResult.java
+++ b/src/main/java/online/lifeasgame/social/application/result/ConnectionResult.java
@@ -1,0 +1,55 @@
+package online.lifeasgame.social.application.result;
+
+import java.util.List;
+
+public final class ConnectionResult {
+
+    private ConnectionResult() {
+    }
+
+    public record Page<T>(
+            List<T> contents,
+            int page,
+            int size,
+            long totalElements,
+            int totalPages
+    ) {
+        public static <T> Page<T> of(
+                List<T> contents,
+                int page,
+                int size,
+                long totalElements
+        ) {
+            return new Page<>(
+                    contents,
+                    page,
+                    size,
+                    totalElements,
+                    (int) Math.ceil(totalElements / (double) Math.max(size, 1))
+            );
+        }
+    }
+
+    public record Peer(
+            Long playerId,
+            String name,
+            String job,
+            int level
+    ) {
+    }
+
+    public record Following(
+            Long followId,
+            Peer peer,
+            boolean muted,
+            boolean blocked
+    ) {
+    }
+
+    public record Follower(
+            Peer peer,
+            boolean followedBack,
+            Long outboundFollowId
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/social/domain/error/SocialError.java
+++ b/src/main/java/online/lifeasgame/social/domain/error/SocialError.java
@@ -12,6 +12,7 @@ public enum SocialError implements ErrorCode {
     PARTY_NOT_FOUND("SOC-404-PARTY-NOT-FOUND","Party Not Found",404),
 
     FOLLOW_NOT_FOUND("SOC-404-FOLLOW-NOT-FOUND","Follow Not Found",404),
+    CONNECTION_PEER_NOT_FOUND("SOC-404-CONNECTION-PEER-NOT-FOUND", "Connection peer not found", 404),
     NOT_FRIEND("SOC-404-NOT-FRIEND", "Friend Not Found", 404),
 
     CHAT_CHANNEL_NOT_FOUND("SOC-404-CHANNEL-NOT-FOUND","Chat Channel Not Found",404),

--- a/src/main/java/online/lifeasgame/social/domain/repository/FollowRepository.java
+++ b/src/main/java/online/lifeasgame/social/domain/repository/FollowRepository.java
@@ -4,6 +4,7 @@ import online.lifeasgame.social.domain.Follow;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface FollowRepository {
     Follow save(Follow f);
@@ -15,6 +16,8 @@ public interface FollowRepository {
     Optional<Follow> findByPlayerIdAndTargetPlayerId(Long playerId, Long targetPlayerId);
 
     boolean existsActiveFollow(Long playerId, Long targetPlayerId);
+
+    List<Follow> findActiveFollowings(Long playerId, Set<Long> targetPlayerIds);
 
     List<Follow> findFollowings(Long playerId, int page, int size);
 

--- a/src/main/java/online/lifeasgame/social/infra/FollowJpaRepository.java
+++ b/src/main/java/online/lifeasgame/social/infra/FollowJpaRepository.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public interface FollowJpaRepository extends JpaRepository<Follow, Long> {
@@ -99,6 +100,12 @@ public interface FollowJpaRepository extends JpaRepository<Follow, Long> {
     boolean existsByPlayerIdAndTargetPlayerIdAndState(
             Long playerId,
             Long targetPlayerId,
+            FollowState state
+    );
+
+    List<Follow> findAllByPlayerIdAndTargetPlayerIdInAndState(
+            Long playerId,
+            Set<Long> targetPlayerIds,
             FollowState state
     );
 }

--- a/src/main/java/online/lifeasgame/social/infra/FollowRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/social/infra/FollowRepositoryAdapter.java
@@ -46,6 +46,18 @@ public class FollowRepositoryAdapter implements FollowRepository {
     }
 
     @Override
+    public List<Follow> findActiveFollowings(Long playerId, Set<Long> targetPlayerIds) {
+        if (targetPlayerIds.isEmpty()) {
+            return List.of();
+        }
+        return followJpaRepository.findAllByPlayerIdAndTargetPlayerIdInAndState(
+                playerId,
+                targetPlayerIds,
+                FollowState.FOLLOWING
+        );
+    }
+
+    @Override
     public List<Follow> findFollowings(Long playerId, int page, int size) {
         Page<Long> idPage = followJpaRepository.findFollowingIds(
                 playerId,

--- a/src/test/java/online/lifeasgame/character/application/PlayerConnectionReadIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/character/application/PlayerConnectionReadIntegrationTest.java
@@ -1,0 +1,78 @@
+package online.lifeasgame.character.application;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import online.lifeasgame.character.application.internal.PlayerConnectionReadApi;
+import online.lifeasgame.character.application.internal.PlayerConnectionReadApi.PlayerSummary;
+import online.lifeasgame.character.domain.GenderType;
+import online.lifeasgame.character.domain.Name;
+import online.lifeasgame.character.domain.Player;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties =
+        "spring.jpa.properties.hibernate.generate_statistics=true")
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("Player connection batch read provider")
+class PlayerConnectionReadIntegrationTest {
+
+    @Autowired
+    private PlayerConnectionReadApi playerConnectionReadApi;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    @Test
+    @DisplayName("여러 Player의 connection summary를 한 query로 반환한다")
+    void readsPlayerSummariesInOneQuery() {
+        Player first = player(28401L, "첫 Player");
+        Player second = player(28402L, "둘째 Player");
+        entityManager.flush();
+        entityManager.clear();
+        Statistics statistics = statistics();
+        statistics.clear();
+
+        Map<Long, PlayerSummary> result = playerConnectionReadApi
+                .findAllByPlayerIds(Set.of(first.getId(), second.getId()));
+
+        assertThat(result).containsOnlyKeys(first.getId(), second.getId());
+        assertThat(result.get(first.getId())).isEqualTo(new PlayerSummary(
+                first.getId(),
+                "첫 Player",
+                null,
+                1
+        ));
+        assertThat(result.get(second.getId())).isEqualTo(new PlayerSummary(
+                second.getId(),
+                "둘째 Player",
+                null,
+                1
+        ));
+        assertThat(statistics.getPrepareStatementCount()).isEqualTo(1);
+    }
+
+    private Player player(Long userId, String name) {
+        Player player = Player.linkStart(userId, Name.of(name), GenderType.MALE);
+        entityManager.persist(player);
+        return player;
+    }
+
+    private Statistics statistics() {
+        return entityManagerFactory.unwrap(SessionFactory.class).getStatistics();
+    }
+}

--- a/src/test/java/online/lifeasgame/social/api/player/PlayerConnectionApiContractTest.java
+++ b/src/test/java/online/lifeasgame/social/api/player/PlayerConnectionApiContractTest.java
@@ -1,0 +1,109 @@
+package online.lifeasgame.social.api.player;
+
+import online.lifeasgame.platform.security.jwt.JwtPrincipal;
+import online.lifeasgame.platform.security.jwt.JwtProvider;
+import online.lifeasgame.platform.web.error.docs.ErrorDocLinker;
+import online.lifeasgame.social.application.ConnectionQueryService;
+import online.lifeasgame.social.application.result.ConnectionResult;
+import online.lifeasgame.support.WebMvcTestConfig;
+import online.lifeasgame.system.bootstrap.error.handler.AppErrorProperties;
+import online.lifeasgame.system.bootstrap.security.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = PlayerConnectionController.class)
+@Import({SecurityConfig.class, WebMvcTestConfig.class})
+@DisplayName("Current Player Connections API contract")
+class PlayerConnectionApiContractTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ConnectionQueryService connectionQueryService;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private AppErrorProperties appErrorProperties;
+
+    @MockitoBean
+    private ErrorDocLinker errorDocLinker;
+
+    @Test
+    @DisplayName("두 canonical route는 directional privacy를 지킨 page envelope를 반환한다")
+    void exposesCanonicalConnectionRoutes() throws Exception {
+        ConnectionResult.Peer peer = new ConnectionResult.Peer(
+                284L,
+                "Peer",
+                "MAGE",
+                7
+        );
+        given(connectionQueryService.followings(0, 20)).willReturn(
+                ConnectionResult.Page.of(
+                        List.of(new ConnectionResult.Following(282L, peer, true, false)),
+                        0,
+                        20,
+                        1
+                )
+        );
+        given(connectionQueryService.followers(0, 20)).willReturn(
+                ConnectionResult.Page.of(
+                        List.of(new ConnectionResult.Follower(peer, true, 283L)),
+                        0,
+                        20,
+                        1
+                )
+        );
+
+        mockMvc.perform(get("/api/v1/connections/followings")
+                        .with(authentication(playerAuthentication())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.*", hasSize(5)))
+                .andExpect(jsonPath("$.result.contents[0].*", hasSize(4)))
+                .andExpect(jsonPath("$.result.contents[0].followId").value(282))
+                .andExpect(jsonPath("$.result.contents[0].peer.playerId").value(284))
+                .andExpect(jsonPath("$.result.contents[0].peer.name").value("Peer"))
+                .andExpect(jsonPath("$.result.contents[0].peer.job").value("MAGE"))
+                .andExpect(jsonPath("$.result.contents[0].peer.level").value(7))
+                .andExpect(jsonPath("$.result.contents[0].muted").value(true))
+                .andExpect(jsonPath("$.result.contents[0].blocked").value(false));
+
+        mockMvc.perform(get("/api/v1/connections/followers")
+                        .with(authentication(playerAuthentication())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.*", hasSize(5)))
+                .andExpect(jsonPath("$.result.contents[0].*", hasSize(3)))
+                .andExpect(jsonPath("$.result.contents[0].peer.playerId").value(284))
+                .andExpect(jsonPath("$.result.contents[0].followedBack").value(true))
+                .andExpect(jsonPath("$.result.contents[0].outboundFollowId").value(283))
+                .andExpect(jsonPath("$.result.contents[0].followId").doesNotExist())
+                .andExpect(jsonPath("$.result.contents[0].muted").doesNotExist())
+                .andExpect(jsonPath("$.result.contents[0].blocked").doesNotExist());
+    }
+
+    private UsernamePasswordAuthenticationToken playerAuthentication() {
+        return new UsernamePasswordAuthenticationToken(
+                new JwtPrincipal(284L, 28401L),
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/social/application/ConnectionQueryIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/social/application/ConnectionQueryIntegrationTest.java
@@ -1,0 +1,159 @@
+package online.lifeasgame.social.application;
+
+import jakarta.persistence.EntityManager;
+import online.lifeasgame.character.domain.GenderType;
+import online.lifeasgame.character.domain.Name;
+import online.lifeasgame.character.domain.Player;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.social.application.command.FollowCommand;
+import online.lifeasgame.social.application.result.ConnectionResult;
+import online.lifeasgame.social.application.result.FollowResult;
+import online.lifeasgame.social.domain.error.SocialError;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("Current Player Connections query")
+class ConnectionQueryIntegrationTest {
+
+    @Autowired
+    private ConnectionQueryService connectionQueryService;
+
+    @Autowired
+    private FollowService followService;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @MockitoBean
+    private CurrentPlayerAccessor currentPlayerAccessor;
+
+    @Nested
+    @DisplayName("팔로잉 연결을 조회할 때")
+    class Followings {
+
+        @Test
+        @DisplayName("active outbound peer와 현재 Player의 mute/block 상태만 반환한다")
+        void returnsEnrichedOutboundState() {
+            Player current = currentPlayer();
+            Player activePeer = player(28402L, "Active Peer");
+            Player stoppedPeer = player(28403L, "Stopped Peer");
+            FollowResult.Info active = follow(current.getId(), activePeer.getId());
+            FollowResult.Info stopped = follow(current.getId(), stoppedPeer.getId());
+            followService.mute(current.getId(), active.id());
+            followService.block(current.getId(), active.id());
+            followService.unfollow(current.getId(), stopped.id());
+
+            ConnectionResult.Page<ConnectionResult.Following> result =
+                    connectionQueryService.followings(0, 20);
+
+            assertThat(result.contents()).containsExactly(new ConnectionResult.Following(
+                    active.id(),
+                    new ConnectionResult.Peer(activePeer.getId(), "Active Peer", null, 1),
+                    true,
+                    true
+            ));
+            assertThat(result.totalElements()).isEqualTo(1);
+            assertThat(result.totalPages()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("팔로워 연결을 조회할 때")
+    class Followers {
+
+        @Test
+        @DisplayName("active inbound peer를 반환하고 active reverse만 action state로 연결한다")
+        void resolvesReverseFollowInBatch() {
+            Player current = currentPlayer();
+            Player followedBackPeer = player(28412L, "Followed Back");
+            Player stoppedReversePeer = player(28413L, "Stopped Reverse");
+            Player stoppedFollower = player(28414L, "Stopped Follower");
+            FollowResult.Info inboundWithReverse = follow(followedBackPeer.getId(), current.getId());
+            follow(stoppedReversePeer.getId(), current.getId());
+            FollowResult.Info inactiveInbound = follow(stoppedFollower.getId(), current.getId());
+            FollowResult.Info activeReverse = follow(current.getId(), followedBackPeer.getId());
+            FollowResult.Info stoppedReverse = follow(current.getId(), stoppedReversePeer.getId());
+            followService.mute(followedBackPeer.getId(), inboundWithReverse.id());
+            followService.block(followedBackPeer.getId(), inboundWithReverse.id());
+            followService.unfollow(current.getId(), stoppedReverse.id());
+            followService.unfollow(stoppedFollower.getId(), inactiveInbound.id());
+
+            ConnectionResult.Page<ConnectionResult.Follower> result =
+                    connectionQueryService.followers(0, 20);
+
+            assertThat(result.contents()).extracting(item -> item.peer().playerId())
+                    .containsExactly(stoppedReversePeer.getId(), followedBackPeer.getId());
+            assertThat(result.contents()).anySatisfy(item -> {
+                assertThat(item.peer()).isEqualTo(new ConnectionResult.Peer(
+                        followedBackPeer.getId(),
+                        "Followed Back",
+                        null,
+                        1
+                ));
+                assertThat(item.followedBack()).isTrue();
+                assertThat(item.outboundFollowId()).isEqualTo(activeReverse.id());
+            });
+            assertThat(result.contents()).anySatisfy(item -> {
+                assertThat(item.peer()).isEqualTo(new ConnectionResult.Peer(
+                        stoppedReversePeer.getId(),
+                        "Stopped Reverse",
+                        null,
+                        1
+                ));
+                assertThat(item.followedBack()).isFalse();
+                assertThat(item.outboundFollowId()).isNull();
+            });
+            assertThat(result.totalElements()).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("Follow peer Player가 없을 때")
+    class MissingPeer {
+
+        @Test
+        @DisplayName("이름을 만들지 않고 controlled connection error로 거부한다")
+        void rejectsMissingPlayerSummary() {
+            Player current = currentPlayer();
+            follow(current.getId(), 999_999L);
+
+            assertThatThrownBy(() -> connectionQueryService.followings(0, 20))
+                    .isInstanceOfSatisfying(DomainException.class, exception ->
+                            assertThat(exception.getErrorCode()).isEqualTo(
+                                    SocialError.CONNECTION_PEER_NOT_FOUND
+                            )
+                    );
+        }
+    }
+
+    private Player currentPlayer() {
+        Player current = player(28401L, "Current Player");
+        given(currentPlayerAccessor.currentPlayerIdOrThrow()).willReturn(current.getId());
+        return current;
+    }
+
+    private Player player(Long userId, String name) {
+        Player player = Player.linkStart(userId, Name.of(name), GenderType.MALE);
+        entityManager.persist(player);
+        entityManager.flush();
+        return player;
+    }
+
+    private FollowResult.Info follow(Long playerId, Long targetPlayerId) {
+        return followService.follow(playerId, new FollowCommand.Create(targetPlayerId));
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1
+    url: jdbc:h2:mem:${random.uuid};MODE=MySQL;DB_CLOSE_DELAY=-1
     username: sa
     password:
     driver-class-name: org.h2.Driver


### PR DESCRIPTION
### Purpose

Add a frontend-ready Current Player Connections read model on top of the hardened Follow lifecycle.

Closes #284

### Delivered

- canonical Connections followings endpoint
- canonical Connections followers endpoint
- Character-owned peer summary Internal API
- batched Player enrichment
- batched follower follow-back resolution
- direction-safe relationship DTOs
- active-only relationship semantics
- controlled missing-peer handling

### Endpoints

```text
GET /api/v1/connections/followings
GET /api/v1/connections/followers
```

### Followings

Each row exposes:

```text
followId
peer(playerId,name,job,level)
muted
blocked
```

The flags belong to the Current Player's outbound Follow.

### Followers

Each row exposes:

```text
peer(playerId,name,job,level)
followedBack
outboundFollowId
```

Inbound follower mute/block state is not exposed.

### Cross-Domain Boundary

Character provides peer summaries through a provider-owned batch Internal API.

Social does not import Character entities or repositories.

### Performance

- peer summaries are batch-loaded
- follower reverse relationships are batch-loaded
- no per-row Character or reverse-Follow lookup

### Compatibility

Existing `/api/v1/follows` endpoints remain unchanged.

### Scope

No:

- Chat channel creation
- block-policy redesign
- Follow lifecycle redesign
- userId exposure
- database migration

### Validation

Focused coverage verifies active-only enriched Connections, directional action semantics, follow-back resolution, batch boundaries, and final build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added paginated endpoints for viewing a player’s followings and followers.
  - Followings display player details along with mute and block status.
  - Followers display reciprocal-follow status and related connection information.
  - Added pagination metadata and consistent response formatting.
  - Added clear error handling when connected player information is unavailable.

- **Tests**
  - Added coverage for API responses, authentication, pagination, privacy fields, filtering, and missing-player scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->