### PR TITLE
[Notification] Add Current Player notification inbox foundation

### DIFF
--- a/src/main/java/online/lifeasgame/notification/api/NotificationController.java
+++ b/src/main/java/online/lifeasgame/notification/api/NotificationController.java
@@ -1,0 +1,66 @@
+package online.lifeasgame.notification.api;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.response.ApiResponse;
+import online.lifeasgame.notification.api.mapper.NotificationWebMapper;
+import online.lifeasgame.notification.api.response.NotificationResponse;
+import online.lifeasgame.notification.api.spec.NotificationApiSpecV1;
+import online.lifeasgame.notification.application.NotificationQueryService;
+import online.lifeasgame.notification.application.NotificationReadMarker;
+import online.lifeasgame.platform.web.response.ApiResponses;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notifications")
+public class NotificationController implements NotificationApiSpecV1 {
+
+    private final NotificationQueryService queryService;
+    private final NotificationReadMarker readMarker;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResponse<NotificationResponse.Page>> inbox(
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size
+    ) {
+        return ApiResponses.ok(NotificationWebMapper.toPage(
+                queryService.inbox(cursor, size)
+        ));
+    }
+
+    @Override
+    @GetMapping("/unread-count")
+    public ResponseEntity<ApiResponse<NotificationResponse.UnreadCount>>
+    unreadCount() {
+        return ApiResponses.ok(NotificationWebMapper.toUnreadCount(
+                queryService.unreadCount()
+        ));
+    }
+
+    @Override
+    @PostMapping("/{notificationId}/read")
+    public ResponseEntity<ApiResponse<Void>> markRead(
+            @PathVariable Long notificationId
+    ) {
+        readMarker.markOne(notificationId);
+        return ApiResponses.ok(null);
+    }
+
+    @Override
+    @PostMapping("/read-all")
+    public ResponseEntity<ApiResponse<NotificationResponse.MarkedCount>>
+    markAllRead() {
+        return ApiResponses.ok(NotificationWebMapper.toMarkedCount(
+                readMarker.markAll()
+        ));
+    }
+}

--- a/src/main/java/online/lifeasgame/notification/api/mapper/NotificationWebMapper.java
+++ b/src/main/java/online/lifeasgame/notification/api/mapper/NotificationWebMapper.java
@@ -1,0 +1,43 @@
+package online.lifeasgame.notification.api.mapper;
+
+import online.lifeasgame.notification.api.response.NotificationResponse;
+import online.lifeasgame.notification.application.result.NotificationResult;
+
+public final class NotificationWebMapper {
+
+    private NotificationWebMapper() {
+    }
+
+    public static NotificationResponse.Page toPage(
+            NotificationResult.Page result
+    ) {
+        return new NotificationResponse.Page(
+                result.notifications().stream()
+                        .map(NotificationWebMapper::toInfo)
+                        .toList(),
+                result.hasMore(),
+                result.nextCursor()
+        );
+    }
+
+    public static NotificationResponse.UnreadCount toUnreadCount(long count) {
+        return new NotificationResponse.UnreadCount(count);
+    }
+
+    public static NotificationResponse.MarkedCount toMarkedCount(int count) {
+        return new NotificationResponse.MarkedCount(count);
+    }
+
+    private static NotificationResponse.Info toInfo(
+            NotificationResult.Info result
+    ) {
+        return new NotificationResponse.Info(
+                result.id(),
+                result.type().name(),
+                result.title(),
+                result.body(),
+                result.occurredAt(),
+                result.read()
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/notification/api/response/NotificationResponse.java
+++ b/src/main/java/online/lifeasgame/notification/api/response/NotificationResponse.java
@@ -1,0 +1,33 @@
+package online.lifeasgame.notification.api.response;
+
+import java.time.Instant;
+import java.util.List;
+
+public final class NotificationResponse {
+
+    private NotificationResponse() {
+    }
+
+    public record Page(
+            List<Info> notifications,
+            boolean hasMore,
+            Long nextCursor
+    ) {
+    }
+
+    public record Info(
+            Long id,
+            String type,
+            String title,
+            String body,
+            Instant occurredAt,
+            boolean read
+    ) {
+    }
+
+    public record UnreadCount(long unreadCount) {
+    }
+
+    public record MarkedCount(int markedCount) {
+    }
+}

--- a/src/main/java/online/lifeasgame/notification/api/spec/NotificationApiSpecV1.java
+++ b/src/main/java/online/lifeasgame/notification/api/spec/NotificationApiSpecV1.java
@@ -1,0 +1,32 @@
+package online.lifeasgame.notification.api.spec;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import online.lifeasgame.core.response.ApiResponse;
+import online.lifeasgame.notification.api.response.NotificationResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Notification API V1 (Player)")
+public interface NotificationApiSpecV1 {
+
+    @Operation(summary = "내 알림 inbox 조회")
+    ResponseEntity<ApiResponse<NotificationResponse.Page>> inbox(
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size
+    );
+
+    @Operation(summary = "내 unread 알림 수 조회")
+    ResponseEntity<ApiResponse<NotificationResponse.UnreadCount>> unreadCount();
+
+    @Operation(summary = "내 알림 하나를 읽음 처리")
+    ResponseEntity<ApiResponse<Void>> markRead(
+            @PathVariable Long notificationId
+    );
+
+    @Operation(summary = "내 unread 알림 전체 읽음 처리")
+    ResponseEntity<ApiResponse<NotificationResponse.MarkedCount>> markAllRead();
+}

--- a/src/main/java/online/lifeasgame/notification/application/NotificationAppendAttempt.java
+++ b/src/main/java/online/lifeasgame/notification/application/NotificationAppendAttempt.java
@@ -1,0 +1,20 @@
+package online.lifeasgame.notification.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.notification.domain.PlayerNotification;
+import online.lifeasgame.notification.domain.repository.PlayerNotificationRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationAppendAttempt {
+
+    private final PlayerNotificationRepository repository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void append(PlayerNotification notification) {
+        repository.saveAndFlush(notification);
+    }
+}

--- a/src/main/java/online/lifeasgame/notification/application/NotificationAppender.java
+++ b/src/main/java/online/lifeasgame/notification/application/NotificationAppender.java
@@ -1,0 +1,48 @@
+package online.lifeasgame.notification.application;
+
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.notification.application.internal.NotificationAppendApi;
+import online.lifeasgame.notification.domain.PlayerNotification;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationAppender implements NotificationAppendApi {
+
+    private final NotificationFinder finder;
+    private final NotificationAppendAttempt appendAttempt;
+
+    @Override
+    @Transactional
+    public void append(AppendCommand command) {
+        Objects.requireNonNull(command, "command must not be null");
+        PlayerNotification notification = PlayerNotification.create(
+                command.playerId(),
+                command.sourceEventId(),
+                command.type(),
+                command.title(),
+                command.body(),
+                command.occurredAt()
+        );
+        if (finder.exists(
+                notification.getPlayerId(),
+                notification.getSourceEventId()
+        )) {
+            return;
+        }
+
+        try {
+            appendAttempt.append(notification);
+        } catch (DataIntegrityViolationException exception) {
+            if (!finder.existsInNewTransaction(
+                    notification.getPlayerId(),
+                    notification.getSourceEventId()
+            )) {
+                throw exception;
+            }
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/notification/application/NotificationFinder.java
+++ b/src/main/java/online/lifeasgame/notification/application/NotificationFinder.java
@@ -1,0 +1,24 @@
+package online.lifeasgame.notification.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.notification.domain.repository.PlayerNotificationRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+public class NotificationFinder {
+
+    private final PlayerNotificationRepository repository;
+
+    public boolean exists(Long playerId, String sourceEventId) {
+        return repository.existsByPlayerIdAndSourceEventId(playerId, sourceEventId);
+    }
+
+    @Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
+    public boolean existsInNewTransaction(Long playerId, String sourceEventId) {
+        return repository.existsByPlayerIdAndSourceEventId(playerId, sourceEventId);
+    }
+}

--- a/src/main/java/online/lifeasgame/notification/application/NotificationQueryService.java
+++ b/src/main/java/online/lifeasgame/notification/application/NotificationQueryService.java
@@ -1,0 +1,68 @@
+package online.lifeasgame.notification.application;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.notification.application.query.NotificationInboxQuery;
+import online.lifeasgame.notification.application.result.NotificationResult;
+import online.lifeasgame.notification.domain.error.NotificationError;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationQueryService {
+
+    private final NotificationInboxQuery query;
+    private final CurrentPlayerAccessor currentPlayerAccessor;
+
+    public NotificationResult.Page inbox(Long cursor, int size) {
+        validateSize(size);
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        List<NotificationInboxQuery.Row> rows = query.findInbox(
+                playerId,
+                cursor,
+                size + 1
+        );
+        boolean hasMore = rows.size() > size;
+        List<NotificationResult.Info> notifications = rows.stream()
+                .limit(size)
+                .map(NotificationQueryService::toInfo)
+                .toList();
+        Long nextCursor = hasMore && !notifications.isEmpty()
+                ? notifications.getLast().id()
+                : null;
+        return new NotificationResult.Page(
+                notifications,
+                hasMore,
+                nextCursor
+        );
+    }
+
+    public long unreadCount() {
+        return query.countUnread(
+                currentPlayerAccessor.currentPlayerIdOrThrow()
+        );
+    }
+
+    private static NotificationResult.Info toInfo(
+            NotificationInboxQuery.Row row
+    ) {
+        return new NotificationResult.Info(
+                row.id(),
+                row.type(),
+                row.title(),
+                row.body(),
+                row.occurredAt(),
+                row.readAt() != null
+        );
+    }
+
+    private static void validateSize(int size) {
+        if (size < 1 || size > 100) {
+            throw new DomainException(NotificationError.PAGE_SIZE_INVALID);
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/notification/application/NotificationReadMarker.java
+++ b/src/main/java/online/lifeasgame/notification/application/NotificationReadMarker.java
@@ -1,0 +1,41 @@
+package online.lifeasgame.notification.application;
+
+import java.time.Clock;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.notification.domain.PlayerNotification;
+import online.lifeasgame.notification.domain.error.NotificationError;
+import online.lifeasgame.notification.domain.repository.PlayerNotificationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationReadMarker {
+
+    private final PlayerNotificationRepository repository;
+    private final CurrentPlayerAccessor currentPlayerAccessor;
+    private final Clock clock;
+
+    @Transactional
+    public void markOne(Long notificationId) {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        PlayerNotification notification = repository.findOwned(
+                        notificationId,
+                        playerId
+                )
+                .orElseThrow(() -> new DomainException(
+                        NotificationError.NOTIFICATION_NOT_FOUND
+                ));
+        notification.markRead(clock.instant());
+    }
+
+    @Transactional
+    public int markAll() {
+        Long playerId = currentPlayerAccessor.currentPlayerIdOrThrow();
+        Instant now = clock.instant();
+        return repository.markAllUnread(playerId, now);
+    }
+}

--- a/src/main/java/online/lifeasgame/notification/application/internal/NotificationAppendApi.java
+++ b/src/main/java/online/lifeasgame/notification/application/internal/NotificationAppendApi.java
@@ -1,0 +1,19 @@
+package online.lifeasgame.notification.application.internal;
+
+import java.time.Instant;
+import online.lifeasgame.notification.domain.NotificationType;
+
+public interface NotificationAppendApi {
+
+    void append(AppendCommand command);
+
+    record AppendCommand(
+            Long playerId,
+            String sourceEventId,
+            NotificationType type,
+            String title,
+            String body,
+            Instant occurredAt
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/notification/application/query/NotificationInboxQuery.java
+++ b/src/main/java/online/lifeasgame/notification/application/query/NotificationInboxQuery.java
@@ -1,0 +1,22 @@
+package online.lifeasgame.notification.application.query;
+
+import java.time.Instant;
+import java.util.List;
+import online.lifeasgame.notification.domain.NotificationType;
+
+public interface NotificationInboxQuery {
+
+    List<Row> findInbox(Long playerId, Long cursor, int limit);
+
+    long countUnread(Long playerId);
+
+    record Row(
+            Long id,
+            NotificationType type,
+            String title,
+            String body,
+            Instant occurredAt,
+            Instant readAt
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/notification/application/result/NotificationResult.java
+++ b/src/main/java/online/lifeasgame/notification/application/result/NotificationResult.java
@@ -1,0 +1,31 @@
+package online.lifeasgame.notification.application.result;
+
+import java.time.Instant;
+import java.util.List;
+import online.lifeasgame.notification.domain.NotificationType;
+
+public final class NotificationResult {
+
+    private NotificationResult() {
+    }
+
+    public record Page(
+            List<Info> notifications,
+            boolean hasMore,
+            Long nextCursor
+    ) {
+        public Page {
+            notifications = List.copyOf(notifications);
+        }
+    }
+
+    public record Info(
+            Long id,
+            NotificationType type,
+            String title,
+            String body,
+            Instant occurredAt,
+            boolean read
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/notification/domain/NotificationType.java
+++ b/src/main/java/online/lifeasgame/notification/domain/NotificationType.java
@@ -1,0 +1,11 @@
+package online.lifeasgame.notification.domain;
+
+public enum NotificationType {
+    MAIL_RECEIVED,
+    QUEST_PROGRESS,
+    QUEST_COMPLETED,
+    QUEST_REWARD_READY,
+    LISTING_SOLD,
+    ACHIEVEMENT_UNLOCK,
+    SYSTEM_NOTICE
+}

--- a/src/main/java/online/lifeasgame/notification/domain/PlayerNotification.java
+++ b/src/main/java/online/lifeasgame/notification/domain/PlayerNotification.java
@@ -1,0 +1,168 @@
+package online.lifeasgame.notification.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import online.lifeasgame.core.annotation.AggregateRoot;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.notification.domain.error.NotificationError;
+import online.lifeasgame.platform.persistence.jpa.AbstractTime;
+
+@Entity
+@AggregateRoot
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "player_notifications",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_player_notification_source",
+                columnNames = {"player_id", "source_event_id"}
+        ),
+        indexes = {
+                @Index(
+                        name = "idx_player_notification_inbox",
+                        columnList = "player_id,id"
+                ),
+                @Index(
+                        name = "idx_player_notification_unread",
+                        columnList = "player_id,read_at"
+                )
+        }
+)
+public class PlayerNotification extends AbstractTime {
+
+    public static final int SOURCE_EVENT_ID_MAX_LENGTH = 255;
+    public static final int TITLE_MAX_LENGTH = 200;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "player_id", nullable = false, updatable = false)
+    private Long playerId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, updatable = false, length = 40)
+    private NotificationType type;
+
+    @Column(nullable = false, updatable = false, length = TITLE_MAX_LENGTH)
+    private String title;
+
+    @Column(nullable = false, updatable = false, columnDefinition = "text")
+    private String body;
+
+    @Column(
+            name = "source_event_id",
+            nullable = false,
+            updatable = false,
+            length = SOURCE_EVENT_ID_MAX_LENGTH
+    )
+    private String sourceEventId;
+
+    @Column(name = "occurred_at", nullable = false, updatable = false)
+    private Instant occurredAt;
+
+    @Column(name = "read_at")
+    private Instant readAt;
+
+    private PlayerNotification(
+            Long playerId,
+            String sourceEventId,
+            NotificationType type,
+            String title,
+            String body,
+            Instant occurredAt
+    ) {
+        this.playerId = requiredPlayerId(playerId);
+        this.sourceEventId = requiredText(
+                sourceEventId,
+                SOURCE_EVENT_ID_MAX_LENGTH,
+                NotificationError.SOURCE_EVENT_ID_REQUIRED,
+                NotificationError.SOURCE_EVENT_ID_TOO_LONG
+        );
+        this.type = required(type, NotificationError.TYPE_REQUIRED);
+        this.title = requiredText(
+                title,
+                TITLE_MAX_LENGTH,
+                NotificationError.TITLE_REQUIRED,
+                NotificationError.TITLE_TOO_LONG
+        );
+        this.body = requiredBody(body);
+        this.occurredAt = required(
+                occurredAt,
+                NotificationError.OCCURRED_AT_REQUIRED
+        );
+    }
+
+    public static PlayerNotification create(
+            Long playerId,
+            String sourceEventId,
+            NotificationType type,
+            String title,
+            String body,
+            Instant occurredAt
+    ) {
+        return new PlayerNotification(
+                playerId,
+                sourceEventId,
+                type,
+                title,
+                body,
+                occurredAt
+        );
+    }
+
+    public void markRead(Instant time) {
+        if (readAt == null) {
+            readAt = required(time, NotificationError.READ_AT_REQUIRED);
+        }
+    }
+
+    private static Long requiredPlayerId(Long playerId) {
+        if (playerId == null || playerId <= 0) {
+            throw new DomainException(NotificationError.PLAYER_ID_REQUIRED);
+        }
+        return playerId;
+    }
+
+    private static String requiredBody(String value) {
+        if (value == null || value.isBlank()) {
+            throw new DomainException(NotificationError.BODY_REQUIRED);
+        }
+        return value.strip();
+    }
+
+    private static String requiredText(
+            String value,
+            int maxLength,
+            NotificationError requiredError,
+            NotificationError lengthError
+    ) {
+        if (value == null || value.isBlank()) {
+            throw new DomainException(requiredError);
+        }
+        String normalized = value.strip();
+        if (normalized.length() > maxLength) {
+            throw new DomainException(lengthError);
+        }
+        return normalized;
+    }
+
+    private static <T> T required(T value, NotificationError error) {
+        if (value == null) {
+            throw new DomainException(error);
+        }
+        return value;
+    }
+}

--- a/src/main/java/online/lifeasgame/notification/domain/error/NotificationError.java
+++ b/src/main/java/online/lifeasgame/notification/domain/error/NotificationError.java
@@ -1,0 +1,64 @@
+package online.lifeasgame.notification.domain.error;
+
+import online.lifeasgame.core.error.ErrorCode;
+
+public enum NotificationError implements ErrorCode {
+    NOTIFICATION_NOT_FOUND(
+            "NTF-404-NOT-FOUND", "Notification not found", 404
+    ),
+    PLAYER_ID_REQUIRED(
+            "NTF-400-PLAYER-ID-REQUIRED", "Notification player id is required", 400
+    ),
+    SOURCE_EVENT_ID_REQUIRED(
+            "NTF-400-SOURCE-EVENT-ID-REQUIRED", "Notification source event id is required", 400
+    ),
+    SOURCE_EVENT_ID_TOO_LONG(
+            "NTF-400-SOURCE-EVENT-ID-TOO-LONG", "Notification source event id is too long", 400
+    ),
+    TYPE_REQUIRED(
+            "NTF-400-TYPE-REQUIRED", "Notification type is required", 400
+    ),
+    TITLE_REQUIRED(
+            "NTF-400-TITLE-REQUIRED", "Notification title is required", 400
+    ),
+    TITLE_TOO_LONG(
+            "NTF-400-TITLE-TOO-LONG", "Notification title is too long", 400
+    ),
+    BODY_REQUIRED(
+            "NTF-400-BODY-REQUIRED", "Notification body is required", 400
+    ),
+    OCCURRED_AT_REQUIRED(
+            "NTF-400-OCCURRED-AT-REQUIRED", "Notification occurred time is required", 400
+    ),
+    READ_AT_REQUIRED(
+            "NTF-400-READ-AT-REQUIRED", "Notification read time is required", 400
+    ),
+    PAGE_SIZE_INVALID(
+            "NTF-400-PAGE-SIZE-INVALID", "Notification page size must be between 1 and 100", 400
+    );
+
+    private final String code;
+    private final String message;
+    private final int status;
+
+    NotificationError(String code, String message, int status) {
+        this.code = code;
+        this.message = message;
+        this.status = status;
+    }
+
+    @Override
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public int status() {
+        return status;
+    }
+}

--- a/src/main/java/online/lifeasgame/notification/domain/repository/PlayerNotificationRepository.java
+++ b/src/main/java/online/lifeasgame/notification/domain/repository/PlayerNotificationRepository.java
@@ -1,0 +1,16 @@
+package online.lifeasgame.notification.domain.repository;
+
+import java.time.Instant;
+import java.util.Optional;
+import online.lifeasgame.notification.domain.PlayerNotification;
+
+public interface PlayerNotificationRepository {
+
+    PlayerNotification saveAndFlush(PlayerNotification notification);
+
+    boolean existsByPlayerIdAndSourceEventId(Long playerId, String sourceEventId);
+
+    Optional<PlayerNotification> findOwned(Long notificationId, Long playerId);
+
+    int markAllUnread(Long playerId, Instant readAt);
+}

--- a/src/main/java/online/lifeasgame/notification/infra/JpaPlayerNotificationRepository.java
+++ b/src/main/java/online/lifeasgame/notification/infra/JpaPlayerNotificationRepository.java
@@ -1,0 +1,30 @@
+package online.lifeasgame.notification.infra;
+
+import java.time.Instant;
+import java.util.Optional;
+import online.lifeasgame.notification.domain.PlayerNotification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface JpaPlayerNotificationRepository
+        extends JpaRepository<PlayerNotification, Long> {
+
+    boolean existsByPlayerIdAndSourceEventId(Long playerId, String sourceEventId);
+
+    Optional<PlayerNotification> findByIdAndPlayerId(Long id, Long playerId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update PlayerNotification notification
+            set notification.readAt = :readAt,
+                notification.updatedAt = :readAt
+            where notification.playerId = :playerId
+              and notification.readAt is null
+            """)
+    int markAllUnread(
+            @Param("playerId") Long playerId,
+            @Param("readAt") Instant readAt
+    );
+}

--- a/src/main/java/online/lifeasgame/notification/infra/NotificationInboxQueryAdapter.java
+++ b/src/main/java/online/lifeasgame/notification/infra/NotificationInboxQueryAdapter.java
@@ -1,0 +1,57 @@
+package online.lifeasgame.notification.infra;
+
+import static online.lifeasgame.notification.domain.QPlayerNotification.playerNotification;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.notification.application.query.NotificationInboxQuery;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationInboxQueryAdapter implements NotificationInboxQuery {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Row> findInbox(Long playerId, Long cursor, int limit) {
+        return queryFactory
+                .select(Projections.constructor(
+                        Row.class,
+                        playerNotification.id,
+                        playerNotification.type,
+                        playerNotification.title,
+                        playerNotification.body,
+                        playerNotification.occurredAt,
+                        playerNotification.readAt
+                ))
+                .from(playerNotification)
+                .where(
+                        playerNotification.playerId.eq(playerId),
+                        before(cursor)
+                )
+                .orderBy(playerNotification.id.desc())
+                .limit(limit)
+                .fetch();
+    }
+
+    @Override
+    public long countUnread(Long playerId) {
+        Long count = queryFactory
+                .select(playerNotification.count())
+                .from(playerNotification)
+                .where(
+                        playerNotification.playerId.eq(playerId),
+                        playerNotification.readAt.isNull()
+                )
+                .fetchOne();
+        return count == null ? 0L : count;
+    }
+
+    private BooleanExpression before(Long cursor) {
+        return cursor == null ? null : playerNotification.id.lt(cursor);
+    }
+}

--- a/src/main/java/online/lifeasgame/notification/infra/PlayerNotificationRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/notification/infra/PlayerNotificationRepositoryAdapter.java
@@ -1,0 +1,45 @@
+package online.lifeasgame.notification.infra;
+
+import java.time.Instant;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.notification.domain.PlayerNotification;
+import online.lifeasgame.notification.domain.repository.PlayerNotificationRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PlayerNotificationRepositoryAdapter
+        implements PlayerNotificationRepository {
+
+    private final JpaPlayerNotificationRepository repository;
+
+    @Override
+    public PlayerNotification saveAndFlush(PlayerNotification notification) {
+        return repository.saveAndFlush(notification);
+    }
+
+    @Override
+    public boolean existsByPlayerIdAndSourceEventId(
+            Long playerId,
+            String sourceEventId
+    ) {
+        return repository.existsByPlayerIdAndSourceEventId(
+                playerId,
+                sourceEventId
+        );
+    }
+
+    @Override
+    public Optional<PlayerNotification> findOwned(
+            Long notificationId,
+            Long playerId
+    ) {
+        return repository.findByIdAndPlayerId(notificationId, playerId);
+    }
+
+    @Override
+    public int markAllUnread(Long playerId, Instant readAt) {
+        return repository.markAllUnread(playerId, readAt);
+    }
+}

--- a/src/main/resources/db/migration/V25__player_notification_inbox.sql
+++ b/src/main/resources/db/migration/V25__player_notification_inbox.sql
@@ -1,0 +1,38 @@
+CREATE TABLE player_notifications (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    player_id BIGINT NOT NULL,
+    type VARCHAR(40) NOT NULL,
+    title VARCHAR(200) NOT NULL,
+    body TEXT NOT NULL,
+    source_event_id VARCHAR(255) NOT NULL,
+    occurred_at DATETIME(6) NOT NULL,
+    read_at DATETIME(6) NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_player_notification_source
+        UNIQUE (player_id, source_event_id),
+    CONSTRAINT ck_player_notification_player CHECK (player_id > 0),
+    CONSTRAINT ck_player_notification_type CHECK (type IN (
+        'MAIL_RECEIVED',
+        'QUEST_PROGRESS',
+        'QUEST_COMPLETED',
+        'QUEST_REWARD_READY',
+        'LISTING_SOLD',
+        'ACHIEVEMENT_UNLOCK',
+        'SYSTEM_NOTICE'
+    )),
+    CONSTRAINT ck_player_notification_source_event CHECK (
+        CHAR_LENGTH(TRIM(source_event_id)) BETWEEN 1 AND 255
+    ),
+    CONSTRAINT ck_player_notification_title CHECK (
+        CHAR_LENGTH(TRIM(title)) BETWEEN 1 AND 200
+    ),
+    CONSTRAINT ck_player_notification_body CHECK (
+        CHAR_LENGTH(TRIM(body)) >= 1
+    ),
+    INDEX idx_player_notification_inbox (player_id, id),
+    INDEX idx_player_notification_unread (player_id, read_at)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_0900_ai_ci;

--- a/src/test/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryIntegrationTest.java
@@ -99,7 +99,7 @@ class InventoryRewardDeliveryIntegrationTest {
     @DisplayName("V17 receipt table은 JPA validate와 unique/check/index 계약을 만족한다")
     void validatesMigrationContract() {
         assertThat(flyway.info().current().getVersion().getVersion())
-                .isEqualTo("24");
+                .isEqualTo("25");
         assertThat(environment.getProperty("spring.jpa.hibernate.ddl-auto"))
                 .isEqualTo("validate");
 

--- a/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
@@ -63,7 +63,7 @@ class FlywayExplicitBaselineTest {
     class ApplyExplicitBaseline {
 
         @Test
-        @DisplayName("V1을 재실행하지 않고 V2부터 V24까지 적용한 뒤 JPA validate를 통과한다")
+        @DisplayName("V1을 재실행하지 않고 V2부터 V25까지 적용한 뒤 JPA validate를 통과한다")
         void migratesFromVersionTwoAndValidatesJpa() throws Exception {
             String jdbcUrl = createV1EquivalentDatabase();
             Flyway flyway = migrationFlyway(jdbcUrl);
@@ -72,13 +72,13 @@ class FlywayExplicitBaselineTest {
             MigrateResult migrateResult = flyway.migrate();
             List<HistoryRow> history = successfulHistory(jdbcUrl);
 
-            assertThat(migrateResult.migrationsExecuted).isEqualTo(23);
+            assertThat(migrateResult.migrationsExecuted).isEqualTo(24);
             assertThat(history).extracting(HistoryRow::version)
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
                             "14", "15", "16", "17", "18", "19", "20",
-                            "21", "22", "23", "24"
+                            "21", "22", "23", "24", "25"
                     );
             assertThat(history.getFirst().type()).isEqualTo("BASELINE");
             assertThat(history.getFirst().script())
@@ -112,7 +112,8 @@ class FlywayExplicitBaselineTest {
                             "V21__role_event_lifelog_linkage.sql",
                             "V22__lifelog_journal_timeline_index.sql",
                             "V23__player_equipment_item_uniqueness.sql",
-                            "V24__equipment_compatibility_kind.sql"
+                            "V24__equipment_compatibility_kind.sql",
+                            "V25__player_notification_inbox.sql"
                     );
             assertThat(history.subList(1, history.size()))
                     .allSatisfy(row -> assertThat(row.checksum()).isNotNull());
@@ -132,7 +133,7 @@ class FlywayExplicitBaselineTest {
                         "spring.jpa.hibernate.ddl-auto"
                 )).isEqualTo("validate");
                 assertThat(context.getBean(Flyway.class).info().current().getVersion().getVersion())
-                        .isEqualTo("24");
+                        .isEqualTo("25");
             }
         }
     }

--- a/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
@@ -33,7 +33,7 @@ class FlywayHistoryChecksumTest {
     class MigrateAgain {
 
         @Test
-        @DisplayName("V1~V20 checksum을 보존하고 V24 이후 두 번째 실행은 no-op이다")
+        @DisplayName("V1~V20 checksum을 보존하고 V25 이후 두 번째 실행은 no-op이다")
         void keepsMigrationHistory() throws Exception {
             Flyway throughV20 = flyway(MigrationVersion.fromVersion("20"));
             MigrateResult legacy = throughV20.migrate();
@@ -47,7 +47,7 @@ class FlywayHistoryChecksumTest {
             List<HistoryRow> secondHistory = successfulHistory();
 
             assertThat(legacy.migrationsExecuted).isEqualTo(20);
-            assertThat(first.migrationsExecuted).isEqualTo(4);
+            assertThat(first.migrationsExecuted).isEqualTo(5);
             assertThat(second.migrationsExecuted).isZero();
             assertThat(secondHistory).isEqualTo(firstHistory);
             assertThat(firstHistory.subList(0, legacyHistory.size()))
@@ -57,7 +57,7 @@ class FlywayHistoryChecksumTest {
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
                             "14", "15", "16", "17", "18", "19", "20",
-                            "21", "22", "23", "24"
+                            "21", "22", "23", "24", "25"
                     );
             assertThat(secondHistory).allSatisfy(history -> {
                 assertThat(history.checksum()).isNotNull();

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -39,7 +39,7 @@ class FlywayMigrationTest {
     class MigrateCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V24까지 적용되고 equipment compatibility kind를 추가한다")
+        @DisplayName("V1부터 V25까지 적용되고 Notification inbox를 추가한다")
         void migratesSchemaAndSeedsRewardProfiles() throws Exception {
             Flyway throughV10 = flyway(MigrationVersion.fromVersion("10"));
             MigrateResult legacyResult = throughV10.migrate();
@@ -58,13 +58,13 @@ class FlywayMigrationTest {
             assertThat(legacyResult.migrationsExecuted).isEqualTo(10);
             assertThat(semanticResult.migrationsExecuted).isEqualTo(1);
             assertThat(itemResult.migrationsExecuted).isEqualTo(1);
-            assertThat(result.migrationsExecuted).isEqualTo(12);
+            assertThat(result.migrationsExecuted).isEqualTo(13);
             assertThat(appliedVersions())
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
                             "14", "15", "16", "17", "18", "19", "20",
-                            "21", "22", "23", "24"
+                            "21", "22", "23", "24", "25"
                     );
             assertThat(existingTables(
                     "users",
@@ -91,7 +91,8 @@ class FlywayMigrationTest {
                     "quest_route_step_quests",
                     "player_quest_routes",
                     "role_events",
-                    "role_event_participants"
+                    "role_event_participants",
+                    "player_notifications"
             )).containsExactlyInAnyOrder(
                     "users",
                     "player",
@@ -117,7 +118,8 @@ class FlywayMigrationTest {
                     "quest_route_step_quests",
                     "player_quest_routes",
                     "role_events",
-                    "role_event_participants"
+                    "role_event_participants",
+                    "player_notifications"
             );
             assertThat(existingTables(
                     "quick_lifelog_entries",
@@ -289,6 +291,18 @@ class FlywayMigrationTest {
                     "life_log_records",
                     "idx_life_log_record_player_timeline"
             )).containsExactly("player_id", "occurred_at", "id");
+            assertThat(uniqueIndexColumns(
+                    "player_notifications",
+                    "uq_player_notification_source"
+            )).containsExactly("player_id", "source_event_id");
+            assertThat(indexColumns(
+                    "player_notifications",
+                    "idx_player_notification_inbox"
+            )).containsExactly("player_id", "id");
+            assertThat(indexColumns(
+                    "player_notifications",
+                    "idx_player_notification_unread"
+            )).containsExactly("player_id", "read_at");
             assertThat(lifeLogRecordColumnNames()).containsExactlyInAnyOrder(
                     "id",
                     "player_id",

--- a/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
@@ -149,7 +149,7 @@ class FlywayProfileCutoverTest {
     class StartLocalWithCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V24까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
+        @DisplayName("V1부터 V25까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
         void migratesThenValidates() {
             ConfigurableEnvironment environment =
                     (ConfigurableEnvironment) applicationContext.getEnvironment();
@@ -161,8 +161,8 @@ class FlywayProfileCutoverTest {
             assertThat(environment.getProperty(
                     "spring.flyway.baseline-on-migrate", Boolean.class
             )).isFalse();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("24");
-            assertThat(appliedMigrationCount()).isEqualTo(24);
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("25");
+            assertThat(appliedMigrationCount()).isEqualTo(25);
         }
     }
 

--- a/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 @SpringBootTest
 @ActiveProfiles({"test", "migration-test"})
-@DisplayName("V24 migration 이후 JPA schema validation")
+@DisplayName("V25 migration 이후 JPA schema validation")
 class JpaValidateAfterMigrationTest {
 
     @Container
@@ -79,14 +79,14 @@ class JpaValidateAfterMigrationTest {
     private QuestDefinitionBootstrapper questDefinitionBootstrapper;
 
     @Nested
-    @DisplayName("V1부터 V24까지 적용된 schema로 ApplicationContext를 기동할 때")
+    @DisplayName("V1부터 V25까지 적용된 schema로 ApplicationContext를 기동할 때")
     class LoadApplicationContext {
 
         @Test
         @DisplayName("ddl-auto validate 상태로 정상 기동한다")
         void loadsWithJpaValidation() {
             assertThat(applicationContext).isNotNull();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("24");
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("25");
             assertThat(applicationContext.getEnvironment().getProperty("spring.jpa.hibernate.ddl-auto"))
                     .isEqualTo("validate");
             assertThat(applicationContext.getEnvironment()

--- a/src/test/java/online/lifeasgame/migration/RolePersonPersistenceFoundationFlywayTest.java
+++ b/src/test/java/online/lifeasgame/migration/RolePersonPersistenceFoundationFlywayTest.java
@@ -46,9 +46,9 @@ class RolePersonPersistenceFoundationFlywayTest {
     }
 
     @Test
-    @DisplayName("V24까지 적용된 schema에서 V19 Role/Person 계약을 고정한다")
+    @DisplayName("V25까지 적용된 schema에서 V19 Role/Person 계약을 고정한다")
     void createsSchemaContract() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("24");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("25");
         assertThat(tableContracts()).containsExactly(
                 new TableContract("roles", "InnoDB", "utf8mb4_0900_ai_ci"),
                 new TableContract("persons", "InnoDB", "utf8mb4_0900_ai_ci"),

--- a/src/test/java/online/lifeasgame/notification/api/NotificationApiContractTest.java
+++ b/src/test/java/online/lifeasgame/notification/api/NotificationApiContractTest.java
@@ -1,0 +1,163 @@
+package online.lifeasgame.notification.api;
+
+import java.time.Instant;
+import java.util.List;
+import online.lifeasgame.notification.application.NotificationQueryService;
+import online.lifeasgame.notification.application.NotificationReadMarker;
+import online.lifeasgame.notification.application.result.NotificationResult;
+import online.lifeasgame.notification.domain.NotificationType;
+import online.lifeasgame.platform.security.jwt.JwtPrincipal;
+import online.lifeasgame.platform.security.jwt.JwtProvider;
+import online.lifeasgame.platform.web.error.docs.ErrorDocLinker;
+import online.lifeasgame.support.WebMvcTestConfig;
+import online.lifeasgame.system.bootstrap.error.handler.AppErrorProperties;
+import online.lifeasgame.system.bootstrap.security.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = NotificationController.class)
+@Import({SecurityConfig.class, WebMvcTestConfig.class})
+@DisplayName("Current Player Notification API contract")
+class NotificationApiContractTest {
+
+    private static final Instant OCCURRED_AT =
+            Instant.parse("2026-08-21T10:00:00Z");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private NotificationQueryService queryService;
+
+    @MockitoBean
+    private NotificationReadMarker readMarker;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private AppErrorProperties appErrorProperties;
+
+    @MockitoBean
+    private ErrorDocLinker errorDocLinker;
+
+    @Test
+    @DisplayName("GET inbox는 기본 size와 공개 필드만 ApiResponse로 반환한다")
+    void returnsInboxEnvelopeWithoutPrivateFields() throws Exception {
+        given(queryService.inbox(null, 20)).willReturn(
+                new NotificationResult.Page(
+                        List.of(new NotificationResult.Info(
+                                292L,
+                                NotificationType.QUEST_COMPLETED,
+                                "퀘스트 완료",
+                                "첫 퀘스트를 완료했습니다.",
+                                OCCURRED_AT,
+                                false
+                        )),
+                        true,
+                        292L
+                )
+        );
+
+        mockMvc.perform(get("/api/v1/notifications")
+                        .with(authentication(playerAuthentication())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.code").value("COMMON-200"))
+                .andExpect(jsonPath("$.result.*", hasSize(3)))
+                .andExpect(jsonPath("$.result.notifications", hasSize(1)))
+                .andExpect(jsonPath("$.result.notifications[0].*", hasSize(6)))
+                .andExpect(jsonPath("$.result.notifications[0].id").value(292))
+                .andExpect(jsonPath("$.result.notifications[0].type")
+                        .value("QUEST_COMPLETED"))
+                .andExpect(jsonPath("$.result.notifications[0].title")
+                        .value("퀘스트 완료"))
+                .andExpect(jsonPath("$.result.notifications[0].body")
+                        .value("첫 퀘스트를 완료했습니다."))
+                .andExpect(jsonPath("$.result.notifications[0].occurredAt")
+                        .value("2026-08-21T10:00:00Z"))
+                .andExpect(jsonPath("$.result.notifications[0].read").value(false))
+                .andExpect(jsonPath("$.result.notifications[0].playerId").doesNotExist())
+                .andExpect(jsonPath("$.result.notifications[0].userId").doesNotExist())
+                .andExpect(jsonPath("$.result.notifications[0].sourceEventId").doesNotExist())
+                .andExpect(jsonPath("$.result.notifications[0].readAt").doesNotExist())
+                .andExpect(jsonPath("$.result.hasMore").value(true))
+                .andExpect(jsonPath("$.result.nextCursor").value(292));
+
+        verify(queryService).inbox(null, 20);
+    }
+
+    @Test
+    @DisplayName("GET unread-count는 Current Player count를 ApiResponse로 반환한다")
+    void returnsUnreadCount() throws Exception {
+        given(queryService.unreadCount()).willReturn(3L);
+
+        mockMvc.perform(get("/api/v1/notifications/unread-count")
+                        .with(authentication(playerAuthentication())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.*", hasSize(1)))
+                .andExpect(jsonPath("$.result.unreadCount").value(3));
+    }
+
+    @Test
+    @DisplayName("POST notification read는 identity body 없이 idempotent success를 반환한다")
+    void marksOneRead() throws Exception {
+        mockMvc.perform(post("/api/v1/notifications/{id}/read", 292L)
+                        .with(authentication(playerAuthentication())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result").doesNotExist());
+
+        verify(readMarker).markOne(292L);
+    }
+
+    @Test
+    @DisplayName("POST read-all은 Current Player markedCount를 반환한다")
+    void marksAllRead() throws Exception {
+        given(readMarker.markAll()).willReturn(4);
+
+        mockMvc.perform(post("/api/v1/notifications/read-all")
+                        .with(authentication(playerAuthentication())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.*", hasSize(1)))
+                .andExpect(jsonPath("$.result.markedCount").value(4));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 101})
+    @DisplayName("inbox size가 1~100 밖이면 400을 반환한다")
+    void rejectsInvalidSize(int size) throws Exception {
+        mockMvc.perform(get("/api/v1/notifications")
+                        .param("size", Integer.toString(size))
+                        .with(authentication(playerAuthentication())))
+                .andExpect(status().isBadRequest());
+    }
+
+    private UsernamePasswordAuthenticationToken playerAuthentication() {
+        return new UsernamePasswordAuthenticationToken(
+                new JwtPrincipal(29201L, 292001L),
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/notification/application/NotificationApplicationIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/notification/application/NotificationApplicationIntegrationTest.java
@@ -1,0 +1,295 @@
+package online.lifeasgame.notification.application;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.security.CurrentPlayerAccessor;
+import online.lifeasgame.notification.application.internal.NotificationAppendApi;
+import online.lifeasgame.notification.application.result.NotificationResult;
+import online.lifeasgame.notification.domain.NotificationType;
+import online.lifeasgame.notification.domain.error.NotificationError;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@Testcontainers
+@SpringBootTest(properties = "spring.datasource.hikari.maximum-pool-size=6")
+@ActiveProfiles({"test", "migration-test"})
+@DisplayName("Current Player Notification application/persistence")
+class NotificationApplicationIntegrationTest {
+
+    private static final Long PLAYER_ID = 29201L;
+    private static final Long OTHER_PLAYER_ID = 29202L;
+    private static final Instant OCCURRED_AT =
+            Instant.parse("2026-08-21T10:00:00Z");
+
+    @Container
+    private static final MySQLContainer<?> MYSQL =
+            new MySQLContainer<>("mysql:8.0.39")
+                    .withDatabaseName("lifeasgame_notification")
+                    .withUsername("lifeasgame")
+                    .withPassword("lifeasgame");
+
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add(
+                "spring.datasource.driver-class-name",
+                MYSQL::getDriverClassName
+        );
+    }
+
+    @Autowired
+    private NotificationAppendApi appendApi;
+
+    @Autowired
+    private NotificationQueryService queryService;
+
+    @Autowired
+    private NotificationReadMarker readMarker;
+
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    @Autowired
+    private Flyway flyway;
+
+    @MockitoBean
+    private CurrentPlayerAccessor currentPlayerAccessor;
+
+    private final AtomicLong currentPlayerId = new AtomicLong(PLAYER_ID);
+
+    @BeforeEach
+    void cleanState() {
+        jdbc.update("DELETE FROM player_notifications");
+        asCurrent(PLAYER_ID);
+        given(currentPlayerAccessor.currentPlayerIdOrThrow())
+                .willAnswer(invocation -> currentPlayerId.get());
+    }
+
+    @Nested
+    @DisplayName("Notification-owned append API로 알림을 추가할 때")
+    class AppendNotification {
+
+        @Test
+        @DisplayName("durable row를 만들고 같은 player replay만 무시한다")
+        void appendsDurablyAndScopesReplayByPlayer() {
+            assertThat(flyway.info().current().getVersion().getVersion())
+                    .isEqualTo("25");
+
+            append(PLAYER_ID, "shared-event");
+            append(PLAYER_ID, "shared-event");
+            append(OTHER_PLAYER_ID, "shared-event");
+
+            assertThat(jdbc.queryForObject(
+                    "SELECT COUNT(*) FROM player_notifications",
+                    Integer.class
+            )).isEqualTo(2);
+            Map<String, Object> row = jdbc.queryForMap("""
+                    SELECT player_id, type, title, body, source_event_id,
+                           occurred_at, read_at, created_at, updated_at
+                    FROM player_notifications
+                    WHERE player_id = ?
+                    """, PLAYER_ID);
+            assertThat(row)
+                    .containsEntry("player_id", PLAYER_ID)
+                    .containsEntry("type", "SYSTEM_NOTICE")
+                    .containsEntry("title", "알림 shared-event")
+                    .containsEntry("body", "본문 shared-event")
+                    .containsEntry("source_event_id", "shared-event")
+                    .containsEntry("read_at", null)
+                    .containsKeys("occurred_at", "created_at", "updated_at");
+            assertThat(row.get("occurred_at")).isNotNull();
+            assertThat(queryService.inbox(null, 20).notifications().getFirst()
+                    .occurredAt()).isEqualTo(OCCURRED_AT);
+        }
+
+        @Test
+        @DisplayName("동시 replay도 DB unique constraint로 한 row만 남긴다")
+        void appendsConcurrentReplayOnce() throws Exception {
+            CountDownLatch ready = new CountDownLatch(2);
+            CountDownLatch start = new CountDownLatch(1);
+            ExecutorService executor = Executors.newFixedThreadPool(2);
+            try {
+                List<Future<?>> attempts = List.of(
+                        executor.submit(() -> concurrentAppend(ready, start)),
+                        executor.submit(() -> concurrentAppend(ready, start))
+                );
+                assertThat(ready.await(10, TimeUnit.SECONDS)).isTrue();
+                start.countDown();
+                for (Future<?> attempt : attempts) {
+                    attempt.get(10, TimeUnit.SECONDS);
+                }
+            } finally {
+                executor.shutdownNow();
+            }
+
+            assertThat(notificationCount(PLAYER_ID, "concurrent-event"))
+                    .isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("Current Player inbox를 조회할 때")
+    class QueryInbox {
+
+        @Test
+        @DisplayName("own 알림을 ID 역순 cursor page와 올바른 nextCursor로 반환한다")
+        void returnsOwnedNewestFirstCursorPage() {
+            append(PLAYER_ID, "event-1");
+            append(PLAYER_ID, "event-2");
+            append(PLAYER_ID, "event-3");
+            append(OTHER_PLAYER_ID, "other-event");
+            List<Long> ownIds = notificationIds(PLAYER_ID);
+
+            NotificationResult.Page first = queryService.inbox(null, 2);
+            NotificationResult.Page second = queryService.inbox(
+                    first.nextCursor(),
+                    2
+            );
+
+            assertThat(first.notifications())
+                    .extracting(NotificationResult.Info::id)
+                    .containsExactly(ownIds.get(0), ownIds.get(1));
+            assertThat(first.hasMore()).isTrue();
+            assertThat(first.nextCursor()).isEqualTo(ownIds.get(1));
+            assertThat(second.notifications())
+                    .extracting(NotificationResult.Info::id)
+                    .containsExactly(ownIds.get(2));
+            assertThat(second.hasMore()).isFalse();
+            assertThat(second.nextCursor()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("Current Player 알림을 읽음 처리할 때")
+    class MarkRead {
+
+        @Test
+        @DisplayName("own unread 하나만 읽고 replay와 cross-owner를 안전하게 처리한다")
+        void marksOneIdempotentlyAndHidesOwnership() {
+            Long firstId = appendAndGetId(PLAYER_ID, "first");
+            append(PLAYER_ID, "second");
+            Long otherId = appendAndGetId(OTHER_PLAYER_ID, "other");
+
+            readMarker.markOne(firstId);
+            Instant firstReadAt = readAt(firstId);
+            readMarker.markOne(firstId);
+
+            assertThat(readAt(firstId)).isEqualTo(firstReadAt);
+            assertThat(queryService.unreadCount()).isEqualTo(1);
+            assertNotFound(otherId);
+            assertNotFound(999_999L);
+            assertThat(readAt(otherId)).isNull();
+        }
+
+        @Test
+        @DisplayName("mark-all은 own unread만 변경하고 이미 읽은 시각을 유지한다")
+        void marksAllOwnedUnreadOnly() {
+            Long alreadyReadId = appendAndGetId(PLAYER_ID, "already-read");
+            append(PLAYER_ID, "unread");
+            Long otherId = appendAndGetId(OTHER_PLAYER_ID, "other-unread");
+            readMarker.markOne(alreadyReadId);
+            Instant originalReadAt = readAt(alreadyReadId);
+
+            assertThat(readMarker.markAll()).isEqualTo(1);
+            assertThat(readMarker.markAll()).isZero();
+
+            assertThat(readAt(alreadyReadId)).isEqualTo(originalReadAt);
+            assertThat(queryService.unreadCount()).isZero();
+            assertThat(readAt(otherId)).isNull();
+        }
+    }
+
+    private void concurrentAppend(CountDownLatch ready, CountDownLatch start) {
+        try {
+            ready.countDown();
+            if (!start.await(10, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("concurrent append start timed out");
+            }
+            append(PLAYER_ID, "concurrent-event");
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(exception);
+        }
+    }
+
+    private Long appendAndGetId(Long playerId, String sourceEventId) {
+        append(playerId, sourceEventId);
+        return notificationIds(playerId).getFirst();
+    }
+
+    private void append(Long playerId, String sourceEventId) {
+        appendApi.append(new NotificationAppendApi.AppendCommand(
+                playerId,
+                sourceEventId,
+                NotificationType.SYSTEM_NOTICE,
+                "알림 " + sourceEventId,
+                "본문 " + sourceEventId,
+                OCCURRED_AT
+        ));
+    }
+
+    private void asCurrent(Long playerId) {
+        currentPlayerId.set(playerId);
+    }
+
+    private List<Long> notificationIds(Long playerId) {
+        return jdbc.queryForList(
+                "SELECT id FROM player_notifications WHERE player_id = ? ORDER BY id DESC",
+                Long.class,
+                playerId
+        );
+    }
+
+    private int notificationCount(Long playerId, String sourceEventId) {
+        return jdbc.queryForObject("""
+                SELECT COUNT(*)
+                FROM player_notifications
+                WHERE player_id = ? AND source_event_id = ?
+                """, Integer.class, playerId, sourceEventId);
+    }
+
+    private Instant readAt(Long notificationId) {
+        Timestamp value = jdbc.queryForObject(
+                "SELECT read_at FROM player_notifications WHERE id = ?",
+                Timestamp.class,
+                notificationId
+        );
+        return value == null ? null : value.toInstant();
+    }
+
+    private void assertNotFound(Long notificationId) {
+        assertThatThrownBy(() -> readMarker.markOne(notificationId))
+                .isInstanceOfSatisfying(DomainException.class, exception ->
+                        assertThat(exception.getErrorCode())
+                                .isEqualTo(NotificationError.NOTIFICATION_NOT_FOUND)
+                );
+    }
+}

--- a/src/test/java/online/lifeasgame/notification/domain/PlayerNotificationTest.java
+++ b/src/test/java/online/lifeasgame/notification/domain/PlayerNotificationTest.java
@@ -1,0 +1,111 @@
+package online.lifeasgame.notification.domain;
+
+import java.time.Instant;
+import java.util.stream.Stream;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.notification.domain.error.NotificationError;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Player Notification domain")
+class PlayerNotificationTest {
+
+    private static final Instant OCCURRED_AT =
+            Instant.parse("2026-08-21T10:00:00Z");
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidNotifications")
+    @DisplayName("필수 알림 값이 유효하지 않으면 생성하지 않는다")
+    void rejectsInvalidRequiredValues(
+            String scenario,
+            Long playerId,
+            String sourceEventId,
+            NotificationType type,
+            String title,
+            String body,
+            Instant occurredAt,
+            NotificationError expected
+    ) {
+        assertThatThrownBy(() -> PlayerNotification.create(
+                playerId,
+                sourceEventId,
+                type,
+                title,
+                body,
+                occurredAt
+        )).isInstanceOfSatisfying(DomainException.class, exception ->
+                assertThat(exception.getErrorCode()).isEqualTo(expected)
+        );
+    }
+
+    @Test
+    @DisplayName("readAt null 여부만으로 unread와 read 상태를 표현한다")
+    void marksReadIdempotently() {
+        PlayerNotification notification = validNotification();
+        Instant firstReadAt = Instant.parse("2026-08-21T11:00:00Z");
+
+        assertThat(notification.getReadAt()).isNull();
+        notification.markRead(firstReadAt);
+        notification.markRead(Instant.parse("2026-08-21T12:00:00Z"));
+
+        assertThat(notification.getReadAt()).isEqualTo(firstReadAt);
+    }
+
+    private static Stream<Arguments> invalidNotifications() {
+        return Stream.of(
+                Arguments.of(
+                        "playerId null",
+                        null, "event-1", NotificationType.SYSTEM_NOTICE,
+                        "제목", "본문", OCCURRED_AT,
+                        NotificationError.PLAYER_ID_REQUIRED
+                ),
+                Arguments.of(
+                        "sourceEventId blank",
+                        1L, " ", NotificationType.SYSTEM_NOTICE,
+                        "제목", "본문", OCCURRED_AT,
+                        NotificationError.SOURCE_EVENT_ID_REQUIRED
+                ),
+                Arguments.of(
+                        "type null",
+                        1L, "event-1", null,
+                        "제목", "본문", OCCURRED_AT,
+                        NotificationError.TYPE_REQUIRED
+                ),
+                Arguments.of(
+                        "title blank",
+                        1L, "event-1", NotificationType.SYSTEM_NOTICE,
+                        " ", "본문", OCCURRED_AT,
+                        NotificationError.TITLE_REQUIRED
+                ),
+                Arguments.of(
+                        "body blank",
+                        1L, "event-1", NotificationType.SYSTEM_NOTICE,
+                        "제목", " ", OCCURRED_AT,
+                        NotificationError.BODY_REQUIRED
+                ),
+                Arguments.of(
+                        "occurredAt null",
+                        1L, "event-1", NotificationType.SYSTEM_NOTICE,
+                        "제목", "본문", null,
+                        NotificationError.OCCURRED_AT_REQUIRED
+                )
+        );
+    }
+
+    private static PlayerNotification validNotification() {
+        return PlayerNotification.create(
+                1L,
+                "event-1",
+                NotificationType.SYSTEM_NOTICE,
+                "제목",
+                "본문",
+                OCCURRED_AT
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/role/application/RolePersonPersistenceIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/role/application/RolePersonPersistenceIntegrationTest.java
@@ -100,7 +100,7 @@ class RolePersonPersistenceIntegrationTest {
 
     @Test
     void persistsOwnerScopedCrudAndKeepsArchivedRows() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("24");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("25");
 
         var role = roleService.create(
                 new RoleCommand.Create("work", "Developer", "Builds")

--- a/src/test/java/online/lifeasgame/role/application/RoleRelationPersistenceIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/role/application/RoleRelationPersistenceIntegrationTest.java
@@ -93,7 +93,7 @@ class RoleRelationPersistenceIntegrationTest {
 
     @Test
     void persistsCrudRejectsActiveDuplicateAndReactivatesArchivedRow() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("24");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("25");
         Long roleId = createRole("Owner role");
         Long personId = createPerson("Alice");
 


### PR DESCRIPTION
## Purpose

Add the canonical backend Notification Stage 1 foundation for the Current Player.

Closes #292

## Delivered

- durable Current Player notification inbox
- Notification-owned append Internal API
- replay-safe append using `playerId + sourceEventId`
- newest-first cursor inbox
- unread count
- mark one read
- mark all read
- Current Player ownership
- append-only Flyway migration
- focused persistence/API coverage

## Public API

```text
GET  /api/v1/notifications?cursor=&size=20
GET  /api/v1/notifications/unread-count
POST /api/v1/notifications/{notificationId}/read
POST /api/v1/notifications/read-all
```

Current Player identity is resolved through `CurrentPlayerAccessor`.

No `playerId` or `userId` is accepted from self-service request input.

## Replay Safety

```text
UNIQUE(player_id, source_event_id)
```

The same source event replay for the same Player does not create a duplicate notification.

`readAt` remains the single read-state source of truth.

## Architecture Boundary

Notification owns its append Internal API.

No source domain imports Notification entity/repository internals.

Production source-domain adapters remain deferred.

## Scope

No:

- SSE/realtime notification transport
- Notification WebSocket/Redis pub-sub
- query-string token transport
- production source-domain adapters
- deep links
- delete/clear-all
- retention/archive
- email/push delivery
- notification preferences
- Role Chat/presence notifications
- frontend changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-app notification inbox with cursor-based pagination.
  * Added unread notification counts and notification categories.
  * Added options to mark individual notifications or all notifications as read.
  * Added notification details including titles, messages, timestamps, and read status.
  * Notifications are protected by ownership checks and duplicate prevention.
* **Bug Fixes**
  * Improved handling of invalid page sizes and missing notifications.
  * Ensured read actions are idempotent and bulk updates report affected notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->