### PR TITLE
[Admin] Establish durable Admin Audit foundation

### DIFF
--- a/docs/contracts/admin/admin-audit-contract.md
+++ b/docs/contracts/admin/admin-audit-contract.md
@@ -1,0 +1,39 @@
+# Admin Audit foundation contract
+
+## Purpose
+
+`adminaudit` is the durable accountability capability for approved high-risk
+Admin commands. It is not gameplay history, an application/access log, or a
+business-domain event store.
+
+## Safe append fields
+
+The provider-owned `AdminAuditInternalApi` accepts only action, target
+type/id, reason, result, correlation ID, and an optional idempotency key.
+The authenticated account ID and occurrence time are server-owned.
+
+Audit records never contain raw JWT/token values, passwords, Journal or
+LifeLog bodies, Person private fields, Direct Chat messages, full
+request/response payloads, arbitrary entity serialization, or generic JSON
+metadata.
+
+## Transaction contract
+
+`append` requires an existing caller transaction. An approved high-risk
+command must perform its mutation and required audit append in that same
+transaction and must not swallow append failures. A missing transaction or
+failed audit persistence aborts the command transaction. Rolled-back attempts
+do not retain a misleading same-transaction audit row; separate failed-attempt
+auditing is outside this foundation.
+
+Reason is nullable at foundation level only. Unit E must make it mandatory
+where each high-risk command contract requires it and must supply its existing
+correlation/idempotency values without inventing global duplicate prevention.
+
+## Reader contract
+
+`GET /admin/v1/audit-events` is ADMIN-only and returns safe fields ordered by
+`occurredAt DESC, id DESC`. It supports actor, action, target type/id, result,
+correlation ID, an inclusive `from`, exclusive `to`, opaque cursor, and a
+server-bounded page size of 1-100. The response contains `items` and
+`nextCursor`; no unbounded listing or delete/update endpoint exists.

--- a/docs/contracts/admin/admin-audit-contract.md
+++ b/docs/contracts/admin/admin-audit-contract.md
@@ -10,19 +10,28 @@ business-domain event store.
 
 The provider-owned `AdminAuditInternalApi` accepts only action, target
 type/id, reason, result, correlation ID, and an optional idempotency key.
-The authenticated account ID and occurrence time are server-owned.
+The actor ID and occurrence time are server-owned. Append resolves the current
+authenticated account and rechecks persisted authorization; only an ACTIVE
+ADMIN account can be recorded as actor.
 
 Audit records never contain raw JWT/token values, passwords, Journal or
 LifeLog bodies, Person private fields, Direct Chat messages, full
 request/response payloads, arbitrary entity serialization, or generic JSON
 metadata.
 
+Reason remains a bounded free-form operational rationale because no global
+reason-code policy exists. A non-null reason is trimmed, limited to 512
+characters, and must be non-blank, single-line, and free of control characters.
+Callers must never copy source private content, credentials, or raw payloads
+into it.
+
 ## Transaction contract
 
 `append` requires an existing caller transaction. An approved high-risk
 command must perform its mutation and required audit append in that same
 transaction and must not swallow append failures. A missing transaction or
-failed audit persistence aborts the command transaction. Rolled-back attempts
+failed audit persistence or actor authorization aborts the command transaction.
+Rolled-back attempts
 do not retain a misleading same-transaction audit row; separate failed-attempt
 auditing is outside this foundation.
 

--- a/docs/contracts/admin/admin-v1-contract.md
+++ b/docs/contracts/admin/admin-v1-contract.md
@@ -11,15 +11,15 @@ This document freezes the backend-owned Admin contract inspected after PR #301. 
 
 ## Inventory scope
 
-The inspection covers all 23 production `api/admin` controllers, their class and method mappings, request/response DTOs, and called Query/Service owner.
+The inspection covers all 24 production Admin controllers, their class and method mappings, request/response DTOs, and called Query/Service owner.
 
-- Live mapped routes: 140
+- Live mapped routes: 141
 - Unmapped controller operations: 4
-- Total inventoried operations: 144
+- Total inventoried operations: 145
 
 | Classification | Count | Frontend rule |
 | --- | ---: | --- |
-| `SUPPORTED_READ` | 21 | `ALLOW` |
+| `SUPPORTED_READ` | 22 | `ALLOW` |
 | `SUPPORTED_COMMAND` | 12 | `ALLOW` |
 | `GATED_HIGH_RISK` | 38 | `GATE` |
 | `IMPLEMENTATION_GAP` | 2 | `GATE` or `DEFER` as recorded |
@@ -49,6 +49,15 @@ The other 36 mapped commands are `GATE`: destructive catalog deletion, direct pl
 - `AdminUserController.get` remains unmapped. Although `UserQueryService.getUserInfo(userId)` exists, `AdminUserWebMapper.toUserInfo()` currently returns placeholder null fields, so `GET /admin/v1/users/{userId}` is not safe to expose.
 - `changeStatus` and `forceChangeNickname` remain unmapped and `GATED_HIGH_RISK`. Do not map them before Admin Audit plus reason/idempotency/stale-command hardening.
 - `AdminUserSettingController.updateSettings` remains an unmapped private implementation gap.
+
+## Admin Audit read
+
+- `GET /admin/v1/audit-events` is the canonical safe metadata reader and is
+  `SUPPORTED_READ + ALLOW`.
+- Its durable append and transaction rules are defined in
+  [admin-audit-contract.md](admin-audit-contract.md).
+- Existing high-risk commands remain `GATED_HIGH_RISK + GATE` until Unit E
+  integrates reason, idempotency, stale/conflict handling, and audit append.
 
 ## Frontend migration rules
 

--- a/docs/contracts/admin/admin-v1-endpoints.csv
+++ b/docs/contracts/admin/admin-v1-endpoints.csv
@@ -1,4 +1,5 @@
 domain,controller,operation,http_method,path,request_type,response_type,classification,frontend_exposure,notes
+adminaudit,AdminAuditController,list,GET,/admin/v1/audit-events,query actorUserId action targetType targetId result correlationId from to cursor size,AdminAuditResponse.Page,SUPPORTED_READ,ALLOW,AdminAuditQueryService safe metadata only
 character,AdminAchievementController,create,POST,/admin/v1/achievements,AdminAchievementRequest.Create,AdminAchievementResponse.Info,SUPPORTED_COMMAND,ALLOW,AchievementService
 character,AdminAchievementController,list,GET,/admin/v1/achievements,query category[],AdminAchievementResponse.Infos,SUPPORTED_READ,ALLOW,AchievementService
 character,AdminAchievementController,get,GET,/admin/v1/achievements/{achievementId},-,AdminAchievementResponse.Info,SUPPORTED_READ,ALLOW,AchievementService

--- a/src/main/java/online/lifeasgame/adminaudit/api/AdminAuditController.java
+++ b/src/main/java/online/lifeasgame/adminaudit/api/AdminAuditController.java
@@ -1,0 +1,89 @@
+package online.lifeasgame.adminaudit.api;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.adminaudit.api.response.AdminAuditResponse;
+import online.lifeasgame.adminaudit.api.spec.AdminAuditApiSpecV1;
+import online.lifeasgame.adminaudit.application.AdminAuditQueryService;
+import online.lifeasgame.adminaudit.application.result.AdminAuditQueryResult;
+import online.lifeasgame.adminaudit.domain.AdminAuditResult;
+import online.lifeasgame.core.response.ApiResponse;
+import online.lifeasgame.platform.web.response.ApiResponses;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/v1/audit-events")
+public class AdminAuditController implements AdminAuditApiSpecV1 {
+
+    private final AdminAuditQueryService queryService;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResponse<AdminAuditResponse.Page>> list(
+            @RequestParam(required = false) @Positive Long actorUserId,
+            @RequestParam(required = false)
+            @Pattern(regexp = "[A-Z][A-Z0-9_]{2,63}") String action,
+            @RequestParam(required = false)
+            @Pattern(regexp = "[A-Z][A-Z0-9_]{2,63}") String targetType,
+            @RequestParam(required = false)
+            @Pattern(regexp = "[A-Za-z0-9][A-Za-z0-9._:-]{0,127}")
+            String targetId,
+            @RequestParam(required = false) AdminAuditResult result,
+            @RequestParam(required = false)
+            @Pattern(regexp = "[A-Za-z0-9][A-Za-z0-9._:-]{0,99}")
+            String correlationId,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to,
+            @RequestParam(required = false) @Size(min = 1, max = 256)
+            String cursor,
+            @RequestParam(defaultValue = "50") @Min(1) @Max(100) int size
+    ) {
+        AdminAuditQueryResult.Page page = queryService.list(
+                actorUserId,
+                action,
+                targetType,
+                targetId,
+                result,
+                correlationId,
+                from,
+                to,
+                cursor,
+                size
+        );
+        return ApiResponses.ok(new AdminAuditResponse.Page(
+                page.items().stream().map(AdminAuditController::toResponse).toList(),
+                page.nextCursor()
+        ));
+    }
+
+    private static AdminAuditResponse.Item toResponse(
+            AdminAuditQueryResult.Item item
+    ) {
+        return new AdminAuditResponse.Item(
+                item.id(),
+                item.actorUserId(),
+                item.action(),
+                item.targetType(),
+                item.targetId(),
+                item.reason(),
+                item.result(),
+                item.correlationId(),
+                item.idempotencyKey(),
+                item.occurredAt()
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/adminaudit/api/response/AdminAuditResponse.java
+++ b/src/main/java/online/lifeasgame/adminaudit/api/response/AdminAuditResponse.java
@@ -1,0 +1,27 @@
+package online.lifeasgame.adminaudit.api.response;
+
+import java.time.Instant;
+import java.util.List;
+
+public final class AdminAuditResponse {
+
+    private AdminAuditResponse() {
+    }
+
+    public record Page(List<Item> items, String nextCursor) {
+    }
+
+    public record Item(
+            Long id,
+            Long actorUserId,
+            String action,
+            String targetType,
+            String targetId,
+            String reason,
+            String result,
+            String correlationId,
+            String idempotencyKey,
+            Instant occurredAt
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/adminaudit/api/spec/AdminAuditApiSpecV1.java
+++ b/src/main/java/online/lifeasgame/adminaudit/api/spec/AdminAuditApiSpecV1.java
@@ -1,0 +1,44 @@
+package online.lifeasgame.adminaudit.api.spec;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import online.lifeasgame.adminaudit.api.response.AdminAuditResponse;
+import online.lifeasgame.adminaudit.domain.AdminAuditResult;
+import online.lifeasgame.core.response.ApiResponse;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.Instant;
+
+@Tag(name = "Admin Audit API V1")
+public interface AdminAuditApiSpecV1 {
+
+    @Operation(summary = "Admin audit event 목록 조회")
+    ResponseEntity<ApiResponse<AdminAuditResponse.Page>> list(
+            @RequestParam(required = false) @Positive Long actorUserId,
+            @RequestParam(required = false)
+            @Pattern(regexp = "[A-Z][A-Z0-9_]{2,63}") String action,
+            @RequestParam(required = false)
+            @Pattern(regexp = "[A-Z][A-Z0-9_]{2,63}") String targetType,
+            @RequestParam(required = false)
+            @Pattern(regexp = "[A-Za-z0-9][A-Za-z0-9._:-]{0,127}")
+            String targetId,
+            @RequestParam(required = false) AdminAuditResult result,
+            @RequestParam(required = false)
+            @Pattern(regexp = "[A-Za-z0-9][A-Za-z0-9._:-]{0,99}")
+            String correlationId,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to,
+            @RequestParam(required = false) @Size(min = 1, max = 256)
+            String cursor,
+            @RequestParam(defaultValue = "50") @Min(1) @Max(100) int size
+    );
+}

--- a/src/main/java/online/lifeasgame/adminaudit/application/AdminAuditAppender.java
+++ b/src/main/java/online/lifeasgame/adminaudit/application/AdminAuditAppender.java
@@ -1,0 +1,42 @@
+package online.lifeasgame.adminaudit.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.adminaudit.application.internal.AdminAuditInternalApi;
+import online.lifeasgame.adminaudit.domain.AdminAuditEvent;
+import online.lifeasgame.adminaudit.domain.repository.AdminAuditEventRepository;
+import online.lifeasgame.core.security.CurrentUserAccessor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class AdminAuditAppender implements AdminAuditInternalApi {
+
+    private final AdminAuditEventRepository repository;
+    private final CurrentUserAccessor currentUserAccessor;
+    private final Clock clock;
+
+    @Override
+    @Transactional(propagation = Propagation.MANDATORY)
+    public AppendResult append(AppendCommand command) {
+        Objects.requireNonNull(command, "command must not be null");
+        Instant occurredAt = Instant.now(clock);
+        AdminAuditEvent event = repository.append(AdminAuditEvent.record(
+                currentUserAccessor.currentUserIdOrThrow(),
+                command.action(),
+                command.targetType(),
+                command.targetId(),
+                command.reason(),
+                command.result(),
+                command.correlationId(),
+                command.idempotencyKey(),
+                occurredAt
+        ));
+        return new AppendResult(event.getId(), occurredAt);
+    }
+}

--- a/src/main/java/online/lifeasgame/adminaudit/application/AdminAuditAppender.java
+++ b/src/main/java/online/lifeasgame/adminaudit/application/AdminAuditAppender.java
@@ -4,7 +4,10 @@ import lombok.RequiredArgsConstructor;
 import online.lifeasgame.adminaudit.application.internal.AdminAuditInternalApi;
 import online.lifeasgame.adminaudit.domain.AdminAuditEvent;
 import online.lifeasgame.adminaudit.domain.repository.AdminAuditEventRepository;
+import online.lifeasgame.core.error.AuthException;
+import online.lifeasgame.core.error.api.AuthError;
 import online.lifeasgame.core.security.CurrentUserAccessor;
+import online.lifeasgame.user.application.internal.UserAuthApi;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +22,7 @@ public class AdminAuditAppender implements AdminAuditInternalApi {
 
     private final AdminAuditEventRepository repository;
     private final CurrentUserAccessor currentUserAccessor;
+    private final UserAuthApi userAuthApi;
     private final Clock clock;
 
     @Override
@@ -27,7 +31,7 @@ public class AdminAuditAppender implements AdminAuditInternalApi {
         Objects.requireNonNull(command, "command must not be null");
         Instant occurredAt = Instant.now(clock);
         AdminAuditEvent event = repository.append(AdminAuditEvent.record(
-                currentUserAccessor.currentUserIdOrThrow(),
+                currentAdminId(),
                 command.action(),
                 command.targetType(),
                 command.targetId(),
@@ -38,5 +42,14 @@ public class AdminAuditAppender implements AdminAuditInternalApi {
                 occurredAt
         ));
         return new AppendResult(event.getId(), occurredAt);
+    }
+
+    private Long currentAdminId() {
+        Long userId = currentUserAccessor.currentUserIdOrThrow();
+        return userAuthApi.resolveAuthorization(userId)
+                .filter(UserAuthApi.AccountAuthorization::active)
+                .filter(UserAuthApi.AccountAuthorization::admin)
+                .map(authorization -> userId)
+                .orElseThrow(() -> new AuthException(AuthError.FORBIDDEN));
     }
 }

--- a/src/main/java/online/lifeasgame/adminaudit/application/AdminAuditCursor.java
+++ b/src/main/java/online/lifeasgame/adminaudit/application/AdminAuditCursor.java
@@ -1,0 +1,50 @@
+package online.lifeasgame.adminaudit.application;
+
+import online.lifeasgame.adminaudit.application.query.AdminAuditEventQuery;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.Base64;
+
+final class AdminAuditCursor {
+
+    private AdminAuditCursor() {
+    }
+
+    static String encode(Instant occurredAt, Long id) {
+        String value = occurredAt + "|" + id;
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(
+                value.getBytes(StandardCharsets.UTF_8)
+        );
+    }
+
+    static AdminAuditEventQuery.Cursor decode(String cursor) {
+        if (cursor == null) {
+            return null;
+        }
+        try {
+            String value = new String(
+                    Base64.getUrlDecoder().decode(cursor),
+                    StandardCharsets.UTF_8
+            );
+            int separator = value.lastIndexOf('|');
+            if (separator <= 0 || separator == value.length() - 1) {
+                throw new IllegalArgumentException("Invalid audit cursor");
+            }
+            Instant occurredAt = Instant.parse(value.substring(0, separator));
+            long id = Long.parseLong(value.substring(separator + 1));
+            if (id <= 0) {
+                throw new IllegalArgumentException("Invalid audit cursor");
+            }
+            return new AdminAuditEventQuery.Cursor(occurredAt, id);
+        } catch (DateTimeParseException | NumberFormatException exception) {
+            throw new IllegalArgumentException("Invalid audit cursor", exception);
+        } catch (IllegalArgumentException exception) {
+            if ("Invalid audit cursor".equals(exception.getMessage())) {
+                throw exception;
+            }
+            throw new IllegalArgumentException("Invalid audit cursor", exception);
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/adminaudit/application/AdminAuditQueryService.java
+++ b/src/main/java/online/lifeasgame/adminaudit/application/AdminAuditQueryService.java
@@ -1,0 +1,92 @@
+package online.lifeasgame.adminaudit.application;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.adminaudit.application.query.AdminAuditEventQuery;
+import online.lifeasgame.adminaudit.application.result.AdminAuditQueryResult;
+import online.lifeasgame.adminaudit.domain.AdminAuditAction;
+import online.lifeasgame.adminaudit.domain.AdminAuditResult;
+import online.lifeasgame.adminaudit.domain.AdminAuditTargetType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminAuditQueryService {
+
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private final AdminAuditEventQuery query;
+
+    public AdminAuditQueryResult.Page list(
+            Long actorUserId,
+            String action,
+            String targetType,
+            String targetId,
+            AdminAuditResult result,
+            String correlationId,
+            Instant from,
+            Instant to,
+            String cursor,
+            int size
+    ) {
+        validate(size, from, to);
+        List<AdminAuditEventQuery.Row> rows = query.find(
+                new AdminAuditEventQuery.Filter(
+                        actorUserId,
+                        action == null ? null : new AdminAuditAction(action),
+                        targetType == null
+                                ? null
+                                : new AdminAuditTargetType(targetType),
+                        targetId,
+                        result,
+                        correlationId,
+                        from,
+                        to,
+                        AdminAuditCursor.decode(cursor)
+                ),
+                size + 1
+        );
+        boolean hasMore = rows.size() > size;
+        List<AdminAuditQueryResult.Item> items = rows.stream()
+                .limit(size)
+                .map(AdminAuditQueryService::toItem)
+                .toList();
+        String nextCursor = hasMore && !items.isEmpty()
+                ? AdminAuditCursor.encode(
+                        items.getLast().occurredAt(),
+                        items.getLast().id()
+                )
+                : null;
+        return new AdminAuditQueryResult.Page(items, nextCursor);
+    }
+
+    private static void validate(int size, Instant from, Instant to) {
+        if (size < 1 || size > MAX_PAGE_SIZE) {
+            throw new IllegalArgumentException("size must be between 1 and 100");
+        }
+        if (from != null && to != null && !from.isBefore(to)) {
+            throw new IllegalArgumentException("from must be before to");
+        }
+    }
+
+    private static AdminAuditQueryResult.Item toItem(
+            AdminAuditEventQuery.Row row
+    ) {
+        return new AdminAuditQueryResult.Item(
+                row.id(),
+                row.actorUserId(),
+                row.action(),
+                row.targetType(),
+                row.targetId(),
+                row.reason(),
+                row.result().name(),
+                row.correlationId(),
+                row.idempotencyKey(),
+                row.occurredAt()
+        );
+    }
+}

--- a/src/main/java/online/lifeasgame/adminaudit/application/internal/AdminAuditInternalApi.java
+++ b/src/main/java/online/lifeasgame/adminaudit/application/internal/AdminAuditInternalApi.java
@@ -1,0 +1,34 @@
+package online.lifeasgame.adminaudit.application.internal;
+
+import online.lifeasgame.adminaudit.domain.AdminAuditAction;
+import online.lifeasgame.adminaudit.domain.AdminAuditResult;
+import online.lifeasgame.adminaudit.domain.AdminAuditTargetType;
+
+import java.time.Instant;
+
+/**
+ * Required Admin accountability boundary for high-risk commands.
+ *
+ * <p>Callers must invoke {@link #append(AppendCommand)} inside the same
+ * transaction as the successful business mutation and let every append
+ * exception propagate. Reason is nullable only for this foundation; Unit E
+ * must require it for each approved high-risk command.</p>
+ */
+public interface AdminAuditInternalApi {
+
+    AppendResult append(AppendCommand command);
+
+    record AppendCommand(
+            AdminAuditAction action,
+            AdminAuditTargetType targetType,
+            String targetId,
+            String reason,
+            AdminAuditResult result,
+            String correlationId,
+            String idempotencyKey
+    ) {
+    }
+
+    record AppendResult(Long auditEventId, Instant occurredAt) {
+    }
+}

--- a/src/main/java/online/lifeasgame/adminaudit/application/internal/AdminAuditInternalApi.java
+++ b/src/main/java/online/lifeasgame/adminaudit/application/internal/AdminAuditInternalApi.java
@@ -11,8 +11,11 @@ import java.time.Instant;
  *
  * <p>Callers must invoke {@link #append(AppendCommand)} inside the same
  * transaction as the successful business mutation and let every append
- * exception propagate. Reason is nullable only for this foundation; Unit E
- * must require it for each approved high-risk command.</p>
+ * exception propagate. The implementation resolves the actor from the current
+ * authenticated ACTIVE ADMIN account; callers cannot supply an actor ID.
+ * Reason is nullable only for this foundation; Unit E must require it for each
+ * approved high-risk command. Callers must pass only a bounded operational
+ * rationale and never source private content, credentials, or raw payloads.</p>
  */
 public interface AdminAuditInternalApi {
 

--- a/src/main/java/online/lifeasgame/adminaudit/application/query/AdminAuditEventQuery.java
+++ b/src/main/java/online/lifeasgame/adminaudit/application/query/AdminAuditEventQuery.java
@@ -1,0 +1,43 @@
+package online.lifeasgame.adminaudit.application.query;
+
+import online.lifeasgame.adminaudit.domain.AdminAuditAction;
+import online.lifeasgame.adminaudit.domain.AdminAuditResult;
+import online.lifeasgame.adminaudit.domain.AdminAuditTargetType;
+
+import java.time.Instant;
+import java.util.List;
+
+public interface AdminAuditEventQuery {
+
+    List<Row> find(Filter filter, int limit);
+
+    record Filter(
+            Long actorUserId,
+            AdminAuditAction action,
+            AdminAuditTargetType targetType,
+            String targetId,
+            AdminAuditResult result,
+            String correlationId,
+            Instant from,
+            Instant to,
+            Cursor cursor
+    ) {
+    }
+
+    record Cursor(Instant occurredAt, Long id) {
+    }
+
+    record Row(
+            Long id,
+            Long actorUserId,
+            String action,
+            String targetType,
+            String targetId,
+            String reason,
+            AdminAuditResult result,
+            String correlationId,
+            String idempotencyKey,
+            Instant occurredAt
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/adminaudit/application/result/AdminAuditQueryResult.java
+++ b/src/main/java/online/lifeasgame/adminaudit/application/result/AdminAuditQueryResult.java
@@ -1,0 +1,27 @@
+package online.lifeasgame.adminaudit.application.result;
+
+import java.time.Instant;
+import java.util.List;
+
+public final class AdminAuditQueryResult {
+
+    private AdminAuditQueryResult() {
+    }
+
+    public record Page(List<Item> items, String nextCursor) {
+    }
+
+    public record Item(
+            Long id,
+            Long actorUserId,
+            String action,
+            String targetType,
+            String targetId,
+            String reason,
+            String result,
+            String correlationId,
+            String idempotencyKey,
+            Instant occurredAt
+    ) {
+    }
+}

--- a/src/main/java/online/lifeasgame/adminaudit/domain/AdminAuditAction.java
+++ b/src/main/java/online/lifeasgame/adminaudit/domain/AdminAuditAction.java
@@ -1,0 +1,18 @@
+package online.lifeasgame.adminaudit.domain;
+
+import java.util.regex.Pattern;
+
+public record AdminAuditAction(String value) {
+
+    private static final Pattern FORMAT = Pattern.compile(
+            "[A-Z][A-Z0-9_]{2,63}"
+    );
+
+    public AdminAuditAction {
+        if (value == null || !FORMAT.matcher(value).matches()) {
+            throw new IllegalArgumentException(
+                    "Admin audit action must be a 3-64 character uppercase code"
+            );
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/adminaudit/domain/AdminAuditEvent.java
+++ b/src/main/java/online/lifeasgame/adminaudit/domain/AdminAuditEvent.java
@@ -81,7 +81,7 @@ public class AdminAuditEvent {
                 "targetType"
         ).value();
         event.targetId = requireIdentifier(targetId, "targetId", 128);
-        event.reason = optionalText(reason, "reason", 512);
+        event.reason = optionalReason(reason);
         event.result = Objects.requireNonNull(result, "result");
         event.correlationId = requireIdentifier(
                 correlationId,
@@ -106,11 +106,23 @@ public class AdminAuditEvent {
         return value;
     }
 
-    private static String optionalText(String value, String field, int max) {
+    private static String optionalReason(String value) {
         if (value == null) {
             return null;
         }
-        return requireText(value, field, max);
+        if (value.codePoints().anyMatch(AdminAuditEvent::isUnsafeReasonCharacter)) {
+            throw new IllegalArgumentException(
+                    "reason must be a single-line operational rationale"
+            );
+        }
+        return requireText(value.strip(), "reason", 512);
+    }
+
+    private static boolean isUnsafeReasonCharacter(int value) {
+        int type = Character.getType(value);
+        return Character.isISOControl(value)
+                || type == Character.LINE_SEPARATOR
+                || type == Character.PARAGRAPH_SEPARATOR;
     }
 
     private static String requireIdentifier(

--- a/src/main/java/online/lifeasgame/adminaudit/domain/AdminAuditEvent.java
+++ b/src/main/java/online/lifeasgame/adminaudit/domain/AdminAuditEvent.java
@@ -1,0 +1,135 @@
+package online.lifeasgame.adminaudit.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+@Getter
+@Entity
+@Table(name = "admin_audit_events")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AdminAuditEvent {
+
+    private static final Pattern SAFE_IDENTIFIER = Pattern.compile(
+            "[A-Za-z0-9][A-Za-z0-9._:-]*"
+    );
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "actor_user_id", nullable = false)
+    private Long actorUserId;
+
+    @Column(nullable = false, length = 64)
+    private String action;
+
+    @Column(name = "target_type", nullable = false, length = 64)
+    private String targetType;
+
+    @Column(name = "target_id", nullable = false, length = 128)
+    private String targetId;
+
+    @Column(length = 512)
+    private String reason;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private AdminAuditResult result;
+
+    @Column(name = "correlation_id", nullable = false, length = 100)
+    private String correlationId;
+
+    @Column(name = "idempotency_key", length = 128)
+    private String idempotencyKey;
+
+    @Column(name = "occurred_at", nullable = false)
+    private Instant occurredAt;
+
+    public static AdminAuditEvent record(
+            Long actorUserId,
+            AdminAuditAction action,
+            AdminAuditTargetType targetType,
+            String targetId,
+            String reason,
+            AdminAuditResult result,
+            String correlationId,
+            String idempotencyKey,
+            Instant occurredAt
+    ) {
+        if (actorUserId == null || actorUserId <= 0) {
+            throw new IllegalArgumentException("actorUserId must be positive");
+        }
+
+        AdminAuditEvent event = new AdminAuditEvent();
+        event.actorUserId = actorUserId;
+        event.action = Objects.requireNonNull(action, "action").value();
+        event.targetType = Objects.requireNonNull(
+                targetType,
+                "targetType"
+        ).value();
+        event.targetId = requireIdentifier(targetId, "targetId", 128);
+        event.reason = optionalText(reason, "reason", 512);
+        event.result = Objects.requireNonNull(result, "result");
+        event.correlationId = requireIdentifier(
+                correlationId,
+                "correlationId",
+                100
+        );
+        event.idempotencyKey = optionalIdentifier(
+                idempotencyKey,
+                "idempotencyKey",
+                128
+        );
+        event.occurredAt = Objects.requireNonNull(occurredAt, "occurredAt");
+        return event;
+    }
+
+    private static String requireText(String value, String field, int max) {
+        if (value == null || value.isBlank() || value.length() > max) {
+            throw new IllegalArgumentException(
+                    field + " must contain 1-" + max + " characters"
+            );
+        }
+        return value;
+    }
+
+    private static String optionalText(String value, String field, int max) {
+        if (value == null) {
+            return null;
+        }
+        return requireText(value, field, max);
+    }
+
+    private static String requireIdentifier(
+            String value,
+            String field,
+            int max
+    ) {
+        String validated = requireText(value, field, max);
+        if (!SAFE_IDENTIFIER.matcher(validated).matches()) {
+            throw new IllegalArgumentException(field + " has an unsafe format");
+        }
+        return validated;
+    }
+
+    private static String optionalIdentifier(
+            String value,
+            String field,
+            int max
+    ) {
+        return value == null ? null : requireIdentifier(value, field, max);
+    }
+}

--- a/src/main/java/online/lifeasgame/adminaudit/domain/AdminAuditResult.java
+++ b/src/main/java/online/lifeasgame/adminaudit/domain/AdminAuditResult.java
@@ -1,0 +1,6 @@
+package online.lifeasgame.adminaudit.domain;
+
+public enum AdminAuditResult {
+    SUCCESS,
+    FAILED
+}

--- a/src/main/java/online/lifeasgame/adminaudit/domain/AdminAuditTargetType.java
+++ b/src/main/java/online/lifeasgame/adminaudit/domain/AdminAuditTargetType.java
@@ -1,0 +1,18 @@
+package online.lifeasgame.adminaudit.domain;
+
+import java.util.regex.Pattern;
+
+public record AdminAuditTargetType(String value) {
+
+    private static final Pattern FORMAT = Pattern.compile(
+            "[A-Z][A-Z0-9_]{2,63}"
+    );
+
+    public AdminAuditTargetType {
+        if (value == null || !FORMAT.matcher(value).matches()) {
+            throw new IllegalArgumentException(
+                    "Admin audit target type must be a 3-64 character uppercase code"
+            );
+        }
+    }
+}

--- a/src/main/java/online/lifeasgame/adminaudit/domain/repository/AdminAuditEventRepository.java
+++ b/src/main/java/online/lifeasgame/adminaudit/domain/repository/AdminAuditEventRepository.java
@@ -1,0 +1,8 @@
+package online.lifeasgame.adminaudit.domain.repository;
+
+import online.lifeasgame.adminaudit.domain.AdminAuditEvent;
+
+public interface AdminAuditEventRepository {
+
+    AdminAuditEvent append(AdminAuditEvent event);
+}

--- a/src/main/java/online/lifeasgame/adminaudit/infra/AdminAuditEventQueryAdapter.java
+++ b/src/main/java/online/lifeasgame/adminaudit/infra/AdminAuditEventQueryAdapter.java
@@ -1,0 +1,110 @@
+package online.lifeasgame.adminaudit.infra;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.adminaudit.application.query.AdminAuditEventQuery;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+
+import static online.lifeasgame.adminaudit.domain.QAdminAuditEvent.adminAuditEvent;
+
+@Repository
+@RequiredArgsConstructor
+class AdminAuditEventQueryAdapter implements AdminAuditEventQuery {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Row> find(Filter filter, int limit) {
+        return queryFactory
+                .select(com.querydsl.core.types.Projections.constructor(
+                        Row.class,
+                        adminAuditEvent.id,
+                        adminAuditEvent.actorUserId,
+                        adminAuditEvent.action,
+                        adminAuditEvent.targetType,
+                        adminAuditEvent.targetId,
+                        adminAuditEvent.reason,
+                        adminAuditEvent.result,
+                        adminAuditEvent.correlationId,
+                        adminAuditEvent.idempotencyKey,
+                        adminAuditEvent.occurredAt
+                ))
+                .from(adminAuditEvent)
+                .where(
+                        actorEq(filter),
+                        actionEq(filter),
+                        targetTypeEq(filter),
+                        targetIdEq(filter),
+                        resultEq(filter),
+                        correlationEq(filter),
+                        occurredAtFrom(filter.from()),
+                        occurredAtBefore(filter.to()),
+                        beforeCursor(filter.cursor())
+                )
+                .orderBy(
+                        adminAuditEvent.occurredAt.desc(),
+                        adminAuditEvent.id.desc()
+                )
+                .limit(limit)
+                .fetch();
+    }
+
+    private BooleanExpression actorEq(Filter filter) {
+        return filter.actorUserId() == null
+                ? null
+                : adminAuditEvent.actorUserId.eq(filter.actorUserId());
+    }
+
+    private BooleanExpression actionEq(Filter filter) {
+        return filter.action() == null
+                ? null
+                : adminAuditEvent.action.eq(filter.action().value());
+    }
+
+    private BooleanExpression targetTypeEq(Filter filter) {
+        return filter.targetType() == null
+                ? null
+                : adminAuditEvent.targetType.eq(filter.targetType().value());
+    }
+
+    private BooleanExpression targetIdEq(Filter filter) {
+        return filter.targetId() == null
+                ? null
+                : adminAuditEvent.targetId.eq(filter.targetId());
+    }
+
+    private BooleanExpression resultEq(Filter filter) {
+        return filter.result() == null
+                ? null
+                : adminAuditEvent.result.eq(filter.result());
+    }
+
+    private BooleanExpression correlationEq(Filter filter) {
+        return filter.correlationId() == null
+                ? null
+                : adminAuditEvent.correlationId.eq(filter.correlationId());
+    }
+
+    private BooleanExpression occurredAtFrom(Instant from) {
+        return from == null ? null : adminAuditEvent.occurredAt.goe(from);
+    }
+
+    private BooleanExpression occurredAtBefore(Instant to) {
+        return to == null ? null : adminAuditEvent.occurredAt.lt(to);
+    }
+
+    private BooleanBuilder beforeCursor(Cursor cursor) {
+        if (cursor == null) {
+            return null;
+        }
+        return new BooleanBuilder()
+                .and(adminAuditEvent.occurredAt.lt(cursor.occurredAt()))
+                .or(adminAuditEvent.occurredAt.eq(cursor.occurredAt())
+                        .and(adminAuditEvent.id.lt(cursor.id())));
+    }
+}

--- a/src/main/java/online/lifeasgame/adminaudit/infra/AdminAuditEventRepositoryAdapter.java
+++ b/src/main/java/online/lifeasgame/adminaudit/infra/AdminAuditEventRepositoryAdapter.java
@@ -1,0 +1,18 @@
+package online.lifeasgame.adminaudit.infra;
+
+import lombok.RequiredArgsConstructor;
+import online.lifeasgame.adminaudit.domain.AdminAuditEvent;
+import online.lifeasgame.adminaudit.domain.repository.AdminAuditEventRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+class AdminAuditEventRepositoryAdapter implements AdminAuditEventRepository {
+
+    private final JpaAdminAuditEventRepository jpa;
+
+    @Override
+    public AdminAuditEvent append(AdminAuditEvent event) {
+        return jpa.saveAndFlush(event);
+    }
+}

--- a/src/main/java/online/lifeasgame/adminaudit/infra/JpaAdminAuditEventRepository.java
+++ b/src/main/java/online/lifeasgame/adminaudit/infra/JpaAdminAuditEventRepository.java
@@ -1,0 +1,8 @@
+package online.lifeasgame.adminaudit.infra;
+
+import online.lifeasgame.adminaudit.domain.AdminAuditEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface JpaAdminAuditEventRepository
+        extends JpaRepository<AdminAuditEvent, Long> {
+}

--- a/src/main/resources/db/migration/V30__admin_audit_foundation.sql
+++ b/src/main/resources/db/migration/V30__admin_audit_foundation.sql
@@ -1,0 +1,33 @@
+CREATE TABLE admin_audit_events (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    actor_user_id BIGINT NOT NULL,
+    action VARCHAR(64) NOT NULL,
+    target_type VARCHAR(64) NOT NULL,
+    target_id VARCHAR(128) NOT NULL,
+    reason VARCHAR(512),
+    result VARCHAR(16) NOT NULL,
+    correlation_id VARCHAR(100) NOT NULL,
+    idempotency_key VARCHAR(128),
+    occurred_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_admin_audit_actor
+        FOREIGN KEY (actor_user_id) REFERENCES users (id),
+    CONSTRAINT ck_admin_audit_action
+        CHECK (action REGEXP '^[A-Z][A-Z0-9_]{2,63}$'),
+    CONSTRAINT ck_admin_audit_target_type
+        CHECK (target_type REGEXP '^[A-Z][A-Z0-9_]{2,63}$'),
+    CONSTRAINT ck_admin_audit_result
+        CHECK (result IN ('SUCCESS', 'FAILED')),
+    INDEX idx_admin_audit_actor_time
+        (actor_user_id, occurred_at DESC, id DESC),
+    INDEX idx_admin_audit_target_time
+        (target_type, target_id, occurred_at DESC, id DESC),
+    INDEX idx_admin_audit_action_time
+        (action, occurred_at DESC, id DESC),
+    INDEX idx_admin_audit_result_time
+        (result, occurred_at DESC, id DESC),
+    INDEX idx_admin_audit_correlation (correlation_id),
+    INDEX idx_admin_audit_time (occurred_at DESC, id DESC)
+) ENGINE=InnoDB
+  DEFAULT CHARSET=utf8mb4
+  COLLATE=utf8mb4_0900_ai_ci;

--- a/src/test/java/online/lifeasgame/adminaudit/api/AdminAuditControllerSecurityTest.java
+++ b/src/test/java/online/lifeasgame/adminaudit/api/AdminAuditControllerSecurityTest.java
@@ -1,0 +1,152 @@
+package online.lifeasgame.adminaudit.api;
+
+import online.lifeasgame.adminaudit.application.AdminAuditQueryService;
+import online.lifeasgame.adminaudit.application.result.AdminAuditQueryResult;
+import online.lifeasgame.platform.security.jwt.JwtProperties;
+import online.lifeasgame.platform.security.jwt.JwtProvider;
+import online.lifeasgame.platform.web.error.docs.ErrorDocLinker;
+import online.lifeasgame.support.WebMvcTestConfig;
+import online.lifeasgame.system.bootstrap.error.handler.AppErrorProperties;
+import online.lifeasgame.system.bootstrap.security.SecurityConfig;
+import online.lifeasgame.user.application.internal.UserAuthApi;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminAuditController.class)
+@ActiveProfiles("test")
+@Import({
+        SecurityConfig.class,
+        WebMvcTestConfig.class,
+        AdminAuditControllerSecurityTest.JwtTestConfig.class
+})
+@DisplayName("Admin Audit controller security")
+class AdminAuditControllerSecurityTest {
+
+    private static final long USER_ID = 30401L;
+    private static final long ADMIN_ID = 30402L;
+    private static final String SECRET =
+            "admin-audit-test-secret-at-least-32-characters";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private UserAuthApi userAuthApi;
+
+    @MockitoBean
+    private AdminAuditQueryService queryService;
+
+    @MockitoBean
+    private AppErrorProperties appErrorProperties;
+
+    @MockitoBean
+    private ErrorDocLinker errorDocLinker;
+
+    @BeforeEach
+    void setUp() {
+        given(queryService.list(
+                null, null, null, null, null,
+                null, null, null, null, 50
+        )).willReturn(new AdminAuditQueryResult.Page(
+                List.of(new AdminAuditQueryResult.Item(
+                        1L,
+                        ADMIN_ID,
+                        "USER_STATUS_CHANGE",
+                        "USER",
+                        "42",
+                        "CASE-304",
+                        "SUCCESS",
+                        "request-304",
+                        null,
+                        Instant.parse("2026-08-24T03:04:05Z")
+                )),
+                null
+        ));
+    }
+
+    @Test
+    @DisplayName("persisted USER authority는 403이다")
+    void rejectsUser() throws Exception {
+        given(userAuthApi.resolveAuthorization(USER_ID)).willReturn(
+                Optional.of(new UserAuthApi.AccountAuthorization(true, false))
+        );
+
+        mockMvc.perform(get("/admin/v1/audit-events")
+                        .header("Authorization", bearer(USER_ID)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("persisted ADMIN authority는 safe audit page를 조회한다")
+    void allowsAdmin() throws Exception {
+        given(userAuthApi.resolveAuthorization(ADMIN_ID)).willReturn(
+                Optional.of(new UserAuthApi.AccountAuthorization(true, true))
+        );
+
+        mockMvc.perform(get("/admin/v1/audit-events")
+                        .header("Authorization", bearer(ADMIN_ID)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.items[0].actorUserId")
+                        .value(ADMIN_ID))
+                .andExpect(jsonPath("$.result.items[0].action")
+                        .value("USER_STATUS_CHANGE"))
+                .andExpect(jsonPath("$.result.items[0].targetId")
+                        .value("42"))
+                .andExpect(jsonPath("$.result.items[0].correlationId")
+                        .value("request-304"));
+    }
+
+    @Test
+    @DisplayName("/api/v1/admin alias는 존재하지 않는다")
+    void hasNoApiV1AdminAlias() throws Exception {
+        given(userAuthApi.resolveAuthorization(ADMIN_ID)).willReturn(
+                Optional.of(new UserAuthApi.AccountAuthorization(true, true))
+        );
+
+        mockMvc.perform(get("/api/v1/admin/audit-events")
+                        .header("Authorization", bearer(ADMIN_ID)))
+                .andExpect(status().isNotFound());
+    }
+
+    private String bearer(long userId) {
+        return "Bearer " + jwtProvider.createAccessToken(userId, null);
+    }
+
+    private static JwtProvider provider() {
+        JwtProperties properties = new JwtProperties();
+        properties.setSecret(SECRET);
+        properties.setAccessTokenExpiryMs(3_600_000L);
+        properties.setRefreshTokenExpiryMs(604_800_000L);
+        return new JwtProvider(properties);
+    }
+
+    @TestConfiguration
+    static class JwtTestConfig {
+
+        @Bean
+        JwtProvider jwtProvider() {
+            return provider();
+        }
+    }
+}

--- a/src/test/java/online/lifeasgame/adminaudit/application/AdminAuditFoundationTest.java
+++ b/src/test/java/online/lifeasgame/adminaudit/application/AdminAuditFoundationTest.java
@@ -85,6 +85,34 @@ class AdminAuditFoundationTest {
     }
 
     @Nested
+    @DisplayName("operator reason을 기록할 때")
+    class Reason {
+
+        @Test
+        @DisplayName("주변 공백을 제거한 bounded operational rationale를 저장한다")
+        void normalizes() {
+            AdminAuditEvent event = event(
+                    "  Balance correction approved for support case CASE-1234  "
+            );
+
+            assertThat(event.getReason()).isEqualTo(
+                    "Balance correction approved for support case CASE-1234"
+            );
+        }
+
+        @Test
+        @DisplayName("blank control character와 multiline payload를 거부한다")
+        void rejectsUnsafeStructure() {
+            assertThatThrownBy(() -> event("   "))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> event("case\u0000payload"))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> event("case-1\nraw body"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
     @DisplayName("audit event 목록을 조회할 때")
     class ListEvents {
 
@@ -151,6 +179,20 @@ class AdminAuditFoundationTest {
                 "USER",
                 "42",
                 "CASE-304",
+                AdminAuditResult.SUCCESS,
+                "request-304",
+                null,
+                OCCURRED_AT
+        );
+    }
+
+    private AdminAuditEvent event(String reason) {
+        return AdminAuditEvent.record(
+                304L,
+                new AdminAuditAction("USER_STATUS_CHANGE"),
+                new AdminAuditTargetType("USER"),
+                "42",
+                reason,
                 AdminAuditResult.SUCCESS,
                 "request-304",
                 null,

--- a/src/test/java/online/lifeasgame/adminaudit/application/AdminAuditFoundationTest.java
+++ b/src/test/java/online/lifeasgame/adminaudit/application/AdminAuditFoundationTest.java
@@ -1,0 +1,160 @@
+package online.lifeasgame.adminaudit.application;
+
+import online.lifeasgame.adminaudit.application.query.AdminAuditEventQuery;
+import online.lifeasgame.adminaudit.application.result.AdminAuditQueryResult;
+import online.lifeasgame.adminaudit.domain.AdminAuditAction;
+import online.lifeasgame.adminaudit.domain.AdminAuditEvent;
+import online.lifeasgame.adminaudit.domain.AdminAuditResult;
+import online.lifeasgame.adminaudit.domain.AdminAuditTargetType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Admin Audit foundation")
+class AdminAuditFoundationTest {
+
+    private static final Instant OCCURRED_AT =
+            Instant.parse("2026-08-24T03:04:05.123456Z");
+
+    @Mock
+    private AdminAuditEventQuery query;
+
+    @Nested
+    @DisplayName("action과 target type을 만들 때")
+    class Codes {
+
+        @Test
+        @DisplayName("bounded uppercase code만 허용한다")
+        void validatesCodes() {
+            assertThat(new AdminAuditAction("USER_STATUS_CHANGE").value())
+                    .isEqualTo("USER_STATUS_CHANGE");
+            assertThat(new AdminAuditTargetType("USER").value())
+                    .isEqualTo("USER");
+            assertThatThrownBy(() -> new AdminAuditAction("user.change"))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> new AdminAuditTargetType("U"))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> AdminAuditEvent.record(
+                    304L,
+                    new AdminAuditAction("USER_STATUS_CHANGE"),
+                    new AdminAuditTargetType("USER"),
+                    "42",
+                    null,
+                    AdminAuditResult.SUCCESS,
+                    "unsafe correlation",
+                    null,
+                    OCCURRED_AT
+            )).isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("unsafe format");
+        }
+    }
+
+    @Nested
+    @DisplayName("audit cursor를 처리할 때")
+    class Cursor {
+
+        @Test
+        @DisplayName("occurredAt과 id를 손실 없이 round-trip한다")
+        void roundTrips() {
+            String encoded = AdminAuditCursor.encode(OCCURRED_AT, 304L);
+
+            assertThat(AdminAuditCursor.decode(encoded))
+                    .isEqualTo(new AdminAuditEventQuery.Cursor(
+                            OCCURRED_AT,
+                            304L
+                    ));
+            assertThatThrownBy(() -> AdminAuditCursor.decode("not-a-cursor"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Invalid audit cursor");
+        }
+    }
+
+    @Nested
+    @DisplayName("audit event 목록을 조회할 때")
+    class ListEvents {
+
+        @Test
+        @DisplayName("size+1 조회로 bounded page와 stable next cursor를 만든다")
+        void createsBoundedPage() {
+            AdminAuditQueryService service = new AdminAuditQueryService(query);
+            when(query.find(any(), eq(3))).thenReturn(List.of(
+                    row(3L),
+                    row(2L),
+                    row(1L)
+            ));
+
+            AdminAuditQueryResult.Page page = service.list(
+                    304L,
+                    "USER_STATUS_CHANGE",
+                    "USER",
+                    "42",
+                    AdminAuditResult.SUCCESS,
+                    "request-304",
+                    OCCURRED_AT.minusSeconds(1),
+                    OCCURRED_AT.plusSeconds(1),
+                    null,
+                    2
+            );
+
+            assertThat(page.items()).extracting(AdminAuditQueryResult.Item::id)
+                    .containsExactly(3L, 2L);
+            assertThat(AdminAuditCursor.decode(page.nextCursor()))
+                    .isEqualTo(new AdminAuditEventQuery.Cursor(
+                            OCCURRED_AT,
+                            2L
+                    ));
+            ArgumentCaptor<AdminAuditEventQuery.Filter> filter =
+                    ArgumentCaptor.forClass(AdminAuditEventQuery.Filter.class);
+            verify(query).find(filter.capture(), eq(3));
+            assertThat(filter.getValue().action().value())
+                    .isEqualTo("USER_STATUS_CHANGE");
+            assertThat(filter.getValue().targetType().value())
+                    .isEqualTo("USER");
+        }
+
+        @Test
+        @DisplayName("unbounded size와 역전된 time range를 거부한다")
+        void rejectsInvalidBounds() {
+            AdminAuditQueryService service = new AdminAuditQueryService(query);
+
+            assertThatThrownBy(() -> service.list(
+                    null, null, null, null, null, null,
+                    null, null, null, 101
+            )).isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> service.list(
+                    null, null, null, null, null, null,
+                    OCCURRED_AT, OCCURRED_AT, null, 20
+            )).isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    private AdminAuditEventQuery.Row row(Long id) {
+        return new AdminAuditEventQuery.Row(
+                id,
+                304L,
+                "USER_STATUS_CHANGE",
+                "USER",
+                "42",
+                "CASE-304",
+                AdminAuditResult.SUCCESS,
+                "request-304",
+                null,
+                OCCURRED_AT
+        );
+    }
+}

--- a/src/test/java/online/lifeasgame/adminaudit/application/AdminAuditIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/adminaudit/application/AdminAuditIntegrationTest.java
@@ -5,7 +5,10 @@ import online.lifeasgame.adminaudit.application.result.AdminAuditQueryResult;
 import online.lifeasgame.adminaudit.domain.AdminAuditAction;
 import online.lifeasgame.adminaudit.domain.AdminAuditResult;
 import online.lifeasgame.adminaudit.domain.AdminAuditTargetType;
+import online.lifeasgame.core.error.AuthException;
+import online.lifeasgame.core.error.api.AuthError;
 import online.lifeasgame.core.security.CurrentUserAccessor;
+import online.lifeasgame.user.application.internal.UserAuthApi;
 import org.flywaydb.core.Flyway;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -26,6 +29,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.Instant;
+import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
@@ -75,6 +79,9 @@ class AdminAuditIntegrationTest {
     @MockitoBean
     private CurrentUserAccessor currentUserAccessor;
 
+    @MockitoBean
+    private UserAuthApi userAuthApi;
+
     private TransactionTemplate transaction;
 
     @BeforeEach
@@ -96,6 +103,14 @@ class AdminAuditIntegrationTest {
                 """, ACTOR_ID, "audit-admin@example.com", "hash", "audit-admin");
         given(currentUserAccessor.currentUserIdOrThrow())
                 .willReturn(ACTOR_ID);
+        given(userAuthApi.resolveAuthorization(ACTOR_ID))
+                .willReturn(Optional.of(
+                        new UserAuthApi.AccountAuthorization(true, true)
+                ));
+        given(userAuthApi.resolveAuthorization(MISSING_ACTOR_ID))
+                .willReturn(Optional.of(
+                        new UserAuthApi.AccountAuthorization(true, true)
+                ));
         transaction = new TransactionTemplate(transactionManager);
     }
 
@@ -145,6 +160,33 @@ class AdminAuditIntegrationTest {
                         "request-failure"
                 ));
             })).isInstanceOf(DataIntegrityViolationException.class);
+
+            assertThat(count("admin_audit_test_mutations")).isZero();
+            assertThat(count("admin_audit_events")).isZero();
+        }
+
+        @Test
+        @DisplayName("authenticated USER actor면 거부하고 business mutation도 rollback한다")
+        void rejectsNonAdminAndRollsBack() {
+            given(userAuthApi.resolveAuthorization(ACTOR_ID))
+                    .willReturn(Optional.of(
+                            new UserAuthApi.AccountAuthorization(true, false)
+                    ));
+
+            assertThatThrownBy(() -> transaction.executeWithoutResult(status -> {
+                jdbc.update(
+                        "INSERT INTO admin_audit_test_mutations (id, note) VALUES (3, 'changed')"
+                );
+                auditApi.append(command(
+                        "USER_STATUS_CHANGE",
+                        "USER",
+                        "42",
+                        "request-non-admin"
+                ));
+            })).isInstanceOfSatisfying(AuthException.class, exception ->
+                    assertThat(exception.getErrorCode())
+                            .isEqualTo(AuthError.FORBIDDEN)
+            );
 
             assertThat(count("admin_audit_test_mutations")).isZero();
             assertThat(count("admin_audit_events")).isZero();

--- a/src/test/java/online/lifeasgame/adminaudit/application/AdminAuditIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/adminaudit/application/AdminAuditIntegrationTest.java
@@ -1,0 +1,247 @@
+package online.lifeasgame.adminaudit.application;
+
+import online.lifeasgame.adminaudit.application.internal.AdminAuditInternalApi;
+import online.lifeasgame.adminaudit.application.result.AdminAuditQueryResult;
+import online.lifeasgame.adminaudit.domain.AdminAuditAction;
+import online.lifeasgame.adminaudit.domain.AdminAuditResult;
+import online.lifeasgame.adminaudit.domain.AdminAuditTargetType;
+import online.lifeasgame.core.security.CurrentUserAccessor;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Instant;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles({"test", "migration-test"})
+@DisplayName("Admin Audit MySQL persistence와 transaction contract")
+class AdminAuditIntegrationTest {
+
+    private static final long ACTOR_ID = 9304L;
+    private static final long MISSING_ACTOR_ID = 9305L;
+
+    @Container
+    private static final MySQLContainer<?> MYSQL =
+            new MySQLContainer<>("mysql:8.0.39")
+                    .withDatabaseName("lifeasgame_admin_audit")
+                    .withUsername("lifeasgame")
+                    .withPassword("lifeasgame");
+
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add(
+                "spring.datasource.driver-class-name",
+                MYSQL::getDriverClassName
+        );
+    }
+
+    @Autowired
+    private AdminAuditInternalApi auditApi;
+
+    @Autowired
+    private AdminAuditQueryService queryService;
+
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    @Autowired
+    private Flyway flyway;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @MockitoBean
+    private CurrentUserAccessor currentUserAccessor;
+
+    private TransactionTemplate transaction;
+
+    @BeforeEach
+    void setUp() {
+        jdbc.execute("""
+                CREATE TABLE IF NOT EXISTS admin_audit_test_mutations (
+                    id BIGINT NOT NULL PRIMARY KEY,
+                    note VARCHAR(32) NOT NULL
+                ) ENGINE=InnoDB
+                """);
+        jdbc.update("DELETE FROM admin_audit_events");
+        jdbc.update("DELETE FROM admin_audit_test_mutations");
+        jdbc.update("DELETE FROM users WHERE id IN (?, ?)", ACTOR_ID, MISSING_ACTOR_ID);
+        jdbc.update("""
+                INSERT INTO users (
+                    id, email, password_hash, nickname, status,
+                    account_authority, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, 'ACTIVE', 'ADMIN', NOW(6), NOW(6))
+                """, ACTOR_ID, "audit-admin@example.com", "hash", "audit-admin");
+        given(currentUserAccessor.currentUserIdOrThrow())
+                .willReturn(ACTOR_ID);
+        transaction = new TransactionTemplate(transactionManager);
+    }
+
+    @Nested
+    @DisplayName("caller transaction에서 append할 때")
+    class TransactionContract {
+
+        @Test
+        @DisplayName("business mutation과 durable audit을 함께 commit한다")
+        void commitsTogether() {
+            transaction.executeWithoutResult(status -> {
+                jdbc.update(
+                        "INSERT INTO admin_audit_test_mutations (id, note) VALUES (1, 'changed')"
+                );
+                auditApi.append(command(
+                        "USER_STATUS_CHANGE",
+                        "USER",
+                        "42",
+                        "request-commit"
+                ));
+            });
+
+            assertThat(flyway.info().current().getVersion().getVersion())
+                    .isEqualTo("30");
+            assertThat(count("admin_audit_test_mutations")).isEqualTo(1);
+            assertThat(count("admin_audit_events")).isEqualTo(1);
+            assertThat(jdbc.queryForObject(
+                    "SELECT actor_user_id FROM admin_audit_events",
+                    Long.class
+            )).isEqualTo(ACTOR_ID);
+        }
+
+        @Test
+        @DisplayName("audit persistence 실패는 business mutation도 rollback한다")
+        void failsClosed() {
+            given(currentUserAccessor.currentUserIdOrThrow())
+                    .willReturn(MISSING_ACTOR_ID);
+
+            assertThatThrownBy(() -> transaction.executeWithoutResult(status -> {
+                jdbc.update(
+                        "INSERT INTO admin_audit_test_mutations (id, note) VALUES (2, 'changed')"
+                );
+                auditApi.append(command(
+                        "USER_STATUS_CHANGE",
+                        "USER",
+                        "42",
+                        "request-failure"
+                ));
+            })).isInstanceOf(DataIntegrityViolationException.class);
+
+            assertThat(count("admin_audit_test_mutations")).isZero();
+            assertThat(count("admin_audit_events")).isZero();
+        }
+
+        @Test
+        @DisplayName("caller transaction이 없으면 append를 거부한다")
+        void requiresCallerTransaction() {
+            assertThatThrownBy(() -> auditApi.append(command(
+                    "USER_STATUS_CHANGE",
+                    "USER",
+                    "42",
+                    "request-without-transaction"
+            ))).isInstanceOf(
+                    org.springframework.transaction.IllegalTransactionStateException.class
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("audit event를 조회할 때")
+    class QueryContract {
+
+        @Test
+        @DisplayName("filters와 occurredAt-id cursor로 안정적인 bounded page를 반환한다")
+        void filtersAndPaginates() {
+            AdminAuditInternalApi.AppendResult first = append(command(
+                    "USER_STATUS_CHANGE", "USER", "42", "request-1"
+            ));
+            AdminAuditInternalApi.AppendResult second = append(command(
+                    "WALLET_ADJUSTMENT", "WALLET", "9", "request-2"
+            ));
+            AdminAuditInternalApi.AppendResult third = append(command(
+                    "USER_STATUS_CHANGE", "USER", "43", "request-3"
+            ));
+
+            AdminAuditQueryResult.Page firstPage = queryService.list(
+                    ACTOR_ID, null, null, null, null, null,
+                    null, null, null, 2
+            );
+            AdminAuditQueryResult.Page secondPage = queryService.list(
+                    ACTOR_ID, null, null, null, null, null,
+                    null, null, firstPage.nextCursor(), 2
+            );
+            AdminAuditQueryResult.Page filtered = queryService.list(
+                    ACTOR_ID,
+                    "USER_STATUS_CHANGE",
+                    "USER",
+                    "42",
+                    AdminAuditResult.SUCCESS,
+                    "request-1",
+                    first.occurredAt().minusSeconds(1),
+                    first.occurredAt().plusSeconds(1),
+                    null,
+                    20
+            );
+
+            assertThat(firstPage.items())
+                    .extracting(AdminAuditQueryResult.Item::id)
+                    .containsExactly(third.auditEventId(), second.auditEventId());
+            assertThat(firstPage.nextCursor()).isNotNull();
+            assertThat(secondPage.items())
+                    .extracting(AdminAuditQueryResult.Item::id)
+                    .containsExactly(first.auditEventId());
+            assertThat(secondPage.nextCursor()).isNull();
+            assertThat(filtered.items()).singleElement().satisfies(item -> {
+                assertThat(item.id()).isEqualTo(first.auditEventId());
+                assertThat(item.reason()).isEqualTo("CASE-304");
+                assertThat(item.idempotencyKey()).isNull();
+            });
+        }
+    }
+
+    private AdminAuditInternalApi.AppendResult append(
+            AdminAuditInternalApi.AppendCommand command
+    ) {
+        return transaction.execute(status -> auditApi.append(command));
+    }
+
+    private AdminAuditInternalApi.AppendCommand command(
+            String action,
+            String targetType,
+            String targetId,
+            String correlationId
+    ) {
+        return new AdminAuditInternalApi.AppendCommand(
+                new AdminAuditAction(action),
+                new AdminAuditTargetType(targetType),
+                targetId,
+                "CASE-304",
+                AdminAuditResult.SUCCESS,
+                correlationId,
+                null
+        );
+    }
+
+    private int count(String table) {
+        return jdbc.queryForObject("SELECT COUNT(*) FROM " + table, Integer.class);
+    }
+}

--- a/src/test/java/online/lifeasgame/economy/application/MarketplaceTradeFulfillmentIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/economy/application/MarketplaceTradeFulfillmentIntegrationTest.java
@@ -205,7 +205,7 @@ class MarketplaceTradeFulfillmentIntegrationTest {
         @DisplayName("legacy null은 허용하고 canonical quantity 제약은 보존한다")
         void validatesMigrationAndJpaContract() {
             assertThat(flyway.info().current().getVersion().getVersion())
-                    .isEqualTo("29");
+                    .isEqualTo("30");
             jdbc.update("""
                     INSERT INTO trades (
                         fee_bps, buyer_player_id, created_at, fee, item_inst_id,

--- a/src/test/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/inventory/application/InventoryRewardDeliveryIntegrationTest.java
@@ -99,7 +99,7 @@ class InventoryRewardDeliveryIntegrationTest {
     @DisplayName("V17 receipt table은 JPA validate와 unique/check/index 계약을 만족한다")
     void validatesMigrationContract() {
         assertThat(flyway.info().current().getVersion().getVersion())
-                .isEqualTo("29");
+                .isEqualTo("30");
         assertThat(environment.getProperty("spring.jpa.hibernate.ddl-auto"))
                 .isEqualTo("validate");
 

--- a/src/test/java/online/lifeasgame/migration/AccountAuthorityFlywayTest.java
+++ b/src/test/java/online/lifeasgame/migration/AccountAuthorityFlywayTest.java
@@ -34,9 +34,9 @@ class AccountAuthorityFlywayTest {
         throughV28.migrate();
         insertUser(30001L, "existing@example.com");
 
-        Flyway latest = flyway(null);
-        assertThat(latest.migrate().migrationsExecuted).isEqualTo(1);
-        assertThat(latest.info().current().getVersion().getVersion())
+        Flyway throughV29 = flyway(MigrationVersion.fromVersion("29"));
+        assertThat(throughV29.migrate().migrationsExecuted).isEqualTo(1);
+        assertThat(throughV29.info().current().getVersion().getVersion())
                 .isEqualTo("29");
         assertThat(authority(30001L)).isEqualTo("USER");
 

--- a/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayExplicitBaselineTest.java
@@ -63,7 +63,7 @@ class FlywayExplicitBaselineTest {
     class ApplyExplicitBaseline {
 
         @Test
-        @DisplayName("V1을 재실행하지 않고 V2부터 V29까지 적용한 뒤 JPA validate를 통과한다")
+        @DisplayName("V1을 재실행하지 않고 V2부터 V30까지 적용한 뒤 JPA validate를 통과한다")
         void migratesFromVersionTwoAndValidatesJpa() throws Exception {
             String jdbcUrl = createV1EquivalentDatabase();
             Flyway flyway = migrationFlyway(jdbcUrl);
@@ -72,13 +72,13 @@ class FlywayExplicitBaselineTest {
             MigrateResult migrateResult = flyway.migrate();
             List<HistoryRow> history = successfulHistory(jdbcUrl);
 
-            assertThat(migrateResult.migrationsExecuted).isEqualTo(28);
+            assertThat(migrateResult.migrationsExecuted).isEqualTo(29);
             assertThat(history).extracting(HistoryRow::version)
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
                             "14", "15", "16", "17", "18", "19", "20",
-                            "21", "22", "23", "24", "25", "26", "27", "28", "29"
+                            "21", "22", "23", "24", "25", "26", "27", "28", "29", "30"
                     );
             assertThat(history.getFirst().type()).isEqualTo("BASELINE");
             assertThat(history.getFirst().script())
@@ -117,7 +117,8 @@ class FlywayExplicitBaselineTest {
                             "V26__inventory_entry_availability.sql",
                             "V27__canonical_listing_reservations.sql",
                             "V28__canonical_trade_item_snapshot.sql",
-                            "V29__user_account_authority.sql"
+                            "V29__user_account_authority.sql",
+                            "V30__admin_audit_foundation.sql"
                     );
             assertThat(history.subList(1, history.size()))
                     .allSatisfy(row -> assertThat(row.checksum()).isNotNull());
@@ -137,7 +138,7 @@ class FlywayExplicitBaselineTest {
                         "spring.jpa.hibernate.ddl-auto"
                 )).isEqualTo("validate");
                 assertThat(context.getBean(Flyway.class).info().current().getVersion().getVersion())
-                        .isEqualTo("29");
+                        .isEqualTo("30");
             }
         }
     }

--- a/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayHistoryChecksumTest.java
@@ -33,7 +33,7 @@ class FlywayHistoryChecksumTest {
     class MigrateAgain {
 
         @Test
-        @DisplayName("V1~V20 checksum을 보존하고 V29 이후 두 번째 실행은 no-op이다")
+        @DisplayName("V1~V20 checksum을 보존하고 V30 이후 두 번째 실행은 no-op이다")
         void keepsMigrationHistory() throws Exception {
             Flyway throughV20 = flyway(MigrationVersion.fromVersion("20"));
             MigrateResult legacy = throughV20.migrate();
@@ -47,7 +47,7 @@ class FlywayHistoryChecksumTest {
             List<HistoryRow> secondHistory = successfulHistory();
 
             assertThat(legacy.migrationsExecuted).isEqualTo(20);
-            assertThat(first.migrationsExecuted).isEqualTo(9);
+            assertThat(first.migrationsExecuted).isEqualTo(10);
             assertThat(second.migrationsExecuted).isZero();
             assertThat(secondHistory).isEqualTo(firstHistory);
             assertThat(firstHistory.subList(0, legacyHistory.size()))
@@ -57,7 +57,7 @@ class FlywayHistoryChecksumTest {
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
                             "14", "15", "16", "17", "18", "19", "20",
-                            "21", "22", "23", "24", "25", "26", "27", "28", "29"
+                            "21", "22", "23", "24", "25", "26", "27", "28", "29", "30"
                     );
             assertThat(secondHistory).allSatisfy(history -> {
                 assertThat(history.checksum()).isNotNull();

--- a/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayMigrationTest.java
@@ -39,7 +39,7 @@ class FlywayMigrationTest {
     class MigrateCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V29까지 적용되고 account authority를 추가한다")
+        @DisplayName("V1부터 V30까지 적용되고 Admin Audit schema를 추가한다")
         void migratesSchemaAndSeedsRewardProfiles() throws Exception {
             Flyway throughV10 = flyway(MigrationVersion.fromVersion("10"));
             MigrateResult legacyResult = throughV10.migrate();
@@ -58,13 +58,13 @@ class FlywayMigrationTest {
             assertThat(legacyResult.migrationsExecuted).isEqualTo(10);
             assertThat(semanticResult.migrationsExecuted).isEqualTo(1);
             assertThat(itemResult.migrationsExecuted).isEqualTo(1);
-            assertThat(result.migrationsExecuted).isEqualTo(17);
+            assertThat(result.migrationsExecuted).isEqualTo(18);
             assertThat(appliedVersions())
                     .containsExactly(
                             "1", "2", "3", "4", "5",
                             "6", "7", "8", "9", "10", "11", "12", "13",
                             "14", "15", "16", "17", "18", "19", "20",
-                            "21", "22", "23", "24", "25", "26", "27", "28", "29"
+                            "21", "22", "23", "24", "25", "26", "27", "28", "29", "30"
                     );
             assertThat(existingTables(
                     "users",
@@ -92,7 +92,8 @@ class FlywayMigrationTest {
                     "player_quest_routes",
                     "role_events",
                     "role_event_participants",
-                    "player_notifications"
+                    "player_notifications",
+                    "admin_audit_events"
             )).containsExactlyInAnyOrder(
                     "users",
                     "player",
@@ -119,7 +120,8 @@ class FlywayMigrationTest {
                     "player_quest_routes",
                     "role_events",
                     "role_event_participants",
-                    "player_notifications"
+                    "player_notifications",
+                    "admin_audit_events"
             );
             assertThat(existingTables(
                     "quick_lifelog_entries",

--- a/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
+++ b/src/test/java/online/lifeasgame/migration/FlywayProfileCutoverTest.java
@@ -149,7 +149,7 @@ class FlywayProfileCutoverTest {
     class StartLocalWithCleanDatabase {
 
         @Test
-        @DisplayName("V1부터 V29까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
+        @DisplayName("V1부터 V30까지 적용한 뒤 Hibernate validate로 Context가 기동한다")
         void migratesThenValidates() {
             ConfigurableEnvironment environment =
                     (ConfigurableEnvironment) applicationContext.getEnvironment();
@@ -161,8 +161,8 @@ class FlywayProfileCutoverTest {
             assertThat(environment.getProperty(
                     "spring.flyway.baseline-on-migrate", Boolean.class
             )).isFalse();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("29");
-            assertThat(appliedMigrationCount()).isEqualTo(29);
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("30");
+            assertThat(appliedMigrationCount()).isEqualTo(30);
         }
     }
 

--- a/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
+++ b/src/test/java/online/lifeasgame/migration/JpaValidateAfterMigrationTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 @SpringBootTest
 @ActiveProfiles({"test", "migration-test"})
-@DisplayName("V29 migration 이후 JPA schema validation")
+@DisplayName("V30 migration 이후 JPA schema validation")
 class JpaValidateAfterMigrationTest {
 
     @Container
@@ -79,14 +79,14 @@ class JpaValidateAfterMigrationTest {
     private QuestDefinitionBootstrapper questDefinitionBootstrapper;
 
     @Nested
-    @DisplayName("V1부터 V29까지 적용된 schema로 ApplicationContext를 기동할 때")
+    @DisplayName("V1부터 V30까지 적용된 schema로 ApplicationContext를 기동할 때")
     class LoadApplicationContext {
 
         @Test
         @DisplayName("ddl-auto validate 상태로 정상 기동한다")
         void loadsWithJpaValidation() {
             assertThat(applicationContext).isNotNull();
-            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("29");
+            assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("30");
             assertThat(applicationContext.getEnvironment().getProperty("spring.jpa.hibernate.ddl-auto"))
                     .isEqualTo("validate");
             assertThat(applicationContext.getEnvironment()

--- a/src/test/java/online/lifeasgame/migration/RolePersonPersistenceFoundationFlywayTest.java
+++ b/src/test/java/online/lifeasgame/migration/RolePersonPersistenceFoundationFlywayTest.java
@@ -46,9 +46,9 @@ class RolePersonPersistenceFoundationFlywayTest {
     }
 
     @Test
-    @DisplayName("V29까지 적용된 schema에서 V19 Role/Person 계약을 고정한다")
+    @DisplayName("V30까지 적용된 schema에서 V19 Role/Person 계약을 고정한다")
     void createsSchemaContract() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("29");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("30");
         assertThat(tableContracts()).containsExactly(
                 new TableContract("roles", "InnoDB", "utf8mb4_0900_ai_ci"),
                 new TableContract("persons", "InnoDB", "utf8mb4_0900_ai_ci"),

--- a/src/test/java/online/lifeasgame/notification/application/NotificationApplicationIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/notification/application/NotificationApplicationIntegrationTest.java
@@ -101,7 +101,7 @@ class NotificationApplicationIntegrationTest {
         @DisplayName("durable row를 만들고 같은 player replay만 무시한다")
         void appendsDurablyAndScopesReplayByPlayer() {
             assertThat(flyway.info().current().getVersion().getVersion())
-                    .isEqualTo("29");
+                    .isEqualTo("30");
 
             append(PLAYER_ID, "shared-event");
             append(PLAYER_ID, "shared-event");

--- a/src/test/java/online/lifeasgame/role/application/RolePersonPersistenceIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/role/application/RolePersonPersistenceIntegrationTest.java
@@ -100,7 +100,7 @@ class RolePersonPersistenceIntegrationTest {
 
     @Test
     void persistsOwnerScopedCrudAndKeepsArchivedRows() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("29");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("30");
 
         var role = roleService.create(
                 new RoleCommand.Create("work", "Developer", "Builds")

--- a/src/test/java/online/lifeasgame/role/application/RoleRelationPersistenceIntegrationTest.java
+++ b/src/test/java/online/lifeasgame/role/application/RoleRelationPersistenceIntegrationTest.java
@@ -93,7 +93,7 @@ class RoleRelationPersistenceIntegrationTest {
 
     @Test
     void persistsCrudRejectsActiveDuplicateAndReactivatesArchivedRow() {
-        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("29");
+        assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("30");
         Long roleId = createRole("Owner role");
         Long personId = createPerson("Alice");
 


### PR DESCRIPTION
## Purpose

Close the third Admin Backend Foundation blocker by introducing a durable, privacy-safe Admin Audit capability for later high-risk command hardening.

Closes #304

## Delivered

- dedicated Admin Audit bounded capability
- append-only durable audit storage
- backend-owned internal append contract
- current authenticated Admin actor resolution
- same-transaction fail-closed append semantics
- privacy-safe structured audit metadata
- Admin-only audit read API
- bounded cursor/filter read model
- focused transaction/security/query coverage
- canonical Admin API contract update

## Audit Record

Audit records contain safe accountability metadata such as:

```text
actor
action
target
reason
result
correlation
idempotency
occurredAt
```

Raw private content and credential material are not stored.

## Transaction Contract

Required audit append participates in the caller transaction.

```text
business mutation
+ required audit append
-> commit together
```

If required audit persistence fails, the caller transaction cannot silently commit a successful audited operation.

## Read Contract

Canonical Admin read API:

```text
GET /admin/v1/audit-events
```

The read surface is bounded, filterable, cursor-oriented, and protected by the existing server-side Admin authority boundary.

## Privacy

Admin Audit does not duplicate raw:

- Journal/LifeLog bodies
- Person private fields
- Direct Chat messages
- access/refresh tokens
- arbitrary request/response payloads

## Scope Boundary

Existing high-risk Admin business commands remain gated.

This PR does not broadly wire or expose Wallet, Player correction, Inventory delivery, Quest override, User mutation, Shop mutation, or Social relationship commands.

Command-specific reason, idempotency, stale/conflict handling, and audit integration remain follow-up hardening work.

## Validation

Validation is limited to the new Admin Audit capability:

- focused unit tests
- one focused persistence/transaction integration test class
- focused Admin security/controller coverage
- one final build

No unnecessary broad test suite is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin audit trail recording administrative actions, actors, targets, outcomes, reasons, and timestamps.
  * Added a paginated audit-event view with filters for actor, action, target, result, correlation ID, and time range.
  * Added cursor-based navigation for browsing large audit histories.
  * Restricted audit-event access to authorized administrators.
* **Documentation**
  * Documented audit-event data rules, privacy safeguards, pagination, and high-risk administrative command requirements.
* **Bug Fixes**
  * Updated migration and schema validation coverage for the new audit functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->