### PR TITLE
[Social] Validate Follow targets through Character Internal API

### DIFF
--- a/src/main/java/online/lifeasgame/character/application/internal/PlayerExistenceReadApi.java
+++ b/src/main/java/online/lifeasgame/character/application/internal/PlayerExistenceReadApi.java
@@ -1,0 +1,6 @@
+package online.lifeasgame.character.application.internal;
+
+public interface PlayerExistenceReadApi {
+
+    boolean existsByPlayerId(Long playerId);
+}

--- a/src/main/java/online/lifeasgame/character/infra/PlayerExistenceReadAdapter.java
+++ b/src/main/java/online/lifeasgame/character/infra/PlayerExistenceReadAdapter.java
@@ -1,0 +1,17 @@
+package online.lifeasgame.character.infra;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.application.internal.PlayerExistenceReadApi;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PlayerExistenceReadAdapter implements PlayerExistenceReadApi {
+
+    private final JpaPlayerRepository playerRepository;
+
+    @Override
+    public boolean existsByPlayerId(Long playerId) {
+        return playerRepository.existsById(playerId);
+    }
+}

--- a/src/main/java/online/lifeasgame/social/api/player/PlayerFollowController.java
+++ b/src/main/java/online/lifeasgame/social/api/player/PlayerFollowController.java
@@ -1,5 +1,6 @@
 package online.lifeasgame.social.api.player;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.core.response.ApiResponse;
 import online.lifeasgame.platform.web.response.ApiResponses;
@@ -61,7 +62,7 @@ public class PlayerFollowController implements PlayerFollowApiSpecV1 {
 
     @PostMapping
     public ResponseEntity<ApiResponse<PlayerFollowResponse.Info>> follow(
-            @RequestBody PlayerFollowRequest.Create request
+            @Valid @RequestBody PlayerFollowRequest.Create request
     ) {
         FollowResult.Info result = followFacade.follow(PlayerFollowWebMapper.toCreateCommand(request));
         return ApiResponses.ok(PlayerFollowWebMapper.toInfo(result));

--- a/src/main/java/online/lifeasgame/social/application/FollowService.java
+++ b/src/main/java/online/lifeasgame/social/application/FollowService.java
@@ -18,16 +18,19 @@ public class FollowService {
 
     private final FollowReader followReader;
     private final FollowRegistrar followRegistrar;
+    private final FollowTargetVerifier followTargetVerifier;
 
     @Transactional
     public FollowResult.Info follow(Long playerId, FollowCommand.Create command) {
+        Long targetPlayerId = command.targetPlayerId();
+        followTargetVerifier.verifyExists(targetPlayerId);
         Follow follow = followReader.findByPlayerIdAndTargetPlayerId(
                 playerId,
-                command.targetPlayerId()
+                targetPlayerId
         ).orElseGet(() -> followRegistrar.register(
                 Follow.create(
                         playerId,
-                        command.targetPlayerId()
+                        targetPlayerId
                 )
         ));
         if (follow.getState() == FollowState.STOPPED) {

--- a/src/main/java/online/lifeasgame/social/application/FollowTargetVerifier.java
+++ b/src/main/java/online/lifeasgame/social/application/FollowTargetVerifier.java
@@ -1,0 +1,23 @@
+package online.lifeasgame.social.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.character.application.internal.PlayerExistenceReadApi;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.social.domain.error.SocialError;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+public class FollowTargetVerifier {
+
+    private final PlayerExistenceReadApi playerExistenceReadApi;
+
+    public void verifyExists(Long targetPlayerId) {
+        if (!playerExistenceReadApi.existsByPlayerId(targetPlayerId)) {
+            throw new DomainException(SocialError.FOLLOW_TARGET_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/social/domain/error/SocialError.java
+++ b/src/main/java/online/lifeasgame/social/domain/error/SocialError.java
@@ -12,6 +12,7 @@ public enum SocialError implements ErrorCode {
     PARTY_NOT_FOUND("SOC-404-PARTY-NOT-FOUND","Party Not Found",404),
 
     FOLLOW_NOT_FOUND("SOC-404-FOLLOW-NOT-FOUND","Follow Not Found",404),
+    FOLLOW_TARGET_NOT_FOUND("SOC-404-FOLLOW-TARGET-NOT-FOUND", "Follow target not found", 404),
     CONNECTION_PEER_NOT_FOUND("SOC-404-CONNECTION-PEER-NOT-FOUND", "Connection peer not found", 404),
     NOT_FRIEND("SOC-404-NOT-FRIEND", "Friend Not Found", 404),
 

--- a/src/test/java/online/lifeasgame/social/api/player/PlayerFollowApiContractTest.java
+++ b/src/test/java/online/lifeasgame/social/api/player/PlayerFollowApiContractTest.java
@@ -1,0 +1,67 @@
+package online.lifeasgame.social.api.player;
+
+import online.lifeasgame.platform.security.jwt.JwtPrincipal;
+import online.lifeasgame.platform.security.jwt.JwtProvider;
+import online.lifeasgame.platform.web.error.docs.ErrorDocLinker;
+import online.lifeasgame.social.application.FollowFacade;
+import online.lifeasgame.support.WebMvcTestConfig;
+import online.lifeasgame.system.bootstrap.error.handler.AppErrorProperties;
+import online.lifeasgame.system.bootstrap.security.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = PlayerFollowController.class)
+@Import({SecurityConfig.class, WebMvcTestConfig.class})
+@DisplayName("Current Player Follow API contract")
+class PlayerFollowApiContractTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private FollowFacade followFacade;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private AppErrorProperties appErrorProperties;
+
+    @MockitoBean
+    private ErrorDocLinker errorDocLinker;
+
+    @Test
+    @DisplayName("targetPlayerId가 null이면 Follow application 호출 전에 요청을 거부한다")
+    void rejectsNullTargetBeforeApplication() throws Exception {
+        mockMvc.perform(post("/api/v1/follows")
+                        .with(authentication(playerAuthentication()))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"targetPlayerId\":null}"))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(followFacade);
+    }
+
+    private UsernamePasswordAuthenticationToken playerAuthentication() {
+        return new UsernamePasswordAuthenticationToken(
+                new JwtPrincipal(287L, 28701L),
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/social/application/ConnectionQueryIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/social/application/ConnectionQueryIntegrationTest.java
@@ -9,6 +9,7 @@ import online.lifeasgame.core.security.CurrentPlayerAccessor;
 import online.lifeasgame.social.application.command.FollowCommand;
 import online.lifeasgame.social.application.result.ConnectionResult;
 import online.lifeasgame.social.application.result.FollowResult;
+import online.lifeasgame.social.domain.Follow;
 import online.lifeasgame.social.domain.error.SocialError;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -129,7 +130,8 @@ class ConnectionQueryIntegrationTest {
         @DisplayName("이름을 만들지 않고 controlled connection error로 거부한다")
         void rejectsMissingPlayerSummary() {
             Player current = currentPlayer();
-            follow(current.getId(), 999_999L);
+            entityManager.persist(Follow.create(current.getId(), 999_999L));
+            entityManager.flush();
 
             assertThatThrownBy(() -> connectionQueryService.followings(0, 20))
                     .isInstanceOfSatisfying(DomainException.class, exception ->

--- a/src/test/java/online/lifeasgame/social/application/FollowLifecycleIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/social/application/FollowLifecycleIntegrationTest.java
@@ -1,6 +1,7 @@
 package online.lifeasgame.social.application;
 
 import jakarta.persistence.EntityManager;
+import online.lifeasgame.character.application.internal.PlayerExistenceReadApi;
 import online.lifeasgame.core.error.DomainException;
 import online.lifeasgame.social.application.command.FollowCommand;
 import online.lifeasgame.social.application.result.FollowResult;
@@ -8,17 +9,21 @@ import online.lifeasgame.social.domain.Follow;
 import online.lifeasgame.social.domain.FollowState;
 import online.lifeasgame.social.domain.error.SocialError;
 import online.lifeasgame.social.domain.repository.FollowRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -40,6 +45,53 @@ class FollowLifecycleIntegrationTest {
 
     @Autowired
     private EntityManager entityManager;
+
+    @MockitoBean
+    private PlayerExistenceReadApi playerExistenceReadApi;
+
+    @BeforeEach
+    void targetExists() {
+        given(playerExistenceReadApi.existsByPlayerId(anyLong())).willReturn(true);
+    }
+
+    @Nested
+    @DisplayName("Follow target을 검증할 때")
+    class TargetValidation {
+
+        @Test
+        @DisplayName("존재하는 target이면 follow한다")
+        void followsExistingTarget() {
+            FollowResult.Info result = follow(PLAYER_ID, FRIEND_ID);
+
+            assertThat(result.targetPlayerId()).isEqualTo(FRIEND_ID);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 target이면 row를 생성하지 않는다")
+        void rejectsMissingTargetWithoutCreatingRow() {
+            given(playerExistenceReadApi.existsByPlayerId(FRIEND_ID)).willReturn(false);
+
+            assertTargetNotFound(() -> follow(PLAYER_ID, FRIEND_ID));
+
+            assertThat(pairRowCount(PLAYER_ID, FRIEND_ID)).isZero();
+        }
+
+        @Test
+        @DisplayName("기존 row가 STOPPED여도 target이 없으면 재활성화하지 않는다")
+        void keepsStoppedRowWhenTargetIsMissing() {
+            FollowResult.Info existing = follow(PLAYER_ID, FRIEND_ID);
+            followService.unfollow(PLAYER_ID, existing.id());
+            given(playerExistenceReadApi.existsByPlayerId(FRIEND_ID)).willReturn(false);
+
+            assertTargetNotFound(() -> follow(PLAYER_ID, FRIEND_ID));
+
+            Follow persisted = followRepository.findByPlayerIdAndTargetPlayerId(
+                    PLAYER_ID,
+                    FRIEND_ID
+            ).orElseThrow();
+            assertThat(persisted.getState()).isEqualTo(FollowState.STOPPED);
+        }
+    }
 
     @Nested
     @DisplayName("같은 pair를 다시 follow할 때")
@@ -152,6 +204,13 @@ class FollowLifecycleIntegrationTest {
         assertThatThrownBy(() -> friendshipVerifier.verify(PLAYER_ID, FRIEND_ID))
                 .isInstanceOfSatisfying(DomainException.class, exception ->
                         assertThat(exception.getErrorCode()).isEqualTo(SocialError.NOT_FRIEND)
+                );
+    }
+
+    private void assertTargetNotFound(Runnable action) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(SocialError.FOLLOW_TARGET_NOT_FOUND)
                 );
     }
 }


### PR DESCRIPTION
### Purpose

Prevent invalid Follow rows from being created for nonexistent Player targets.

Closes #286

### Delivered

- Character-owned Player existence Internal API
- Social Follow target verifier
- dedicated missing-target Social error
- pre-mutation target validation
- refollow target validation
- preserved Follow lifecycle behavior
- focused integrity regression coverage

### Write Integrity

Follow command ordering is now:

```text
verify target Player
resolve directed Follow pair
create / reuse / reactivate
```

A missing target is rejected before any Follow state changes.

### Cross-Domain Boundary

Social does not import Character entities or repositories.

Character exposes only the minimal existence contract needed by Social.

### Lifecycle Preservation

For valid targets:

```text
no row -> create
FOLLOWING -> reuse same row
STOPPED -> reactivate same row
```

### Defensive Read Integrity

The Connections missing-peer guard remains in place for legacy/corrupt data.

### Ownership

Current Player identity remains authentication-owned.

No player/user identity is added to the request.

### Scope

No:

- database foreign key
- Player deletion cascade
- legacy invalid-row cleanup
- block-policy redesign
- Direct Chat work
- frontend work

### Validation

Focused coverage verifies valid follow, missing-target rejection without persistence, stopped-row non-reactivation for missing targets, and final build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation to ensure follow targets exist before creating or restoring a follow.
  * Added a clear 404 error when the requested follow target cannot be found.
  * Added request validation for missing follow target IDs.
* **Bug Fixes**
  * Prevented follow records from being created for nonexistent players.
  * Preserved stopped follow records when a target is unavailable.
  * Invalid follow requests now return a 400 Bad Request response.
* **Tests**
  * Expanded coverage for valid targets, missing targets, lifecycle behavior, and invalid requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->