### PR TITLE
[Admin] Establish server-side Admin authority foundation

### DIFF
--- a/src/main/java/online/lifeasgame/auth/application/AuthFacade.java
+++ b/src/main/java/online/lifeasgame/auth/application/AuthFacade.java
@@ -34,14 +34,14 @@ public class AuthFacade {
     }
 
     public AuthResult.TokenPair refresh(String refreshToken) {
-        Long userId = jwtProvider.extractUserId(refreshToken)
+        Long userId = jwtProvider.extractRefreshUserId(refreshToken)
                 .orElseThrow(() -> new AuthException(AuthError.TOKEN_INVALID));
         userAuthApi.resolveAuthorization(userId)
                 .filter(UserAuthApi.AccountAuthorization::active)
                 .orElseThrow(() -> new AuthException(
                         AuthError.TOKEN_INVALID
-                ));
+        ));
         Long playerId = playerLookupApi.findPlayerIdByUserId(userId);
-        return authService.reissueToken(refreshToken, playerId);
+        return authService.reissueToken(userId, playerId);
     }
 }

--- a/src/main/java/online/lifeasgame/auth/application/AuthFacade.java
+++ b/src/main/java/online/lifeasgame/auth/application/AuthFacade.java
@@ -36,6 +36,11 @@ public class AuthFacade {
     public AuthResult.TokenPair refresh(String refreshToken) {
         Long userId = jwtProvider.extractUserId(refreshToken)
                 .orElseThrow(() -> new AuthException(AuthError.TOKEN_INVALID));
+        userAuthApi.resolveAuthorization(userId)
+                .filter(UserAuthApi.AccountAuthorization::active)
+                .orElseThrow(() -> new AuthException(
+                        AuthError.TOKEN_INVALID
+                ));
         Long playerId = playerLookupApi.findPlayerIdByUserId(userId);
         return authService.reissueToken(refreshToken, playerId);
     }

--- a/src/main/java/online/lifeasgame/auth/application/AuthService.java
+++ b/src/main/java/online/lifeasgame/auth/application/AuthService.java
@@ -3,8 +3,6 @@ package online.lifeasgame.auth.application;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.auth.application.result.AuthResult;
 import online.lifeasgame.auth.application.internal.AuthTokenApi;
-import online.lifeasgame.core.error.AuthException;
-import online.lifeasgame.core.error.api.AuthError;
 import online.lifeasgame.platform.security.jwt.JwtProvider;
 import org.springframework.stereotype.Service;
 
@@ -23,9 +21,7 @@ public class AuthService implements AuthTokenApi {
         );
     }
 
-    public AuthResult.TokenPair reissueToken(String refreshToken, Long playerId) {
-        Long userId = jwtProvider.extractUserId(refreshToken)
-                .orElseThrow(() -> new AuthException(AuthError.TOKEN_INVALID));
+    public AuthResult.TokenPair reissueToken(Long userId, Long playerId) {
         return new AuthResult.TokenPair(
                 jwtProvider.createAccessToken(userId, playerId),
                 jwtProvider.createRefreshToken(userId),

--- a/src/main/java/online/lifeasgame/platform/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/online/lifeasgame/platform/security/jwt/JwtAuthenticationFilter.java
@@ -1,11 +1,13 @@
 package online.lifeasgame.platform.security.jwt;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import online.lifeasgame.user.application.internal.UserAuthApi;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.MDC;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -22,6 +24,7 @@ import java.util.Optional;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
+    private final UserAuthApi userAuthApi;
 
     @Override
     protected void doFilterInternal(
@@ -30,7 +33,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             FilterChain chain
     ) throws ServletException, IOException {
 
-        extractToken(req).flatMap(jwtProvider::parse).ifPresent(this::setAuth);
+        extractToken(req)
+                .flatMap(jwtProvider::parseAccessToken)
+                .flatMap(this::parsePrincipal)
+                .flatMap(this::resolveAuthentication)
+                .ifPresent(this::setAuth);
         chain.doFilter(req, res);
     }
 
@@ -40,16 +47,44 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 ? Optional.of(h.substring(7)) : Optional.empty();
     }
 
-    private void setAuth(Claims claims) {
-        JwtPrincipal principal = new JwtPrincipal(
-                Long.valueOf(claims.getSubject()),
-                claims.get("pid", Long.class)
-        );
+    private Optional<JwtPrincipal> parsePrincipal(
+            Claims claims
+    ) {
+        try {
+            return Optional.of(new JwtPrincipal(
+                    Long.valueOf(claims.getSubject()),
+                    claims.get("pid", Long.class)
+            ));
+        } catch (JwtException | IllegalArgumentException exception) {
+            return Optional.empty();
+        }
+    }
+
+    private Optional<ResolvedAuthentication> resolveAuthentication(
+            JwtPrincipal principal
+    ) {
+        return userAuthApi.resolveAuthorization(principal.userId())
+                .filter(UserAuthApi.AccountAuthorization::active)
+                .map(authorization -> new ResolvedAuthentication(
+                        principal,
+                        authorization.admin()
+                ));
+    }
+
+    private void setAuth(ResolvedAuthentication resolved) {
+        JwtPrincipal principal = resolved.principal();
 
         SecurityContextHolder.getContext().setAuthentication(
                 new UsernamePasswordAuthenticationToken(
                         principal, null,
-                        List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                        resolved.admin()
+                                ? List.of(
+                                new SimpleGrantedAuthority("ROLE_USER"),
+                                new SimpleGrantedAuthority("ROLE_ADMIN")
+                        )
+                                : List.of(
+                                new SimpleGrantedAuthority("ROLE_USER")
+                        )
                 )
         );
 
@@ -57,5 +92,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (principal.playerId() != null) {
             MDC.put("playerId", String.valueOf(principal.playerId()));
         }
+    }
+
+    private record ResolvedAuthentication(
+            JwtPrincipal principal,
+            boolean admin
+    ) {
     }
 }

--- a/src/main/java/online/lifeasgame/platform/security/jwt/JwtCurrentPlayerAccessor.java
+++ b/src/main/java/online/lifeasgame/platform/security/jwt/JwtCurrentPlayerAccessor.java
@@ -20,7 +20,7 @@ public class JwtCurrentPlayerAccessor implements CurrentPlayerAccessor {
         }
 
         if (auth.getPrincipal() instanceof JwtPrincipal p) {
-            return Optional.of(p.playerId());
+            return Optional.ofNullable(p.playerId());
         }
 
         return Optional.empty();

--- a/src/main/java/online/lifeasgame/platform/security/jwt/JwtProvider.java
+++ b/src/main/java/online/lifeasgame/platform/security/jwt/JwtProvider.java
@@ -62,6 +62,17 @@ public class JwtProvider {
         );
     }
 
+    public Optional<Claims> parseRefreshToken(String token) {
+        return parse(token).filter(claims ->
+                "refresh".equals(claims.get("type", String.class))
+        );
+    }
+
+    public Optional<Long> extractRefreshUserId(String token) {
+        return parseRefreshToken(token)
+                .map(claims -> Long.valueOf(claims.getSubject()));
+    }
+
     public Optional<Long> extractUserId(String token) {
         return parse(token).map(c -> Long.valueOf(c.getSubject()));
     }

--- a/src/main/java/online/lifeasgame/platform/security/jwt/JwtProvider.java
+++ b/src/main/java/online/lifeasgame/platform/security/jwt/JwtProvider.java
@@ -56,6 +56,12 @@ public class JwtProvider {
         }
     }
 
+    public Optional<Claims> parseAccessToken(String token) {
+        return parse(token).filter(claims ->
+                "access".equals(claims.get("type", String.class))
+        );
+    }
+
     public Optional<Long> extractUserId(String token) {
         return parse(token).map(c -> Long.valueOf(c.getSubject()));
     }

--- a/src/main/java/online/lifeasgame/system/bootstrap/security/SecurityConfig.java
+++ b/src/main/java/online/lifeasgame/system/bootstrap/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import online.lifeasgame.platform.security.jwt.JwtAuthenticationFilter;
 import online.lifeasgame.platform.security.jwt.JwtProvider;
+import online.lifeasgame.user.application.internal.UserAuthApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -23,6 +24,7 @@ import java.util.List;
 public class SecurityConfig {
 
     private final JwtProvider jwtProvider;
+    private final UserAuthApi userAuthApi;
     private final WebCorsProperties webCorsProperties;
 
     @Bean
@@ -54,7 +56,7 @@ public class SecurityConfig {
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated())
                 .addFilterBefore(
-                        new JwtAuthenticationFilter(jwtProvider),
+                        new JwtAuthenticationFilter(jwtProvider, userAuthApi),
                         UsernamePasswordAuthenticationFilter.class)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)

--- a/src/main/java/online/lifeasgame/user/application/UserAuthService.java
+++ b/src/main/java/online/lifeasgame/user/application/UserAuthService.java
@@ -8,8 +8,11 @@ import online.lifeasgame.user.application.internal.UserAuthApi;
 import online.lifeasgame.user.application.model.RawPassword;
 import online.lifeasgame.user.domain.Nickname;
 import online.lifeasgame.user.domain.User;
+import online.lifeasgame.user.domain.UserStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -25,7 +28,11 @@ public class UserAuthService implements UserAuthApi {
     public Long authenticate(String email, String rawPassword) {
         User user = userReader.findByEmailOrElseThrow(email);
 
-        if (!passwordHasher.matches(RawPassword.of(rawPassword), user.getPasswordHash())) {
+        boolean passwordMatches = passwordHasher.matches(
+                RawPassword.of(rawPassword),
+                user.getPasswordHash()
+        );
+        if (!passwordMatches || user.getStatus() != UserStatus.ACTIVE) {
             throw new AuthException(AuthError.BAD_CREDENTIALS);
         }
 
@@ -45,6 +52,16 @@ public class UserAuthService implements UserAuthApi {
                 .orElseGet(() -> userWriter.registerByOAuth(
                         online.lifeasgame.user.domain.Email.of(email),
                         Nickname.of(resolveUniqueNickname(name))
+                ));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<AccountAuthorization> resolveAuthorization(Long userId) {
+        return userReader.findById(userId)
+                .map(user -> new AccountAuthorization(
+                        user.getStatus() == UserStatus.ACTIVE,
+                        user.isAdmin()
                 ));
     }
 

--- a/src/main/java/online/lifeasgame/user/application/UserReader.java
+++ b/src/main/java/online/lifeasgame/user/application/UserReader.java
@@ -29,6 +29,10 @@ class UserReader {
                 .orElseThrow(() -> new DomainException(UserError.USER_NOT_FOUND));
     }
 
+    public Optional<User> findById(Long userId) {
+        return userRepository.findById(userId);
+    }
+
     public User findByEmailOrElseThrow(String emailStr) {
         return userRepository.findByEmail(Email.of(emailStr))
                 .orElseThrow(() -> new DomainException(UserError.USER_NOT_FOUND));

--- a/src/main/java/online/lifeasgame/user/application/internal/UserAuthApi.java
+++ b/src/main/java/online/lifeasgame/user/application/internal/UserAuthApi.java
@@ -1,5 +1,7 @@
 package online.lifeasgame.user.application.internal;
 
+import java.util.Optional;
+
 public interface UserAuthApi {
 
     Long authenticate(String email, String rawPassword);
@@ -7,4 +9,9 @@ public interface UserAuthApi {
     Long register(String email, String rawPassword, String nickname);
 
     Long findOrRegisterByGoogle(String email, String name);
+
+    Optional<AccountAuthorization> resolveAuthorization(Long userId);
+
+    record AccountAuthorization(boolean active, boolean admin) {
+    }
 }

--- a/src/main/java/online/lifeasgame/user/domain/AccountAuthority.java
+++ b/src/main/java/online/lifeasgame/user/domain/AccountAuthority.java
@@ -1,0 +1,6 @@
+package online.lifeasgame.user.domain;
+
+public enum AccountAuthority {
+    USER,
+    ADMIN
+}

--- a/src/main/java/online/lifeasgame/user/domain/User.java
+++ b/src/main/java/online/lifeasgame/user/domain/User.java
@@ -38,6 +38,10 @@ public class User extends AbstractTime {
     @Column(length=20, nullable=false)
     private UserStatus status;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "account_authority", length = 16, nullable = false)
+    private AccountAuthority accountAuthority = AccountAuthority.USER;
+
     @Transient
     private final List<DomainEvent> domainEvents = new ArrayList<>();
 
@@ -46,6 +50,7 @@ public class User extends AbstractTime {
         this.passwordHash = passwordHash;
         this.nickname = nickname;
         this.status = status;
+        this.accountAuthority = AccountAuthority.USER;
     }
 
     public static User register(Email email, HashedPassword passwordHash, Nickname nickname) {
@@ -77,6 +82,10 @@ public class User extends AbstractTime {
 
     public boolean isOAuthAccount() {
         return this.passwordHash != null && this.passwordHash.isOAuthAccount();
+    }
+
+    public boolean isAdmin() {
+        return accountAuthority == AccountAuthority.ADMIN;
     }
 
     public List<DomainEvent> pullEvents() {

--- a/src/main/resources/db/migration/V29__user_account_authority.sql
+++ b/src/main/resources/db/migration/V29__user_account_authority.sql
@@ -1,0 +1,6 @@
+ALTER TABLE users
+    ADD COLUMN account_authority VARCHAR(16) NOT NULL DEFAULT 'USER'
+        AFTER status,
+    ADD CONSTRAINT ck_user_account_authority CHECK (
+        account_authority IN ('USER', 'ADMIN')
+    );

--- a/src/test/java/online/lifeasgame/auth/application/AuthFacadeTest.java
+++ b/src/test/java/online/lifeasgame/auth/application/AuthFacadeTest.java
@@ -87,12 +87,12 @@ class AuthFacadeTest {
 
         @Test @DisplayName("linkStart 후 refresh → playerId 포함 토큰 재발급")
         void afterLinkStart_playerId() {
-            when(jwtProvider.extractUserId("rt")).thenReturn(Optional.of(1L));
+            when(jwtProvider.extractRefreshUserId("rt")).thenReturn(Optional.of(1L));
             when(userAuthApi.resolveAuthorization(1L)).thenReturn(
                     activeAuthorization()
             );
             when(playerLookupApi.findPlayerIdByUserId(1L)).thenReturn(2L);  // linkStart 완료
-            when(authService.reissueToken("rt",2L)).thenReturn(PAIR);
+            when(authService.reissueToken(1L,2L)).thenReturn(PAIR);
 
             AuthResult.TokenPair r = authFacade.refresh("rt");
 
@@ -101,29 +101,33 @@ class AuthFacadeTest {
 
         @Test @DisplayName("linkStart 전 refresh → playerId=null")
         void beforeLinkStart_nullPlayerId() {
-            when(jwtProvider.extractUserId("rt")).thenReturn(Optional.of(1L));
+            when(jwtProvider.extractRefreshUserId("rt")).thenReturn(Optional.of(1L));
             when(userAuthApi.resolveAuthorization(1L)).thenReturn(
                     activeAuthorization()
             );
             when(playerLookupApi.findPlayerIdByUserId(1L)).thenReturn(null);
-            when(authService.reissueToken("rt",null))
+            when(authService.reissueToken(1L,null))
                     .thenReturn(new AuthResult.TokenPair("a","r",1L,null));
 
             assertThat(authFacade.refresh("rt").playerId()).isNull();
         }
 
-        @Test @DisplayName("유효하지 않은 refreshToken → 예외")
-        void invalid_throws() {
-            when(jwtProvider.extractUserId("bad")).thenReturn(Optional.empty());
+        @Test @DisplayName("access token을 refresh에 전달하면 TOKEN_INVALID")
+        void accessToken_throws() {
+            when(jwtProvider.extractRefreshUserId("access")).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> authFacade.refresh("bad"))
-                    .isInstanceOf(AuthException.class);
+            assertThatThrownBy(() -> authFacade.refresh("access"))
+                    .isInstanceOfSatisfying(
+                            AuthException.class,
+                            exception -> assertThat(exception.getErrorCode())
+                                    .isEqualTo(AuthError.TOKEN_INVALID)
+                    );
             verifyNoInteractions(authService);
         }
 
         @Test @DisplayName("revoked account의 refresh → 예외")
         void revokedAccount_throws() {
-            when(jwtProvider.extractUserId("rt")).thenReturn(Optional.of(1L));
+            when(jwtProvider.extractRefreshUserId("rt")).thenReturn(Optional.of(1L));
             when(userAuthApi.resolveAuthorization(1L)).thenReturn(
                     Optional.of(new UserAuthApi.AccountAuthorization(
                             false,

--- a/src/test/java/online/lifeasgame/auth/application/AuthFacadeTest.java
+++ b/src/test/java/online/lifeasgame/auth/application/AuthFacadeTest.java
@@ -88,6 +88,9 @@ class AuthFacadeTest {
         @Test @DisplayName("linkStart 후 refresh → playerId 포함 토큰 재발급")
         void afterLinkStart_playerId() {
             when(jwtProvider.extractUserId("rt")).thenReturn(Optional.of(1L));
+            when(userAuthApi.resolveAuthorization(1L)).thenReturn(
+                    activeAuthorization()
+            );
             when(playerLookupApi.findPlayerIdByUserId(1L)).thenReturn(2L);  // linkStart 완료
             when(authService.reissueToken("rt",2L)).thenReturn(PAIR);
 
@@ -99,6 +102,9 @@ class AuthFacadeTest {
         @Test @DisplayName("linkStart 전 refresh → playerId=null")
         void beforeLinkStart_nullPlayerId() {
             when(jwtProvider.extractUserId("rt")).thenReturn(Optional.of(1L));
+            when(userAuthApi.resolveAuthorization(1L)).thenReturn(
+                    activeAuthorization()
+            );
             when(playerLookupApi.findPlayerIdByUserId(1L)).thenReturn(null);
             when(authService.reissueToken("rt",null))
                     .thenReturn(new AuthResult.TokenPair("a","r",1L,null));
@@ -114,5 +120,24 @@ class AuthFacadeTest {
                     .isInstanceOf(AuthException.class);
             verifyNoInteractions(authService);
         }
+
+        @Test @DisplayName("revoked account의 refresh → 예외")
+        void revokedAccount_throws() {
+            when(jwtProvider.extractUserId("rt")).thenReturn(Optional.of(1L));
+            when(userAuthApi.resolveAuthorization(1L)).thenReturn(
+                    Optional.of(new UserAuthApi.AccountAuthorization(
+                            false,
+                            true
+                    ))
+            );
+
+            assertThatThrownBy(() -> authFacade.refresh("rt"))
+                    .isInstanceOf(AuthException.class);
+            verifyNoInteractions(playerLookupApi, authService);
+        }
+    }
+
+    private Optional<UserAuthApi.AccountAuthorization> activeAuthorization() {
+        return Optional.of(new UserAuthApi.AccountAuthorization(true, false));
     }
 }

--- a/src/test/java/online/lifeasgame/auth/application/AuthServiceTest.java
+++ b/src/test/java/online/lifeasgame/auth/application/AuthServiceTest.java
@@ -1,13 +1,11 @@
 package online.lifeasgame.auth.application;
 
 import online.lifeasgame.auth.application.result.AuthResult;
-import online.lifeasgame.core.error.AuthException;
 import online.lifeasgame.platform.security.jwt.JwtProvider;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
-import java.util.Optional;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -35,17 +33,9 @@ class AuthServiceTest {
 
     @Test @DisplayName("reissueToken — 유효한 refresh → 새 TokenPair")
     void reissueToken_success() {
-        when(jwtProvider.extractUserId("rt")).thenReturn(Optional.of(1L));
         when(jwtProvider.createAccessToken(1L, 2L)).thenReturn("new-access");
         when(jwtProvider.createRefreshToken(1L)).thenReturn("new-refresh");
-        AuthResult.TokenPair r = authService.reissueToken("rt", 2L);
+        AuthResult.TokenPair r = authService.reissueToken(1L, 2L);
         assertThat(r.accessToken()).isEqualTo("new-access");
-    }
-
-    @Test @DisplayName("reissueToken — 유효하지 않은 토큰 → 예외")
-    void reissueToken_invalid_throws() {
-        when(jwtProvider.extractUserId("bad")).thenReturn(Optional.empty());
-        assertThatThrownBy(() -> authService.reissueToken("bad", null))
-                .isInstanceOf(AuthException.class);
     }
 }

--- a/src/test/java/online/lifeasgame/economy/application/MarketplaceTradeFulfillmentIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/economy/application/MarketplaceTradeFulfillmentIntegrationTest.java
@@ -205,7 +205,7 @@ class MarketplaceTradeFulfillmentIntegrationTest {
         @DisplayName("legacy null은 허용하고 canonical quantity 제약은 보존한다")
         void validatesMigrationAndJpaContract() {
             assertThat(flyway.info().current().getVersion().getVersion())
-                    .isEqualTo("28");
+                    .isEqualTo("29");
             jdbc.update("""
                     INSERT INTO trades (
                         fee_bps, buyer_player_id, created_at, fee, item_inst_id,

--- a/src/test/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryIntegrationTest.java
@@ -99,7 +99,7 @@ class InventoryRewardDeliveryIntegrationTest {
     @DisplayName("V17 receipt table은 JPA validate와 unique/check/index 계약을 만족한다")
     void validatesMigrationContract() {
         assertThat(flyway.info().current().getVersion().getVersion())
-                .isEqualTo("28");
+                .isEqualTo("29");
         assertThat(environment.getProperty("spring.jpa.hibernate.ddl-auto"))
                 .isEqualTo("validate");
 

--- a/src/test/java/online/lifeasgame/migration/AccountAuthorityFlywayTest.java
+++ b/src/test/java/online/lifeasgame/migration/AccountAuthorityFlywayTest.java
@@ -1,0 +1,99 @@
+package online.lifeasgame.migration;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+@DisplayName("V29 account authority migration")
+class AccountAuthorityFlywayTest {
+
+    @Container
+    private static final MySQLContainer<?> MYSQL = new MySQLContainer<>(
+            "mysql:8.0.39"
+    )
+            .withDatabaseName("lifeasgame_account_authority")
+            .withUsername("lifeasgame")
+            .withPassword("lifeasgame");
+
+    @Test
+    @DisplayName("existing/new account는 USER이고 USER/ADMIN 외 값은 거절한다")
+    void migratesExistingAndNewAccountsSafely() throws Exception {
+        Flyway throughV28 = flyway(MigrationVersion.fromVersion("28"));
+        throughV28.migrate();
+        insertUser(30001L, "existing@example.com");
+
+        Flyway latest = flyway(null);
+        assertThat(latest.migrate().migrationsExecuted).isEqualTo(1);
+        assertThat(latest.info().current().getVersion().getVersion())
+                .isEqualTo("29");
+        assertThat(authority(30001L)).isEqualTo("USER");
+
+        insertUser(30002L, "new@example.com");
+        assertThat(authority(30002L)).isEqualTo("USER");
+        assertThatThrownBy(() -> updateAuthority(30002L, "GAMEPLAY_ROLE"))
+                .isInstanceOf(Exception.class)
+                .hasMessageContaining("ck_user_account_authority");
+    }
+
+    private Flyway flyway(MigrationVersion target) {
+        var configuration = Flyway.configure()
+                .dataSource(
+                        MYSQL.getJdbcUrl(),
+                        MYSQL.getUsername(),
+                        MYSQL.getPassword()
+                )
+                .locations("classpath:db/migration")
+                .baselineOnMigrate(false);
+        if (target != null) {
+            configuration.target(target);
+        }
+        return configuration.load();
+    }
+
+    private void insertUser(long id, String email) throws Exception {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement()) {
+            statement.executeUpdate("""
+                    INSERT INTO users (
+                        id, email, password_hash, nickname, status,
+                        created_at, updated_at
+                    ) VALUES (
+                        %d, '%s', 'hashed-password', 'user%d', 'ACTIVE',
+                        CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)
+                    )
+                    """.formatted(id, email, id));
+        }
+    }
+
+    private String authority(long id) throws Exception {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement();
+             ResultSet result = statement.executeQuery("""
+                     SELECT account_authority FROM users WHERE id = %d
+                     """.formatted(id))) {
+            assertThat(result.next()).isTrue();
+            return result.getString(1);
+        }
+    }
+
+    private void updateAuthority(long id, String authority) throws Exception {
+        try (Connection connection = MYSQL.createConnection("");
+             Statement statement = connection.createStatement()) {
+            statement.executeUpdate("""
+                    UPDATE users SET account_authority = '%s' WHERE id = %d
+                    """.formatted(authority, id));
+        }
+    }
+}

--- a/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
@@ -63,7 +63,7 @@ class FlywayExplicitBaselineTest {
     class ApplyExplicitBaseline {
 
         @Test
-        @DisplayName("V1을 재실행하지 않고 V2부터 V28까지 적용한 뒤 JPA validate를 통과한다")
+        @DisplayName("V1을 재실행하지 않고 V2부터 V29까지 적용한 뒤 JPA validate를 통과한다")
         void migratesFromVersionTwoAndValidatesJpa() throws Exception {
             String jdbcUrl = createV1EquivalentDatabase();
             Flyway flyway = migrationFlyway(jdbcUrl);
@@ -72,13 +72,13 @@ class FlywayExplicitBaselineTest {
             MigrateResult migrateResult = flyway.migrate();
             List<HistoryRow> history = successfulHistory(jdbcUrl);
 
-            assertThat(migrateResult.migrationsExecuted).isEqualTo(27);
+            assertThat(migrateResult.migrationsExecuted).isEqualTo(28);
             assertThat(history).extracting(HistoryRow::version)
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
                             "14", "15", "16", "17", "18", "19", "20",
-                            "21", "22", "23", "24", "25", "26", "27", "28"
+                            "21", "22", "23", "24", "25", "26", "27", "28", "29"
                     );
             assertThat(history.getFirst().type()).isEqualTo("BASELINE");
             assertThat(history.getFirst().script())
@@ -116,7 +116,8 @@ class FlywayExplicitBaselineTest {
                             "V25__player_notification_inbox.sql",
                             "V26__inventory_entry_availability.sql",
                             "V27__canonical_listing_reservations.sql",
-                            "V28__canonical_trade_item_snapshot.sql"
+                            "V28__canonical_trade_item_snapshot.sql",
+                            "V29__user_account_authority.sql"
                     );
             assertThat(history.subList(1, history.size()))
                     .allSatisfy(row -> assertThat(row.checksum()).isNotNull());
@@ -136,7 +137,7 @@ class FlywayExplicitBaselineTest {
                         "spring.jpa.hibernate.ddl-auto"
                 )).isEqualTo("validate");
                 assertThat(context.getBean(Flyway.class).info().current().getVersion().getVersion())
-                        .isEqualTo("28");
+                        .isEqualTo("29");
             }
         }
     }

--- a/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
@@ -33,7 +33,7 @@ class FlywayHistoryChecksumTest {
     class MigrateAgain {
 
         @Test
-        @DisplayName("V1~V20 checksum을 보존하고 V28 이후 두 번째 실행은 no-op이다")
+        @DisplayName("V1~V20 checksum을 보존하고 V29 이후 두 번째 실행은 no-op이다")
         void keepsMigrationHistory() throws Exception {
             Flyway throughV20 = flyway(MigrationVersion.fromVersion("20"));
             MigrateResult legacy = throughV20.migrate();
@@ -47,7 +47,7 @@ class FlywayHistoryChecksumTest {
             List<HistoryRow> secondHistory = successfulHistory();
 
             assertThat(legacy.migrationsExecuted).isEqualTo(20);
-            assertThat(first.migrationsExecuted).isEqualTo(8);
+            assertThat(first.migrationsExecuted).isEqualTo(9);
             assertThat(second.migrationsExecuted).isZero();
             assertThat(secondHistory).isEqualTo(firstHistory);
             assertThat(firstHistory.subList(0, legacyHistory.size()))
@@ -57,7 +57,7 @@ class FlywayHistoryChecksumTest {
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
                             "14", "15", "16", "17", "18", "19", "20",
-                            "21", "22", "23", "24", "25", "26", "27", "28"
+                            "21", "22", "23", "24", "25", "26", "27", "28", "29"
                     );
             assertThat(secondHistory).allSatisfy(history -> {
                 assertThat(history.checksum()).isNotNull();

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -39,7 +39,7 @@ class FlywayMigrationTest {
     class MigrateCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V28까지 적용되고 canonical Trade snapshot을 추가한다")
+        @DisplayName("V1부터 V29까지 적용되고 account authority를 추가한다")
         void migratesSchemaAndSeedsRewardProfiles() throws Exception {
             Flyway throughV10 = flyway(MigrationVersion.fromVersion("10"));
             MigrateResult legacyResult = throughV10.migrate();
@@ -58,13 +58,13 @@ class FlywayMigrationTest {
             assertThat(legacyResult.migrationsExecuted).isEqualTo(10);
             assertThat(semanticResult.migrationsExecuted).isEqualTo(1);
             assertThat(itemResult.migrationsExecuted).isEqualTo(1);
-            assertThat(result.migrationsExecuted).isEqualTo(16);
+            assertThat(result.migrationsExecuted).isEqualTo(17);
             assertThat(appliedVersions())
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
                             "14", "15", "16", "17", "18", "19", "20",
-                            "21", "22", "23", "24", "25", "26", "27", "28"
+                            "21", "22", "23", "24", "25", "26", "27", "28", "29"
                     );
             assertThat(existingTables(
                     "users",

--- a/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
@@ -149,7 +149,7 @@ class FlywayProfileCutoverTest {
     class StartLocalWithCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V28까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
+        @DisplayName("V1부터 V29까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
         void migratesThenValidates() {
             ConfigurableEnvironment environment =
                     (ConfigurableEnvironment) applicationContext.getEnvironment();
@@ -161,8 +161,8 @@ class FlywayProfileCutoverTest {
             assertThat(environment.getProperty(
                     "spring.flyway.baseline-on-migrate", Boolean.class
             )).isFalse();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("28");
-            assertThat(appliedMigrationCount()).isEqualTo(28);
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("29");
+            assertThat(appliedMigrationCount()).isEqualTo(29);
         }
     }
 

--- a/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 @SpringBootTest
 @ActiveProfiles({"test", "migration-test"})
-@DisplayName("V28 migration 이후 JPA schema validation")
+@DisplayName("V29 migration 이후 JPA schema validation")
 class JpaValidateAfterMigrationTest {
 
     @Container
@@ -79,14 +79,14 @@ class JpaValidateAfterMigrationTest {
     private QuestDefinitionBootstrapper questDefinitionBootstrapper;
 
     @Nested
-    @DisplayName("V1부터 V28까지 적용된 schema로 ApplicationContext를 기동할 때")
+    @DisplayName("V1부터 V29까지 적용된 schema로 ApplicationContext를 기동할 때")
     class LoadApplicationContext {
 
         @Test
         @DisplayName("ddl-auto validate 상태로 정상 기동한다")
         void loadsWithJpaValidation() {
             assertThat(applicationContext).isNotNull();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("28");
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("29");
             assertThat(applicationContext.getEnvironment().getProperty("spring.jpa.hibernate.ddl-auto"))
                     .isEqualTo("validate");
             assertThat(applicationContext.getEnvironment()

--- a/src/test/java/online/lifeasgame/migration/RolePersonPersistenceFoundationFlywayTest.java
+++ b/src/test/java/online/lifeasgame/migration/RolePersonPersistenceFoundationFlywayTest.java
@@ -46,9 +46,9 @@ class RolePersonPersistenceFoundationFlywayTest {
     }
 
     @Test
-    @DisplayName("V28까지 적용된 schema에서 V19 Role/Person 계약을 고정한다")
+    @DisplayName("V29까지 적용된 schema에서 V19 Role/Person 계약을 고정한다")
     void createsSchemaContract() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("28");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("29");
         assertThat(tableContracts()).containsExactly(
                 new TableContract("roles", "InnoDB", "utf8mb4_0900_ai_ci"),
                 new TableContract("persons", "InnoDB", "utf8mb4_0900_ai_ci"),

--- a/src/test/java/online/lifeasgame/notification/application/NotificationApplicationIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/notification/application/NotificationApplicationIntegrationTest.java
@@ -101,7 +101,7 @@ class NotificationApplicationIntegrationTest {
         @DisplayName("durable row를 만들고 같은 player replay만 무시한다")
         void appendsDurablyAndScopesReplayByPlayer() {
             assertThat(flyway.info().current().getVersion().getVersion())
-                    .isEqualTo("28");
+                    .isEqualTo("29");
 
             append(PLAYER_ID, "shared-event");
             append(PLAYER_ID, "shared-event");

--- a/src/test/java/online/lifeasgame/platform/security/jwt/JwtCurrentAccessorTest.java
+++ b/src/test/java/online/lifeasgame/platform/security/jwt/JwtCurrentAccessorTest.java
@@ -1,0 +1,57 @@
+package online.lifeasgame.platform.security.jwt;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("JWT CurrentUser / CurrentPlayer identity")
+class JwtCurrentAccessorTest {
+
+    private final JwtCurrentUserAccessor currentUser =
+            new JwtCurrentUserAccessor();
+    private final JwtCurrentPlayerAccessor currentPlayer =
+            new JwtCurrentPlayerAccessor();
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("ADMIN authority가 추가되어도 기존 user/player identity를 유지한다")
+    void preservesUserAndPlayerIdentity() {
+        authenticate(new JwtPrincipal(30001L, 300001L));
+
+        assertThat(currentUser.currentUserId()).contains(30001L);
+        assertThat(currentPlayer.currentPlayerId()).contains(300001L);
+    }
+
+    @Test
+    @DisplayName("Player가 없는 ADMIN도 CurrentUser는 유지하고 CurrentPlayer는 비어 있다")
+    void allowsAdminWithoutPlayer() {
+        authenticate(new JwtPrincipal(30002L, null));
+
+        assertThat(currentUser.currentUserId()).contains(30002L);
+        assertThat(currentPlayer.currentPlayerId()).isEmpty();
+    }
+
+    private void authenticate(JwtPrincipal principal) {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        principal,
+                        null,
+                        List.of(
+                                new SimpleGrantedAuthority("ROLE_USER"),
+                                new SimpleGrantedAuthority("ROLE_ADMIN")
+                        )
+                )
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/platform/security/jwt/JwtProviderTest.java
+++ b/src/test/java/online/lifeasgame/platform/security/jwt/JwtProviderTest.java
@@ -32,6 +32,7 @@ class JwtProviderTest {
         String token = provider.createRefreshToken(10L);
         assertThat(provider.extractUserId(token)).contains(10L);
         assertThat(provider.extractPlayerId(token)).isEmpty();
+        assertThat(provider.parseAccessToken(token)).isEmpty();
     }
 
     @Test @DisplayName("위변조 → empty")

--- a/src/test/java/online/lifeasgame/platform/security/jwt/JwtProviderTest.java
+++ b/src/test/java/online/lifeasgame/platform/security/jwt/JwtProviderTest.java
@@ -19,6 +19,8 @@ class JwtProviderTest {
         String token = provider.createAccessToken(10L, 42L);
         assertThat(provider.extractUserId(token)).contains(10L);
         assertThat(provider.extractPlayerId(token)).contains(42L);
+        assertThat(provider.parseAccessToken(token)).isPresent();
+        assertThat(provider.parseRefreshToken(token)).isEmpty();
     }
 
     @Test @DisplayName("accessToken — playerId=null 허용")
@@ -30,9 +32,25 @@ class JwtProviderTest {
     @Test @DisplayName("refreshToken — userId만 포함")
     void refreshToken_onlyUserId() {
         String token = provider.createRefreshToken(10L);
-        assertThat(provider.extractUserId(token)).contains(10L);
+        assertThat(provider.extractRefreshUserId(token)).contains(10L);
         assertThat(provider.extractPlayerId(token)).isEmpty();
         assertThat(provider.parseAccessToken(token)).isEmpty();
+        assertThat(provider.parseRefreshToken(token)).isPresent();
+    }
+
+    @Test @DisplayName("위변조 refreshToken → refresh parser empty")
+    void tamperedRefreshToken_returnsEmpty() {
+        String token = provider.createRefreshToken(1L) + "x";
+        assertThat(provider.parseRefreshToken(token)).isEmpty();
+    }
+
+    @Test @DisplayName("만료 refreshToken → refresh parser empty")
+    void expiredRefreshToken_returnsEmpty() throws InterruptedException {
+        JwtProperties p = new JwtProperties(); p.setSecret(SECRET); p.setRefreshTokenExpiryMs(1L);
+        JwtProvider short$ = new JwtProvider(p);
+        String token = short$.createRefreshToken(1L);
+        Thread.sleep(10);
+        assertThat(short$.parseRefreshToken(token)).isEmpty();
     }
 
     @Test @DisplayName("위변조 → empty")

--- a/src/test/java/online/lifeasgame/role/application/RolePersonPersistenceIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/role/application/RolePersonPersistenceIntegrationTest.java
@@ -100,7 +100,7 @@ class RolePersonPersistenceIntegrationTest {
 
     @Test
     void persistsOwnerScopedCrudAndKeepsArchivedRows() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("28");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("29");
 
         var role = roleService.create(
                 new RoleCommand.Create("work", "Developer", "Builds")

--- a/src/test/java/online/lifeasgame/role/application/RoleRelationPersistenceIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/role/application/RoleRelationPersistenceIntegrationTest.java
@@ -93,7 +93,7 @@ class RoleRelationPersistenceIntegrationTest {
 
     @Test
     void persistsCrudRejectsActiveDuplicateAndReactivatesArchivedRow() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("28");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("29");
         Long roleId = createRole("Owner role");
         Long personId = createPerson("Alice");
 

--- a/src/test/java/online/lifeasgame/support/WebMvcTestConfig.java
+++ b/src/test/java/online/lifeasgame/support/WebMvcTestConfig.java
@@ -5,11 +5,21 @@ import online.lifeasgame.platform.web.error.PiiScrubber;
 import online.lifeasgame.platform.web.error.docs.ErrorDocLinker;
 import online.lifeasgame.platform.web.error.handler.ProblemDetailFactory;
 import online.lifeasgame.system.bootstrap.error.handler.AppErrorProperties;
+import online.lifeasgame.user.application.internal.UserAuthApi;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 
+import static org.mockito.Mockito.mock;
+
 @TestConfiguration
 public class WebMvcTestConfig {
+
+    @Bean
+    @ConditionalOnMissingBean(UserAuthApi.class)
+    UserAuthApi userAuthApi() {
+        return mock(UserAuthApi.class);
+    }
 
     @Bean
     ProblemDetailFactory problemDetailFactory(ErrorDocLinker linker) {

--- a/src/test/java/online/lifeasgame/system/bootstrap/security/AdminAuthorizationContractTest.java
+++ b/src/test/java/online/lifeasgame/system/bootstrap/security/AdminAuthorizationContractTest.java
@@ -1,39 +1,71 @@
 package online.lifeasgame.system.bootstrap.security;
 
+import online.lifeasgame.platform.security.jwt.JwtProperties;
 import online.lifeasgame.platform.security.jwt.JwtProvider;
 import online.lifeasgame.platform.web.error.docs.ErrorDocLinker;
 import online.lifeasgame.support.WebMvcTestConfig;
 import online.lifeasgame.system.bootstrap.error.handler.AppErrorProperties;
+import online.lifeasgame.user.api.admin.AdminUserController;
+import online.lifeasgame.user.application.UserQueryService;
+import online.lifeasgame.user.application.UserService;
+import online.lifeasgame.user.application.internal.UserAuthApi;
+import online.lifeasgame.user.application.result.UserResult;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = AdminAuthorizationContractTest.ContractController.class)
+@WebMvcTest(controllers = {
+        AdminUserController.class,
+        AdminAuthorizationContractTest.ContractController.class
+})
 @ActiveProfiles("test")
 @Import({
-        AdminAuthorizationContractTest.ContractController.class,
         SecurityConfig.class,
-        WebMvcTestConfig.class
+        WebMvcTestConfig.class,
+        AdminAuthorizationContractTest.ContractController.class,
+        AdminAuthorizationContractTest.JwtTestConfig.class
 })
-@DisplayName("Admin authorization contract")
+@DisplayName("persisted Admin authorization contract")
 class AdminAuthorizationContractTest {
+
+    private static final long USER_ID = 30001L;
+    private static final long ADMIN_ID = 30002L;
+    private static final String SECRET =
+            "admin-authority-test-secret-at-least-32-characters";
 
     @Autowired
     private MockMvc mockMvc;
 
-    @MockitoBean
+    @Autowired
     private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private UserAuthApi userAuthApi;
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private UserQueryService userQueryService;
 
     @MockitoBean
     private AppErrorProperties appErrorProperties;
@@ -41,44 +73,144 @@ class AdminAuthorizationContractTest {
     @MockitoBean
     private ErrorDocLinker errorDocLinker;
 
-    @Test
-    @DisplayName("인증 없이 Admin path에 접근하면 401이다")
-    void rejectsUnauthenticatedAdminRequest() throws Exception {
-        mockMvc.perform(get("/admin/v1/security-contract/ping"))
-                .andExpect(status().isUnauthorized());
+    @BeforeEach
+    void setUp() {
+        given(userQueryService.search(any())).willReturn(
+                new UserResult.UserList(
+                        List.of(),
+                        new UserResult.UserList.PageInfo(0, 20, 0)
+                )
+        );
+    }
+
+    @Nested
+    @DisplayName("GET /admin/v1/users")
+    class AdminPath {
+
+        @Test
+        @DisplayName("token이 없으면 401이다")
+        void rejectsUnauthenticatedRequest() throws Exception {
+            mockMvc.perform(get("/admin/v1/users"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("persisted USER account이면 403이다")
+        void rejectsUserAuthority() throws Exception {
+            given(userAuthApi.resolveAuthorization(USER_ID))
+                    .willReturn(Optional.of(activeUser()));
+
+            mockMvc.perform(get("/admin/v1/users")
+                            .header("Authorization", bearer(userToken())))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("persisted ADMIN account이면 Player 없이도 controller에 진입한다")
+        void allowsAdminAuthority() throws Exception {
+            given(userAuthApi.resolveAuthorization(ADMIN_ID))
+                    .willReturn(Optional.of(activeAdmin()));
+
+            mockMvc.perform(get("/admin/v1/users")
+                            .header("Authorization", bearer(adminToken())))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("위조된 token은 401이다")
+        void rejectsForgedToken() throws Exception {
+            mockMvc.perform(get("/admin/v1/users")
+                            .header("Authorization", bearer(
+                                    provider(SECRET + "-forged", 3_600_000L)
+                                            .createAccessToken(ADMIN_ID, null)
+                            )))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("만료된 token은 401이다")
+        void rejectsExpiredToken() throws Exception {
+            mockMvc.perform(get("/admin/v1/users")
+                            .header("Authorization", bearer(
+                                    provider(SECRET, -1_000L)
+                                            .createAccessToken(ADMIN_ID, null)
+                            )))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("같은 token도 downgrade 다음 요청은 403, 계정 revocation 다음 요청은 401이다")
+        void appliesDowngradeAndRevocationOnNextRequest() throws Exception {
+            given(userAuthApi.resolveAuthorization(ADMIN_ID))
+                    .willReturn(Optional.of(activeAdmin()))
+                    .willReturn(Optional.of(activeUser()))
+                    .willReturn(Optional.of(
+                            new UserAuthApi.AccountAuthorization(false, false)
+                    ));
+            String token = adminToken();
+
+            mockMvc.perform(get("/admin/v1/users")
+                            .header("Authorization", bearer(token)))
+                    .andExpect(status().isOk());
+            mockMvc.perform(get("/admin/v1/users")
+                            .header("Authorization", bearer(token)))
+                    .andExpect(status().isForbidden());
+            mockMvc.perform(get("/admin/v1/users")
+                            .header("Authorization", bearer(token)))
+                    .andExpect(status().isUnauthorized());
+        }
     }
 
     @Test
-    @DisplayName("ROLE_USER는 Admin path에 접근할 수 없다")
-    void rejectsUserRoleFromAdminPath() throws Exception {
-        mockMvc.perform(get("/admin/v1/security-contract/ping")
-                        .with(user("user").roles("USER")))
-                .andExpect(status().isForbidden());
-    }
+    @DisplayName("정상 USER access token은 일반 authenticated path를 유지한다")
+    void keepsNormalUserAuthentication() throws Exception {
+        given(userAuthApi.resolveAuthorization(USER_ID))
+                .willReturn(Optional.of(activeUser()));
 
-    @Test
-    @DisplayName("ROLE_ADMIN은 Admin matcher를 통과한다")
-    void allowsAdminRoleThroughAdminMatcher() throws Exception {
-        mockMvc.perform(get("/admin/v1/security-contract/ping")
-                        .with(user("admin").roles("ADMIN")))
-                .andExpect(status().isOk());
-    }
-
-    @Test
-    @DisplayName("ROLE_USER는 일반 authenticated path를 사용할 수 있다")
-    void keepsAuthenticatedPlayerPathAvailable() throws Exception {
         mockMvc.perform(get("/api/v1/security-contract/ping")
-                        .with(user("user").roles("USER")))
+                        .header("Authorization", bearer(userToken())))
                 .andExpect(status().isOk());
+    }
+
+    private UserAuthApi.AccountAuthorization activeUser() {
+        return new UserAuthApi.AccountAuthorization(true, false);
+    }
+
+    private UserAuthApi.AccountAuthorization activeAdmin() {
+        return new UserAuthApi.AccountAuthorization(true, true);
+    }
+
+    private String userToken() {
+        return jwtProvider.createAccessToken(USER_ID, 300001L);
+    }
+
+    private String adminToken() {
+        return jwtProvider.createAccessToken(ADMIN_ID, null);
+    }
+
+    private String bearer(String token) {
+        return "Bearer " + token;
+    }
+
+    private static JwtProvider provider(String secret, long accessExpiryMs) {
+        JwtProperties properties = new JwtProperties();
+        properties.setSecret(secret);
+        properties.setAccessTokenExpiryMs(accessExpiryMs);
+        properties.setRefreshTokenExpiryMs(604_800_000L);
+        return new JwtProvider(properties);
+    }
+
+    @TestConfiguration
+    static class JwtTestConfig {
+
+        @Bean
+        JwtProvider jwtProvider() {
+            return provider(SECRET, 3_600_000L);
+        }
     }
 
     @RestController
     static class ContractController {
-
-        @GetMapping("/admin/v1/security-contract/ping")
-        String adminPing() {
-            return "ok";
-        }
 
         @GetMapping("/api/v1/security-contract/ping")
         String playerPing() {

--- a/src/test/java/online/lifeasgame/system/bootstrap/security/CorsSecurityContractTest.java
+++ b/src/test/java/online/lifeasgame/system/bootstrap/security/CorsSecurityContractTest.java
@@ -5,6 +5,7 @@ import online.lifeasgame.platform.security.jwt.JwtProvider;
 import online.lifeasgame.platform.web.error.docs.ErrorDocLinker;
 import online.lifeasgame.support.WebMvcTestConfig;
 import online.lifeasgame.system.bootstrap.error.handler.AppErrorProperties;
+import online.lifeasgame.user.application.internal.UserAuthApi;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -60,6 +61,9 @@ class CorsSecurityContractTest {
 
     @MockitoBean
     private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private UserAuthApi userAuthApi;
 
     @MockitoBean
     private AppErrorProperties appErrorProperties;
@@ -133,9 +137,16 @@ class CorsSecurityContractTest {
         @DisplayName("유효한 JWT의 actual protected request를 허용하고 불필요한 header는 expose하지 않는다")
         void allowsActualRequestWithJwt() throws Exception {
             Claims claims = mock(Claims.class);
-            given(jwtProvider.parse("valid-access-token")).willReturn(Optional.of(claims));
+            given(jwtProvider.parseAccessToken("valid-access-token"))
+                    .willReturn(Optional.of(claims));
             given(claims.getSubject()).willReturn("1");
             given(claims.get("pid", Long.class)).willReturn(2L);
+            given(userAuthApi.resolveAuthorization(1L)).willReturn(
+                    Optional.of(new UserAuthApi.AccountAuthorization(
+                            true,
+                            false
+                    ))
+            );
 
             mockMvc.perform(get(PROTECTED_PATH)
                             .header(HttpHeaders.ORIGIN, PRODUCTION_ORIGIN)

--- a/src/test/java/online/lifeasgame/user/application/UserAuthServiceTest.java
+++ b/src/test/java/online/lifeasgame/user/application/UserAuthServiceTest.java
@@ -1,15 +1,27 @@
 package online.lifeasgame.user.application;
 
+import online.lifeasgame.core.error.AuthException;
+import online.lifeasgame.core.error.api.AuthError;
 import online.lifeasgame.user.application.command.UserCommand;
 import online.lifeasgame.user.application.internal.UserAuthApi;
 import online.lifeasgame.user.application.result.UserResult;
+import online.lifeasgame.user.domain.AccountAuthority;
+import online.lifeasgame.user.domain.Email;
+import online.lifeasgame.user.domain.HashedPassword;
+import online.lifeasgame.user.domain.Nickname;
+import online.lifeasgame.user.domain.User;
+import online.lifeasgame.user.domain.UserStatus;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -46,5 +58,69 @@ class UserAuthServiceTest {
                 "password1",
                 "player"
         ));
+    }
+
+    @Test
+    void resolvesActiveUserAuthority() {
+        User user = user();
+        given(userReader.findById(300L)).willReturn(Optional.of(user));
+
+        assertThat(userAuthService.resolveAuthorization(300L))
+                .contains(new UserAuthApi.AccountAuthorization(true, false));
+    }
+
+    @Test
+    void authenticatesActiveUserWithExistingIdentity() {
+        User user = user();
+        given(userReader.findByEmailOrElseThrow("user@example.com"))
+                .willReturn(user);
+        given(passwordHasher.matches(any(), any())).willReturn(true);
+
+        assertThat(userAuthService.authenticate(
+                "user@example.com",
+                "password1"
+        )).isEqualTo(300L);
+    }
+
+    @Test
+    void resolvesActiveAdminAuthority() {
+        User user = user();
+        ReflectionTestUtils.setField(
+                user,
+                "accountAuthority",
+                AccountAuthority.ADMIN
+        );
+        given(userReader.findById(300L)).willReturn(Optional.of(user));
+
+        assertThat(userAuthService.resolveAuthorization(300L))
+                .contains(new UserAuthApi.AccountAuthorization(true, true));
+    }
+
+    @Test
+    void rejectsInactiveAccountAuthentication() {
+        User user = user();
+        user.changeStatus(UserStatus.BANNED);
+        given(userReader.findByEmailOrElseThrow("user@example.com"))
+                .willReturn(user);
+        given(passwordHasher.matches(any(), any())).willReturn(true);
+
+        assertThatThrownBy(() -> userAuthService.authenticate(
+                "user@example.com",
+                "password1"
+        )).isInstanceOfSatisfying(
+                AuthException.class,
+                exception -> assertThat(exception.getErrorCode())
+                        .isEqualTo(AuthError.BAD_CREDENTIALS)
+        );
+    }
+
+    private User user() {
+        User user = User.register(
+                Email.of("user@example.com"),
+                HashedPassword.of("hashedpassword1234567"),
+                Nickname.of("player")
+        );
+        ReflectionTestUtils.setField(user, "id", 300L);
+        return user;
     }
 }

--- a/src/test/java/online/lifeasgame/user/application/UserServiceTest.java
+++ b/src/test/java/online/lifeasgame/user/application/UserServiceTest.java
@@ -96,6 +96,7 @@ class UserServiceTest {
             User u = mock(User.class);
             when(u.getId()).thenReturn(1L);
             when(u.getPasswordHash()).thenReturn(TEST_HASH);
+            when(u.getStatus()).thenReturn(UserStatus.ACTIVE);
             when(userReader.findByEmailOrElseThrow(anyString())).thenReturn(u);
             when(passwordHasher.matches(any(RawPassword.class), any(HashedPassword.class)))
                     .thenReturn(true);

--- a/src/test/java/online/lifeasgame/user/domain/UserTest.java
+++ b/src/test/java/online/lifeasgame/user/domain/UserTest.java
@@ -26,9 +26,14 @@ class UserTest {
     class Register {
 
         @Test
-        @DisplayName("정상 생성 → ACTIVE 상태")
+        @DisplayName("정상 생성 → ACTIVE / USER 상태")
         void shouldBeActive() {
-            assertThat(activeUser().getStatus()).isEqualTo(UserStatus.ACTIVE);
+            User user = activeUser();
+
+            assertThat(user.getStatus()).isEqualTo(UserStatus.ACTIVE);
+            assertThat(user.getAccountAuthority())
+                    .isEqualTo(AccountAuthority.USER);
+            assertThat(user.isAdmin()).isFalse();
         }
 
         @Test


### PR DESCRIPTION
## Purpose

Close the first Admin Backend Foundation blocker by establishing a legitimate server-side `ADMIN` authority source and proving the `/admin/**` authorization boundary.

Closes #300

## Delivered

- persisted account authorization source
- minimum USER / ADMIN authority model
- Spring Security authority resolution
- server-side Admin route enforcement proof
- Admin positive-access security coverage
- normal USER denial coverage
- invalid/expired authentication regression coverage
- documented Admin downgrade/revocation semantics

## Security Boundary

Admin authorization is owned by account/security identity and is separate from the LifeAsGame gameplay Role domain.

The coarse backend boundary remains:

```text
/admin/** -> hasRole("ADMIN")
```

The frontend `/admin` route guard is not treated as a security boundary.

## Authority Contract

Normal users receive the standard user authority.

Admin accounts additionally resolve the authority required by Spring Security to satisfy `hasRole("ADMIN")`.

New and migrated existing accounts remain non-Admin by default.

## Verification

The focused security contract proves:

```text
unauthenticated -> 401
USER -> 403
ADMIN -> allowed
invalid/expired authentication -> 401
```

Authority downgrade/revocation behavior follows the implemented authentication/token lifecycle and is covered by regression tests.

## Scope Boundaries

This PR does not add:

- Admin business CRUD
- domain-specific RBAC
- Admin promotion UI/API
- frontend Admin contract cutover
- Admin Audit Log
- Admin query/search/paging
- private-data Admin access
- content publication controls
- Economy repair operations

This is P0 security foundation only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account roles for regular users and administrators.
  * Administrators can access protected administrative features.
  * Access tokens now verify account status and reject revoked or inactive accounts.
  * Refresh requests reject inactive or unavailable accounts.
  * Added database migration for account authority, defaulting existing accounts to regular-user access.
* **Bug Fixes**
  * Missing player IDs no longer cause authentication errors.
  * Refresh tokens are no longer accepted as access tokens.
* **Tests**
  * Expanded coverage for role-based access, token validation, account status, and migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->