### PR TITLE
[Economy] Complete atomic marketplace trade fulfillment

### DIFF
--- a/src/main/java/online/lifeasgame/economy/application/MarketplaceService.java
+++ b/src/main/java/online/lifeasgame/economy/application/MarketplaceService.java
@@ -10,6 +10,7 @@ import online.lifeasgame.economy.domain.error.EconomyError;
 import online.lifeasgame.economy.domain.event.EconomyEvent;
 import online.lifeasgame.economy.domain.event.EconomyEventType;
 import online.lifeasgame.inventory.application.internal.InventoryMarketAvailabilityApi;
+import online.lifeasgame.inventory.application.internal.InventoryMarketTransferApi;
 import online.lifeasgame.platform.idempotency.IdempotencyKeyStore;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,6 +32,7 @@ public class MarketplaceService {
     private final WalletWriter walletWriter;
     private final WalletReader walletReader;
     private final InventoryMarketAvailabilityApi inventoryMarketAvailabilityApi;
+    private final InventoryMarketTransferApi inventoryMarketTransferApi;
     private final IdempotencyKeyStore idempotencyKeyStore;
     private final DomainEventPublisher domainEventPublisher;
 
@@ -39,7 +41,9 @@ public class MarketplaceService {
         Listing listing = listingReader.getForUpdate(command.listingId());
         Instant now = Instant.now();
 
-        if (listing.getStatus() != ListingStatus.OPEN) {
+        if (listing.getStatus() != ListingStatus.OPEN
+                || listing.getItemId() == null
+                || listing.getSaleQuantity() == null) {
             throw new DomainException(EconomyError.LISTING_NOT_AVAILABLE);
         }
         if (buyerId.equals(listing.getSellerPlayerId())) {
@@ -96,6 +100,11 @@ public class MarketplaceService {
         if (buyerId.equals(listing.getSellerPlayerId())) {
             throw new DomainException(EconomyError.CANNOT_PURCHASE_OWN_LISTING);
         }
+        if (listing.getStatus() != ListingStatus.OPEN
+                || listing.getItemId() == null
+                || listing.getSaleQuantity() == null) {
+            throw new DomainException(EconomyError.LISTING_NOT_AVAILABLE);
+        }
 
         ListingReservation reservation = listingReservationReader
                 .findActiveForUpdate(listing.getId())
@@ -111,13 +120,16 @@ public class MarketplaceService {
         Wallet buyerWallet = lockWallet(buyerId);
         Wallet sellerWallet = lockOrCreateWallet(listing.getSellerPlayerId());
 
-        reservation.consume(buyerId, command.reservationToken(), now);
         buyerWallet.commitHold(reservation.getWalletHoldId());
-        listingReservationWriter.save(reservation);
-        inventoryMarketAvailabilityApi.beginTransfer(
+        inventoryMarketTransferApi.transferWholeEntry(
                 listing.getSellerPlayerId(),
-                listing.getItemInstanceId()
+                buyerId,
+                listing.getItemInstanceId(),
+                listing.getItemId(),
+                listing.getSaleQuantity()
         );
+        reservation.consume(buyerId, command.reservationToken(), now);
+        listingReservationWriter.save(reservation);
 
         Trade trade = listing.sellTo(buyerId);
 

--- a/src/main/java/online/lifeasgame/economy/domain/Listing.java
+++ b/src/main/java/online/lifeasgame/economy/domain/Listing.java
@@ -109,7 +109,15 @@ public class Listing extends AbstractTime {
         this.status = ListingStatus.SOLD;
         closeActive();
         clearReservation();
-        return Trade.of(this.id, buyerPlayerId, sellerPlayerId, itemInstanceId, price);
+        return Trade.of(
+                this.id,
+                buyerPlayerId,
+                sellerPlayerId,
+                itemInstanceId,
+                Guard.notNull(itemId, "itemId"),
+                Guard.notNull(saleQuantity, "saleQuantity"),
+                price
+        );
     }
 
     public void cancel(Long bySellerId) {

--- a/src/main/java/online/lifeasgame/economy/domain/Trade.java
+++ b/src/main/java/online/lifeasgame/economy/domain/Trade.java
@@ -53,6 +53,12 @@ public class Trade extends AbstractTime {
     @Column(name = "item_inst_id", nullable = false)
     private Long itemInstanceId;
 
+    @Column(name = "item_id")
+    private Long itemId;
+
+    @Column(name = "sale_quantity")
+    private Integer saleQuantity;
+
     @Embedded
     private Money price = Money.of(0, Currency.GOLD);
 
@@ -65,11 +71,26 @@ public class Trade extends AbstractTime {
     @Column(name = "fee_bps", nullable = false)
     private Integer feeBps = 100;
 
-    private Trade(Long listingId, Long buyerId, Long sellerId, Long itemInstId, Money price, int feeBps) {
+    private Trade(
+            Long listingId,
+            Long buyerId,
+            Long sellerId,
+            Long itemInstId,
+            Long itemId,
+            int saleQuantity,
+            Money price,
+            int feeBps
+    ) {
         this.listingId = Guard.notNull(listingId, "listingId");
         this.buyerPlayerId = Guard.notNull(buyerId, "buyerPlayerId");
         this.sellerPlayerId = Guard.notNull(sellerId, "sellerPlayerId");
         this.itemInstanceId = Guard.notNull(itemInstId, "itemInstanceId");
+        this.itemId = Guard.notNull(itemId, "itemId");
+        this.saleQuantity = Guard.minValue(
+                saleQuantity,
+                1,
+                "saleQuantity"
+        );
         this.price = Guard.notNull(price, "price");
         this.feeBps = feeBps;
         this.fee = price.percent(feeBps);
@@ -82,9 +103,20 @@ public class Trade extends AbstractTime {
             Long buyerId,
             Long sellerId,
             Long itemInstId,
+            Long itemId,
+            int saleQuantity,
             Money price
     ) {
-        return new Trade(listingId, buyerId, sellerId, itemInstId, price, 100);
+        return new Trade(
+                listingId,
+                buyerId,
+                sellerId,
+                itemInstId,
+                itemId,
+                saleQuantity,
+                price,
+                100
+        );
     }
 
     public Money getPrice() {
@@ -105,6 +137,14 @@ public class Trade extends AbstractTime {
 
     public Long getItemInstanceId() {
         return itemInstanceId;
+    }
+
+    public Long getItemId() {
+        return itemId;
+    }
+
+    public Integer getSaleQuantity() {
+        return saleQuantity;
     }
 
     public Long getListingId() {

--- a/src/main/java/online/lifeasgame/inventory/application/InventoryMarketTransferService.java
+++ b/src/main/java/online/lifeasgame/inventory/application/InventoryMarketTransferService.java
@@ -1,0 +1,76 @@
+package online.lifeasgame.inventory.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.core.event.DomainEventPublisher;
+import online.lifeasgame.inventory.application.internal.InventoryMarketTransferApi;
+import online.lifeasgame.inventory.domain.ItemCarryPolicy;
+import online.lifeasgame.inventory.domain.PlayerInventory;
+import online.lifeasgame.inventory.domain.error.InventoryError;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class InventoryMarketTransferService
+        implements InventoryMarketTransferApi {
+
+    private final InventoryReader inventoryReader;
+    private final ItemReader itemReader;
+    private final DomainEventPublisher domainEventPublisher;
+
+    @Override
+    @Transactional(propagation = Propagation.MANDATORY)
+    public TransferResult transferWholeEntry(
+            Long sellerPlayerId,
+            Long buyerPlayerId,
+            Long inventoryEntryId,
+            Long expectedItemId,
+            int expectedQuantity
+    ) {
+        if (sellerPlayerId == null
+                || buyerPlayerId == null
+                || inventoryEntryId == null
+                || expectedItemId == null
+                || expectedQuantity < 1
+                || Objects.equals(sellerPlayerId, buyerPlayerId)) {
+            throw new DomainException(
+                    InventoryError.MARKET_TRANSFER_CONFLICT
+            );
+        }
+        PlayerInventory first = inventoryReader
+                .getByPlayerIdForUpdateOrThrow(
+                        Math.min(sellerPlayerId, buyerPlayerId)
+                );
+        PlayerInventory second = inventoryReader
+                .getByPlayerIdForUpdateOrThrow(
+                        Math.max(sellerPlayerId, buyerPlayerId)
+                );
+        PlayerInventory seller = first.getPlayerId().equals(sellerPlayerId)
+                ? first
+                : second;
+        PlayerInventory buyer = first.getPlayerId().equals(buyerPlayerId)
+                ? first
+                : second;
+
+        PlayerInventory.MarketplaceTransfer transfer = seller
+                .transferWholeMarketplaceEntryTo(
+                        buyer,
+                        inventoryEntryId,
+                        expectedItemId,
+                        expectedQuantity,
+                        ItemCarryPolicy.from(
+                                itemReader.getByIdOrThrow(expectedItemId)
+                        )
+                );
+        domainEventPublisher.publishAll(buyer.pullEvents());
+        return new TransferResult(
+                transfer.sourceInventoryEntryId(),
+                transfer.itemId(),
+                transfer.quantity()
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/inventory/application/internal/InventoryMarketTransferApi.java
+++ b/src/main/java/online/lifeasgame/inventory/application/internal/InventoryMarketTransferApi.java
@@ -1,0 +1,19 @@
+package online.lifeasgame.inventory.application.internal;
+
+public interface InventoryMarketTransferApi {
+
+    TransferResult transferWholeEntry(
+            Long sellerPlayerId,
+            Long buyerPlayerId,
+            Long inventoryEntryId,
+            Long expectedItemId,
+            int expectedQuantity
+    );
+
+    record TransferResult(
+            Long sourceInventoryEntryId,
+            Long itemId,
+            int quantity
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/inventory/domain/InventoryEntry.java
+++ b/src/main/java/online/lifeasgame/inventory/domain/InventoryEntry.java
@@ -104,6 +104,38 @@ public class InventoryEntry extends AbstractTime {
         );
     }
 
+    static InventoryEntry transferred(
+            PlayerInventory playerInventory,
+            SlotIndex slotIndex,
+            ItemCarryPolicy itemCarryPolicy,
+            Quantity quantity,
+            Rarity rarity,
+            Durability durability,
+            boolean bound,
+            InstanceAttrs instAttrs
+    ) {
+        itemCarryPolicy.assertValidInitialQuantity(quantity.value());
+        Integer durabilityValue = durability == null ? null : durability.value();
+        Integer normalizedDurability = itemCarryPolicy.normalizedDurability(
+                durabilityValue
+        );
+        if (!Objects.equals(durabilityValue, normalizedDurability)) {
+            throw new DomainException(
+                    InventoryError.MARKET_TRANSFER_CONFLICT
+            );
+        }
+        return new InventoryEntry(
+                playerInventory,
+                slotIndex,
+                itemCarryPolicy.itemId(),
+                Guard.notNull(rarity, "rarity"),
+                quantity,
+                durability,
+                bound,
+                instAttrs
+        );
+    }
+
     public void increaseQuantity(int delta, ItemCarryPolicy itemCarryPolicy) {
         assertOrdinaryMutationAllowed();
         Guard.minValue(delta, 1, "delta");

--- a/src/main/java/online/lifeasgame/inventory/domain/PlayerInventory.java
+++ b/src/main/java/online/lifeasgame/inventory/domain/PlayerInventory.java
@@ -367,6 +367,144 @@ public class PlayerInventory extends AbstractTime {
         getEntryByIdOrThrow(inventoryEntryId).releaseEquipped();
     }
 
+    public MarketplaceTransfer transferWholeMarketplaceEntryTo(
+            PlayerInventory buyerInventory,
+            Long inventoryEntryId,
+            Long expectedItemId,
+            int expectedQuantity,
+            ItemCarryPolicy policy
+    ) {
+        InventoryEntry source = getEntryByIdOrThrow(inventoryEntryId);
+        if (buyerInventory == this
+                || !Objects.equals(source.getItemId(), expectedItemId)
+                || source.getQuantity().value() != expectedQuantity
+                || !Objects.equals(policy.itemId(), expectedItemId)
+                || source.getRarity() != policy.rarity()) {
+            throw new DomainException(
+                    InventoryError.MARKET_TRANSFER_CONFLICT
+            );
+        }
+        source.assertAvailability(InventoryAvailability.RESERVED_FOR_TRADE);
+        buyerInventory.assertCanReceiveMarketplaceTransfer(source, policy);
+
+        source.beginTransfer();
+        entries.remove(source);
+        buyerInventory.receiveMarketplaceTransfer(source, policy);
+
+        return new MarketplaceTransfer(
+                inventoryEntryId,
+                source.getItemId(),
+                source.getQuantity().value()
+        );
+    }
+
+    public record MarketplaceTransfer(
+            Long sourceInventoryEntryId,
+            Long itemId,
+            int quantity
+    ) {
+    }
+
+    private void assertCanReceiveMarketplaceTransfer(
+            InventoryEntry source,
+            ItemCarryPolicy policy
+    ) {
+        policy.assertValidInitialQuantity(source.getQuantity().value());
+        Integer durability = source.getDurability() == null
+                ? null
+                : source.getDurability().value();
+        if (!Objects.equals(
+                durability,
+                policy.normalizedDurability(durability)
+        )) {
+            throw new DomainException(
+                    InventoryError.MARKET_TRANSFER_CONFLICT
+            );
+        }
+
+        int remaining = source.getQuantity().value();
+        for (InventoryEntry stack : transferStacksOf(source, policy)) {
+            remaining -= policy.clampAddToLimit(
+                    stack.getQuantity().value(),
+                    remaining
+            );
+        }
+        if (entries.size() + policy.estimateNewStacksNeeded(remaining)
+                > capacitySlots) {
+            throw new DomainException(InventoryError.INVENTORY_FULL);
+        }
+    }
+
+    private void receiveMarketplaceTransfer(
+            InventoryEntry source,
+            ItemCarryPolicy policy
+    ) {
+        int remaining = source.getQuantity().value();
+        for (InventoryEntry stack : transferStacksOf(source, policy)) {
+            if (remaining == 0) {
+                break;
+            }
+            int added = policy.clampAddToLimit(
+                    stack.getQuantity().value(),
+                    remaining
+            );
+            if (added > 0) {
+                stack.increaseQuantity(added, policy);
+                remaining -= added;
+            }
+        }
+
+        while (remaining > 0) {
+            int put = policy.stackable()
+                    ? Math.min(policy.maxStack(), remaining)
+                    : 1;
+            entries.add(InventoryEntry.transferred(
+                    this,
+                    nextFreeSlot(),
+                    policy,
+                    Quantity.of(put),
+                    source.getRarity(),
+                    source.getDurability(),
+                    source.isBound(),
+                    source.getInstAttrs()
+            ));
+            remaining -= put;
+        }
+
+        recordEvent(InventoryItemAdded.of(
+                playerId,
+                source.getItemId(),
+                source.getRarity().name(),
+                policy.stackable(),
+                source.isBound(),
+                source.getQuantity().value()
+        ));
+    }
+
+    private List<InventoryEntry> transferStacksOf(
+            InventoryEntry source,
+            ItemCarryPolicy policy
+    ) {
+        return entries.stream()
+                .filter(entry -> entry.isFreeForOrdinaryStacking()
+                        && Objects.equals(
+                        entry.getItemId(),
+                        source.getItemId()
+                )
+                        && entry.getRarity() == source.getRarity()
+                        && Objects.equals(
+                        entry.getDurability(),
+                        source.getDurability()
+                )
+                        && policy.sameStackKey(
+                        entry.isBound(),
+                        safeAttrs(entry.getInstAttrs()),
+                        source.isBound(),
+                        safeAttrs(source.getInstAttrs())
+                ))
+                .toList();
+    }
+
     private List<InventoryEntry> stacksOf(ItemCarryPolicy policy, boolean bound, InstanceAttrs attrs) {
         Map<String, Object> target = (attrs == null) ? Map.of() : attrs.attrs();
         return entries.stream()

--- a/src/main/java/online/lifeasgame/inventory/domain/error/InventoryError.java
+++ b/src/main/java/online/lifeasgame/inventory/domain/error/InventoryError.java
@@ -19,6 +19,7 @@ public enum InventoryError implements ErrorCode {
     INVENTORY_ENTRY_NOT_FOUND("INV-ENTRY-NOT-FOUND","Inventory entry not found",404),
     INVENTORY_ENTRY_UNAVAILABLE("INV-ENTRY-UNAVAILABLE","Inventory entry is unavailable",409),
     INVALID_AVAILABILITY_TRANSITION("INV-AVAILABILITY-TRANSITION","Inventory availability transition is not allowed",409),
+    MARKET_TRANSFER_CONFLICT("INV-MARKET-TRANSFER-CONFLICT","Marketplace transfer facts do not match",409),
     REWARD_LINE_ID_INVALID("INV-REWARD-LINE-ID-INVALID","Reward line ID must be positive",400),
     PLAYER_ID_INVALID("INV-PLAYER-ID-INVALID","Player ID must be positive",400),
     REWARD_ITEM_CODE_INVALID("INV-REWARD-ITEM-CODE-INVALID","Reward item code is invalid",400),

--- a/src/main/resources/db/migration/V28__canonical_trade_item_snapshot.sql
+++ b/src/main/resources/db/migration/V28__canonical_trade_item_snapshot.sql
@@ -1,0 +1,6 @@
+ALTER TABLE trades
+    ADD COLUMN item_id BIGINT NULL AFTER item_inst_id,
+    ADD COLUMN sale_quantity INTEGER NULL AFTER item_id,
+    ADD CONSTRAINT ck_trade_sale_quantity CHECK (
+        sale_quantity IS NULL OR sale_quantity > 0
+    );

--- a/src/test/java/online/lifeasgame/economy/application/MarketplaceReservationLifecycleTest.java
+++ b/src/test/java/online/lifeasgame/economy/application/MarketplaceReservationLifecycleTest.java
@@ -10,9 +10,11 @@ import online.lifeasgame.economy.domain.ListingReservationState;
 import online.lifeasgame.economy.domain.ListingStatus;
 import online.lifeasgame.economy.domain.Money;
 import online.lifeasgame.economy.domain.ReservationToken;
+import online.lifeasgame.economy.domain.Trade;
 import online.lifeasgame.economy.domain.Wallet;
 import online.lifeasgame.economy.domain.error.EconomyError;
 import online.lifeasgame.inventory.application.internal.InventoryMarketAvailabilityApi;
+import online.lifeasgame.inventory.application.internal.InventoryMarketTransferApi;
 import online.lifeasgame.platform.idempotency.IdempotencyKeyStore;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -64,6 +66,8 @@ class MarketplaceReservationLifecycleTest {
     @Mock
     private InventoryMarketAvailabilityApi inventoryApi;
     @Mock
+    private InventoryMarketTransferApi inventoryTransferApi;
+    @Mock
     private IdempotencyKeyStore idempotencyKeyStore;
     @Mock
     private DomainEventPublisher eventPublisher;
@@ -101,7 +105,7 @@ class MarketplaceReservationLifecycleTest {
     class Purchase {
 
         @Test
-        @DisplayName("canonical ACTIVE 예약을 소비하고 Inventory transfer를 시작한 뒤 Listing을 판매 완료한다")
+        @DisplayName("whole Inventory transfer와 canonical terminal state를 함께 완료한다")
         void purchasesCanonicalReservation() {
             Listing listing = listing();
             Wallet buyerWallet = fundedWallet();
@@ -130,9 +134,20 @@ class MarketplaceReservationLifecycleTest {
 
             assertThat(reservation.getState()).isEqualTo(ListingReservationState.CONSUMED);
             assertThat(listing.getStatus()).isEqualTo(ListingStatus.SOLD);
-            verify(inventoryApi).beginTransfer(SELLER_ID, ENTRY_ID);
+            assertThat(sellerWallet.getBalance(Currency.GOLD).available())
+                    .isEqualTo(40L);
+            verify(inventoryTransferApi).transferWholeEntry(
+                    SELLER_ID,
+                    BUYER_ID,
+                    ENTRY_ID,
+                    40L,
+                    3
+            );
             verify(listingWriter).create(listing);
-            verify(tradeWriter).create(any());
+            ArgumentCaptor<Trade> trade = ArgumentCaptor.forClass(Trade.class);
+            verify(tradeWriter).create(trade.capture());
+            assertThat(trade.getValue().getItemId()).isEqualTo(40L);
+            assertThat(trade.getValue().getSaleQuantity()).isEqualTo(3);
         }
 
         @Test
@@ -162,24 +177,31 @@ class MarketplaceReservationLifecycleTest {
                     walletWriter,
                     listingWriter,
                     tradeWriter,
-                    inventoryApi
+                    inventoryApi,
+                    inventoryTransferApi
             );
         }
 
         @Test
-        @DisplayName("snapshot이 없는 legacy OPEN Listing도 ACTIVE 예약 없이는 거절한다")
-        void rejectsLegacyDirectPurchase() {
+        @DisplayName("ACTIVE 예약이 있어도 snapshot 없는 legacy Listing은 거절한다")
+        void rejectsLegacyPurchaseWithoutSnapshot() {
             Listing listing = listing();
             ReflectionTestUtils.setField(listing, "saleQuantity", null);
+            ListingReservation reservation = ListingReservation.active(
+                    LISTING_ID,
+                    BUYER_ID,
+                    "legacy-hold-296",
+                    Instant.now(),
+                    60
+            );
             given(idempotencyKeyStore.acquire(any(), any())).willReturn(true);
             given(listingReader.getForUpdate(LISTING_ID)).willReturn(listing);
-            given(reservationReader.findActiveForUpdate(LISTING_ID)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> service.purchase(
                     BUYER_ID,
                     new EconomyCommand.PurchaseListing(
                             LISTING_ID,
-                            null,
+                            reservation.getReservationToken(),
                             "legacy-open-296"
                     )
             )).isInstanceOfSatisfying(
@@ -194,7 +216,8 @@ class MarketplaceReservationLifecycleTest {
                     walletWriter,
                     listingWriter,
                     tradeWriter,
-                    inventoryApi
+                    inventoryApi,
+                    inventoryTransferApi
             );
         }
 
@@ -226,8 +249,6 @@ class MarketplaceReservationLifecycleTest {
             );
             given(idempotencyKeyStore.acquire(any(), any())).willReturn(true);
             given(listingReader.getForUpdate(LISTING_ID)).willReturn(listing);
-            given(reservationReader.findActiveForUpdate(LISTING_ID))
-                    .willReturn(Optional.empty());
 
             assertThatThrownBy(() -> service.purchase(
                     BUYER_ID,
@@ -248,7 +269,8 @@ class MarketplaceReservationLifecycleTest {
                     walletWriter,
                     listingWriter,
                     tradeWriter,
-                    inventoryApi
+                    inventoryApi,
+                    inventoryTransferApi
             );
         }
     }

--- a/src/test/java/online/lifeasgame/economy/application/MarketplaceTradeFulfillmentIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/economy/application/MarketplaceTradeFulfillmentIntegrationTest.java
@@ -1,0 +1,431 @@
+package online.lifeasgame.economy.application;
+
+import online.lifeasgame.core.error.DomainException;
+import online.lifeasgame.economy.application.command.EconomyCommand;
+import online.lifeasgame.inventory.domain.error.InventoryError;
+import online.lifeasgame.platform.idempotency.IdempotencyKeyStore;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.containers.MySQLContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+@ActiveProfiles({"test", "migration-test"})
+@DisplayName("Marketplace whole-entry fulfillment MySQL integration")
+class MarketplaceTradeFulfillmentIntegrationTest {
+
+    private static final long SELLER_ID = 298001L;
+    private static final long BUYER_ID = 298002L;
+    private static final String ITEM_CODE = "IT_298_MARKETPLACE";
+    private static final String RESERVATION_TOKEN = "reservation-298";
+    private static final String HOLD_ID = "hold-298";
+
+    private static final MySQLContainer<?> MYSQL = new MySQLContainer<>(
+            "mysql:8.0.39"
+    )
+            .withDatabaseName("lifeasgame_marketplace_298")
+            .withUsername("lifeasgame")
+            .withPassword("lifeasgame");
+
+    static {
+        MYSQL.start();
+    }
+
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add(
+                "spring.datasource.driver-class-name",
+                MYSQL::getDriverClassName
+        );
+    }
+
+    @Autowired
+    private MarketplaceService marketplaceService;
+    @Autowired
+    private JdbcTemplate jdbc;
+    @Autowired
+    private Flyway flyway;
+
+    @MockitoBean
+    private IdempotencyKeyStore idempotencyKeyStore;
+
+    private Long itemId;
+    private Long sourceEntryId;
+    private Long listingId;
+
+    @BeforeEach
+    void setUp() {
+        jdbc.update("DELETE FROM outbox_events");
+        jdbc.update("DELETE FROM trades");
+        jdbc.update("DELETE FROM listing_reservations");
+        jdbc.update("DELETE FROM wallet_holds");
+        jdbc.update("DELETE FROM wallet_balances");
+        jdbc.update("DELETE FROM wallets");
+        jdbc.update("DELETE FROM listings");
+        jdbc.update("DELETE FROM player_equipment");
+        jdbc.update("DELETE FROM inventory_entries");
+        jdbc.update("DELETE FROM player_inventory");
+        jdbc.update("DELETE FROM items WHERE code = ?", ITEM_CODE);
+
+        itemId = insertItem();
+        insertInventory(SELLER_ID, 2);
+        insertInventory(BUYER_ID, 3);
+        sourceEntryId = insertEntry(
+                SELLER_ID,
+                itemId,
+                0,
+                7,
+                "RESERVED_FOR_TRADE"
+        );
+        insertEntry(BUYER_ID, itemId, 0, 4, "FREE");
+        listingId = insertListing();
+        insertWalletsAndReservation();
+        given(idempotencyKeyStore.acquire(any(), any())).willReturn(true);
+    }
+
+    @Nested
+    @DisplayName("canonical purchase가 성공하면")
+    class SuccessfulPurchase {
+
+        @Test
+        @DisplayName("Economy terminal state와 seller removal 및 buyer fulfillment를 함께 commit한다")
+        void commitsWholeBusinessEffect() {
+            marketplaceService.purchase(
+                    BUYER_ID,
+                    purchaseCommand("purchase-success-298")
+            );
+
+            assertThat(listingStatus()).isEqualTo("SOLD");
+            assertThat(reservationState()).isEqualTo("CONSUMED");
+            assertThat(holdStatus()).isEqualTo("COMMITTED");
+            assertThat(sellerBalance()).isEqualTo(109L);
+            assertThat(entryCount(SELLER_ID, itemId)).isZero();
+            assertThat(totalQuantity(BUYER_ID, itemId)).isEqualTo(11L);
+            assertThat(jdbc.queryForList("""
+                    SELECT quantity, rarity, durability, bound, availability,
+                           JSON_UNQUOTE(JSON_EXTRACT(inst_attrs, '$.quality')) AS quality
+                    FROM inventory_entries
+                    WHERE player_id = ? AND item_id = ?
+                    ORDER BY slot_index
+                    """, BUYER_ID, itemId))
+                    .allSatisfy(row -> {
+                        assertThat(row.get("rarity")).isEqualTo("RARE");
+                        assertThat(row.get("durability")).isEqualTo(6);
+                        assertThat(row.get("bound")).isIn(true, (byte) 1);
+                        assertThat(row.get("availability")).isEqualTo("FREE");
+                        assertThat(row.get("quality")).isEqualTo("kept");
+                    });
+            assertThat(jdbc.queryForMap("""
+                    SELECT item_inst_id, item_id, sale_quantity,
+                           buyer_player_id, seller_player_id
+                    FROM trades
+                    WHERE listing_id = ?
+                    """, listingId))
+                    .containsEntry("item_inst_id", sourceEntryId)
+                    .containsEntry("item_id", itemId)
+                    .containsEntry("sale_quantity", 7)
+                    .containsEntry("buyer_player_id", BUYER_ID)
+                    .containsEntry("seller_player_id", SELLER_ID);
+        }
+    }
+
+    @Nested
+    @DisplayName("buyer Inventory가 가득 찼으면")
+    class CapacityFailure {
+
+        @Test
+        @DisplayName("구매 전 Economy와 Inventory 상태를 전부 유지한다")
+        void rollsBackWholeBusinessEffect() {
+            jdbc.update(
+                    "DELETE FROM inventory_entries WHERE player_id = ?",
+                    BUYER_ID
+            );
+            jdbc.update(
+                    "UPDATE player_inventory SET capacity_slots = 1 WHERE player_id = ?",
+                    BUYER_ID
+            );
+            insertEntry(BUYER_ID, differentItemId(), 0, 1, "FREE");
+
+            assertThatThrownBy(() -> marketplaceService.purchase(
+                    BUYER_ID,
+                    purchaseCommand("purchase-capacity-298")
+            )).isInstanceOfSatisfying(
+                    DomainException.class,
+                    exception -> assertThat(exception.getErrorCode())
+                            .isEqualTo(InventoryError.INVENTORY_FULL)
+            );
+
+            assertThat(listingStatus()).isEqualTo("OPEN");
+            assertThat(reservationState()).isEqualTo("ACTIVE");
+            assertThat(holdStatus()).isEqualTo("OPEN");
+            assertThat(sellerBalance()).isEqualTo(10L);
+            assertThat(entryCount(SELLER_ID, itemId)).isOne();
+            assertThat(jdbc.queryForObject("""
+                    SELECT availability
+                    FROM inventory_entries
+                    WHERE id = ?
+                    """, String.class, sourceEntryId))
+                    .isEqualTo("RESERVED_FOR_TRADE");
+            assertThat(entryCount(BUYER_ID, itemId)).isZero();
+            assertThat(jdbc.queryForObject(
+                    "SELECT COUNT(*) FROM trades WHERE listing_id = ?",
+                    Long.class,
+                    listingId
+            )).isZero();
+            assertThat(jdbc.queryForObject(
+                    "SELECT COUNT(*) FROM outbox_events",
+                    Long.class
+            )).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("V28 Trade snapshot schema를 검증하면")
+    class TradeSnapshotSchema {
+
+        @Test
+        @DisplayName("legacy null은 허용하고 canonical quantity 제약은 보존한다")
+        void validatesMigrationAndJpaContract() {
+            assertThat(flyway.info().current().getVersion().getVersion())
+                    .isEqualTo("28");
+            jdbc.update("""
+                    INSERT INTO trades (
+                        fee_bps, buyer_player_id, created_at, fee, item_inst_id,
+                        listing_id, price, seller_player_id, seller_proceeds,
+                        updated_at, currency, fee_currency,
+                        seller_proceeds_currency, item_id, sale_quantity
+                    ) VALUES (
+                        100, ?, CURRENT_TIMESTAMP(6), 1, ?, ?, 100, ?, 99,
+                        CURRENT_TIMESTAMP(6), 'GOLD', 'GOLD', 'GOLD', NULL, NULL
+                    )
+                    """, BUYER_ID, sourceEntryId, listingId + 100, SELLER_ID);
+
+            assertThatThrownBy(() -> jdbc.update("""
+                    INSERT INTO trades (
+                        fee_bps, buyer_player_id, created_at, fee, item_inst_id,
+                        listing_id, price, seller_player_id, seller_proceeds,
+                        updated_at, currency, fee_currency,
+                        seller_proceeds_currency, item_id, sale_quantity
+                    ) VALUES (
+                        100, ?, CURRENT_TIMESTAMP(6), 1, ?, ?, 100, ?, 99,
+                        CURRENT_TIMESTAMP(6), 'GOLD', 'GOLD', 'GOLD', ?, 0
+                    )
+                    """, BUYER_ID, sourceEntryId, listingId + 101,
+                    SELLER_ID, itemId))
+                    .isInstanceOf(DataAccessException.class);
+        }
+    }
+
+    private EconomyCommand.PurchaseListing purchaseCommand(String key) {
+        return new EconomyCommand.PurchaseListing(
+                listingId,
+                RESERVATION_TOKEN,
+                key
+        );
+    }
+
+    private Long insertItem() {
+        jdbc.update("""
+                INSERT INTO items (
+                    code, name, category, type, rarity, base_attrs,
+                    stackable, max_stack, max_durability,
+                    created_at, updated_at
+                ) VALUES (
+                    ?, 'Issue 298 marketplace item', 'QUEST', 'ETC',
+                    'RARE', JSON_OBJECT(), TRUE, 10, 10,
+                    CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
+                )
+                """, ITEM_CODE);
+        return jdbc.queryForObject(
+                "SELECT id FROM items WHERE code = ?",
+                Long.class,
+                ITEM_CODE
+        );
+    }
+
+    private Long differentItemId() {
+        jdbc.update("""
+                INSERT INTO items (
+                    code, name, category, type, rarity, base_attrs,
+                    stackable, max_stack, max_durability,
+                    created_at, updated_at
+                ) VALUES (
+                    'IT_298_BLOCKER', 'Issue 298 blocker', 'QUEST', 'ETC',
+                    'RARE', JSON_OBJECT(), FALSE, 1, 10,
+                    CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
+                ) ON DUPLICATE KEY UPDATE updated_at = CURRENT_TIMESTAMP(6)
+                """);
+        return jdbc.queryForObject(
+                "SELECT id FROM items WHERE code = 'IT_298_BLOCKER'",
+                Long.class
+        );
+    }
+
+    private void insertInventory(long playerId, int capacity) {
+        jdbc.update("""
+                INSERT INTO player_inventory (
+                    player_id, capacity_slots, version,
+                    created_at, updated_at
+                ) VALUES (?, ?, 0, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6))
+                """, playerId, capacity);
+    }
+
+    private Long insertEntry(
+            long playerId,
+            long entryItemId,
+            int slot,
+            int quantity,
+            String availability
+    ) {
+        jdbc.update("""
+                INSERT INTO inventory_entries (
+                    bound, durability, quantity, slot_index,
+                    created_at, item_id, player_id, updated_at,
+                    inst_attrs, rarity, availability
+                ) VALUES (
+                    TRUE, 6, ?, ?, CURRENT_TIMESTAMP(6), ?, ?,
+                    CURRENT_TIMESTAMP(6), JSON_OBJECT('quality', 'kept'),
+                    'RARE', ?
+                )
+                """, quantity, slot, entryItemId, playerId, availability);
+        return jdbc.queryForObject("""
+                SELECT id
+                FROM inventory_entries
+                WHERE player_id = ? AND slot_index = ?
+                """, Long.class, playerId, slot);
+    }
+
+    private Long insertListing() {
+        jdbc.update("""
+                INSERT INTO listings (
+                    active_flag, created_at, item_id, sale_quantity,
+                    item_inst_id, price, seller_player_id, updated_at,
+                    version, currency, status
+                ) VALUES (
+                    1, CURRENT_TIMESTAMP(6), ?, 7, ?, 100, ?,
+                    CURRENT_TIMESTAMP(6), 0, 'GOLD', 'OPEN'
+                )
+                """, itemId, sourceEntryId, SELLER_ID);
+        return jdbc.queryForObject(
+                "SELECT id FROM listings WHERE item_inst_id = ?",
+                Long.class,
+                sourceEntryId
+        );
+    }
+
+    private void insertWalletsAndReservation() {
+        insertWallet(BUYER_ID, 100L);
+        insertWallet(SELLER_ID, 10L);
+        Long buyerWalletId = walletId(BUYER_ID);
+        jdbc.update("""
+                INSERT INTO wallet_holds (
+                    amount, created_at, expires_at, updated_at, wallet_id,
+                    hold_id, reason, currency, status
+                ) VALUES (
+                    100, CURRENT_TIMESTAMP(6),
+                    DATE_ADD(CURRENT_TIMESTAMP(6), INTERVAL 1 HOUR),
+                    CURRENT_TIMESTAMP(6), ?, ?, 'listing-reserve',
+                    'GOLD', 'OPEN'
+                )
+                """, buyerWalletId, HOLD_ID);
+        jdbc.update("""
+                INSERT INTO listing_reservations (
+                    active_flag, created_at, expires_at, buyer_player_id,
+                    listing_id, updated_at, version, reservation_token,
+                    wallet_hold_id, state
+                ) VALUES (
+                    1, CURRENT_TIMESTAMP(6),
+                    DATE_ADD(CURRENT_TIMESTAMP(6), INTERVAL 1 HOUR),
+                    ?, ?, CURRENT_TIMESTAMP(6), 0, ?, ?, 'ACTIVE'
+                )
+                """, BUYER_ID, listingId, RESERVATION_TOKEN, HOLD_ID);
+    }
+
+    private void insertWallet(long ownerId, long balance) {
+        jdbc.update("""
+                INSERT INTO wallets (
+                    created_at, owner_id, updated_at, version
+                ) VALUES (
+                    CURRENT_TIMESTAMP(6), ?, CURRENT_TIMESTAMP(6), 0
+                )
+                """, ownerId);
+        jdbc.update("""
+                INSERT INTO wallet_balances (
+                    amount, created_at, updated_at, wallet_id, currency
+                ) VALUES (
+                    ?, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6), ?, 'GOLD'
+                )
+                """, balance, walletId(ownerId));
+    }
+
+    private Long walletId(long ownerId) {
+        return jdbc.queryForObject(
+                "SELECT id FROM wallets WHERE owner_id = ?",
+                Long.class,
+                ownerId
+        );
+    }
+
+    private String listingStatus() {
+        return jdbc.queryForObject(
+                "SELECT status FROM listings WHERE id = ?",
+                String.class,
+                listingId
+        );
+    }
+
+    private String reservationState() {
+        return jdbc.queryForObject("""
+                SELECT state FROM listing_reservations WHERE listing_id = ?
+                """, String.class, listingId);
+    }
+
+    private String holdStatus() {
+        return jdbc.queryForObject(
+                "SELECT status FROM wallet_holds WHERE hold_id = ?",
+                String.class,
+                HOLD_ID
+        );
+    }
+
+    private long sellerBalance() {
+        return jdbc.queryForObject("""
+                SELECT balance.amount
+                FROM wallet_balances balance
+                JOIN wallets wallet ON wallet.id = balance.wallet_id
+                WHERE wallet.owner_id = ? AND balance.currency = 'GOLD'
+                """, Long.class, SELLER_ID);
+    }
+
+    private long entryCount(long playerId, long entryItemId) {
+        return jdbc.queryForObject("""
+                SELECT COUNT(*) FROM inventory_entries
+                WHERE player_id = ? AND item_id = ?
+                """, Long.class, playerId, entryItemId);
+    }
+
+    private long totalQuantity(long playerId, long entryItemId) {
+        return jdbc.queryForObject("""
+                SELECT COALESCE(SUM(quantity), 0) FROM inventory_entries
+                WHERE player_id = ? AND item_id = ?
+                """, Long.class, playerId, entryItemId);
+    }
+}

--- a/src/test/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryIntegrationTest.java
@@ -99,7 +99,7 @@ class InventoryRewardDeliveryIntegrationTest {
     @DisplayName("V17 receipt table은 JPA validate와 unique/check/index 계약을 만족한다")
     void validatesMigrationContract() {
         assertThat(flyway.info().current().getVersion().getVersion())
-                .isEqualTo("27");
+                .isEqualTo("28");
         assertThat(environment.getProperty("spring.jpa.hibernate.ddl-auto"))
                 .isEqualTo("validate");
 

--- a/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
@@ -63,7 +63,7 @@ class FlywayExplicitBaselineTest {
     class ApplyExplicitBaseline {
 
         @Test
-        @DisplayName("V1을 재실행하지 않고 V2부터 V27까지 적용한 뒤 JPA validate를 통과한다")
+        @DisplayName("V1을 재실행하지 않고 V2부터 V28까지 적용한 뒤 JPA validate를 통과한다")
         void migratesFromVersionTwoAndValidatesJpa() throws Exception {
             String jdbcUrl = createV1EquivalentDatabase();
             Flyway flyway = migrationFlyway(jdbcUrl);
@@ -72,13 +72,13 @@ class FlywayExplicitBaselineTest {
             MigrateResult migrateResult = flyway.migrate();
             List<HistoryRow> history = successfulHistory(jdbcUrl);
 
-            assertThat(migrateResult.migrationsExecuted).isEqualTo(26);
+            assertThat(migrateResult.migrationsExecuted).isEqualTo(27);
             assertThat(history).extracting(HistoryRow::version)
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
                             "14", "15", "16", "17", "18", "19", "20",
-                            "21", "22", "23", "24", "25", "26", "27"
+                            "21", "22", "23", "24", "25", "26", "27", "28"
                     );
             assertThat(history.getFirst().type()).isEqualTo("BASELINE");
             assertThat(history.getFirst().script())
@@ -115,7 +115,8 @@ class FlywayExplicitBaselineTest {
                             "V24__equipment_compatibility_kind.sql",
                             "V25__player_notification_inbox.sql",
                             "V26__inventory_entry_availability.sql",
-                            "V27__canonical_listing_reservations.sql"
+                            "V27__canonical_listing_reservations.sql",
+                            "V28__canonical_trade_item_snapshot.sql"
                     );
             assertThat(history.subList(1, history.size()))
                     .allSatisfy(row -> assertThat(row.checksum()).isNotNull());
@@ -135,7 +136,7 @@ class FlywayExplicitBaselineTest {
                         "spring.jpa.hibernate.ddl-auto"
                 )).isEqualTo("validate");
                 assertThat(context.getBean(Flyway.class).info().current().getVersion().getVersion())
-                        .isEqualTo("27");
+                        .isEqualTo("28");
             }
         }
     }

--- a/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
@@ -33,7 +33,7 @@ class FlywayHistoryChecksumTest {
     class MigrateAgain {
 
         @Test
-        @DisplayName("V1~V20 checksum을 보존하고 V27 이후 두 번째 실행은 no-op이다")
+        @DisplayName("V1~V20 checksum을 보존하고 V28 이후 두 번째 실행은 no-op이다")
         void keepsMigrationHistory() throws Exception {
             Flyway throughV20 = flyway(MigrationVersion.fromVersion("20"));
             MigrateResult legacy = throughV20.migrate();
@@ -47,7 +47,7 @@ class FlywayHistoryChecksumTest {
             List<HistoryRow> secondHistory = successfulHistory();
 
             assertThat(legacy.migrationsExecuted).isEqualTo(20);
-            assertThat(first.migrationsExecuted).isEqualTo(7);
+            assertThat(first.migrationsExecuted).isEqualTo(8);
             assertThat(second.migrationsExecuted).isZero();
             assertThat(secondHistory).isEqualTo(firstHistory);
             assertThat(firstHistory.subList(0, legacyHistory.size()))
@@ -57,7 +57,7 @@ class FlywayHistoryChecksumTest {
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
                             "14", "15", "16", "17", "18", "19", "20",
-                            "21", "22", "23", "24", "25", "26", "27"
+                            "21", "22", "23", "24", "25", "26", "27", "28"
                     );
             assertThat(secondHistory).allSatisfy(history -> {
                 assertThat(history.checksum()).isNotNull();

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -39,7 +39,7 @@ class FlywayMigrationTest {
     class MigrateCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V27까지 적용되고 canonical ListingReservation을 추가한다")
+        @DisplayName("V1부터 V28까지 적용되고 canonical Trade snapshot을 추가한다")
         void migratesSchemaAndSeedsRewardProfiles() throws Exception {
             Flyway throughV10 = flyway(MigrationVersion.fromVersion("10"));
             MigrateResult legacyResult = throughV10.migrate();
@@ -58,13 +58,13 @@ class FlywayMigrationTest {
             assertThat(legacyResult.migrationsExecuted).isEqualTo(10);
             assertThat(semanticResult.migrationsExecuted).isEqualTo(1);
             assertThat(itemResult.migrationsExecuted).isEqualTo(1);
-            assertThat(result.migrationsExecuted).isEqualTo(15);
+            assertThat(result.migrationsExecuted).isEqualTo(16);
             assertThat(appliedVersions())
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
                             "14", "15", "16", "17", "18", "19", "20",
-                            "21", "22", "23", "24", "25", "26", "27"
+                            "21", "22", "23", "24", "25", "26", "27", "28"
                     );
             assertThat(existingTables(
                     "users",

--- a/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
@@ -149,7 +149,7 @@ class FlywayProfileCutoverTest {
     class StartLocalWithCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V27까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
+        @DisplayName("V1부터 V28까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
         void migratesThenValidates() {
             ConfigurableEnvironment environment =
                     (ConfigurableEnvironment) applicationContext.getEnvironment();
@@ -161,8 +161,8 @@ class FlywayProfileCutoverTest {
             assertThat(environment.getProperty(
                     "spring.flyway.baseline-on-migrate", Boolean.class
             )).isFalse();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("27");
-            assertThat(appliedMigrationCount()).isEqualTo(27);
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("28");
+            assertThat(appliedMigrationCount()).isEqualTo(28);
         }
     }
 

--- a/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 @SpringBootTest
 @ActiveProfiles({"test", "migration-test"})
-@DisplayName("V27 migration 이후 JPA schema validation")
+@DisplayName("V28 migration 이후 JPA schema validation")
 class JpaValidateAfterMigrationTest {
 
     @Container
@@ -79,14 +79,14 @@ class JpaValidateAfterMigrationTest {
     private QuestDefinitionBootstrapper questDefinitionBootstrapper;
 
     @Nested
-    @DisplayName("V1부터 V27까지 적용된 schema로 ApplicationContext를 기동할 때")
+    @DisplayName("V1부터 V28까지 적용된 schema로 ApplicationContext를 기동할 때")
     class LoadApplicationContext {
 
         @Test
         @DisplayName("ddl-auto validate 상태로 정상 기동한다")
         void loadsWithJpaValidation() {
             assertThat(applicationContext).isNotNull();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("27");
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("28");
             assertThat(applicationContext.getEnvironment().getProperty("spring.jpa.hibernate.ddl-auto"))
                     .isEqualTo("validate");
             assertThat(applicationContext.getEnvironment()

--- a/src/test/java/online/lifeasgame/migration/RolePersonPersistenceFoundationFlywayTest.java
+++ b/src/test/java/online/lifeasgame/migration/RolePersonPersistenceFoundationFlywayTest.java
@@ -46,9 +46,9 @@ class RolePersonPersistenceFoundationFlywayTest {
     }
 
     @Test
-    @DisplayName("V27까지 적용된 schema에서 V19 Role/Person 계약을 고정한다")
+    @DisplayName("V28까지 적용된 schema에서 V19 Role/Person 계약을 고정한다")
     void createsSchemaContract() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("27");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("28");
         assertThat(tableContracts()).containsExactly(
                 new TableContract("roles", "InnoDB", "utf8mb4_0900_ai_ci"),
                 new TableContract("persons", "InnoDB", "utf8mb4_0900_ai_ci"),

--- a/src/test/java/online/lifeasgame/notification/application/NotificationApplicationIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/notification/application/NotificationApplicationIntegrationTest.java
@@ -101,7 +101,7 @@ class NotificationApplicationIntegrationTest {
         @DisplayName("durable row를 만들고 같은 player replay만 무시한다")
         void appendsDurablyAndScopesReplayByPlayer() {
             assertThat(flyway.info().current().getVersion().getVersion())
-                    .isEqualTo("27");
+                    .isEqualTo("28");
 
             append(PLAYER_ID, "shared-event");
             append(PLAYER_ID, "shared-event");

--- a/src/test/java/online/lifeasgame/role/application/RolePersonPersistenceIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/role/application/RolePersonPersistenceIntegrationTest.java
@@ -100,7 +100,7 @@ class RolePersonPersistenceIntegrationTest {
 
     @Test
     void persistsOwnerScopedCrudAndKeepsArchivedRows() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("27");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("28");
 
         var role = roleService.create(
                 new RoleCommand.Create("work", "Developer", "Builds")

--- a/src/test/java/online/lifeasgame/role/application/RoleRelationPersistenceIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/role/application/RoleRelationPersistenceIntegrationTest.java
@@ -93,7 +93,7 @@ class RoleRelationPersistenceIntegrationTest {
 
     @Test
     void persistsCrudRejectsActiveDuplicateAndReactivatesArchivedRow() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("27");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("28");
         Long roleId = createRole("Owner role");
         Long personId = createPerson("Alice");
 


### PR DESCRIPTION
## Purpose

Complete the canonical marketplace purchase closed loop by making Inventory fulfillment, Listing/Reservation completion, Wallet settlement, and Trade persistence one atomic business effect.

Closes #298

## Delivered

- provider-owned Inventory marketplace transfer finalization
- whole-entry seller-to-buyer Inventory fulfillment
- seller source InventoryEntry removal
- buyer capacity/stack/slot handling through Inventory authority
- atomic Listing SOLD / ListingReservation CONSUMED / Wallet settlement / Trade persistence
- durable canonical Trade item/quantity snapshot
- rollback-safe buyer Inventory capacity failure
- focused cross-domain transaction coverage

## Canonical Completion Contract

```text
Listing OPEN
+ ACTIVE ListingReservation
+ Inventory RESERVED_FOR_TRADE
+ buyer WalletHold OPEN
```

Successful purchase atomically commits:

```text
Listing SOLD
ListingReservation CONSUMED
buyer WalletHold COMMITTED
seller Wallet credited
seller source InventoryEntry removed
buyer Inventory fulfilled
Trade persisted
```

## Inventory Authority

Economy does not access Inventory persistence internals.

The final transfer is owned by a provider-side Inventory application boundary.

Whole-entry transfer preserves existing Inventory capacity, slot, stack, and entry-compatibility rules.

No partial transfer is introduced.

## Trade Audit

New canonical Trade rows retain durable item and quantity facts needed after the seller source InventoryEntry is removed.

Legacy rows are not populated with fabricated historical facts.

## Rollback Safety

Buyer Inventory capacity or transfer failure leaves the canonical pre-purchase authorities unchanged:
- Listing remains OPEN
- ListingReservation remains ACTIVE
- buyer hold remains OPEN
- seller Wallet remains unchanged
- seller source InventoryEntry remains present and RESERVED_FOR_TRADE
- no Trade row is committed

## Scope Boundaries

This PR does not implement:
- purchase idempotency redesign
- partial listing
- LISTING_SOLD Notification adapter
- frontend Economy integration
- Shop redesign
- marketplace fee-policy redesign

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Marketplace purchases now transfer complete inventory entries from sellers to buyers.
  - Trade records capture the purchased item and quantity.
  - Inventory transfers preserve item attributes and combine compatible stacks where possible.

- **Bug Fixes**
  - Purchases and reservations reject missing or invalid item and quantity details.
  - Transfers detect mismatched marketplace data and insufficient buyer capacity.
  - Failed transfers roll back related marketplace and inventory changes.

- **Database**
  - Added trade snapshot fields for item identity and sale quantity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->